### PR TITLE
ops: MCP singleton + Fox scheduler idempotency (#60, #38)

### DIFF
--- a/src/foxess/client.py
+++ b/src/foxess/client.py
@@ -626,8 +626,44 @@ class FoxESSClient:
         )
         return _parse_scheduler_v3_result(raw)
 
-    def set_scheduler_v3(self, groups: list[SchedulerGroup], is_default: bool = False) -> None:
-        """Upload full day schedule (one API call)."""
+    def set_scheduler_v3(
+        self,
+        groups: list[SchedulerGroup],
+        is_default: bool = False,
+        *,
+        skip_if_equal: bool = True,
+    ) -> None:
+        """Upload full day schedule (one API call).
+
+        With ``skip_if_equal=True`` (default) read current hardware state first
+        and short-circuit when the new fingerprint list equals what's already
+        on the inverter — avoids Fox v3 leaving the old groups *disabled*
+        instead of replacing them on an identical re-upload (#38). The pre-read
+        costs one call, so we skip it when the Fox daily budget has fewer than
+        two calls left (fail-open: the safety invariant "push the latest plan"
+        beats saving one redundant call when the quota is already tight).
+        """
+        if skip_if_equal:
+            try:
+                from ..api_quota import quota_remaining
+                remaining = quota_remaining("fox")
+            except Exception:
+                remaining = 2  # treat as headroom when the quota module is down
+            if remaining >= 2:
+                try:
+                    current = self.get_scheduler_v3()
+                    new_fp = [g.fingerprint() for g in groups]
+                    cur_fp = [g.fingerprint() for g in (current.groups or [])]
+                    if new_fp == cur_fp:
+                        logger.info(
+                            "Fox scheduler unchanged (%d groups) — skipping upload",
+                            len(groups),
+                        )
+                        return
+                except Exception as e:
+                    logger.debug(
+                        "Fox scheduler pre-read failed, uploading anyway: %s", e
+                    )
         payload = {
             "deviceSN": self._sn_scheduler(),
             "isDefault": bool(is_default),

--- a/src/foxess/models.py
+++ b/src/foxess/models.py
@@ -72,6 +72,23 @@ class SchedulerGroup:
             "extraParam": extra,
         }
 
