### PR TITLE
fix(lp): close SelfUse gaps during multi-slot negative-price runs (#57)

### DIFF
--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -75,6 +75,11 @@ def lp_plan_to_slots(plan: LpPlan) -> list[HalfHourSlot]:
                 kind = "negative"
             else:
                 kind = "cheap"
+        elif price <= 0:
+            # Negative price + LP chose chg ≈ 0 (battery saturated or PV alone
+            # suffices). LP hard-forbids dis during negatives — encode that on
+            # hardware via Fox's native "Backup" mode (see _slot_fox_tuple).
+            kind = "negative_hold"
         elif allow_exp and dis > EPS and exp > EPS:
             kind = "peak_export"
         elif ed < EPS and es < EPS and price >= peak_thr:

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -445,6 +445,14 @@ def solve_lp(
         if has_future_neg[i] and price_line[i] >= 0:
             prob += chg[i] <= pv_use[i]
 
+    # Negative-price discharge lock: dis = 0 when price < 0. Discharging while
+    # the grid is paying us to import is strictly dominated — surplus import
+    # capacity must flow into chg, e_hp, or exp. Also guarantees the dispatcher
+    # can trust plan.battery_discharge_kwh[i] < EPS for every negative slot.
+    for i in range(n):
+        if price_line[i] < 0:
+            prob += dis[i] == 0
+
     # -----------------------------------------------------------------------
     # Terminal constraints
     # -----------------------------------------------------------------------
@@ -503,7 +511,13 @@ def solve_lp(
     objective = obj_grid + obj_cycle + obj_comfort + obj_tank_hi
 
     if use_stress and stress_aux:
-        objective += pulp.lpSum(stress_aux[i] * slot_h for i in range(n))
+        # Stress cost is suppressed during negative-price slots: every kWh of
+        # chg earns revenue, so imaginary inverter-wear penalty must not bias
+        # the LP toward under-charging. Positive-price slots keep the smoothing.
+        stress_gate = [1.0 if price_line[i] >= 0 else 0.0 for i in range(n)]
+        objective += pulp.lpSum(
+            stress_aux[i] * slot_h * stress_gate[i] for i in range(n)
+        )
 
     if w_bat_tv > 0 and tv_chg:
         objective += w_bat_tv * (

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -296,6 +296,11 @@ def _slot_fox_tuple(
             config.FOX_FORCE_CHARGE_MAX_PWR,
             min_r,
         )
+    if s.kind == "negative_hold":
+        # Fox "Backup" work mode = native "hold battery": no discharge, no grid
+        # charge. Directly enforces the LP's dis = 0 constraint during negative
+        # slots when chg is also zero (battery saturated or PV alone suffices).
+        return ("Backup", None, None, min_r)
     return ("SelfUse", None, None, min_r)
 
 

--- a/tests/test_fox_lp_dispatch_soc.py
+++ b/tests/test_fox_lp_dispatch_soc.py
@@ -122,3 +122,59 @@ def test_slot_fox_tuple_standard_selfuse_uses_reserve_min_soc() -> None:
     wm, fds, pwr, msg = _slot_fox_tuple(s)
     assert wm == "SelfUse"
     assert msg == _min_r()
+
+
+def test_negative_hold_kind_when_battery_full_and_price_negative() -> None:
+    """When LP has chg≈0 during a negative-price slot (battery saturated), the
+    dispatcher must emit kind='negative_hold' — not 'standard'. This maps to
+    Fox Backup mode to prevent battery discharge while grid is paying us to
+    import (see #57).
+    """
+    t0 = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    cap = float(config.BATTERY_CAPACITY_KWH)
+    plan = LpPlan(
+        ok=True,
+        status="Optimal",
+        objective_pence=-5.0,
+        slot_starts_utc=[t0, t0 + timedelta(minutes=30)],
+        price_pence=[-1.3, -0.9],
+        import_kwh=[0.3, 0.3],  # grid covers base load
+        export_kwh=[0.0, 0.0],
+        battery_charge_kwh=[0.0, 0.0],  # battery already full
+        battery_discharge_kwh=[0.0, 0.0],  # Fix B
+        pv_use_kwh=[0.0, 0.0],
+        pv_curtail_kwh=[0.0, 0.0],
+        dhw_electric_kwh=[0.0, 0.0],
+        space_electric_kwh=[0.0, 0.0],
+        soc_kwh=[cap, cap, cap],  # fully saturated
+        peak_threshold_pence=30.0,
+    )
+    slots = lp_plan_to_slots(plan)
+    assert len(slots) == 2
+    for i, s in enumerate(slots):
+        assert s.kind == "negative_hold", (
+            f"slot {i} (price={plan.price_pence[i]}p, chg=0, full SoC): kind={s.kind!r}"
+        )
+    wm, fds, pwr, _ = _slot_fox_tuple(slots[0])
+    assert wm == "Backup", f"negative_hold must map to Fox Backup mode, got {wm!r}"
+    assert fds is None
+    assert pwr is None
+
+
+def test_negative_hold_merges_adjacent_with_same_params() -> None:
+    """Adjacent negative_hold slots must collapse into one Backup group so the
+    Fox schedule stays within the 8-group limit during long plunge windows.
+    """
+    t0 = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    slots = [
+        HalfHourSlot(
+            start_utc=t0 + timedelta(minutes=30 * i),
+            end_utc=t0 + timedelta(minutes=30 * (i + 1)),
+            price_pence=-1.0,
+            kind="negative_hold",
+        )
+        for i in range(4)
+    ]
+    groups = _merge_fox_groups(slots)
+    assert len(groups) == 1
+    assert groups[0].work_mode == "Backup"

--- a/tests/test_lp_optimizer.py
+++ b/tests/test_lp_optimizer.py
@@ -415,3 +415,155 @@ def test_lwt_offset_capped_at_5():
     assert max(plan.lwt_offset_c) <= lwt_max_cfg + 0.1, (
         f"lwt_offset_c.max={max(plan.lwt_offset_c):.2f} > cap {lwt_max_cfg}"
     )
+
+
+def test_dis_zero_during_negative_slots():
+    """Fix B: LP must plan dis=0 for every slot where price < 0, even when a
+    subsequent high-price slot would make discharge nominally profitable.
+    """
+    base = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    n = 8
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    w = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[12.0] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[100.0] * n,
+        pv_kwh_per_slot=[0.0] * n,
+        cop_space=[3.2] * n,
+        cop_dhw=[2.7] * n,
+    )
+    # 4 negative slots followed by 4 peak slots (tempting discharge during negatives
+    # if the LP were allowed to swing battery both ways within the horizon).
+    prices = [-3.0] * 4 + [35.0] * 4
+    base_load = [0.3] * n
+    st = LpInitialState(soc_kwh=9.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=st,
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok
+    for i in range(4):
+        assert plan.battery_discharge_kwh[i] < 1e-3, (
+            f"negative slot {i} (price={prices[i]}p): dis={plan.battery_discharge_kwh[i]:.4f} must be 0"
+        )
+
+
+def test_stress_cost_inactive_during_negative_prices(monkeypatch):
+    """Fix A: the inverter-stress penalty must be suppressed during negative slots,
+    so solving with or without stress yields the same battery trajectory when all
+    slots are negative-priced.
+    """
+    base = datetime(2026, 4, 23, 12, 0, tzinfo=UTC)
+    n = 8
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    w = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[12.0] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[100.0] * n,
+        pv_kwh_per_slot=[0.0] * n,
+        cop_space=[3.2] * n,
+        cop_dhw=[2.7] * n,
+    )
+    prices = [-2.0] * n
+    base_load = [0.3] * n
+    st = LpInitialState(soc_kwh=2.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+
+    monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
+    plan_no = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=st,
+        tz=ZoneInfo("Europe/London"),
+    )
+    monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 1.0)
+    plan_yes = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=st,
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan_no.ok and plan_yes.ok
+    # Objective must match: if the stress gate works, the stress-cost term
+    # contributes 0 during all-negative horizons, so the optimum is identical
+    # to the no-stress baseline. (Per-slot chg distribution may differ because
+    # any ordering that saturates the battery is an equivalent optimum.)
+    assert abs(plan_no.objective_pence - plan_yes.objective_pence) < 0.05, (
+        f"objective differs — no_stress={plan_no.objective_pence:.3f} "
+        f"vs stress={plan_yes.objective_pence:.3f} — stress gate not fully suppressing"
+    )
+    # Total energy absorbed into the battery should also match.
+    tot_no = sum(plan_no.battery_charge_kwh)
+    tot_yes = sum(plan_yes.battery_charge_kwh)
+    assert abs(tot_no - tot_yes) < 0.05, (
+        f"total chg differs — no_stress={tot_no:.3f} vs stress={tot_yes:.3f}"
+    )
+
+
+def test_negative_run_has_no_charge_gaps(monkeypatch):
+    """Fix A + B in concert: a contiguous negative-price run should produce
+    battery_charge_kwh > EPS in every slot until SoC saturates — no alternating
+    zero-charge gaps caused by stress-cost smoothing.
+    """
+    # Keep stress cost at production default (0.10); if Fix A is correctly gating
+    # it during negatives, this test passes. Without Fix A it fails.
+    monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.10)
+    monkeypatch.setattr(app_config, "EXPORT_RATE_PENCE", 0.0)
+    base = datetime(2026, 4, 23, 11, 30, tzinfo=UTC)
+    n = 6
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    w = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[12.0] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[100.0] * n,
+        pv_kwh_per_slot=[0.0] * n,
+        cop_space=[3.2] * n,
+        cop_dhw=[2.7] * n,
+    )
+    # Mimic real Agile plunge: most-negative slot at index 2, shallower at 1, 4.
+    prices = [-1.24, -0.90, -1.30, -1.30, -1.10, -0.95]
+    base_load = [0.3] * n
+    # SoC=5 kWh (50%): battery has ~5 kWh of headroom — ~2 slots of full-power charging.
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=st,
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok
+    # The bug this guards: alternating chg>0 / chg=0 pattern within a negative run
+    # ("SelfUse gaps"). Characterise the chg sequence as binary (EPS-threshold)
+    # and count transitions from "charging" back to "idle". A correct plan has
+    # at most ONE such transition (saturation point); an alternation pattern has
+    # two or more.
+    is_charging = [c > 0.05 for c in plan.battery_charge_kwh]
+    transitions_charging_to_idle = sum(
+        1 for i in range(1, n) if is_charging[i - 1] and not is_charging[i]
+    )
+    assert transitions_charging_to_idle <= 1, (
+        f"LP produced alternating chg/idle gaps during negative run: "
+        f"chg={[round(c, 2) for c in plan.battery_charge_kwh]}, "
+        f"transitions={transitions_charging_to_idle}"
+    )
+    # Battery must actually saturate (if it doesn't, the LP didn't absorb enough
+    # negative-price energy).
+    cap = float(app_config.BATTERY_CAPACITY_KWH)
+    assert plan.soc_kwh[-1] >= cap - 0.5, (
+        f"terminal SoC {plan.soc_kwh[-1]:.2f} < {cap - 0.5} — battery didn't saturate"
+    )
+    # And no dis in any negative slot (Fix B).
+    for i in range(n):
+        assert plan.battery_discharge_kwh[i] < 1e-3


