### PR TITLE
fix(lp): reduce DHW ceiling slack penalty so negative windows fill the tank

### DIFF
--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -493,9 +493,13 @@ def solve_lp(
     obj_grid = pulp.lpSum(imp[i] * price_line[i] - exp[i] * export_rate for i in range(n))
     obj_cycle = cycle_pen * pulp.lpSum(chg[i] + dis[i] for i in range(n))
     obj_comfort = comfort_pen * pulp.lpSum(s_lo[i] + s_hi[i] for i in range(n))
-    # Heavy penalty on per-slot DHW ceiling breach — same weight as indoor comfort slack
-    # so a single °C-slot overshoot costs the same as a 1 °C indoor comfort miss.
-    obj_tank_hi = comfort_pen * pulp.lpSum(s_tank_hi[i] for i in range(n))
+    # DHW overshoot above the comfort ceiling is not a comfort issue — it's just stored
+    # hot water that will drift back naturally via tank losses. A *tiny* penalty
+    # (0.01 p/°C-slot) breaks ties toward the lower tank target without blocking the LP
+    # from filling the tank to 65 °C during negative-price windows (the whole point of
+    # #50). Positive-price DHW heating is already discouraged by obj_grid, so no extra
+    # penalty is needed to prevent gratuitous overshoot.
+    obj_tank_hi = 0.01 * pulp.lpSum(s_tank_hi[i] for i in range(n))
     objective = obj_grid + obj_cycle + obj_comfort + obj_tank_hi
 
     if use_stress and stress_aux:


### PR DESCRIPTION
## Summary

After deploying PR #53, the LP solved instead of falling back — but the plan for 2026-04-22 showed \`max_heat LWT-10 tank=48C\` during the negative window. That's the opposite of filling thermal storage during free energy.

Root cause: PR #53 penalised the DHW ceiling slack at \`LP_COMFORT_SLACK_PENCE_PER_DEGC_SLOT\` (100 p/°C/slot). When the LP evaluated "heat tank to 65 °C during a negative slot", the post-window cooling trajectory hits the 48 °C ceiling for ~15 slots × 8 °C avg overshoot = 12000p penalty — dwarfing the ~20p stored-heat profit. The LP rationally declined.

DHW overshoot above the comfort ceiling isn't actually a comfort issue — it's just stored hot water that drifts back naturally. Positive-price heating is already discouraged by the main grid-cost objective. So the penalty should be a tiny tie-breaker, not a dominant term.

### Change
Reduce \`obj_tank_hi\` coefficient from \`comfort_pen\` (100) to \`0.01\` p/°C-slot.

### Reproducer result
With indoor thermal headroom (20.5 → 22 °C to give the LP tradeoff space), a 4-slot negative window now pulls the tank from 45 °C to exactly 65 °C, then lets it cool through subsequent positive slots. Objective −132p vs −123p before — extra 9p profit per 2-hour plunge in this scenario.

### Tests
142 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)