+    def fingerprint(self) -> tuple:
+        """Stable hashable representation for skip-when-unchanged guard (#38).
+
+        Built from ``to_api_dict()`` so it tracks exactly the fields we write.
+        Sorted tuple of ``extraParam`` items keeps dict-order out of equality.
+        """
+        d = self.to_api_dict()
+        ep = tuple(sorted(d["extraParam"].items()))
+        return (
+            d["startHour"],
+            d["startMinute"],
+            d["endHour"],
+            d["endMinute"],
+            d["workMode"],
+            ep,
+        )
+
 
 @dataclass
 class SchedulerState:

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -10,9 +10,15 @@ Writes honour ``OPENCLAW_READ_ONLY`` (default true) and the same rate limits as 
 """
 from __future__ import annotations
 
+import atexit
 import concurrent.futures
+import fcntl
 import logging
+import os
+import signal
 import sys
+import time
+from pathlib import Path
 from typing import Any
 
 # Single-worker executor for non-blocking optimizer calls from the MCP transport.
@@ -1852,14 +1858,108 @@ def build_mcp() -> FastMCP:
     return mcp
 
 
+def _lock_path() -> Path:
+    """Lock file path — /run if writable (systemd tmpfs on prod), else /tmp."""
+    for base in ("/run", "/tmp"):
+        d = Path(base)
+        if d.is_dir() and os.access(d, os.W_OK):
+            return d / "hem-mcp.lock"
+    return Path("/tmp/hem-mcp.lock")
+
+
+def _acquire_singleton_lock(log: logging.Logger) -> int | None:
+    """Acquire exclusive lock or kill-and-retry; return fd on success, None to exit."""
+    path = _lock_path()
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        prior_pid: int | None = None
+        try:
+            raw = os.read(fd, 32).decode().strip()
+            prior_pid = int(raw) if raw else None
+        except (OSError, ValueError):
+            prior_pid = None
+        if prior_pid and prior_pid != os.getpid():
+            log.warning(
+                "MCP lock held by pid=%s — sending SIGTERM and retrying", prior_pid
+            )
+            try:
+                os.kill(prior_pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            # Wait up to 2s for the holder to release. flock auto-releases on exit.
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    time.sleep(0.1)
+            else:
+                log.error(
+                    "MCP singleton: lock still held by pid=%s after SIGTERM — exiting",
+                    prior_pid,
+                )
+                os.close(fd)
+                return None
+        else:
+            log.error("MCP singleton: lock held with unreadable pid — exiting")
+            os.close(fd)
+            return None
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.ftruncate(fd, 0)
+    os.write(fd, f"{os.getpid()}\n".encode())
+    os.fsync(fd)
+    return fd
+
+
 def main() -> None:
-    """Entry point: MCP over stdio (do not write logs to stdout)."""
+    """Entry point: MCP over stdio (do not write logs to stdout).
+
+    Enforces single-instance via fcntl.flock on a PID file (#60). OpenClaw
+    respawns this process without killing the prior one, which previously
+    led to multiple parallel MCP servers accumulating RAM. On startup we:
+      1. flock a PID file; on conflict, SIGTERM the prior PID and retry once.
+      2. Install SIGTERM/SIGHUP handlers for clean exit.
+      3. Wrap the FastMCP stdio loop in try/finally so the lock always releases.
+    """
     logging.basicConfig(
         level=logging.INFO,
         stream=sys.stderr,
         format="%(levelname)s %(name)s: %(message)s",
     )
-    build_mcp().run(transport="stdio")
+    log = logging.getLogger("mcp_server")
+
+    lock_fd = _acquire_singleton_lock(log)
+    if lock_fd is None:
+        sys.exit(0)
+
+    def _release_lock() -> None:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        try:
+            os.close(lock_fd)
+        except OSError:
+            pass
+
+    atexit.register(_release_lock)
+
+    def _on_signal(signum: int, _frame: Any) -> None:
+        log.info("MCP received signal %d — shutting down", signum)
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGHUP, _on_signal)
+
+    try:
+        build_mcp().run(transport="stdio")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        _release_lock()
 
 
 if __name__ == "__main__":

--- a/tests/test_foxess_scheduler_readback.py
+++ b/tests/test_foxess_scheduler_readback.py
@@ -1,4 +1,4 @@
-"""Fox Scheduler V3 read-back after set (#23)."""
+"""Fox Scheduler V3 read-back after set (#23) + idempotent upload guard (#38)."""
 
 import logging
 
@@ -44,3 +44,102 @@ def test_warn_if_scheduler_v3_mismatch_logs_on_get_failure(caplog):
     caplog.set_level(logging.WARNING)
     FoxESSClient.warn_if_scheduler_v3_mismatch(Dummy(), [])
     assert "read-back after set failed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# #38 — idempotent set_scheduler_v3: skip POST when identical, upload on diff.
+# ---------------------------------------------------------------------------
+
+
+class _CaptureClient:
+    """Minimal duck-typed FoxESSClient for set_scheduler_v3 idempotency tests."""
+
+    def __init__(self, current: list[SchedulerGroup]):
+        self._current = current
+        self.post_calls: list[tuple[str, dict]] = []
+
+    def _sn_scheduler(self) -> str:
+        return "TEST-SN"
+
+    def get_scheduler_v3(self) -> SchedulerState:
+        return SchedulerState(enabled=True, groups=list(self._current))
+
+    def _open_post_v3(self, path: str, payload: dict) -> None:
+        self.post_calls.append((path, payload))
+
+
+def test_set_scheduler_v3_skips_when_equal(monkeypatch, caplog):
+    monkeypatch.setattr("src.api_quota.quota_remaining", lambda vendor: 1000)
+    g = [
+        SchedulerGroup(0, 0, 6, 0, "SelfUse", min_soc_on_grid=10),
+        SchedulerGroup(6, 0, 12, 0, "ForceCharge", min_soc_on_grid=10, fd_soc=95, fd_pwr=3000),
+    ]
+    client = _CaptureClient(current=g)
+    caplog.set_level(logging.INFO, logger="src.foxess.client")
+    FoxESSClient.set_scheduler_v3(client, g)
+    assert client.post_calls == [], "identical schedule must not be re-uploaded"
+    assert "unchanged" in caplog.text
+
+
+def test_set_scheduler_v3_uploads_when_different(monkeypatch):
+    monkeypatch.setattr("src.api_quota.quota_remaining", lambda vendor: 1000)
+    current = [SchedulerGroup(0, 0, 12, 0, "SelfUse", min_soc_on_grid=10)]
+    new = [
+        SchedulerGroup(0, 0, 6, 0, "SelfUse", min_soc_on_grid=10),
+        SchedulerGroup(6, 0, 12, 0, "ForceCharge", min_soc_on_grid=10, fd_soc=95, fd_pwr=3000),
+    ]
+    client = _CaptureClient(current=current)
+    FoxESSClient.set_scheduler_v3(client, new)
+    assert len(client.post_calls) == 1
+    path, payload = client.post_calls[0]
+    assert path == "/device/scheduler/enable"
+    assert len(payload["groups"]) == 2
+
+
+def test_set_scheduler_v3_uploads_unconditionally_when_budget_low(monkeypatch):
+    """Fail-open: when Fox quota has <2 calls left, skip the pre-read GET and
+    upload anyway — the safety invariant 'push the latest plan' beats saving
+    one redundant call when the quota is already tight."""
+    monkeypatch.setattr("src.api_quota.quota_remaining", lambda vendor: 1)
+    g = [SchedulerGroup(0, 0, 24, 0, "SelfUse")]
+
+    class NoGet(_CaptureClient):
+        def get_scheduler_v3(self) -> SchedulerState:  # type: ignore[override]
+            raise AssertionError("pre-read GET must be skipped under low budget")
+
+    client = NoGet(current=[])
+    FoxESSClient.set_scheduler_v3(client, g)
+    assert len(client.post_calls) == 1
+
+
+def test_set_scheduler_v3_uploads_when_get_fails(monkeypatch):
+    """If the pre-read GET raises, fall through and upload — we never want a
+    network hiccup on the optimisation happy-path to also block the write."""
+    monkeypatch.setattr("src.api_quota.quota_remaining", lambda vendor: 1000)
+    g = [SchedulerGroup(0, 0, 24, 0, "SelfUse")]
+
+    class FlakyGet(_CaptureClient):
+        def get_scheduler_v3(self) -> SchedulerState:  # type: ignore[override]
+            raise RuntimeError("transient network")
+
+    client = FlakyGet(current=[])
+    FoxESSClient.set_scheduler_v3(client, g)
+    assert len(client.post_calls) == 1
+
+
+def test_set_scheduler_v3_skip_if_equal_false_forces_upload(monkeypatch):
+    monkeypatch.setattr("src.api_quota.quota_remaining", lambda vendor: 1000)
+    g = [SchedulerGroup(0, 0, 24, 0, "SelfUse")]
+    client = _CaptureClient(current=g)
+    FoxESSClient.set_scheduler_v3(client, g, skip_if_equal=False)
+    assert len(client.post_calls) == 1
+
+
+def test_scheduler_group_fingerprint_stable_and_distinguishes():
+    a = SchedulerGroup(6, 0, 12, 0, "ForceCharge", min_soc_on_grid=10, fd_soc=95, fd_pwr=3000)
+    b = SchedulerGroup(6, 0, 12, 0, "ForceCharge", min_soc_on_grid=10, fd_soc=95, fd_pwr=3000)
+    c = SchedulerGroup(6, 0, 12, 0, "ForceCharge", min_soc_on_grid=10, fd_soc=95, fd_pwr=2500)
+    assert a.fingerprint() == b.fingerprint()
+    assert a.fingerprint() != c.fingerprint()
+    # Must be hashable (goes into sets / dict keys in future callers).
+    assert hash(a.fingerprint()) == hash(b.fingerprint())

--- a/tests/test_mcp_singleton.py
+++ b/tests/test_mcp_singleton.py
@@ -1,0 +1,104 @@
+"""MCP singleton lock — SIGTERM-and-retry behavior (#60)."""
+
+import fcntl
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from src.mcp_server import _acquire_singleton_lock  # noqa: E402
+
+
+@pytest.fixture
+def tmp_lock(tmp_path, monkeypatch):
+    lock = tmp_path / "hem-mcp.lock"
+    monkeypatch.setattr("src.mcp_server._lock_path", lambda: lock)
+    return lock
+
+
+def _release(fd: int) -> None:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def test_first_acquire_writes_own_pid(tmp_lock):
+    log = logging.getLogger("test")
+    fd = _acquire_singleton_lock(log)
+    assert fd is not None
+    try:
+        assert int(tmp_lock.read_text().strip()) == os.getpid()
+    finally:
+        _release(fd)
+
+
+def test_second_acquire_sigterms_prior_and_succeeds(tmp_lock):
+    """When another process holds the lock, _acquire_singleton_lock must
+    SIGTERM it and retake the lock (the root cause of the MCP zombie pile-up
+    in #60 was that nothing ever killed the prior instance).
+    """
+    holder_src = (
+        "import fcntl, os, sys, time\n"
+        f"fd = os.open(r'{tmp_lock}', os.O_RDWR | os.O_CREAT)\n"
+        "fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+        "os.ftruncate(fd, 0)\n"
+        "os.write(fd, f'{os.getpid()}\\n'.encode())\n"
+        "os.fsync(fd)\n"
+        "sys.stdout.write('LOCKED\\n'); sys.stdout.flush()\n"
+        "time.sleep(30)\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", holder_src],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    acquired_fd: int | None = None
+    try:
+        line = proc.stdout.readline().decode().strip()
+        assert line == "LOCKED", f"holder did not lock: stderr={proc.stderr.read()!r}"
+        log = logging.getLogger("test")
+        acquired_fd = _acquire_singleton_lock(log)
+        assert acquired_fd is not None, "failed to acquire after SIGTERM retry"
+        assert int(tmp_lock.read_text().strip()) == os.getpid()
+        rc = proc.wait(timeout=5)
+        # SIGTERM → -15 on POSIX. Accept either -signal or conventional 128+signal.
+        assert rc in (-signal.SIGTERM, 128 + signal.SIGTERM, 0), (
+            f"holder exit code {rc} unexpected"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        if acquired_fd is not None:
+            _release(acquired_fd)
+
+
+def test_acquire_gives_up_when_prior_pid_unkillable(tmp_lock, monkeypatch):
+    """If SIGTERM has no effect within the 2s window, we must exit cleanly
+    (return None) instead of looping — OpenClaw would otherwise respawn us
+    in a tight loop."""
+    # Hold the lock in this same process via another fd; our own PID cannot
+    # be SIGTERM'd out from under us without actually terminating the test.
+    # Monkey-patch os.kill to a no-op so the retry loop runs to the end.
+    fd_holder = os.open(tmp_lock, os.O_RDWR | os.O_CREAT)
+    fcntl.flock(fd_holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    os.ftruncate(fd_holder, 0)
+    os.write(fd_holder, f"{os.getpid() + 999999}\n".encode())  # fake PID in file
+    os.fsync(fd_holder)
+
+    monkeypatch.setattr("src.mcp_server.os.kill", lambda pid, sig: None)
+    log = logging.getLogger("test")
+    start = time.monotonic()
+    fd = _acquire_singleton_lock(log)
+    elapsed = time.monotonic() - start
+    try:
+        assert fd is None, "should have given up after retry window"
+        assert 1.5 <= elapsed <= 3.5, f"retry window ~2s, got {elapsed:.2f}s"
+    finally:
+        _release(fd_holder)


### PR DESCRIPTION
## Summary

Closes #60, closes #38. Two independent production-ops fixes bundled in one PR because they're both ~50 LOC and share no moving parts.

### #60 — MCP singleton lock (`src/mcp_server.py`)
OpenClaw respawns `python -m src.mcp_server` without killing the prior subprocess. Six parallel MCP servers were observed at 08:00/09:00/10:00 in prod, exhausting 3.3GB+ RAM and triggering swap.

Fix in `main()`:
1. `fcntl.flock` exclusive lock on `/run/hem-mcp.lock` (prod root) with `/tmp` fallback.
2. On `BlockingIOError`: read the recorded PID, send `SIGTERM`, wait up to 2 s for release, retry once. If still held → log + `sys.exit(0)` (**not** raise — OpenClaw would respawn in a tight loop).
3. Install `SIGTERM`/`SIGHUP` handlers + `atexit` for clean lock release.
4. Wrap the FastMCP stdio loop in `try/finally` so the lock always releases.

### #38 — Fox V3 replace vs disable / skip when unchanged (`src/foxess/*`)
Identical re-uploads through Fox Open API v3 leave the old groups *disabled* instead of cleanly replacing them. Added:

- `SchedulerGroup.fingerprint()` — stable hashable tuple built from `to_api_dict()`.
- `set_scheduler_v3(..., *, skip_if_equal=True)` — read current hardware state, compare fingerprint lists, skip the POST on match.
- **Fail-open on tight budget**: when Fox daily budget has <2 calls left, skip the pre-read GET and upload unconditionally — the safety invariant "push the latest plan" beats saving one redundant call when we're already near the quota wall.

Call-sites at `src/scheduler/lp_dispatch.py:336` and `src/scheduler/optimizer.py:760` get the new behavior via default kwargs — no changes needed there.

## Test plan

- [x] `tests/test_mcp_singleton.py` (new, 3 tests)
  - First acquire writes own PID.
  - Second acquire SIGTERMs prior holder and succeeds.
  - Gives up cleanly (returns `None`) when prior PID can't be killed — prevents the OpenClaw respawn loop.
- [x] `tests/test_foxess_scheduler_readback.py` extended with 6 tests:
  - Skip-when-equal (no POST).
  - Upload-when-different.
  - Low-budget fail-open (GET skipped, POST runs).
  - Pre-read GET failure → upload anyway.
  - `skip_if_equal=False` forces POST.
  - `fingerprint()` stability and inequality for distinct fd_pwr.
- [x] Full suite: **186 passed, 1 skipped**, plus 2 **pre-existing** `ZoneInfo`/`MagicMock` failures in `test_set_daikin_power_success` / `test_set_daikin_temperature_weather_regulation` that are unrelated to this change (they fail on clean `main` at `8ea246c`).

## Deployment

Code-only change; no `.env` updates.

Verify on Hetzner after deploy:
- `pgrep -af 'src.mcp_server' | wc -l` → ≤ 1 after repeated OpenClaw restarts.
- `ls /run/hem-mcp.lock` exists and contains the live MCP PID.
- `journalctl -u home-energy-manager -n 200` shows `"Fox scheduler unchanged — skipping upload"` on the next identical plan push.