### PR DESCRIPTION
## Summary

Closes #57. Three coordinated changes so the LP owns the calc and the Fox schedule faithfully reflects its output during Agile plunge windows — no dispatch-layer heuristics that override LP decisions.

### Fix A — LP: gate inverter-stress penalty by price sign (`lp_optimizer.py`)
The piecewise stress cost (`LP_INVERTER_STRESS_COST_PENCE=0.10`) was biasing the LP to spread charging thinly across negative slots, even though every kWh of `chg` during a negative slot is revenue. Now the stress term is multiplied by a 0/1 gate that is 0 when `price_line[i] < 0`. Positive-price slots keep the smoothing exactly as before.

### Fix B — LP: hard constraint `dis[i] = 0` during negative slots (`lp_optimizer.py`)
Discharging while the grid pays us to import is strictly dominated. This constraint prevents numerical-artefact `dis > 0` during negatives and gives the dispatcher a guaranteed invariant.

### Fix C — Dispatch: new `negative_hold` kind → Fox native `Backup` mode
When LP outputs `chg ≈ 0` during a negative slot (battery saturated, or PV alone suffices), dispatch now classifies as `"negative_hold"` instead of `"standard"`, and `_slot_fox_tuple` maps to `("Backup", None, None, MIN_SOC_RESERVE_PERCENT)`.

