### PR TITLE
Phase 1: dispatch bugs (#28), replan amnesia (#27), Daikin payload (#18)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -323,6 +323,9 @@ class Config:
     # Cheap/negative windows shorter than this are merged forward or dropped to avoid rapid heat-pump
     # cycling.  2 = 1 hour minimum (recommended).  0 = disabled (legacy behaviour, any length).
     DAIKIN_MIN_WINDOW_SLOTS: int = int(os.getenv("DAIKIN_MIN_WINDOW_SLOTS", "2"))
+    # Delay between critical Onecta writes (climate power, DHW) so the 3-way valve can settle (#18).
+    # 0 = skip sleeps (tests).
+    DAIKIN_VALVE_SETTLE_SECONDS: int = int(os.getenv("DAIKIN_VALVE_SETTLE_SECONDS", "10"))
     FOX_LP_BRIDGE_MAX_PRICE_PENCE: float = float(os.getenv("FOX_LP_BRIDGE_MAX_PRICE_PENCE", "0"))
     SOLAR_GAIN_FRACTION: float = float(os.getenv("SOLAR_GAIN_FRACTION", "0.15"))
     COP_DHW_PENALTY: float = float(os.getenv("COP_DHW_PENALTY", "0.5"))

--- a/src/config.py
+++ b/src/config.py
@@ -316,14 +316,13 @@ class Config:
     # Round each slot price to this grid (pence) before the MILP objective — ignores sub‑grid price noise.
     # 0 = use exact Agile prices. Try 1–3 for less “fidgety” schedules.
     LP_PRICE_QUANTIZE_PENCE: float = float(os.getenv("LP_PRICE_QUANTIZE_PENCE", "0"))
-    # LP dispatch → Fox/Daikin: promote short ``standard`` runs sandwiched between cheap/negative charge
-    # slots to ``cheap`` so Scheduler V3 stays in ForceCharge (fewer SelfUse islands). 0 = disabled.
+    # Legacy (unused): was “gap bridge” in lp_dispatch; removed in Phase 1 — keep keys so .env
+    # does not break. Values are ignored.
     FOX_LP_BRIDGE_GAP_SLOTS: int = int(os.getenv("FOX_LP_BRIDGE_GAP_SLOTS", "2"))
     # Daikin: minimum consecutive slots (half-hours) for a non-standard window to be scheduled.
     # Cheap/negative windows shorter than this are merged forward or dropped to avoid rapid heat-pump
     # cycling.  2 = 1 hour minimum (recommended).  0 = disabled (legacy behaviour, any length).
     DAIKIN_MIN_WINDOW_SLOTS: int = int(os.getenv("DAIKIN_MIN_WINDOW_SLOTS", "2"))
-    # Only bridge when every standard slot’s Agile price is ≤ this (p/kWh). 0 = use LP plan peak_threshold.
     FOX_LP_BRIDGE_MAX_PRICE_PENCE: float = float(os.getenv("FOX_LP_BRIDGE_MAX_PRICE_PENCE", "0"))
     SOLAR_GAIN_FRACTION: float = float(os.getenv("SOLAR_GAIN_FRACTION", "0.15"))
     COP_DHW_PENALTY: float = float(os.getenv("COP_DHW_PENALTY", "0.5"))

--- a/src/daikin_bulletproof.py
+++ b/src/daikin_bulletproof.py
@@ -28,8 +28,10 @@ def daikin_device_matches_params(dev: DaikinDevice, params: dict[str, Any]) -> b
     All other fields (lwt_offset, tank_temp, climate_on) use tolerance-based comparison.
     """
     if "lwt_offset" in params and dev.lwt_offset is not None:
-        if not _fclose(dev.lwt_offset, float(params["lwt_offset"])):
-            return False
+        # leavingWaterOffset is not writable when climate is off — ignore mismatch (#18).
+        if not ("climate_on" in params and not bool(params["climate_on"])):
+            if not _fclose(dev.lwt_offset, float(params["lwt_offset"])):
+                return False
     if "tank_temp" in params and dev.tank_target is not None:
         if not _fclose(dev.tank_target, float(params["tank_temp"]), eps=0.6):
             return False
@@ -50,23 +52,28 @@ def apply_scheduled_daikin_params(
     skip_if_matches: bool = True,
 ) -> bool:
     """Apply params; return True if any write was attempted (and not skipped)."""
-    if skip_if_matches and daikin_device_matches_params(dev, params):
+    p = dict(params)
+    if "climate_on" in p and not bool(p["climate_on"]):
+        p.pop("lwt_offset", None)
+
+    if skip_if_matches and daikin_device_matches_params(dev, p):
         return False
     if config.OPERATION_MODE != "operational" or config.OPENCLAW_READ_ONLY:
         db.log_action(
             device="daikin",
             action="scheduled_apply",
-            params=params,
+            params=p,
             result="skipped",
             trigger=trigger,
             error_msg="read_only or simulation",
         )
         return False
+    settle = max(0, int(getattr(config, "DAIKIN_VALVE_SETTLE_SECONDS", 10)))
     try:
-        climate_going_off = "climate_on" in params and not bool(params["climate_on"])
-        climate_going_on = "climate_on" in params and bool(params["climate_on"])
+        climate_going_off = "climate_on" in p and not bool(p["climate_on"])
+        climate_going_on = "climate_on" in p and bool(p["climate_on"])
         device_is_on = bool(dev.is_on)
-        has_dhw_cmds = "tank_power" in params or "tank_powerful" in params
+        has_dhw_cmds = "tank_power" in p or "tank_powerful" in p
 
         # leavingWaterOffset is read-only when the climate zone is physically OFF.
         # Zone will be ON after this call only if it's currently ON (and not turning off)
@@ -74,21 +81,21 @@ def apply_scheduled_daikin_params(
         zone_will_be_on = (device_is_on and not climate_going_off) or climate_going_on
 
         # If turning ON: send power first so lwt_offset is writable on the next call.
-        # The 3-way valve takes 10-15 s to settle; sleep before DHW commands to prevent
+        # The 3-way valve needs time to settle; sleep before DHW commands to prevent
         # silent command drops from the Daikin mainboard.
         if climate_going_on:
             client.set_power(dev, True)
-            if has_dhw_cmds:
-                time.sleep(10)
+            if has_dhw_cmds and settle:
+                time.sleep(settle)
 
-        if "lwt_offset" in params:
+        if "lwt_offset" in p:
             if not zone_will_be_on:
                 logger.debug("Skipping lwt_offset: zone is OFF or turning OFF (read-only characteristic)")
             elif dev.lwt_offset_range is not None and not getattr(dev.lwt_offset_range, "settable", True):
                 logger.debug("Skipping lwt_offset: device reports characteristic as non-settable (weatherDependent mode)")
             else:
                 try:
-                    client.set_lwt_offset(dev, float(params["lwt_offset"]))
+                    client.set_lwt_offset(dev, float(p["lwt_offset"]))
                 except DaikinError as exc:
                     if "[read_only]" in str(exc):
                         # Non-fatal: lwt_offset read-only (e.g. weatherDependent setpoint mode).
@@ -99,33 +106,35 @@ def apply_scheduled_daikin_params(
 
         if climate_going_off:
             client.set_power(dev, False)
+            if has_dhw_cmds and settle:
+                time.sleep(settle)
 
         # tank_power must be set before tank_temp: Daikin returns READ_ONLY_CHARACTERISTIC
         # for the target temperature when the tank is powered off.
-        tank_turning_on = "tank_power" in params and bool(params["tank_power"])
+        tank_turning_on = "tank_power" in p and bool(p["tank_power"])
         if tank_turning_on:
             client.set_tank_power(dev, True)
-            if "tank_temp" in params:
-                time.sleep(10)  # Daikin cloud propagation: onOffMode must settle before temperatureControl is writable
+            if "tank_temp" in p and settle:
+                time.sleep(settle)  # onOffMode must settle before temperatureControl is writable
 
-        if "tank_temp" in params:
+        if "tank_temp" in p:
             try:
-                client.set_tank_temperature(dev, float(params["tank_temp"]))
+                client.set_tank_temperature(dev, float(p["tank_temp"]))
             except DaikinError as exc:
                 if "[read_only]" in str(exc) and tank_turning_on:
                     # Cloud hasn't propagated tank-on yet; heartbeat will retry next tick
                     logger.warning("tank_temp read-only after tank_power=on (cloud lag) — will retry: %s", exc)
                 else:
                     raise
-        if not tank_turning_on and "tank_power" in params:
-            client.set_tank_power(dev, bool(params["tank_power"]))
-        if "tank_powerful" in params:
-            client.set_tank_powerful(dev, bool(params["tank_powerful"]))
+        if not tank_turning_on and "tank_power" in p:
+            client.set_tank_power(dev, bool(p["tank_power"]))
+        if "tank_powerful" in p:
+            client.set_tank_powerful(dev, bool(p["tank_powerful"]))
     except (DaikinError, ValueError) as e:
         db.log_action(
             device="daikin",
             action="scheduled_apply",
-            params=params,
+            params=p,
             result="failure",
             trigger=trigger,
             error_msg=str(e),
@@ -134,7 +143,7 @@ def apply_scheduled_daikin_params(
     db.log_action(
         device="daikin",
         action="scheduled_apply",
-        params=params,
+        params=p,
         result="success",
         trigger=trigger,
     )

--- a/src/db.py
+++ b/src/db.py
@@ -1053,17 +1053,78 @@ def update_octopus_fetch_state(
             conn.close()
 
 
+def _parse_action_time_utc(s: str) -> datetime:
+    x = str(s).replace("Z", "+00:00")
+    dt = datetime.fromisoformat(x)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _now_utc() -> datetime:
+    """Wall clock for replan preservation tests (monkeypatch target)."""
+    return datetime.now(UTC)
+
+
+def _preserve_daikin_pending_ids_for_replan(plan_date: str) -> set[int]:
+    """Row ids that must survive clear_actions before a replan (issue #27).
+
+    * Pending **restore** rows referenced by an **active** main action (otherwise the
+      post-shutdown restore disappears while the commanded state is still active).
+    * Pending main actions in ``[start, end)`` (MPC can run before heartbeat marks them
+      ``active``) plus their paired restore row, if any.
+    """
+    now_utc = _now_utc()
+    preserve: set[int] = set()
+    for r in get_actions_for_plan_date(plan_date, device="daikin"):
+        st = r.get("status") or ""
+        if st == "active" and r.get("restore_action_id"):
+            preserve.add(int(r["restore_action_id"]))
+        if st != "pending":
+            continue
+        try:
+            start = _parse_action_time_utc(str(r["start_time"]))
+            end = _parse_action_time_utc(str(r["end_time"]))
+        except (ValueError, KeyError, TypeError):
+            continue
+        if start <= now_utc < end:
+            preserve.add(int(r["id"]))
+            rid = r.get("restore_action_id")
+            if rid is not None:
+                preserve.add(int(rid))
+    return preserve
+
+
 def clear_actions_for_date(plan_date: str, device: str | None = None) -> None:
-    """Remove pending actions for a plan date (before re-optimizing)."""
+    """Remove pending actions for a plan date (before re-optimizing).
+
+    Daikin: does **not** delete pending rows still needed for in-flight execution — see
+    :func:`_preserve_daikin_pending_ids_for_replan`.
+    """
+    preserve_ids: set[int] = set()
+    if device == "daikin":
+        preserve_ids = _preserve_daikin_pending_ids_for_replan(plan_date)
     with _lock:
         conn = get_connection()
         try:
             if device:
-                conn.execute(
-                    """DELETE FROM action_schedule
-                       WHERE date = ? AND device = ? AND status = 'pending'""",
-                    (plan_date, device),
-                )
+                if preserve_ids:
+                    placeholders = ",".join("?" * len(preserve_ids))
+                    q = (
+                        f"""DELETE FROM action_schedule
+                            WHERE date = ? AND device = ? AND status = 'pending'
+                            AND id NOT IN ({placeholders})"""
+                    )
+                    conn.execute(
+                        q,
+                        (plan_date, device, *sorted(preserve_ids)),
+                    )
+                else:
+                    conn.execute(
+                        """DELETE FROM action_schedule
+                           WHERE date = ? AND device = ? AND status = 'pending'""",
+                        (plan_date, device),
+                    )
             else:
                 conn.execute(
                     """DELETE FROM action_schedule

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -26,44 +26,13 @@ logger = logging.getLogger(__name__)
 EPS = 0.05
 
 
-def apply_lp_dispatch_gap_bridge(slots: list[HalfHourSlot], plan: LpPlan) -> None:
-    """Promote short ``standard`` runs between cheap/negative blocks to ``cheap`` (mutates ``slots``).
-
-    When the MILP skips charging for a few half-hours but prices are still below peak, dispatch
-    would otherwise flip Fox between ForceCharge and SelfUse — this fills those gaps (up to
-    ``FOX_LP_BRIDGE_GAP_SLOTS``) so hardware schedules stay consolidated.
-    """
-    max_gap = int(config.FOX_LP_BRIDGE_GAP_SLOTS)
-    if max_gap <= 0 or len(slots) < 3:
-        return
-    cap = float(config.FOX_LP_BRIDGE_MAX_PRICE_PENCE)
-    if cap <= 0:
-        cap = float(plan.peak_threshold_pence)
-    cheapish = frozenset({"cheap", "negative"})
-    n = len(slots)
-    i = 0
-    while i < n:
-        if slots[i].kind != "standard":
-            i += 1
-            continue
-        j = i
-        while j < n and slots[j].kind == "standard":
-            j += 1
-        length = j - i
-        prev_ok = i > 0 and slots[i - 1].kind in cheapish
-        next_ok = j < n and slots[j].kind in cheapish
-        if prev_ok and next_ok and length <= max_gap:
-            if all(slots[k].price_pence <= cap for k in range(i, j)):
-                for k in range(i, j):
-                    slots[k].kind = "cheap"
-        i = j
-
-
 def lp_dispatch_slots_for_hardware(plan: LpPlan) -> list[HalfHourSlot]:
-    """Half-hour kinds for Fox/Daikin after optional gap-bridging (see :func:`apply_lp_dispatch_gap_bridge`)."""
-    slots = lp_plan_to_slots(plan)
-    apply_lp_dispatch_gap_bridge(slots, plan)
-    return slots
+    """Half-hour kinds for Fox/Daikin — identical to :func:`lp_plan_to_slots` (pure MILP mapping).
+
+    V7-era "gap bridge" heuristics that promoted ``standard`` slots between charge blocks to
+    ``cheap`` are removed: they overrode the solver and extended ForceCharge windows.
+    """
+    return lp_plan_to_slots(plan)
 
 
 def lp_plan_to_slots(plan: LpPlan) -> list[HalfHourSlot]:
@@ -173,8 +142,7 @@ def _merge_half_hour_slots_for_daikin(plan: LpPlan) -> list[tuple[datetime, date
       any interleaving standard gap ≤ 1 slot), or
     * **dropped** — converted back to ``standard`` so no Daikin action is scheduled.
 
-    This mirrors the Fox ``FOX_LP_BRIDGE_GAP_SLOTS`` consolidation and prevents the heat-pump
-    from being toggled on/off every 30 minutes.
+    This filters ultra-short Daikin windows so the heat-pump is not toggled every 30 minutes.
     """
     slots = lp_dispatch_slots_for_hardware(plan)
     if not slots:

--- a/tests/test_daikin_bulletproof.py
+++ b/tests/test_daikin_bulletproof.py
@@ -1,0 +1,84 @@
+"""Daikin bulletproof apply: payload pruning (#18) and valve settle timing."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.daikin.models import DaikinDevice, SetpointRange
+from src.daikin_bulletproof import apply_scheduled_daikin_params, daikin_device_matches_params
+
+
+@pytest.fixture
+def operational(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPERATION_MODE", "operational")
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+
+
+@pytest.fixture
+def no_settle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_VALVE_SETTLE_SECONDS", 0)
+
+
+def test_prune_drops_lwt_offset_when_climate_off_no_set_lwt(
+    operational: None,
+    no_settle: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Onecta rejects leavingWaterOffset when zone is off — do not call set_lwt_offset (#18)."""
+    monkeypatch.setattr("src.daikin_bulletproof.db.log_action", MagicMock())
+    dev = DaikinDevice(id="gw", name="x", is_on=False, lwt_offset=-3.0)
+    dev.lwt_offset_range = SetpointRange(settable=True)
+    client = MagicMock()
+    apply_scheduled_daikin_params(
+        dev,
+        client,
+        {
+            "lwt_offset": -5.0,
+            "climate_on": False,
+            "tank_power": False,
+            "tank_temp": 50.0,
+        },
+        trigger="test",
+        skip_if_matches=False,
+    )
+    client.set_lwt_offset.assert_not_called()
+    client.set_power.assert_called_once_with(dev, False)
+
+
+def test_device_matches_ignores_lwt_when_climate_commanded_off() -> None:
+    dev = DaikinDevice(id="gw", name="x", is_on=False, lwt_offset=0.0)
+    assert daikin_device_matches_params(
+        dev,
+        {"lwt_offset": -9.0, "climate_on": False},
+    )
+
+
+def test_valve_settle_after_climate_off_before_dhw(
+    operational: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_VALVE_SETTLE_SECONDS", 10)
+    monkeypatch.setattr("src.daikin_bulletproof.db.log_action", MagicMock())
+    sleeps: list[float] = []
+
+    def capture_sleep(s: float) -> None:
+        sleeps.append(s)
+
+    monkeypatch.setattr("src.daikin_bulletproof.time.sleep", capture_sleep)
+
+    dev = DaikinDevice(id="gw", name="x", is_on=True, lwt_offset=0.0)
+    dev.lwt_offset_range = SetpointRange(settable=True)
+    client = MagicMock()
+    apply_scheduled_daikin_params(
+        dev,
+        client,
+        {
+            "climate_on": False,
+            "tank_power": True,
+            "tank_temp": 48.0,
+        },
+        trigger="test",
+        skip_if_matches=False,
+    )
+    assert 10.0 in sleeps

--- a/tests/test_lp_dispatch_gap_bridge.py
+++ b/tests/test_lp_dispatch_gap_bridge.py
@@ -1,0 +1,47 @@
+"""Gap bridge removal (issue #28): dispatch must mirror PuLP slot kinds, not fill gaps."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from src.scheduler.lp_dispatch import lp_dispatch_slots_for_hardware, lp_plan_to_slots
+from src.scheduler.lp_optimizer import LpPlan
+
+
+def _four_slot_plan_with_standard_gap() -> LpPlan:
+    """LP chose grid charge only in slot 0 and 3; slots 1–2 stay idle (standard).
+
+    The old ``apply_lp_dispatch_gap_bridge`` incorrectly promoted those standard slots to
+    ``cheap`` so Fox would ForceCharge through the gap, overriding the MILP.
+    """
+    t0 = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+    starts = [t0 + i * timedelta(minutes=30) for i in range(4)]
+    # Peak threshold 30p — mid slots priced 15p stay "standard" when LP does not charge.
+    price = [10.0, 15.0, 15.0, 10.0]
+    chg = [0.15, 0.0, 0.0, 0.15]
+    imp = [0.2, 0.0, 0.0, 0.2]
+    return LpPlan(
+        ok=True,
+        status="Optimal",
+        objective_pence=0.0,
+        slot_starts_utc=starts,
+        price_pence=price,
+        import_kwh=imp,
+        export_kwh=[0.0, 0.0, 0.0, 0.0],
+        battery_charge_kwh=chg,
+        battery_discharge_kwh=[0.0, 0.0, 0.0, 0.0],
+        pv_use_kwh=[0.0, 0.0, 0.0, 0.0],
+        pv_curtail_kwh=[0.0, 0.0, 0.0, 0.0],
+        dhw_electric_kwh=[0.0, 0.0, 0.0, 0.0],
+        space_electric_kwh=[0.0, 0.0, 0.0, 0.0],
+        soc_kwh=[5.0, 6.0, 6.0, 6.0, 7.0],
+        peak_threshold_pence=30.0,
+    )
+
+
+def test_lp_dispatch_slots_match_lp_plan_no_gap_bridge_promotion() -> None:
+    plan = _four_slot_plan_with_standard_gap()
+    raw = lp_plan_to_slots(plan)
+    assert [s.kind for s in raw] == ["cheap", "standard", "standard", "cheap"]
+
+    dispatched = lp_dispatch_slots_for_hardware(plan)
+    assert [s.kind for s in dispatched] == [s.kind for s in raw]

--- a/tests/test_replan_preserves_daikin_actions.py
+++ b/tests/test_replan_preserves_daikin_actions.py
@@ -1,0 +1,148 @@
+"""Replan must not drop in-flight Daikin rows (#27 — replan amnesia)."""
+from __future__ import annotations
+
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src import db
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture
+def tmp_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        yield
+
+
+def test_clear_preserves_pending_restore_while_main_action_active(
+    tmp_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pending restore linked from an active row must survive clear_actions (MPC replan)."""
+    day = "2026-06-01"
+    frozen = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: frozen)
+
+    t_shutdown0 = datetime(2026, 6, 1, 16, 0, tzinfo=UTC)
+    t_shutdown1 = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)
+    t_restore1 = datetime(2026, 6, 1, 19, 1, tzinfo=UTC)
+
+    rid = db.upsert_action(
+        plan_date=day,
+        start_time=_iso(t_shutdown1),
+        end_time=_iso(t_restore1),
+        device="daikin",
+        action_type="restore",
+        params={"lwt_offset": 0.0},
+        status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date=day,
+        start_time=_iso(t_shutdown0),
+        end_time=_iso(t_shutdown1),
+        device="daikin",
+        action_type="shutdown",
+        params={"climate_on": False},
+        status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+    db.mark_action(aid, "active")
+
+    db.clear_actions_for_date(day, device="daikin")
+
+    restore = db.get_action_by_id(rid)
+    assert restore is not None
+    assert restore["status"] == "pending"
+    main = db.get_action_by_id(aid)
+    assert main is not None
+    assert main["status"] == "active"
+
+
+def test_clear_preserves_in_window_pending_pair_before_heartbeat(
+    tmp_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If MPC runs before heartbeat marks the main row active, keep main + paired restore."""
+    day = "2026-06-01"
+    frozen = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: frozen)
+
+    t0 = datetime(2026, 6, 1, 16, 0, tzinfo=UTC)
+    t1 = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)
+    t_restore_end = t1 + timedelta(minutes=1)
+
+    rid = db.upsert_action(
+        plan_date=day,
+        start_time=_iso(t1),
+        end_time=_iso(t_restore_end),
+        device="daikin",
+        action_type="restore",
+        params={},
+        status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date=day,
+        start_time=_iso(t0),
+        end_time=_iso(t1),
+        device="daikin",
+        action_type="shutdown",
+        params={},
+        status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+
+    db.clear_actions_for_date(day, device="daikin")
+
+    assert db.get_action_by_id(aid) is not None
+    assert db.get_action_by_id(rid) is not None
+
+
+def test_clear_deletes_future_only_pending_pair(
+    tmp_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Purely future pending rows are removed so the new LP plan can replace them."""
+    day = "2026-06-01"
+    frozen = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: frozen)
+
+    t0 = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+    t1 = datetime(2026, 6, 1, 21, 0, tzinfo=UTC)
+    t_restore_end = t1 + timedelta(minutes=1)
+
+    rid = db.upsert_action(
+        plan_date=day,
+        start_time=_iso(t1),
+        end_time=_iso(t_restore_end),
+        device="daikin",
+        action_type="restore",
+        params={},
+        status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date=day,
+        start_time=_iso(t0),
+        end_time=_iso(t1),
+        device="daikin",
+        action_type="pre_heat",
+        params={},
+        status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+
+    db.clear_actions_for_date(day, device="daikin")
+
+    assert db.get_action_by_id(aid) is None
+    assert db.get_action_by_id(rid) is None


### PR DESCRIPTION
## Summary
Implements **Epic Phase 1** ([Issue #31](https://github.com/albinati/home-energy-manager/issues/31)): critical dispatcher and hardware execution fixes (no LP physics changes).

### #28 — Remove Gap Bridge
- Removed `apply_lp_dispatch_gap_bridge`; `lp_dispatch_slots_for_hardware` now mirrors `lp_plan_to_slots` so Fox/Daikin schedules match the MILP.
- Regression test: standard slots between charge blocks stay standard.

### #27 — Replan amnesia
- `clear_actions_for_date(..., device="daikin")` keeps pending rows still needed: paired restores for **active** actions, and in-window **pending** mains (+ paired restore) before heartbeat promotes them.
- `_now_utc()` hook for tests.

### #18 — Daikin HTTP 400 / valve
- Prune `lwt_offset` from applied params when `climate_on` is false; align `daikin_device_matches_params`.
- `DAIKIN_VALVE_SETTLE_SECONDS` (default 10); sleep after climate-off before DHW when applicable.

### How to test
```bash
pytest tests/test_lp_dispatch_gap_bridge.py tests/test_replan_preserves_daikin_actions.py tests/test_daikin_bulletproof.py -q
```


Made with [Cursor](https://cursor.com)