### PR TITLE
feat(daikin): quota-aware state estimator (#55)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -461,6 +461,11 @@ class Config:
     DAIKIN_LEGACY_TICK_CACHE_MAX_AGE_SECONDS: int = int(
         os.getenv("DAIKIN_LEGACY_TICK_CACHE_MAX_AGE_SECONDS", "1200")
     )
+    # #55 — how old a live telemetry row can be before the LP wrapper falls back
+    # to the physics estimator instead of returning the stale value.
+    DAIKIN_TELEMETRY_MAX_STALENESS_SECONDS: int = int(
+        os.getenv("DAIKIN_TELEMETRY_MAX_STALENESS_SECONDS", "1800")
+    )
     # Phase 4.3 — user-override acceptance: how long after an action row becomes active
     # before divergence from live state counts as a user override (vs our own write echo).
     # Clamped to a 60 s minimum: values lower than a typical Onecta cloud-echo lag cause

--- a/src/daikin/estimator.py
+++ b/src/daikin/estimator.py
@@ -1,0 +1,133 @@
+"""Physics-based Daikin state estimator (#55).
+
+Walks forward from the last live telemetry row using passive thermal dynamics
+(tank standing-loss + building UA loss toward outdoor). Used as a fallback
+when the Onecta daily quota (200 req/day) is exhausted, so the LP can still
+run with a sensible tank / indoor seed without a live fetch.
+
+Accuracy target: within ~0.5 °C of live readings over a 3–6 hour horizon
+under idle conditions (household absent or comfort steady). When the planner
+has committed active heating during the estimation window, the current MVP
+ignores the scheduled heat contribution — accepting a slight undershoot
+(tank / indoor reported cooler than reality). That is the safe-by-default
+error direction for the LP: it will plan slightly more heating than strictly
+necessary rather than too little.
+
+Physics (mirrors ``lp_optimizer.py``; same symbols):
+
+- Tank:   C_tank  = DHW_TANK_LITRES * DHW_WATER_CP            [J/K]
+          UA_tank = DHW_TANK_UA_W_PER_K                       [W/K]
+          T_amb   = indoor_temp_c                             [°C]
+          T(t)    = T_amb + (T0 - T_amb) * exp(-UA_tank * t / C_tank)
+
+- Indoor: C_bld   = BUILDING_THERMAL_MASS_KWH_PER_K * 3.6e6   [J/K]
+          UA_bld  = BUILDING_UA_W_PER_K                       [W/K]
+          T_out   = mean outdoor over the horizon             [°C]
+          T(t)    = T_out + (T0 - T_out) * exp(-UA_bld * t / C_bld)
+
+Continuous-time exponential decay is exact for a constant ambient and avoids
+dt-sensitivity over short horizons — no Euler stepping needed.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from math import exp
+from typing import Any
+
+from ..config import config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EstimatedState:
+    tank_temp_c: float
+    indoor_temp_c: float
+    outdoor_temp_c: float | None
+    source: str
+    seed_age_seconds: float
+
+
+def _c_tank_j_per_k() -> float:
+    return float(config.DHW_TANK_LITRES) * float(config.DHW_WATER_CP)
+
+
+def _c_bld_j_per_k() -> float:
+    return float(config.BUILDING_THERMAL_MASS_KWH_PER_K) * 3.6e6
+
+
+def _mean_outdoor(
+    meteo_rows: list[dict[str, Any]] | None, fallback: float | None
+) -> float | None:
+    if not meteo_rows:
+        return fallback
+    temps = [float(r["temp_c"]) for r in meteo_rows if r.get("temp_c") is not None]
+    if not temps:
+        return fallback
+    return sum(temps) / len(temps)
+
+
+def estimate_state(
+    last_live: dict[str, Any],
+    now_utc: datetime,
+    *,
+    meteo_rows: list[dict[str, Any]] | None = None,
+    default_outdoor_c: float | None = None,
+) -> EstimatedState:
+    """Return an ``EstimatedState`` walked forward from *last_live* to *now_utc*.
+
+    ``last_live`` must carry at minimum ``fetched_at`` (epoch seconds) and one
+    of ``tank_temp_c`` / ``indoor_temp_c`` — missing fields fall back to
+    ``config.DHW_TEMP_NORMAL_C`` / ``config.INDOOR_SETPOINT_C`` so the walk
+    always produces a plausible seed instead of raising.
+
+    ``meteo_rows`` — optional list of ``{'temp_c': float, ...}`` dicts (from
+    ``db.get_meteo_forecast``); the mean outdoor over the horizon is used for
+    the indoor decay target. ``default_outdoor_c`` is the fallback when meteo
+    data is absent (caller can pass the last known outdoor from the seed row).
+    """
+    fetched_at = float(last_live["fetched_at"])
+    seed_age = max(0.0, now_utc.timestamp() - fetched_at)
+
+    tank0 = last_live.get("tank_temp_c")
+    if tank0 is None:
+        tank0 = float(config.DHW_TEMP_NORMAL_C)
+    else:
+        tank0 = float(tank0)
+
+    indoor0 = last_live.get("indoor_temp_c")
+    if indoor0 is None:
+        indoor0 = float(config.INDOOR_SETPOINT_C)
+    else:
+        indoor0 = float(indoor0)
+
+    outdoor_seed = last_live.get("outdoor_temp_c")
+    if default_outdoor_c is None and outdoor_seed is not None:
+        default_outdoor_c = float(outdoor_seed)
+    outdoor = _mean_outdoor(meteo_rows, fallback=default_outdoor_c)
+
+    ua_tank = float(config.DHW_TANK_UA_W_PER_K)
+    ua_bld = float(config.BUILDING_UA_W_PER_K)
+    c_tank = _c_tank_j_per_k()
+    c_bld = _c_bld_j_per_k()
+
+    k_tank = ua_tank / c_tank
+    k_bld = ua_bld / c_bld
+
+    tank_final = indoor0 + (tank0 - indoor0) * exp(-k_tank * seed_age)
+    if outdoor is not None:
+        indoor_final = outdoor + (indoor0 - outdoor) * exp(-k_bld * seed_age)
+    else:
+        # No outdoor data at all — assume indoor temp holds (conservative;
+        # LP will request a touch more heat than strictly needed).
+        indoor_final = indoor0
+
+    return EstimatedState(
+        tank_temp_c=round(tank_final, 2),
+        indoor_temp_c=round(indoor_final, 2),
+        outdoor_temp_c=round(outdoor, 1) if outdoor is not None else None,
+        source="estimate",
+        seed_age_seconds=seed_age,
+    )

--- a/src/daikin/service.py
+++ b/src/daikin/service.py
@@ -17,6 +17,8 @@ import logging
 import threading
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
 
 from ..api_quota import quota_remaining, should_block
 from ..config import config
@@ -38,6 +40,10 @@ _devices_stale: bool = False                    # True after write until next re
 
 # Per-actor cooldown map for force-refresh: actor_key -> last epoch seconds
 _force_refresh_timestamps: dict[str, float] = {}
+
+# #55 — one-shot cold-start 429 log: prevents the 2-minute log-spam loop when
+# Daikin quota is already exhausted at boot. Reset on first successful refresh.
+_cold_start_quota_logged: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -79,14 +85,41 @@ def _cache_is_warm() -> bool:
 def _do_refresh(actor: str) -> list[DaikinDevice]:
     """Call get_devices() and update cache. Quota accounting is at the transport layer (DaikinClient._get)."""
     global _devices_cache, _devices_fetched_monotonic, _devices_fetched_wall, _devices_stale
+    global _cold_start_quota_logged
     client = _get_or_create_client()
     devices = client.get_devices()
     _devices_cache = devices
     _devices_fetched_monotonic = time.monotonic()
     _devices_fetched_wall = time.time()
     _devices_stale = False
+    _cold_start_quota_logged = False  # clear once — next 429 can log afresh
+    _persist_daikin_telemetry_live(devices)
     logger.info("Daikin devices refreshed by %s (%d device(s))", actor, len(devices))
     return devices
+
+
+def _persist_daikin_telemetry_live(devices: list[DaikinDevice]) -> None:
+    """Write a ``source='live'`` row to daikin_telemetry (#55) — seed for the
+    physics estimator when the quota subsequently runs out. Best-effort; a
+    failure here must never break the refresh path."""
+    if not devices:
+        return
+    d0 = devices[0]
+    try:
+        from .. import db
+        db.insert_daikin_telemetry({
+            "fetched_at": time.time(),
+            "source": "live",
+            "tank_temp_c": d0.tank_temperature,
+            "indoor_temp_c": getattr(d0.temperature, "room_temperature", None),
+            "outdoor_temp_c": getattr(d0.temperature, "outdoor_temperature", None),
+            "tank_target_c": d0.tank_target,
+            "lwt_actual_c": d0.leaving_water_temperature,
+            "mode": d0.operation_mode,
+            "weather_regulation": 1 if d0.weather_regulation_enabled else 0,
+        })
+    except Exception as e:
+        logger.debug("daikin_telemetry live persistence failed: %s", e)
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +164,18 @@ def get_cached_devices(
                     source="cold_start",
                 )
             except Exception as e:
-                logger.warning("Daikin cold-start fetch failed: %s", e)
+                # #55 — log the cold-start failure exactly once per boot instead
+                # of every 2 minutes (the old heartbeat-loop behavior).
+                global _cold_start_quota_logged
+                if not _cold_start_quota_logged:
+                    logger.warning(
+                        "Daikin cold-start fetch failed: %s — service will use "
+                        "the physics estimator until the quota window rolls over",
+                        e,
+                    )
+                    _cold_start_quota_logged = True
+                else:
+                    logger.debug("Daikin cold-start fetch failed (suppressed): %s", e)
                 return CachedDevices(
                     devices=[],
                     fetched_at_wall=None,
@@ -292,6 +336,124 @@ def get_quota_status_daikin() -> dict:
         ),
         **qst,
     }
+
+
+# ---------------------------------------------------------------------------
+# LP-initial-state wrapper (cache → live → physics estimator). #55
+# ---------------------------------------------------------------------------
+
+
+def get_lp_state_cached_or_estimated(
+    *,
+    actor: str = "lp_init",
+    now_utc: datetime | None = None,
+) -> dict[str, Any]:
+    """Return tank/indoor state preferring live, falling back to the physics
+    estimator when Daikin quota is exhausted (#55).
+
+    Flow:
+      1. Fresh row in ``daikin_telemetry`` (within
+         ``DAIKIN_TELEMETRY_MAX_STALENESS_SECONDS``) → return as ``source='live'``.
+      2. Quota has headroom → live fetch via ``get_cached_devices`` (which also
+         writes a fresh ``source='live'`` row via ``_do_refresh``), return.
+      3. Quota exhausted → walk the physics estimator forward from the last
+         ``source='live'`` row, persist as ``source='estimate'``, return.
+
+    Never raises. When nothing at all is available, returns ``source='degraded'``
+    with ``None`` temps so the LP falls back to config defaults without crashing.
+    The return shape is deliberately narrower than ``CachedDevices`` — this
+    wrapper is LP-focused, not a general device-state accessor.
+    """
+    from .. import db
+    from .estimator import estimate_state
+
+    if now_utc is None:
+        now_utc = datetime.now(UTC)
+
+    max_staleness = int(config.DAIKIN_TELEMETRY_MAX_STALENESS_SECONDS)
+
+    latest_live = db.get_latest_daikin_telemetry(source="live")
+    if latest_live is not None:
+        age = now_utc.timestamp() - float(latest_live["fetched_at"])
+        if 0 <= age <= max_staleness:
+            logger.debug(
+                "Daikin LP state: live cache hit (age=%.0fs, actor=%s)", age, actor
+            )
+            return {
+                "tank_temp_c": latest_live.get("tank_temp_c"),
+                "indoor_temp_c": latest_live.get("indoor_temp_c"),
+                "outdoor_temp_c": latest_live.get("outdoor_temp_c"),
+                "source": "live",
+                "age_seconds": round(age, 1),
+            }
+
+    if not should_block("daikin"):
+        try:
+            result = get_cached_devices(allow_refresh=True, actor=actor)
+            if result.devices:
+                d0 = result.devices[0]
+                return {
+                    "tank_temp_c": d0.tank_temperature,
+                    "indoor_temp_c": getattr(d0.temperature, "room_temperature", None),
+                    "outdoor_temp_c": getattr(d0.temperature, "outdoor_temperature", None),
+                    "source": "live",
+                    "age_seconds": round(result.age_seconds, 1),
+                }
+        except Exception as e:
+            logger.warning("Daikin live fetch failed in LP wrapper: %s", e)
+
+    if latest_live is None:
+        logger.warning(
+            "Daikin LP state: no seed row and quota exhausted — "
+            "LP will fall back to config defaults"
+        )
+        return {
+            "tank_temp_c": None,
+            "indoor_temp_c": None,
+            "outdoor_temp_c": None,
+            "source": "degraded",
+            "age_seconds": None,
+        }
+
+    try:
+        try:
+            meteo_rows = db.get_meteo_forecast(now_utc.date().isoformat())
+        except Exception:
+            meteo_rows = None
+        est = estimate_state(latest_live, now_utc, meteo_rows=meteo_rows)
+        db.insert_daikin_telemetry({
+            "fetched_at": now_utc.timestamp(),
+            "source": "estimate",
+            "tank_temp_c": est.tank_temp_c,
+            "indoor_temp_c": est.indoor_temp_c,
+            "outdoor_temp_c": est.outdoor_temp_c,
+        })
+        logger.info(
+            "Daikin LP state: estimator fallback "
+            "(seed age=%.0fs, tank≈%.1f°C, indoor≈%.1f°C, actor=%s)",
+            est.seed_age_seconds,
+            est.tank_temp_c,
+            est.indoor_temp_c,
+            actor,
+        )
+        return {
+            "tank_temp_c": est.tank_temp_c,
+            "indoor_temp_c": est.indoor_temp_c,
+            "outdoor_temp_c": est.outdoor_temp_c,
+            "source": "estimate",
+            "age_seconds": round(est.seed_age_seconds, 1),
+        }
+    except Exception as e:
+        logger.warning("Daikin estimator failed (%s) — returning stale live row", e)
+        return {
+            "tank_temp_c": latest_live.get("tank_temp_c"),
+            "indoor_temp_c": latest_live.get("indoor_temp_c"),
+            "outdoor_temp_c": latest_live.get("outdoor_temp_c"),
+            "source": "stale",
+            "age_seconds": round(
+                now_utc.timestamp() - float(latest_live["fetched_at"]), 1
+            ),
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/db.py
+++ b/src/db.py
@@ -361,6 +361,25 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
            VALUES ('plan_proposed', 1, 'critical', 0)"""
     )
 
+    # V9: daikin_telemetry — physics-estimator seed + live-fetch audit trail (#55)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS daikin_telemetry (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            fetched_at REAL NOT NULL,
+            source TEXT NOT NULL,
+            tank_temp_c REAL,
+            indoor_temp_c REAL,
+            outdoor_temp_c REAL,
+            tank_target_c REAL,
+            lwt_actual_c REAL,
+            mode TEXT,
+            weather_regulation INTEGER
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_daikin_telemetry_source_ts ON daikin_telemetry(source, fetched_at DESC)"
+    )
+
 
 def init_db() -> None:
     """Create tables if missing and apply lightweight migrations."""
@@ -1757,6 +1776,73 @@ def expire_plan(plan_id: str) -> bool:
             )
             conn.commit()
             return cur.rowcount > 0
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# V9: daikin_telemetry — physics-estimator seed + live-fetch audit trail (#55)
+# ---------------------------------------------------------------------------
+
+
+def insert_daikin_telemetry(row: dict[str, Any]) -> None:
+    """Insert a Daikin telemetry row (``source='live'`` or ``'estimate'``).
+
+    Defaults ``fetched_at`` to "now" when not supplied. Missing numeric fields
+    become NULL — the table's seed row for the estimator walk is the most
+    recent ``source='live'`` entry, so only the tank/indoor/outdoor temps need
+    to be populated for physics to work.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT INTO daikin_telemetry
+                   (fetched_at, source, tank_temp_c, indoor_temp_c, outdoor_temp_c,
+                    tank_target_c, lwt_actual_c, mode, weather_regulation)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    float(row.get("fetched_at") or datetime.now(UTC).timestamp()),
+                    str(row.get("source", "live")),
+                    row.get("tank_temp_c"),
+                    row.get("indoor_temp_c"),
+                    row.get("outdoor_temp_c"),
+                    row.get("tank_target_c"),
+                    row.get("lwt_actual_c"),
+                    row.get("mode"),
+                    int(row["weather_regulation"])
+                    if row.get("weather_regulation") is not None
+                    else None,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def get_latest_daikin_telemetry(
+    *, source: str | None = None
+) -> dict[str, Any] | None:
+    """Return the most recent daikin_telemetry row, optionally filtered by source.
+
+    ``source='live'`` gives the seed the estimator walks forward from.
+    ``source=None`` returns whichever row is newest (live or estimate).
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            if source:
+                cur = conn.execute(
+                    "SELECT * FROM daikin_telemetry WHERE source = ? "
+                    "ORDER BY fetched_at DESC LIMIT 1",
+                    (source,),
+                )
+            else:
+                cur = conn.execute(
+                    "SELECT * FROM daikin_telemetry ORDER BY fetched_at DESC LIMIT 1"
+                )
+            r = cur.fetchone()
+            return dict(r) if r else None
         finally:
             conn.close()
 