Why **`Backup`** (not `SelfUse + minSocOnGrid=100`):
- Native Fox mode documented for exactly this purpose — "hold battery, grid covers load".
- Our client already supports it (`src/foxess/models.py:45`).
- Idempotent per schedule period — no lingering global-setting side effects.
- Validated on H1-5.0 by Fox community forum.

## Root causes verified

From observed 2026-04-22 plan: two negative slots (including the deepest −1.302p) dispatched as `SelfUse`. Walk through code:
1. `lp_optimizer.py:505` applied stress cost unconditionally → LP spread `chg` across slots, some landed at `chg ≈ 0`.
2. `lp_dispatch.py:67–81` classifier required `chg > EPS` for `negative` kind → slots with `chg = 0` fell through to `standard`.
3. `_slot_fox_tuple` mapped `standard` → `SelfUse + min_soc=MIN_R(15%)`, letting Fox discharge the battery to cover HP + base load during a negative slot — draining stored energy at the worst possible time.

## Test plan

- [x] `test_dis_zero_during_negative_slots` — even with a tempting peak slot ahead, LP never schedules discharge in negative slots.
- [x] `test_stress_cost_inactive_during_negative_prices` — objective matches between stress=0 and stress=1 baselines.
- [x] `test_negative_run_has_no_charge_gaps` — no alternating chg/idle transitions within a 6-slot negative run.
- [x] `test_negative_hold_kind_when_battery_full_and_price_negative` — dispatch emits `negative_hold` → `Backup` mode.
- [x] `test_negative_hold_merges_adjacent_with_same_params` — merging keeps us under the 8-group Fox limit.
- [x] Full test suite: 152 passed, 7 skipped (no regressions).

## Deployment

Code-only change; no `.env` updates needed. On Hetzner: `scripts/deploy_hetzner.sh` then verify:
- `systemctl status home-energy-manager` is green.
- After next MPC re-solve: `sqlite3 data/energy_state.db "SELECT start_time, action_type, params FROM action_schedule WHERE date=date('now') AND device='fox'"` — expect no rows with `SelfUse (minSocOnGrid=15)` during negative-price hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)