### PR TITLE
Phase 3 polish: MPC/fetch coalescing, calibration hints, comfort_check logs, Fox V3 read-back, DHW standing-loss helper + phase3 task doc

### DIFF
--- a/docs/phase3-epic-tasks.md
+++ b/docs/phase3-epic-tasks.md
@@ -1,0 +1,44 @@
+# Phase 3 — Polish (MPC/fetch, calibration hints, comfort, Fox, DHW telemetry)
+
+Epic: [#33 — Phase 3: Polish](https://github.com/albinati/home-energy-manager/issues/33)
+
+Working branch: `chore/phase3-polish`
+
+**Git preference:** one commit per issue on the branch (not one mega-commit).
+
+---
+
+## How to close GitHub issues from a PR
+
+Same as [phase2-epic-tasks.md](./phase2-epic-tasks.md): use `Closes #…` on its own line in the PR description for each completed issue.
+
+---
+
+## Issue [#34](https://github.com/albinati/home-energy-manager/issues/34) — MPC vs Octopus fetch duplicate PuLP
+
+- **Done:** `mpc_should_skip_hour_for_octopus_fetch` + early return in `bulletproof_mpc_job` when local hour equals `OCTOPUS_FETCH_HOUR`; dead code removed after `return total` in `_sync_fox_energy_history`.
+- **Tests:** `tests/test_runner_mpc_fetch_coalesce.py`
+
+## Issue [#26](https://github.com/albinati/home-energy-manager/issues/26) — Calibration comments for building model
+
+- **Done:** `# CALIBRATION REQUIRED` (style) comments on `BUILDING_UA_W_PER_K` and `BUILDING_THERMAL_MASS_KWH_PER_K` in `src/config.py`.
+
+## Issue [#25](https://github.com/albinati/home-energy-manager/issues/25) — morning comfort_check logging
+
+- **Done:** Edge-triggered `execution_log` rows with `source=comfort_check` at `LP_OCCUPIED_MORNING_START` / `LP_OCCUPIED_MORNING_END` windows (heartbeat-aligned).
+- **Tests:** `tests/test_runner_comfort_morning.py`
+
+## Issue [#23](https://github.com/albinati/home-energy-manager/issues/23) — Fox scheduler read-back after set
+
+- **Done:** `FoxESSClient.warn_if_scheduler_v3_mismatch` after `set_scheduler_v3` in optimizer, `lp_dispatch`, and `state_machine` re-upload paths.
+- **Tests:** `tests/test_foxess_scheduler_readback.py`
+
+## Issue [#24](https://github.com/albinati/home-energy-manager/issues/24) — DHW standing loss from logs
+
+- **Done:** `db.estimate_dhw_standing_loss_c_per_hour_p50` and `scripts/print_dhw_standing_loss.py`.
+- **Tests:** `tests/test_db_dhw_standing_loss.py`
+- **Note:** Requires `daikin_tank_power_on=0` in logs during cooldown; if the heartbeat still logs a constant, calibrate once real tank power is logged.
+
+## Issue [#22](https://github.com/albinati/home-energy-manager/issues/22) — Occupancy-aware DHW
+
+Tracked separately (e.g. `feature/occupancy-dhw-pulp`); not part of this chore branch unless explicitly ported.

--- a/scripts/print_dhw_standing_loss.py
+++ b/scripts/print_dhw_standing_loss.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Print median DHW standing loss (°C/h) from execution_log when tank heating is off (#24)."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from src import db  # noqa: E402
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=2016,
+        help="execution_log rows to scan (newest first)",
+    )
+    args = p.parse_args()
+    db.init_db()
+    est = db.estimate_dhw_standing_loss_c_per_hour_p50(limit=args.limit)
+    if est is None:
+        print(
+            "dhw_standing_loss_c_per_h=None (need ≥3 cooldown samples with "
+            "daikin_tank_power_on=0 and tank temps)"
+        )
+        print(
+            "Tip: ensure the heartbeat logs real tank power state into execution_log, "
+            "then collect a few hours of history."
+        )
+        sys.exit(1)
+    print(f"dhw_standing_loss_c_per_h={est:.4f} (p50, limit={args.limit})")
+    print(
+        "Compare with DHW_TANK_UA_W_PER_K and tank size when calibrating tank loss in the LP."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -340,7 +340,10 @@ class Config:
     LP_COP_SPACE_LWT_CEILING_C: float = float(os.getenv("LP_COP_SPACE_LWT_CEILING_C", "50.0"))
     DHW_TANK_LITRES: float = float(os.getenv("DHW_TANK_LITRES", "200"))
     DHW_WATER_CP: float = float(os.getenv("DHW_WATER_CP", "4186"))  # J/(kg·K)
+    # CALIBRATION REQUIRED — building envelope + thermal mass for the LP single-zone model.
+    # Tune from bills / heat-loss survey / co-heating test; defaults are placeholders.
     BUILDING_UA_W_PER_K: float = float(os.getenv("BUILDING_UA_W_PER_K", "180"))
+    # CALIBRATION REQUIRED — effective thermal inertia (kWh/K) driving indoor temperature dynamics.
     BUILDING_THERMAL_MASS_KWH_PER_K: float = float(os.getenv("BUILDING_THERMAL_MASS_KWH_PER_K", "8.0"))
     INDOOR_SETPOINT_C: float = float(os.getenv("INDOOR_SETPOINT_C", "21"))
     INDOOR_COMFORT_BAND_C: float = float(os.getenv("INDOOR_COMFORT_BAND_C", "1.5"))

--- a/src/db.py
+++ b/src/db.py
@@ -668,6 +668,62 @@ def hourly_load_profile_kwh(limit: int = 2016) -> dict[int, float]:
     return profile
 
 
+def estimate_dhw_standing_loss_c_per_hour_p50(
+    *,
+    limit: int = 2016,
+    max_gap_hours: float = 8.0,
+) -> float | None:
+    """Median tank cooldown °C/h when DHW heating is off, from execution_log (#24).
+
+    Uses consecutive log rows (time-ordered) where ``daikin_tank_power_on == 0`` and both
+    rows have ``daikin_tank_temp``. Skips gaps longer than *max_gap_hours* and samples where
+    the tank is warming. Returns None if there are fewer than three usable cooldown rates.
+
+    Requires accurate ``daikin_tank_power_on`` in logs (not a constant).
+    """
+    from statistics import median
+
+    rows = get_execution_logs(limit=limit)
+    if len(rows) < 2:
+        return None
+    chrono = list(reversed(rows))
+
+    def _parse_ts(ts: str) -> datetime | None:
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return None
+
+    rates: list[float] = []
+    for i in range(len(chrono) - 1):
+        a, b = chrono[i], chrono[i + 1]
+        if a.get("daikin_tank_power_on") != 0:
+            continue
+        if b.get("daikin_tank_power_on") != 0:
+            continue
+        ta = a.get("daikin_tank_temp")
+        tb = b.get("daikin_tank_temp")
+        if ta is None or tb is None:
+            continue
+        tsa = _parse_ts(a.get("timestamp") or "")
+        tsb = _parse_ts(b.get("timestamp") or "")
+        if tsa is None or tsb is None:
+            continue
+        dt_h = (tsb - tsa).total_seconds() / 3600.0
+        if dt_h <= 0 or dt_h > max_gap_hours:
+            continue
+        dtemp = float(tb) - float(ta)
+        if dtemp > 0.05:
+            continue
+        rate = -dtemp / dt_h
+        if 0 < rate < 5.0:
+            rates.append(rate)
+
+    if len(rates) < 3:
+        return None
+    return float(median(rates))
+
+
 def actions_for_device_at(
     device: str,
     when_utc: datetime,

--- a/src/foxess/client.py
+++ b/src/foxess/client.py
@@ -16,12 +16,15 @@ Docs: https://www.foxesscloud.com/public/i18n/en/OpenApiDocument.html
 """
 import hashlib
 import json
+import logging
 import time
 import urllib.error
 import urllib.request
 from datetime import date, datetime
 
 from .models import ChargePeriod, DeviceInfo, RealTimeData, SchedulerGroup, SchedulerState
+
+logger = logging.getLogger(__name__)
 
 # Known work mode strings (set_work_mode accepts these)
 WORK_MODE_VALID = frozenset({"Self Use", "Feed-in Priority", "Back Up", "Force charge", "Force discharge"})
@@ -631,6 +634,22 @@ class FoxESSClient:
             "groups": [g.to_api_dict() for g in groups],
         }
         self._open_post_v3("/device/scheduler/enable", payload)
+
+    def warn_if_scheduler_v3_mismatch(self, expected_groups: list[SchedulerGroup]) -> None:
+        """After set_scheduler_v3, read hardware state and warn if group counts differ (#23)."""
+        n_exp = len(expected_groups)
+        try:
+            st = self.get_scheduler_v3()
+        except Exception as e:
+            logger.warning("Fox scheduler read-back after set failed: %s", e)
+            return
+        n_hw = len(st.groups or [])
+        if n_hw != n_exp:
+            logger.warning(
+                "Fox scheduler V3 read-back mismatch after set: uploaded %d groups, device reports %d",
+                n_exp,
+                n_hw,
+            )
 
     def get_scheduler_flag(self) -> bool:
         """Return True if inverter time scheduler master switch is enabled."""

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -333,6 +333,7 @@ def upload_fox_if_operational(fox: FoxESSClient | None, groups: list[SchedulerGr
     if fox and fox.api_key and config.OPERATION_MODE == "operational" and not config.OPENCLAW_READ_ONLY:
         try:
             fox.set_scheduler_v3(groups, is_default=False)
+            fox.warn_if_scheduler_v3_mismatch(groups)
             fox.set_scheduler_flag(True)
             fox_ok = True
             db.save_fox_schedule_state([g.to_api_dict() for g in groups], enabled=True)

--- a/src/scheduler/octopus_fetch.py
+++ b/src/scheduler/octopus_fetch.py
@@ -174,14 +174,3 @@ def _sync_fox_energy_history(fox: FoxESSClient, months_back: int = 3) -> int:
             logger.debug("Fox energy sync %d-%02d failed: %s", yr, mo, e)
 
     return total
-    st = db.get_octopus_fetch_state()
-    if st.consecutive_failures == 0 or not st.failure_streak_started_at:
-        return False
-    try:
-        last = datetime.fromisoformat((st.last_attempt_at or "").replace("Z", "+00:00"))
-        if last.tzinfo is None:
-            last = last.replace(tzinfo=UTC)
-    except ValueError:
-        last = datetime.now(UTC) - timedelta(days=1)
-    delay = next_retry_seconds(st.consecutive_failures)
-    return (datetime.now(UTC) - last).total_seconds() >= delay

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -761,6 +761,7 @@ def _run_optimizer_heuristic(fox: FoxESSClient | None, daikin: Any | None = None
     if fox and fox.api_key and config.OPERATION_MODE == "operational" and not config.OPENCLAW_READ_ONLY:
         try:
             fox.set_scheduler_v3(groups, is_default=False)
+            fox.warn_if_scheduler_v3_mismatch(groups)
             fox.set_scheduler_flag(True)
             fox_ok = True
             db.save_fox_schedule_state([g.to_api_dict() for g in groups], enabled=True)

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -28,6 +28,7 @@ _last_exec_halfhour_key: str | None = None
 _last_room_temp: float | None = None
 _last_room_wall_utc: datetime | None = None
 _last_notified_slot_kind: str | None = None
+_comfort_morning_logged: set[str] = set()
 
 
 def _get_forecast_temp_c(now_utc: datetime) -> float | None:
@@ -274,6 +275,90 @@ def bulletproof_mpc_job() -> None:
         logger.warning("MPC job failed: %s", e)
 
 
+def _hhmm_to_minutes(s: str) -> int:
+    parts = (s or "00:00").strip().split(":")
+    h = int(parts[0]) if parts else 0
+    m = int(parts[1]) if len(parts) > 1 else 0
+    return h * 60 + m
+
+
+def _prune_comfort_morning_keys() -> None:
+    global _comfort_morning_logged
+    if len(_comfort_morning_logged) <= 120:
+        return
+    cutoff = (date.today() - timedelta(days=14)).isoformat()
+    _comfort_morning_logged = {k for k in _comfort_morning_logged if k[:10] >= cutoff}
+
+
+def _maybe_log_comfort_morning_check(
+    *,
+    now_local: datetime,
+    now_utc: datetime,
+    plan_date: str,
+    room_t: float | None,
+    soc: float | None,
+    fox_mode: str | None,
+    outdoor_t: float | None,
+    lwt_off: float | None,
+    tank_t: float | None,
+    tank_tgt: float | None,
+    tank_on: bool,
+    dev0: Any,
+) -> None:
+    global _comfort_morning_logged
+    if room_t is None or not dev0:
+        return
+    cur = now_local.hour * 60 + now_local.minute
+    sp = float(config.INDOOR_SETPOINT_C)
+    for slot_kind, hhmm in (
+        ("occupied_morning_start", config.LP_OCCUPIED_MORNING_START),
+        ("occupied_morning_end", config.LP_OCCUPIED_MORNING_END),
+    ):
+        m0 = _hhmm_to_minutes(hhmm)
+        if m0 - 2 <= cur < m0 + 8:
+            key = f"{plan_date}_{slot_kind}"
+            if key in _comfort_morning_logged:
+                continue
+            _comfort_morning_logged.add(key)
+            _prune_comfort_morning_keys()
+            fc = _get_forecast_temp_c(now_utc)
+            db.log_execution(
+                {
+                    "timestamp": now_utc.isoformat(),
+                    "consumption_kwh": None,
+                    "agile_price_pence": None,
+                    "svt_shadow_price_pence": None,
+                    "fixed_shadow_price_pence": None,
+                    "cost_realised_pence": None,
+                    "cost_svt_shadow_pence": None,
+                    "cost_fixed_shadow_pence": None,
+                    "delta_vs_svt_pence": None,
+                    "delta_vs_fixed_pence": None,
+                    "soc_percent": soc,
+                    "fox_mode": fox_mode,
+                    "daikin_lwt_offset": lwt_off,
+                    "daikin_tank_temp": tank_t,
+                    "daikin_tank_target": tank_tgt,
+                    "daikin_tank_power_on": 1 if tank_on else 0,
+                    "daikin_powerful_mode": None,
+                    "daikin_room_temp": room_t,
+                    "daikin_outdoor_temp": outdoor_t,
+                    "daikin_lwt": dev0.leaving_water_temperature,
+                    "forecast_temp_c": fc or outdoor_t,
+                    "forecast_solar_kw": None,
+                    "forecast_heating_demand": None,
+                    "slot_kind": slot_kind,
+                    "source": "comfort_check",
+                }
+            )
+            logger.info(
+                "Comfort check (%s): room=%.2f°C setpoint=%.2f°C",
+                slot_kind,
+                room_t,
+                sp,
+            )
+
+
 def bulletproof_plan_push_job() -> None:
     """Nightly plan dispatch: push tomorrow's LP plan to Fox ESS + Daikin at LP_PLAN_PUSH_HOUR:MINUTE.
 
@@ -422,6 +507,22 @@ def bulletproof_heartbeat_tick() -> None:
             now_utc,
             trigger="heartbeat",
             outdoor_c=outdoor_t,
+        )
+
+    if dev0:
+        _maybe_log_comfort_morning_check(
+            now_local=now_local,
+            now_utc=now_utc,
+            plan_date=plan_date,
+            room_t=room_t,
+            soc=soc,
+            fox_mode=fox_mode,
+            outdoor_t=outdoor_t,
+            lwt_off=lwt_off,
+            tank_t=tank_t,
+            tank_tgt=tank_tgt,
+            tank_on=tank_on,
+            dev0=dev0,
         )
 
     if mon - _last_fox_verify_monotonic >= 1800 and fox and fox.api_key:

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -175,6 +175,14 @@ def bulletproof_daily_brief_job() -> None:
         logger.warning("Daily brief failed: %s", e)
 
 
+def mpc_should_skip_hour_for_octopus_fetch(local_hour: int) -> bool:
+    """When True, skip MPC at this local hour — the Octopus fetch cron runs later the same hour.
+
+    Avoids two full PuLP runs within minutes (MPC at :00 vs fetch at :05 with fresh rates). #34
+    """
+    return int(local_hour) == int(config.OCTOPUS_FETCH_HOUR)
+
+
 def bulletproof_mpc_job() -> None:
     """Intra-day MPC re-optimise: refresh forecast + live SoC + live PV, re-upload Fox/Daikin.
 
@@ -190,6 +198,16 @@ def bulletproof_mpc_job() -> None:
     backend = (config.OPTIMIZER_BACKEND or "lp").strip().lower()
     if backend != "lp":
         logger.debug("MPC skipped: OPTIMIZER_BACKEND=%s", backend)
+        return
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE if config.USE_BULLETPROOF_ENGINE else config.OPTIMIZATION_TIMEZONE)
+    now_local = datetime.now(tz)
+    if mpc_should_skip_hour_for_octopus_fetch(now_local.hour):
+        logger.info(
+            "MPC skipped: local hour %02d matches OCTOPUS_FETCH_HOUR — fetch at %02d:%02d will run optimizer",
+            now_local.hour,
+            int(config.OCTOPUS_FETCH_HOUR),
+            int(config.OCTOPUS_FETCH_MINUTE),
+        )
         return
     try:
         from .optimizer import run_optimizer

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -289,6 +289,7 @@ def heartbeat_repair_fox_scheduler(fox: FoxESSClient) -> None:
                 ):
                     logger.info("Fox V3 differs from SQLite plan — re-uploading (heartbeat)")
                     fox.set_scheduler_v3(stored_groups, is_default=False)
+                    fox.warn_if_scheduler_v3_mismatch(stored_groups)
                     fox.set_scheduler_flag(True)
                     db.log_action(
                         device="foxess",
@@ -387,6 +388,7 @@ def recover_on_boot(
                 if stored_groups and _schedule_signature(hw.groups) != _schedule_signature(stored_groups):
                     logger.info("Fox V3 differs from SQLite plan — re-uploading")
                     fox.set_scheduler_v3(stored_groups, is_default=False)
+                    fox.warn_if_scheduler_v3_mismatch(stored_groups)
                     fox.set_scheduler_flag(True)
                     db.log_action(
                         device="foxess",

--- a/tests/test_db_dhw_standing_loss.py
+++ b/tests/test_db_dhw_standing_loss.py
@@ -1,0 +1,56 @@
+"""DHW standing loss estimate from execution_log (#24)."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src import db
+
+
+def test_estimate_dhw_standing_loss_p50(monkeypatch: pytest.MonkeyPatch) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            # 1 °C/h cooldown while power off: four hourly samples → three pair rates
+            for h, temp in enumerate([50.0, 49.0, 48.0, 47.0]):
+                conn.execute(
+                    """
+                    INSERT INTO execution_log (
+                        timestamp, daikin_tank_temp, daikin_tank_power_on
+                    ) VALUES (?, ?, 0)
+                    """,
+                    (f"2026-01-10T{8+h:02d}:00:00Z", temp),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        est = db.estimate_dhw_standing_loss_c_per_hour_p50(limit=100)
+        assert est == pytest.approx(1.0, abs=0.01)
+
+
+def test_estimate_dhw_standing_loss_insufficient_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            conn.execute(
+                """
+                INSERT INTO execution_log (
+                    timestamp, daikin_tank_temp, daikin_tank_power_on
+                ) VALUES (?, ?, 0)
+                """,
+                ("2026-01-10T08:00:00Z", 50.0),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert db.estimate_dhw_standing_loss_c_per_hour_p50(limit=50) is None

--- a/tests/test_foxess_scheduler_readback.py
+++ b/tests/test_foxess_scheduler_readback.py
@@ -1,0 +1,46 @@
+"""Fox Scheduler V3 read-back after set (#23)."""
+
+import logging
+
+import pytest
+
+from src.foxess.client import FoxESSClient
+from src.foxess.models import SchedulerGroup, SchedulerState
+
+
+def test_warn_if_scheduler_v3_mismatch_logs_when_counts_differ(caplog):
+    exp = [
+        SchedulerGroup(0, 0, 6, 0, "SelfUse"),
+        SchedulerGroup(6, 0, 12, 0, "SelfUse"),
+    ]
+
+    class Dummy:
+        def get_scheduler_v3(self) -> SchedulerState:
+            return SchedulerState(enabled=True, groups=[exp[0]])
+
+    caplog.set_level(logging.WARNING)
+    FoxESSClient.warn_if_scheduler_v3_mismatch(Dummy(), exp)
+    assert "read-back mismatch" in caplog.text
+
+
+def test_warn_if_scheduler_v3_mismatch_silent_when_match(caplog):
+    g = SchedulerGroup(0, 0, 12, 0, "SelfUse")
+    exp = [g]
+
+    class Dummy:
+        def get_scheduler_v3(self) -> SchedulerState:
+            return SchedulerState(enabled=True, groups=[g])
+
+    caplog.set_level(logging.WARNING)
+    FoxESSClient.warn_if_scheduler_v3_mismatch(Dummy(), exp)
+    assert "read-back mismatch" not in caplog.text
+
+
+def test_warn_if_scheduler_v3_mismatch_logs_on_get_failure(caplog):
+    class Dummy:
+        def get_scheduler_v3(self) -> SchedulerState:
+            raise RuntimeError("network")
+
+    caplog.set_level(logging.WARNING)
+    FoxESSClient.warn_if_scheduler_v3_mismatch(Dummy(), [])
+    assert "read-back after set failed" in caplog.text

--- a/tests/test_runner_comfort_morning.py
+++ b/tests/test_runner_comfort_morning.py
@@ -1,0 +1,97 @@
+"""Morning comfort_check execution_log sampling (#25)."""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.config import config as app_config
+from src.scheduler import runner
+
+
+@pytest.fixture(autouse=True)
+def clear_comfort_keys():
+    runner._comfort_morning_logged.clear()
+    yield
+    runner._comfort_morning_logged.clear()
+
+
+def test_comfort_morning_start_logs_once(monkeypatch):
+    logged: list[dict] = []
+
+    def _capture(row: dict) -> None:
+        logged.append(row)
+
+    monkeypatch.setattr(runner.db, "log_execution", _capture)
+    monkeypatch.setattr(runner, "_get_forecast_temp_c", lambda _utc: None)
+    monkeypatch.setattr(app_config, "LP_OCCUPIED_MORNING_START", "06:30")
+    monkeypatch.setattr(app_config, "LP_OCCUPIED_MORNING_END", "08:30")
+
+    class Dev:
+        leaving_water_temperature = 40.0
+
+    dev = Dev()
+    tz = ZoneInfo("Europe/London")
+    local = datetime(2026, 4, 21, 6, 31, tzinfo=tz)
+    utc = local.astimezone(UTC)
+    runner._maybe_log_comfort_morning_check(
+        now_local=local,
+        now_utc=utc,
+        plan_date="2026-04-21",
+        room_t=20.0,
+        soc=50.0,
+        fox_mode="Self Use",
+        outdoor_t=10.0,
+        lwt_off=0.0,
+        tank_t=42.0,
+        tank_tgt=48.0,
+        tank_on=True,
+        dev0=dev,
+    )
+    assert len(logged) == 1
+    assert logged[0]["source"] == "comfort_check"
+    assert logged[0]["slot_kind"] == "occupied_morning_start"
+    assert logged[0]["daikin_room_temp"] == 20.0
+
+    runner._maybe_log_comfort_morning_check(
+        now_local=local,
+        now_utc=utc,
+        plan_date="2026-04-21",
+        room_t=20.0,
+        soc=50.0,
+        fox_mode="Self Use",
+        outdoor_t=10.0,
+        lwt_off=0.0,
+        tank_t=42.0,
+        tank_tgt=48.0,
+        tank_on=True,
+        dev0=dev,
+    )
+    assert len(logged) == 1
+
+
+def test_comfort_morning_outside_window_no_log(monkeypatch):
+    logged: list[dict] = []
+
+    monkeypatch.setattr(runner.db, "log_execution", lambda row: logged.append(row))
+    monkeypatch.setattr(app_config, "LP_OCCUPIED_MORNING_START", "06:30")
+
+    class Dev:
+        leaving_water_temperature = 40.0
+
+    local = datetime(2026, 4, 21, 10, 0, tzinfo=ZoneInfo("Europe/London"))
+    runner._maybe_log_comfort_morning_check(
+        now_local=local,
+        now_utc=local.astimezone(UTC),
+        plan_date="2026-04-21",
+        room_t=20.0,
+        soc=None,
+        fox_mode=None,
+        outdoor_t=None,
+        lwt_off=None,
+        tank_t=None,
+        tank_tgt=None,
+        tank_on=True,
+        dev0=Dev(),
+    )
+    assert logged == []

--- a/tests/test_runner_mpc_fetch_coalesce.py
+++ b/tests/test_runner_mpc_fetch_coalesce.py
@@ -1,0 +1,17 @@
+"""MPC vs Octopus fetch hour coalescing (#34)."""
+
+from src.config import config as app_config
+from src.scheduler.runner import mpc_should_skip_hour_for_octopus_fetch
+
+
+def test_mpc_skip_when_local_hour_matches_octopus_fetch_hour(monkeypatch):
+    monkeypatch.setattr(app_config, "OCTOPUS_FETCH_HOUR", 16)
+    assert mpc_should_skip_hour_for_octopus_fetch(16) is True
+    assert mpc_should_skip_hour_for_octopus_fetch(15) is False
+    assert mpc_should_skip_hour_for_octopus_fetch(17) is False
+
+
+def test_mpc_skip_respects_fetch_hour_zero(monkeypatch):
+    monkeypatch.setattr(app_config, "OCTOPUS_FETCH_HOUR", 0)
+    assert mpc_should_skip_hour_for_octopus_fetch(0) is True
+    assert mpc_should_skip_hour_for_octopus_fetch(23) is False


### PR DESCRIPTION
## Summary

Phase 3 polish from [Epic #33](https://github.com/albinati/home-energy-manager/issues/33): MPC/fetch coalescing, calibration hints, comfort_check logs, Fox V3 read-back, DHW standing-loss helper + phase3 task doc.

Branch: chore/phase3-polish — one commit per issue.

## Issues

Closes #34
Closes #26
Closes #25
Closes #23
Closes #24
Related to #33

## Note on #24

The estimator needs `daikin_tank_power_on == 0` in execution_log during passive cooldown; the heartbeat still uses `tank_on = True` for that field today, so the script may return no estimate until real tank power is logged. Follow-up if needed.

## Testing

```bash
.venv/bin/python -m pytest tests/test_runner_mpc_fetch_coalesce.py tests/test_runner_comfort_morning.py tests/test_foxess_scheduler_readback.py tests/test_db_dhw_standing_loss.py -v
```