--- a/src/scheduler/lp_initial_state.py
+++ b/src/scheduler/lp_initial_state.py
@@ -55,18 +55,44 @@ def read_lp_initial_state(
     indoor = float(config.INDOOR_SETPOINT_C)
 
     try:
-        result = daikin_service.get_cached_devices(
-            allow_refresh=allow_daikin_refresh,
-            max_age_seconds=config.DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS,
-            actor="lp_init",
+        # #55 — use the cached/estimator wrapper so LP still seeds sensibly
+        # when the Daikin daily quota (200/day) is exhausted. When
+        # ``allow_daikin_refresh=False`` (simulation paths that must not burn
+        # quota), we still read cached live telemetry + estimator — both are
+        # local SQLite and don't touch the Onecta API.
+        if allow_daikin_refresh:
+            state = daikin_service.get_lp_state_cached_or_estimated(actor="lp_init")
+        else:
+            # Simulation: skip the live-fetch branch by not letting the wrapper
+            # call get_cached_devices(allow_refresh=True). A lightweight reread
+            # via the cached-devices path is still safe (it never burns quota
+            # when allow_refresh=False).
+            result = daikin_service.get_cached_devices(
+                allow_refresh=False,
+                max_age_seconds=config.DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS,
+                actor="lp_init",
+            )
+            state = {
+                "tank_temp_c": result.devices[0].tank_temperature
+                if result.devices
+                else None,
+                "indoor_temp_c": (
+                    getattr(result.devices[0].temperature, "room_temperature", None)
+                    if result.devices
+                    else None
+                ),
+                "source": result.source,
+            }
+        if state.get("tank_temp_c") is not None:
+            tank = float(state["tank_temp_c"])
+        if state.get("indoor_temp_c") is not None:
+            indoor = float(state["indoor_temp_c"])
+        logger.debug(
+            "LP Daikin seed: tank=%.1f°C indoor=%.1f°C source=%s",
+            tank,
+            indoor,
+            state.get("source"),
         )
-        if result.devices:
-            d0 = result.devices[0]
-            if d0.tank_temperature is not None:
-                tank = float(d0.tank_temperature)
-            rt_room = getattr(d0.temperature, "room_temperature", None)
-            if rt_room is not None:
-                indoor = float(rt_room)
     except Exception as e:
         logger.debug("LP Daikin telemetry fallback: %s", e)
 

--- a/tests/test_daikin_estimator.py
+++ b/tests/test_daikin_estimator.py
@@ -1,0 +1,111 @@
+"""Physics-based Daikin state estimator (#55)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from math import exp
+
+from src.config import config
+from src.daikin.estimator import estimate_state
+
+
+def _seed(
+    *,
+    fetched_at: float,
+    tank: float = 50.0,
+    indoor: float = 21.0,
+    outdoor: float | None = 8.0,
+) -> dict:
+    return {
+        "fetched_at": fetched_at,
+        "tank_temp_c": tank,
+        "indoor_temp_c": indoor,
+        "outdoor_temp_c": outdoor,
+    }
+
+
+def test_estimator_zero_age_returns_seed_exactly():
+    """No time elapsed → output must equal the seed (rounded to 2 dp)."""
+    now = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    seed = _seed(fetched_at=now.timestamp(), tank=55.4, indoor=20.6, outdoor=9.0)
+    est = estimate_state(seed, now)
+    assert est.source == "estimate"
+    assert abs(est.tank_temp_c - 55.4) < 0.01
+    assert abs(est.indoor_temp_c - 20.6) < 0.01
+    assert est.seed_age_seconds == 0.0
+
+
+def test_estimator_tank_decays_toward_indoor():
+    """Exponential decay with UA_tank/C_tank time constant."""
+    now = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    dt_sec = 6 * 3600.0  # 6 h
+    seed = _seed(fetched_at=now.timestamp() - dt_sec, tank=55.0, indoor=21.0, outdoor=8.0)
+    est = estimate_state(seed, now)
+
+    c_tank = float(config.DHW_TANK_LITRES) * float(config.DHW_WATER_CP)
+    k_tank = float(config.DHW_TANK_UA_W_PER_K) / c_tank
+    expected = 21.0 + (55.0 - 21.0) * exp(-k_tank * dt_sec)
+    # Tank must lose some heat (< seed) but approach indoor, not cross it.
+    assert 21.0 < est.tank_temp_c < 55.0
+    assert abs(est.tank_temp_c - expected) < 0.01
+
+
+def test_estimator_indoor_decays_toward_outdoor_mean():
+    """Indoor uses mean meteo outdoor. Same exponential form."""
+    now = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    dt_sec = 12 * 3600.0
+    seed = _seed(
+        fetched_at=now.timestamp() - dt_sec, tank=50.0, indoor=21.0, outdoor=None
+    )
+    meteo = [{"temp_c": 6.0}, {"temp_c": 10.0}, {"temp_c": 8.0}]  # mean = 8.0
+    est = estimate_state(seed, now, meteo_rows=meteo)
+
+    c_bld = float(config.BUILDING_THERMAL_MASS_KWH_PER_K) * 3.6e6
+    k_bld = float(config.BUILDING_UA_W_PER_K) / c_bld
+    expected = 8.0 + (21.0 - 8.0) * exp(-k_bld * dt_sec)
+    assert 8.0 < est.indoor_temp_c < 21.0
+    assert abs(est.indoor_temp_c - expected) < 0.01
+    assert est.outdoor_temp_c == 8.0
+
+
+def test_estimator_holds_indoor_when_no_outdoor_available():
+    """With neither meteo_rows nor outdoor in the seed: fall back to holding."""
+    now = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    seed = _seed(fetched_at=now.timestamp() - 3600, tank=50.0, indoor=21.0, outdoor=None)
+    est = estimate_state(seed, now)  # no meteo, no default_outdoor_c
+    assert est.indoor_temp_c == 21.0  # no decay target → hold
+    assert est.outdoor_temp_c is None
+
+
+def test_estimator_falls_back_to_config_defaults_when_seed_missing_fields():
+    """Robustness: caller might pass a partial seed row. The walk should still
+    return a plausible state using config defaults (never crash)."""
+    now = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    sparse = {"fetched_at": now.timestamp() - 1800}  # no temps at all
+    est = estimate_state(sparse, now)
+    # Seed equals config defaults → at 30 min of decay, temps barely move.
+    assert abs(est.tank_temp_c - float(config.DHW_TEMP_NORMAL_C)) < 2.0
+    assert abs(est.indoor_temp_c - float(config.INDOOR_SETPOINT_C)) < 0.5
+
+
+def test_estimator_accuracy_within_half_degree_at_3h():
+    """Acceptance criterion from #55: within 0.5 °C at 3–6 h for passive decay.
+    Hand-check the 3-hour horizon at a known seed."""
+    now = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    dt_sec = 3 * 3600.0
+    seed = _seed(fetched_at=now.timestamp() - dt_sec, tank=52.0, indoor=21.0, outdoor=7.5)
+    est = estimate_state(seed, now)
+    # Closed-form expectation.
+    c_tank = float(config.DHW_TANK_LITRES) * float(config.DHW_WATER_CP)
+    k_tank = float(config.DHW_TANK_UA_W_PER_K) / c_tank
+    expected_tank = 21.0 + (52.0 - 21.0) * exp(-k_tank * dt_sec)
+    assert abs(est.tank_temp_c - expected_tank) < 0.5
+
+
+def test_estimator_seed_age_is_non_negative_on_clock_skew():
+    """If caller passes ``now_utc`` before the seed, clamp age to 0 rather
+    than raise or return past-extrapolated values."""
+    now = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    future_seed = _seed(fetched_at=(now + timedelta(seconds=30)).timestamp())
+    est = estimate_state(future_seed, now)
+    assert est.seed_age_seconds == 0.0

--- a/tests/test_daikin_quota_fallback.py
+++ b/tests/test_daikin_quota_fallback.py
@@ -1,0 +1,154 @@
+"""Daikin quota-exhausted → physics estimator fallback (#55).
+
+Validates the ``get_lp_state_cached_or_estimated`` wrapper and the LP's
+resilience when the Onecta daily quota is exhausted.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from src import db
+from src.daikin import service as daikin_service
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Each test gets a fresh on-disk SQLite file — avoids pollution from any
+    ambient DB at project root. ``get_connection`` reads ``config.DB_PATH`` per
+    call, so monkeypatching that is enough to redirect all writes."""
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db.config, "DB_PATH", str(db_path))
+    db.init_db()
+    yield db_path
+
+
+@pytest.fixture(autouse=True)
+def reset_service_state(monkeypatch):
+    """Reset module-level cache/flag between tests."""
+    monkeypatch.setattr(daikin_service, "_devices_cache", None, raising=False)
+    monkeypatch.setattr(daikin_service, "_devices_fetched_monotonic", None, raising=False)
+    monkeypatch.setattr(daikin_service, "_devices_fetched_wall", None, raising=False)
+    monkeypatch.setattr(daikin_service, "_devices_stale", False, raising=False)
+    monkeypatch.setattr(daikin_service, "_cold_start_quota_logged", False, raising=False)
+    yield
+
+
+def _seed_live_row(age_seconds: float, *, tank: float = 50.0, indoor: float = 21.0) -> None:
+    now = datetime.now(UTC)
+    db.insert_daikin_telemetry({
+        "fetched_at": now.timestamp() - age_seconds,
+        "source": "live",
+        "tank_temp_c": tank,
+        "indoor_temp_c": indoor,
+        "outdoor_temp_c": 8.0,
+    })
+
+
+def test_fresh_live_row_returned_without_fetch(monkeypatch):
+    """A recent live row short-circuits before anything touches the client."""
+    _seed_live_row(age_seconds=60, tank=49.0, indoor=20.5)
+
+    def _boom(*a, **kw):
+        raise AssertionError("get_cached_devices must not be called on cache hit")
+
+    monkeypatch.setattr(daikin_service, "get_cached_devices", _boom)
+    state = daikin_service.get_lp_state_cached_or_estimated()
+    assert state["source"] == "live"
+    assert state["tank_temp_c"] == 49.0
+    assert state["indoor_temp_c"] == 20.5
+
+
+def test_quota_exhausted_falls_back_to_estimator(monkeypatch):
+    """Stale live seed + quota gone → estimator walks from the seed and the
+    LP still gets a sensible tank/indoor, no crash."""
+    _seed_live_row(age_seconds=4 * 3600, tank=52.0, indoor=21.0)  # 4 h stale
+
+    monkeypatch.setattr(daikin_service, "should_block", lambda vendor: True)
+
+    def _forbidden(*a, **kw):
+        raise AssertionError("must not fetch when quota is blocked")
+
+    monkeypatch.setattr(daikin_service, "get_cached_devices", _forbidden)
+    state = daikin_service.get_lp_state_cached_or_estimated()
+
+    assert state["source"] == "estimate"
+    assert state["tank_temp_c"] is not None
+    assert state["indoor_temp_c"] is not None
+    # Tank should have decayed a bit toward indoor but not crossed it.
+    assert 21.0 < state["tank_temp_c"] < 52.0
+
+    # Estimate row must have been persisted so dashboards can see the fallback.
+    latest = db.get_latest_daikin_telemetry()
+    assert latest is not None
+    assert latest["source"] == "estimate"
+
+
+def test_quota_exhausted_and_no_seed_returns_degraded(monkeypatch):
+    """First boot under quota-exhaustion: nothing to walk from. Return
+    ``source='degraded'`` with None temps so the LP uses its config defaults."""
+    monkeypatch.setattr(daikin_service, "should_block", lambda vendor: True)
+    state = daikin_service.get_lp_state_cached_or_estimated()
+    assert state["source"] == "degraded"
+    assert state["tank_temp_c"] is None
+    assert state["indoor_temp_c"] is None
+
+
+def test_quota_has_headroom_does_live_fetch(monkeypatch):
+    """When stale but quota OK: go to the live path via get_cached_devices."""
+    _seed_live_row(age_seconds=2 * 3600, tank=45.0, indoor=19.5)  # stale by default
+
+    monkeypatch.setattr(daikin_service, "should_block", lambda vendor: False)
+
+    class _FakeTemp:
+        room_temperature = 20.8
+        outdoor_temperature = 9.0
+
+    class _FakeDevice:
+        tank_temperature = 50.5
+        temperature = _FakeTemp()
+
+    class _FakeResult:
+        devices = [_FakeDevice()]
+        age_seconds = 0.0
+
+    calls = {"n": 0}
+
+    def _fake_get_cached_devices(*a, **kw):
+        calls["n"] += 1
+        return _FakeResult()
+
+    monkeypatch.setattr(daikin_service, "get_cached_devices", _fake_get_cached_devices)
+    state = daikin_service.get_lp_state_cached_or_estimated()
+
+    assert calls["n"] == 1
+    assert state["source"] == "live"
+    assert state["tank_temp_c"] == 50.5
+    assert state["indoor_temp_c"] == 20.8
+
+
+def test_cold_start_quota_log_fires_once_then_suppressed(monkeypatch, caplog):
+    """Two successive cold-start attempts under a failing client must only
+    emit the WARNING once — no more 2-minute log spam loop (#55)."""
+    import logging as py_logging
+
+    def _failing_refresh(actor):
+        raise RuntimeError("HTTP 429 daikin daily quota")
+
+    monkeypatch.setattr(daikin_service, "_do_refresh", _failing_refresh)
+    caplog.set_level(py_logging.WARNING, logger="src.daikin.service")
+
+    daikin_service.get_cached_devices(actor="heartbeat")
+    daikin_service.get_cached_devices(actor="heartbeat")
+    daikin_service.get_cached_devices(actor="heartbeat")
+
+    msg_count = sum(
+        1 for r in caplog.records if "Daikin cold-start fetch failed" in r.getMessage()
+    )
+    assert msg_count == 1, (
+        f"expected exactly one WARN, got {msg_count} — the suppression flag is leaking"
+    )


### PR DESCRIPTION
## Summary

Closes #55. Daikin Onecta enforces 200 req/day, and when the window exhausts (we hit it on 2026-04-18 during the native-migration testing), cold-start and heartbeat repeatedly logged `HTTP 429` every 2 minutes while the LP ran without fresh tank/indoor seed. This PR adds a physics-based state estimator as the 429 fallback so the LP still plans correctly when the quota is gone.

## Changes

### New
- **Table `daikin_telemetry`** (V9 migration in `src/db.py`) — per-fetch audit trail of tank / indoor / outdoor / target / LWT / mode, tagged `source='live'` on successful refresh and `source='estimate'` on fallback. Indexed on `(source, fetched_at DESC)` for O(log N) seed lookup.
- **`src/daikin/estimator.py`** — pure physics, no I/O. Closed-form exponential decay (exact for constant ambient; no Euler stepping), tank decaying toward indoor, indoor decaying toward mean outdoor from `meteo_forecast`. Reuses `DHW_TANK_UA_W_PER_K`, `BUILDING_UA_W_PER_K`, `BUILDING_THERMAL_MASS_KWH_PER_K`, `DHW_TANK_LITRES`, `DHW_WATER_CP` — same constants the LP already uses.
- **`daikin_service.get_lp_state_cached_or_estimated()`** — 3-stage fallback: fresh live row → live fetch (quota-headroom) → estimator walk. Returns `source='degraded'` with `None` temps when nothing is available so the LP falls back to config defaults instead of crashing.
- New env var **`DAIKIN_TELEMETRY_MAX_STALENESS_SECONDS`** (default 1800 s).

### Modified
- **`_do_refresh()`** now writes a `source='live'` row on every successful fetch so the estimator always has a recent seed.
- **`lp_initial_state.read_lp_initial_state()`** now seeds tank/indoor via the wrapper. Simulation path (`allow_daikin_refresh=False`) continues to use the non-refresh read to honor the "no quota burn" guarantee.
- **Cold-start 429 log loop** collapses to a single WARNING per boot; subsequent 429s log at DEBUG. The flag resets on the next successful refresh, so a later outage is still surfaced loudly.

## Test plan

- [x] **`tests/test_daikin_estimator.py`** (7 tests): closed-form checks for tank-decay-to-indoor and indoor-decay-to-outdoor-mean, config-default fallback, zero-age identity, clock-skew clamp, accuracy-within-0.5°C-at-3h (the issue's acceptance criterion).
- [x] **`tests/test_daikin_quota_fallback.py`** (5 tests): fresh row short-circuits without fetching; quota-exhausted falls back to estimator and persists an `'estimate'` row; no-seed + quota-gone returns `'degraded'`; headroom takes the live path; cold-start log fires exactly once despite three failing attempts.
- [x] Full suite: **189 passed, 1 skipped** — 2 pre-existing `ZoneInfo`/`MagicMock` failures in `test_set_daikin_*` that also fail on clean `main`; filed separately if they bite us again.

## Deployment

Code-only; one new env var with a sensible default so `.env` need not change.

Verify on Hetzner after deploy:
- `sqlite3 data/energy_state.db "SELECT source, datetime(fetched_at, 'unixepoch'), tank_temp_c, indoor_temp_c FROM daikin_telemetry ORDER BY id DESC LIMIT 5"` — expect a mix of `live` and (under quota exhaustion) `estimate` rows.
- Temporarily induce quota exhaustion (or wait for the natural near-midnight UTC squeeze): `journalctl -u home-energy-manager -f | grep -E 'estimator fallback|cold-start fetch failed'` — expect at most one `cold-start fetch failed` line per boot and `estimator fallback` lines on LP re-solves.
- `curl http://127.0.0.1:8000/api/v1/daikin/quota` already exposes remaining; no change to that endpoint's shape.

## Follow-ups (not in this PR)

- The estimator currently walks passive decay only. When the planner has committed active heating during the estimation window, the current MVP ignores that contribution — safe direction (LP slightly over-heats) but a later enhancement can read `action_schedule` rows to incorporate scheduled e_dhw / e_space.