### PR TITLE
fix(lp): soft DHW ceiling + heuristic cheap cap (follow-up to #50)

### DIFF
--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -422,12 +422,16 @@ def solve_lp(
             prob += tank[i + 1] >= t_min_dhw
 
     # Per-slot DHW ceiling: 48 °C unless price < 0 (then 65 °C).
+    # Soft constraint — heavy penalty on breach — so an initial tank already above 48 °C
+    # (inherited from a prior negative window) stays feasible and is allowed to cool
+    # naturally instead of forcing an infeasible instantaneous drop.
     tank_hi_slot = [
         float(config.DHW_TEMP_MAX_C) if price_line[i] < 0 else float(config.DHW_TEMP_COMFORT_C)
         for i in range(n)
     ]
+    s_tank_hi = pulp.LpVariable.dicts("tank_hi_slack", range(n), lowBound=0)
     for i in range(n):
-        prob += tank[i + 1] <= tank_hi_slot[i]
+        prob += tank[i + 1] <= tank_hi_slot[i] + s_tank_hi[i]
 
     # Pre-plunge discipline: if a negative slot is still ahead in the horizon,
     # disallow grid→battery flow during positive-priced slots. PV→battery
@@ -489,7 +493,10 @@ def solve_lp(
     obj_grid = pulp.lpSum(imp[i] * price_line[i] - exp[i] * export_rate for i in range(n))
     obj_cycle = cycle_pen * pulp.lpSum(chg[i] + dis[i] for i in range(n))
     obj_comfort = comfort_pen * pulp.lpSum(s_lo[i] + s_hi[i] for i in range(n))
-    objective = obj_grid + obj_cycle + obj_comfort
+    # Heavy penalty on per-slot DHW ceiling breach — same weight as indoor comfort slack
+    # so a single °C-slot overshoot costs the same as a 1 °C indoor comfort miss.
+    obj_tank_hi = comfort_pen * pulp.lpSum(s_tank_hi[i] for i in range(n))
+    objective = obj_grid + obj_cycle + obj_comfort + obj_tank_hi
 
     if use_stress and stress_aux:
         objective += pulp.lpSum(stress_aux[i] * slot_h for i in range(n))

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -566,10 +566,13 @@ def _daikin_params_for_kind(kind: str, peak_frost: bool) -> dict[str, Any]:
             "climate_on": True,
         }
     if kind == "cheap":
+        # Heuristic fallback mirrors the LP policy from issue #50: tank only goes above
+        # DHW_TEMP_COMFORT_C when price < 0 (the "negative" kind). For "cheap" (positive
+        # price) we stay at the comfort ceiling.
         return {
             "lwt_offset": min(config.LWT_OFFSET_PREHEAT_BOOST, config.LWT_OFFSET_MAX),
-            "tank_powerful": False,  # V2: disable tank_powerful on cheap slots (save demand)
-            "tank_temp": config.DHW_TEMP_CHEAP_C,
+            "tank_powerful": False,
+            "tank_temp": config.DHW_TEMP_COMFORT_C,
             "tank_power": True,
             "climate_on": True,
         }


### PR DESCRIPTION
## Summary

Two follow-up fixes to PR #51 surfaced by the prod deploy:

1. **LP was infeasible on cold-start** because the per-slot DHW ceiling added in #50 was a hard constraint. Prod boots with whatever tank temp Daikin last targeted (60–65 °C after an afternoon negative window), making \`tank[1] ≤ 48\` unsatisfiable in the first step. Service gracefully fell back to the heuristic classifier, but we want the LP running.
2. **Heuristic \`_daikin_params_for_kind(\"cheap\")\` still used \`DHW_TEMP_CHEAP_C=60\`** — only the LP dispatch path was switched to \`DHW_TEMP_COMFORT_C\` in #50. If the LP ever falls back, the heuristic would reintroduce the 60 °C-at-cheap-price behavior issue #50 specifically called out.

### Changes
- \`src/scheduler/lp_optimizer.py\`: add per-slot slack \`s_tank_hi[i] ≥ 0\` so \`tank[i+1] ≤ ceiling + s_tank_hi[i]\`. Penalise slack in the objective at the existing comfort-slack weight (\`LP_COMFORT_SLACK_PENCE_PER_DEGC_SLOT\`). Cooling-only overshoot is now feasible; gratuitous overshoot is expensive.
- \`src/scheduler/optimizer.py\`: cheap-slot Daikin params write \`tank_temp = DHW_TEMP_COMFORT_C\` (48 °C) so the heuristic matches the LP policy.

All 142 unit tests pass.

### Test plan
- [x] \`pytest\` all green locally
- [ ] On prod: redeploy, confirm \`journalctl -u home-energy-manager\` shows \`PuLP status Optimal\` (not Infeasible) on cold-start
- [ ] Verify tomorrow's (2026-04-23) plan is LP-generated, not heuristic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)