### PR TITLE
feat(config): runtime-tunable settings (#52)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -36,6 +36,7 @@ from ..scheduler.optimizer import run_optimizer
 from ..scheduler.runner import (
     get_scheduler_status,
     pause_scheduler,
+    reregister_cron_jobs,
     resume_scheduler,
     start_background_scheduler,
     stop_background_scheduler,
@@ -373,6 +374,70 @@ async def daikin_quota():
 async def foxess_quota():
     """Return Fox ESS API quota usage, cache age, and stale status."""
     return get_refresh_stats_extended()
+
+
+# ---------------------------------------------------------------------------
+# Runtime-tunable settings (#52). PUT takes effect within the 30-sec cache
+# TTL; settings that drive cron cadence trigger an APScheduler re-register.
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/v1/settings")
+async def settings_list():
+    """Return every runtime-tunable setting with its current value, env default,
+    range, and ``overridden`` flag (true when the DB row supplants the env)."""
+    from .. import runtime_settings as rts
+    return {"settings": rts.list_settings()}
+
+
+@app.get("/api/v1/settings/{key}")
+async def settings_get(key: str):
+    from .. import runtime_settings as rts
+    if key not in rts.SCHEMA:
+        raise HTTPException(status_code=404, detail=f"unknown setting {key!r}")
+    try:
+        value = rts.get_setting(key)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+    return {"key": key, "value": value}
+
+
+@app.put("/api/v1/settings/{key}")
+async def settings_put(key: str, payload: dict):
+    """Validate + persist + (if cron) re-register APScheduler jobs.
+
+    Body: ``{"value": <new>}``. Type coercion follows the schema:
+    ``list[int]`` accepts ``"6,12,18"`` or ``[6, 12, 18]``.
+    """
+    from .. import runtime_settings as rts
+    if key not in rts.SCHEMA:
+        raise HTTPException(status_code=404, detail=f"unknown setting {key!r}")
+    if "value" not in payload:
+        raise HTTPException(status_code=400, detail="missing 'value' in body")
+    try:
+        canonical = rts.set_setting(key, payload["value"], actor="api")
+    except rts.SettingValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    cron_status = None
+    if rts.SCHEMA[key].cron_reload:
+        cron_status = reregister_cron_jobs(reason=f"settings_put:{key}")
+
+    return {"key": key, "value": canonical, "cron_status": cron_status}
+
+
+@app.delete("/api/v1/settings/{key}")
+async def settings_delete(key: str):
+    """Clear the override row — the next read returns the env default. Same
+    cron side effect as PUT when the key is cadence-related."""
+    from .. import runtime_settings as rts
+    if key not in rts.SCHEMA:
+        raise HTTPException(status_code=404, detail=f"unknown setting {key!r}")
+    removed = rts.delete_setting(key, actor="api")
+    cron_status = None
+    if rts.SCHEMA[key].cron_reload:
+        cron_status = reregister_cron_jobs(reason=f"settings_delete:{key}")
+    return {"key": key, "removed": removed, "cron_status": cron_status}
 
 
 @app.get("/api/v1/daikin/status", response_model=list[DaikinStatusResponse])

--- a/src/config.py
+++ b/src/config.py
@@ -2,6 +2,7 @@
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 from dotenv import load_dotenv
 
@@ -198,9 +199,9 @@ class Config:
 
     DHW_TEMP_MAX_C: float = float(os.getenv("DHW_TEMP_MAX_C", "65"))
     # Plunge-only ceiling (≥ DHW_TEMP_COMFORT_C and ≤ DHW_TEMP_MAX_C is allowed only when price < 0).
-    DHW_TEMP_COMFORT_C: float = float(os.getenv("DHW_TEMP_COMFORT_C", "48"))
+    # DHW_TEMP_COMFORT_C + DHW_TEMP_NORMAL_C are runtime-tunable via
+    # /api/v1/settings (#52) — see the @property definitions below.
     DHW_TEMP_CHEAP_C: float = float(os.getenv("DHW_TEMP_CHEAP_C", "60"))
-    DHW_TEMP_NORMAL_C: float = float(os.getenv("DHW_TEMP_NORMAL_C", "50"))
     # DEPRECATED: Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously
     # (Sunday ~11:00 local). The LP / dispatch layer no longer enforces these bounds.
     # Kept only so stale .env files don't break on load; remove in a follow-up.
@@ -255,11 +256,11 @@ class Config:
     OPTIMIZATION_ENGINE_ENABLED: bool = os.getenv(
         "OPTIMIZATION_ENGINE_ENABLED", "false"
     ).lower() in ("true", "1", "yes")
-    OPTIMIZATION_PRESET: str = (os.getenv("OPTIMIZATION_PRESET") or "normal").strip().lower()
+    # OPTIMIZATION_PRESET + ENERGY_STRATEGY_MODE are runtime-tunable via
+    # /api/v1/settings (#52) — see the @property definitions below.
     # savings_first (default): import/savings focus; peak grid export (force discharge) only when
     # OPTIMIZATION_PRESET is travel/away AND cached SoC >= EXPORT_DISCHARGE_MIN_SOC_PERCENT.
     # strict_savings — never schedule peak export discharge (max self-use).
-    ENERGY_STRATEGY_MODE: str = (os.getenv("ENERGY_STRATEGY_MODE") or "savings_first").strip().lower()
     EXPORT_DISCHARGE_MIN_SOC_PERCENT: float = float(
         os.getenv("EXPORT_DISCHARGE_MIN_SOC_PERCENT", "95")
     )
@@ -361,7 +362,7 @@ class Config:
     BUILDING_UA_W_PER_K: float = float(os.getenv("BUILDING_UA_W_PER_K", "180"))
     # CALIBRATION REQUIRED — effective thermal inertia (kWh/K) driving indoor temperature dynamics.
     BUILDING_THERMAL_MASS_KWH_PER_K: float = float(os.getenv("BUILDING_THERMAL_MASS_KWH_PER_K", "8.0"))
-    INDOOR_SETPOINT_C: float = float(os.getenv("INDOOR_SETPOINT_C", "21"))
+    # INDOOR_SETPOINT_C is runtime-tunable via /api/v1/settings (#52) — see @property below.
     INDOOR_COMFORT_BAND_C: float = float(os.getenv("INDOOR_COMFORT_BAND_C", "1.5"))
     RADIATOR_MAX_KW: float = float(os.getenv("RADIATOR_MAX_KW", "6.0"))
     # Physical climate (weather-compensation) curve from the Daikin panel.
@@ -398,8 +399,8 @@ class Config:
     LP_SOC_FINAL_KWH: float = float(os.getenv("LP_SOC_FINAL_KWH", "0"))
 
     # Model Predictive Control: re-run the LP intra-day with refreshed SoC / tank / forecasts.
-    # Comma-separated local hours (24-h). E.g. "6,12,18" fires at 06:00, 12:00, and 18:00.
-    LP_MPC_HOURS: str = (os.getenv("LP_MPC_HOURS") or "6,12,21").strip()
+    # LP_MPC_HOURS is runtime-tunable via /api/v1/settings (#52); cron jobs are
+    # re-registered without a process restart when it changes. See @property below.
 
     # Whether intra-day MPC re-runs (and the evening fetch) push the updated plan to Fox/Daikin.
     # Default false: compute + log only; the nightly push job dispatches at LP_PLAN_PUSH_HOUR:MINUTE.
@@ -408,8 +409,7 @@ class Config:
     # Nightly plan push: UTC wall-clock time to upload tomorrow's LP plan to Fox ESS + Daikin.
     # Anchored to UTC so it lands just after Daikin's daily 200-req quota rollover (midnight UTC).
     # The scheduler forces UTC for this cron regardless of BULLETPROOF_TIMEZONE.
-    LP_PLAN_PUSH_HOUR: int = int(os.getenv("LP_PLAN_PUSH_HOUR", "0"))
-    LP_PLAN_PUSH_MINUTE: int = int(os.getenv("LP_PLAN_PUSH_MINUTE", "5"))
+    # LP_PLAN_PUSH_HOUR/MINUTE are runtime-tunable (#52) — see @property below.
 
     # Load-profile: rolling-window of execution_log slots used for per-hour-of-day load estimation.
     # The flat mean is used when fewer rows are available or when this is 0 (legacy).
@@ -419,12 +419,107 @@ class Config:
     def DAIKIN_COP_CURVE(self) -> list[tuple[float, float]]:
         return parse_cop_curve_csv(self.DAIKIN_COP_CURVE_STR)
 
+    # -- Runtime-tunable knobs (#52). -----------------------------------------
+    # Read through ``runtime_settings.get_setting`` so ``config.KNOB`` returns
+    # the DB-backed override (or env default) without per-call-site churn.
+    # Setters write to an in-memory override dict ``_overrides`` so legacy
+    # call-sites that do ``setattr(config, name, value)`` (notably
+    # ``simulate_plan`` and existing pytest ``monkeypatch.setattr`` calls)
+    # keep working without polluting the DB. To *persist* a new value across
+    # restarts, use ``runtime_settings.set_setting`` or ``PUT /api/v1/settings``.
+    # Local import in each getter prevents a cycle at module load —
+    # runtime_settings imports db which imports config during init.
+
+    _overrides: dict[str, Any] = {}  # class-level: one dict for the singleton
+
+    def _rt_get(self, key: str) -> Any:
+        if key in self._overrides:
+            return self._overrides[key]
+        from .runtime_settings import get_setting
+        return get_setting(key)
+
+    def _rt_set(self, key: str, value: Any) -> None:
+        self._overrides[key] = value
+
+    @property
+    def DHW_TEMP_COMFORT_C(self) -> float:
+        return float(self._rt_get("DHW_TEMP_COMFORT_C"))
+
+    @DHW_TEMP_COMFORT_C.setter
+    def DHW_TEMP_COMFORT_C(self, value: float) -> None:
+        self._rt_set("DHW_TEMP_COMFORT_C", float(value))
+
+    @property
+    def DHW_TEMP_NORMAL_C(self) -> float:
+        return float(self._rt_get("DHW_TEMP_NORMAL_C"))
+
+    @DHW_TEMP_NORMAL_C.setter
+    def DHW_TEMP_NORMAL_C(self, value: float) -> None:
+        self._rt_set("DHW_TEMP_NORMAL_C", float(value))
+
+    @property
+    def INDOOR_SETPOINT_C(self) -> float:
+        return float(self._rt_get("INDOOR_SETPOINT_C"))
+
+    @INDOOR_SETPOINT_C.setter
+    def INDOOR_SETPOINT_C(self, value: float) -> None:
+        self._rt_set("INDOOR_SETPOINT_C", float(value))
+
+    @property
+    def OPTIMIZATION_PRESET(self) -> str:
+        return str(self._rt_get("OPTIMIZATION_PRESET"))
+
+    @OPTIMIZATION_PRESET.setter
+    def OPTIMIZATION_PRESET(self, value: str) -> None:
+        self._rt_set("OPTIMIZATION_PRESET", str(value).strip().lower())
+
+    @property
+    def ENERGY_STRATEGY_MODE(self) -> str:
+        return str(self._rt_get("ENERGY_STRATEGY_MODE"))
+
+    @ENERGY_STRATEGY_MODE.setter
+    def ENERGY_STRATEGY_MODE(self, value: str) -> None:
+        self._rt_set("ENERGY_STRATEGY_MODE", str(value).strip().lower())
+
+    @property
+    def LP_PLAN_PUSH_HOUR(self) -> int:
+        return int(self._rt_get("LP_PLAN_PUSH_HOUR"))
+
+    @LP_PLAN_PUSH_HOUR.setter
+    def LP_PLAN_PUSH_HOUR(self, value: int) -> None:
+        self._rt_set("LP_PLAN_PUSH_HOUR", int(value))
+
+    @property
+    def LP_PLAN_PUSH_MINUTE(self) -> int:
+        return int(self._rt_get("LP_PLAN_PUSH_MINUTE"))
+
+    @LP_PLAN_PUSH_MINUTE.setter
+    def LP_PLAN_PUSH_MINUTE(self, value: int) -> None:
+        self._rt_set("LP_PLAN_PUSH_MINUTE", int(value))
+
+    @property
+    def LP_MPC_HOURS(self) -> str:
+        """Comma-separated string form — legacy callers (incl. pytest
+        ``monkeypatch.setattr(config, 'LP_MPC_HOURS', '6,12,18')``) expect
+        this setter shape. The canonical value is ``LP_MPC_HOURS_LIST``."""
+        val = self._rt_get("LP_MPC_HOURS")
+        if isinstance(val, str):
+            return val
+        if isinstance(val, (list, tuple)):
+            return ",".join(str(int(h)) for h in val)
+        return str(val or "")
+
+    @LP_MPC_HOURS.setter
+    def LP_MPC_HOURS(self, value: str) -> None:
+        self._rt_set("LP_MPC_HOURS", str(value))
+
     @property
     def LP_MPC_HOURS_LIST(self) -> list[int]:
-        """Parsed LP_MPC_HOURS as sorted ints."""
-        if not self.LP_MPC_HOURS:
+        """Parsed MPC re-solve hours (local). Runtime-tunable via settings PUT."""
+        raw = self.LP_MPC_HOURS
+        if not raw:
             return []
-        return sorted({int(h.strip()) for h in self.LP_MPC_HOURS.split(",") if h.strip()})
+        return sorted({int(h.strip()) for h in raw.split(",") if h.strip()})
 
     # Directory for config snapshots (JSON). Snapshots are saved before any mode transition.
     CONFIG_SNAPSHOT_DIR: str = (os.getenv("CONFIG_SNAPSHOT_DIR") or "data/config_snapshots").strip()

--- a/src/db.py
+++ b/src/db.py
@@ -380,6 +380,15 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_daikin_telemetry_source_ts ON daikin_telemetry(source, fetched_at DESC)"
     )
 
+    # V10: runtime_settings — user-editable tunables that take effect without restart (#52)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS runtime_settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )"""
+    )
+
 
 def init_db() -> None:
     """Create tables if missing and apply lightweight migrations."""
@@ -1843,6 +1852,81 @@ def get_latest_daikin_telemetry(
                 )
             r = cur.fetchone()
             return dict(r) if r else None
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# V10: runtime_settings — user-editable tunables that take effect without restart.
+# Values are stored as TEXT (the service layer handles coercion). A ``None`` read
+# is the signal to fall back to the env-derived default in ``src/runtime_settings.py``.
+# ---------------------------------------------------------------------------
+
+
+def get_runtime_setting(key: str) -> str | None:
+    """Return the string value for *key*, or None if the row is absent.
+
+    Returns None (forcing the env-default fallback) when the table hasn't been
+    created yet — tests and early-boot code exercise config properties before
+    ``init_db`` has run, and a missing ``runtime_settings`` table must not
+    crash those paths.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT value FROM runtime_settings WHERE key = ?", (key,)
+            )
+            r = cur.fetchone()
+            return str(r[0]) if r else None
+        except sqlite3.OperationalError:
+            return None
+        finally:
+            conn.close()
+
+
+def set_runtime_setting(key: str, value: str) -> None:
+    """Upsert *value* for *key* with an UTC timestamp. ``value`` must be pre-validated
+    by the caller — this layer is purely persistence."""
+    ts = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT INTO runtime_settings (key, value, updated_at)
+                   VALUES (?, ?, ?)
+                   ON CONFLICT(key) DO UPDATE SET
+                     value=excluded.value,
+                     updated_at=excluded.updated_at""",
+                (key, value, ts),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def delete_runtime_setting(key: str) -> bool:
+    """Remove the row for *key* so reads fall back to the env default. Returns
+    True when a row was deleted."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute("DELETE FROM runtime_settings WHERE key = ?", (key,))
+            conn.commit()
+            return cur.rowcount > 0
+        finally:
+            conn.close()
+
+
+def list_runtime_settings() -> list[dict[str, Any]]:
+    """Return all runtime_settings rows as ``{key, value, updated_at}`` dicts."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT key, value, updated_at FROM runtime_settings ORDER BY key"
+            )
+            return [dict(r) for r in cur.fetchall()]
         finally:
             conn.close()
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1851,6 +1851,87 @@ def build_mcp() -> FastMCP:
             ),
         }
 
+    # -----------------------------------------------------------------------
+    # Runtime-tunable settings (#52)
+    # -----------------------------------------------------------------------
+
+    @mcp.tool(
+        name="list_settings",
+        description=(
+            "List every runtime-tunable setting with current value, env default, "
+            "range, and `overridden` flag. Pairs with set_setting for live tuning."
+        ),
+    )
+    def list_settings() -> dict[str, Any]:
+        from . import runtime_settings as rts
+        try:
+            return {"ok": True, "settings": rts.list_settings()}
+        except Exception as e:
+            logger.warning("list_settings failed: %s", e)
+            return {"ok": False, "error": str(e)}
+
+    @mcp.tool(
+        name="get_setting",
+        description="Return the current value of a single runtime-tunable setting.",
+    )
+    def get_setting(key: str) -> dict[str, Any]:
+        from . import runtime_settings as rts
+        if key not in rts.SCHEMA:
+            return {"ok": False, "error": f"unknown setting {key!r}"}
+        try:
+            return {"ok": True, "key": key, "value": rts.get_setting(key)}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    @mcp.tool(
+        name="set_setting",
+        description=(
+            "Update a runtime-tunable setting. Takes effect within the 30 s cache "
+            "TTL; schedule-class keys (LP_PLAN_PUSH_HOUR/MINUTE, LP_MPC_HOURS) "
+            "also trigger an APScheduler cron re-register. Pass confirmed=True "
+            "to actually apply — the default is a dry-run that returns the "
+            "canonical (post-validation) value without persisting, so an agent "
+            "can show the user what would change before committing."
+        ),
+    )
+    def set_setting(
+        key: str, value: Any, confirmed: bool = False
+    ) -> dict[str, Any]:
+        from . import runtime_settings as rts
+        from .scheduler.runner import reregister_cron_jobs
+        if key not in rts.SCHEMA:
+            return {"ok": False, "error": f"unknown setting {key!r}"}
+        spec = rts.SCHEMA[key]
+        try:
+            # Always validate first — dry-runs exercise the schema.
+            canonical = rts._validate(spec, value)
+        except rts.SettingValidationError as e:
+            return {"ok": False, "error": str(e)}
+        if not confirmed:
+            return {
+                "ok": True,
+                "confirmed": False,
+                "key": key,
+                "would_set": canonical,
+                "current": rts.get_setting(key),
+                "cron_reload": spec.cron_reload,
+                "message": "dry-run; pass confirmed=True to apply",
+            }
+        try:
+            canonical = rts.set_setting(key, value, actor="mcp")
+        except rts.SettingValidationError as e:
+            return {"ok": False, "error": str(e)}
+        cron_status = None
+        if spec.cron_reload:
+            cron_status = reregister_cron_jobs(reason=f"mcp:{key}")
+        return {
+            "ok": True,
+            "confirmed": True,
+            "key": key,
+            "value": canonical,
+            "cron_status": cron_status,
+        }
+
     # Phase 4.5 — boundary audit. Emits WARN per hardware-write tool that lacks
     # a `confirmed` parameter. Clean surface = silent; regressions are loud.
     audit_mcp_tool_surface(mcp)

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -1,0 +1,341 @@
+"""Runtime-tunable settings layer (#52).
+
+Callers read settings via ``get_setting(key)`` which returns the coerced value
+(float/int/str/list) from a 30-sec TTL + version-counter cache. Cache misses
+hit SQLite (``runtime_settings`` table); absent rows fall back to the
+env-derived default declared in :data:`SCHEMA`. Writes happen only via
+``set_setting`` — validation, persistence, and cache invalidation are atomic.
+
+Design choices:
+  * **Schema-driven**: every tunable has an entry in :data:`SCHEMA` — no silent
+    extension. A PUT for an unknown key returns 400.
+  * **Env defaults via lambda**: the ``env_default`` callable is re-evaluated
+    only on first read (or after a ``delete_setting``), so env changes after
+    process start do **not** retroactively shift the default. Matches the
+    "zero-risk rollback" behavior in the issue — delete the row, env reasserts.
+  * **TTL + version**: single-process hot paths short-circuit on version match
+    (O(1) dict lookup). The 30-sec TTL is a belt-and-braces floor so
+    out-of-band writes (a human typing ``UPDATE runtime_settings ...``) get
+    picked up without a restart.
+  * **Cron hot-reload side effect**: settings whose change requires
+    APScheduler job re-registration are tagged ``cron_reload=True``; the PUT
+    handler calls ``scheduler.runner.reregister_cron_jobs(reason)`` after
+    persistence. All other keys take effect on the next cache-miss read.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from . import db
+
+logger = logging.getLogger(__name__)
+
+
+class SettingValidationError(ValueError):
+    """Raised by :func:`set_setting` when the new value fails schema validation."""
+
+
+@dataclass(frozen=True)
+class SettingSpec:
+    key: str
+    type_name: str  # "float" | "int" | "str" | "list[int]"
+    env_default: Callable[[], Any]
+    min_value: float | None = None
+    max_value: float | None = None
+    enum: tuple[str, ...] | None = None
+    cron_reload: bool = False
+    description: str = ""
+
+
+def _float_env(name: str, default: str) -> Callable[[], float]:
+    return lambda: float(os.getenv(name, default))
+
+
+def _int_env(name: str, default: str) -> Callable[[], int]:
+    return lambda: int(os.getenv(name, default))
+
+
+def _str_env(name: str, default: str) -> Callable[[], str]:
+    return lambda: (os.getenv(name) or default).strip().lower()
+
+
+def _int_list_env(name: str, default: str) -> Callable[[], list[int]]:
+    def _load() -> list[int]:
+        raw = (os.getenv(name) or default).strip()
+        if not raw:
+            return []
+        return sorted({int(p.strip()) for p in raw.split(",") if p.strip()})
+    return _load
+
+
+SCHEMA: dict[str, SettingSpec] = {
+    # DHW comfort knobs — user-tunable per season / presence.
+    "DHW_TEMP_COMFORT_C": SettingSpec(
+        key="DHW_TEMP_COMFORT_C",
+        type_name="float",
+        env_default=_float_env("DHW_TEMP_COMFORT_C", "48"),
+        min_value=40.0,
+        max_value=65.0,
+        description="Tank target when negative-price plunge fills headroom (°C).",
+    ),
+    "DHW_TEMP_NORMAL_C": SettingSpec(
+        key="DHW_TEMP_NORMAL_C",
+        type_name="float",
+        env_default=_float_env("DHW_TEMP_NORMAL_C", "50"),
+        min_value=40.0,
+        max_value=65.0,
+        description="Restore / safe-default tank target (°C).",
+    ),
+    "INDOOR_SETPOINT_C": SettingSpec(
+        key="INDOOR_SETPOINT_C",
+        type_name="float",
+        env_default=_float_env("INDOOR_SETPOINT_C", "21"),
+        min_value=16.0,
+        max_value=26.0,
+        description="Indoor comfort setpoint (°C).",
+    ),
+    # Strategy switches.
+    "OPTIMIZATION_PRESET": SettingSpec(
+        key="OPTIMIZATION_PRESET",
+        type_name="str",
+        env_default=_str_env("OPTIMIZATION_PRESET", "normal"),
+        enum=("normal", "guests", "travel", "away"),
+        description="Occupancy preset — affects DHW floor and peak-export gates.",
+    ),
+    "ENERGY_STRATEGY_MODE": SettingSpec(
+        key="ENERGY_STRATEGY_MODE",
+        type_name="str",
+        env_default=_str_env("ENERGY_STRATEGY_MODE", "savings_first"),
+        enum=("savings_first", "strict_savings"),
+        description="savings_first allows peak-export discharge; strict_savings never does.",
+    ),
+    # Schedule cadence — require cron hot-reload when changed.
+    "LP_PLAN_PUSH_HOUR": SettingSpec(
+        key="LP_PLAN_PUSH_HOUR",
+        type_name="int",
+        env_default=_int_env("LP_PLAN_PUSH_HOUR", "0"),
+        min_value=0,
+        max_value=23,
+        cron_reload=True,
+        description="UTC hour for the nightly plan-push cron.",
+    ),
+    "LP_PLAN_PUSH_MINUTE": SettingSpec(
+        key="LP_PLAN_PUSH_MINUTE",
+        type_name="int",
+        env_default=_int_env("LP_PLAN_PUSH_MINUTE", "5"),
+        min_value=0,
+        max_value=59,
+        cron_reload=True,
+        description="UTC minute for the nightly plan-push cron.",
+    ),
+    "LP_MPC_HOURS": SettingSpec(
+        key="LP_MPC_HOURS",
+        type_name="list[int]",
+        env_default=_int_list_env("LP_MPC_HOURS", "6,12,21"),
+        cron_reload=True,
+        description="Local hours at which the MPC re-solves the LP (e.g. [6,12,21]).",
+    ),
+}
+
+
+# Version counter: bumped on every set_setting() so get() can short-circuit
+# without a DB round-trip when the cache entry is current. A TTL-based fallback
+# catches out-of-band writes (e.g. manual UPDATE from sqlite3 shell).
+_lock = threading.RLock()
+_version: int = 0
+_cache: dict[str, tuple[Any, int, float]] = {}  # key -> (value, version, monotonic_at)
+_TTL_SECONDS: float = 30.0
+
+
+def _coerce(spec: SettingSpec, raw: str) -> Any:
+    if spec.type_name == "float":
+        return float(raw)
+    if spec.type_name == "int":
+        return int(raw)
+    if spec.type_name == "str":
+        return raw.strip().lower()
+    if spec.type_name == "list[int]":
+        return sorted({int(p.strip()) for p in raw.split(",") if p.strip()})
+    raise SettingValidationError(f"unknown type {spec.type_name!r}")
+
+
+def _validate(spec: SettingSpec, value: Any) -> Any:
+    """Coerce and range/enum-check. Returns the canonical in-memory value.
+
+    Raises :class:`SettingValidationError` with a human-readable message that
+    becomes the 400 response body.
+    """
+    try:
+        if spec.type_name == "float":
+            v = float(value)
+        elif spec.type_name == "int":
+            v = int(value)
+        elif spec.type_name == "str":
+            v = str(value).strip().lower()
+        elif spec.type_name == "list[int]":
+            if isinstance(value, str):
+                v = sorted({int(p.strip()) for p in value.split(",") if p.strip()})
+            else:
+                v = sorted({int(p) for p in value})
+        else:
+            raise SettingValidationError(f"unknown type {spec.type_name!r}")
+    except (TypeError, ValueError) as e:
+        raise SettingValidationError(
+            f"{spec.key}: cannot coerce {value!r} to {spec.type_name}: {e}"
+        ) from e
+
+    if spec.enum is not None and v not in spec.enum:
+        raise SettingValidationError(
+            f"{spec.key}: {v!r} not in {list(spec.enum)}"
+        )
+    if spec.min_value is not None and isinstance(v, (int, float)):
+        if v < spec.min_value:
+            raise SettingValidationError(
+                f"{spec.key}: {v} < min {spec.min_value}"
+            )
+    if spec.max_value is not None and isinstance(v, (int, float)):
+        if v > spec.max_value:
+            raise SettingValidationError(
+                f"{spec.key}: {v} > max {spec.max_value}"
+            )
+    return v
+
+
+def _serialize(spec: SettingSpec, value: Any) -> str:
+    if spec.type_name == "list[int]":
+        return ",".join(str(int(x)) for x in value)
+    return str(value)
+
+
+def get_setting(key: str) -> Any:
+    """Return the current value for *key*.
+
+    Reads hit an in-memory cache that is valid for the current ``_version`` and
+    up to ``_TTL_SECONDS``. On miss: read the DB; if absent, call the spec's
+    ``env_default`` once and cache it.
+    """
+    spec = SCHEMA.get(key)
+    if spec is None:
+        raise KeyError(f"unknown runtime setting: {key!r}")
+    now = time.monotonic()
+    with _lock:
+        entry = _cache.get(key)
+        if entry is not None:
+            value, version, cached_at = entry
+            if version == _version and (now - cached_at) < _TTL_SECONDS:
+                return value
+
+        raw = db.get_runtime_setting(key)
+        if raw is None:
+            try:
+                value = spec.env_default()
+            except Exception as e:
+                logger.warning(
+                    "runtime_setting %s: env_default failed (%s); using 0", key, e
+                )
+                value = 0
+        else:
+            try:
+                value = _coerce(spec, raw)
+            except Exception as e:
+                logger.warning(
+                    "runtime_setting %s: stored value %r failed to coerce (%s); "
+                    "falling back to env default",
+                    key,
+                    raw,
+                    e,
+                )
+                value = spec.env_default()
+        _cache[key] = (value, _version, now)
+        return value
+
+
+def set_setting(key: str, value: Any, *, actor: str = "api") -> Any:
+    """Validate + persist + invalidate cache. Returns the canonical value stored.
+
+    Side effect: when the spec has ``cron_reload=True`` the caller (API/MCP
+    handler) must invoke ``scheduler.runner.reregister_cron_jobs`` after this
+    function returns. We do **not** import the scheduler here to avoid a
+    circular dependency (scheduler reads config which will soon read this).
+    """
+    spec = SCHEMA.get(key)
+    if spec is None:
+        raise SettingValidationError(f"unknown runtime setting: {key!r}")
+
+    canonical = _validate(spec, value)
+    serialized = _serialize(spec, canonical)
+    db.set_runtime_setting(key, serialized)
+    global _version
+    with _lock:
+        _version += 1
+        _cache.pop(key, None)
+    logger.info(
+        "runtime_setting updated: %s=%r (actor=%s, cron_reload=%s)",
+        key,
+        canonical,
+        actor,
+        spec.cron_reload,
+    )
+    return canonical
+
+
+def delete_setting(key: str, *, actor: str = "api") -> bool:
+    """Drop the override row so the next read returns the env default.
+
+    Returns True when a row was removed.
+    """
+    spec = SCHEMA.get(key)
+    if spec is None:
+        raise SettingValidationError(f"unknown runtime setting: {key!r}")
+    removed = db.delete_runtime_setting(key)
+    global _version
+    with _lock:
+        _version += 1
+        _cache.pop(key, None)
+    logger.info(
+        "runtime_setting cleared: %s (actor=%s, removed=%s)", key, actor, removed
+    )
+    return removed
+
+
+def list_settings() -> list[dict[str, Any]]:
+    """Return current state of every known key, with default and updated_at."""
+    rows = {r["key"]: r for r in db.list_runtime_settings()}
+    out: list[dict[str, Any]] = []
+    for key, spec in SCHEMA.items():
+        row = rows.get(key)
+        try:
+            current = get_setting(key)
+        except Exception:
+            current = None
+        try:
+            default = spec.env_default()
+        except Exception:
+            default = None
+        out.append({
+            "key": key,
+            "value": current,
+            "default": default,
+            "updated_at": row["updated_at"] if row else None,
+            "overridden": row is not None,
+            "type": spec.type_name,
+            "min": spec.min_value,
+            "max": spec.max_value,
+            "enum": list(spec.enum) if spec.enum else None,
+            "cron_reload": spec.cron_reload,
+            "description": spec.description,
+        })
+    return out
+
+
+def clear_cache() -> None:
+    """Invalidate the entire cache (used by tests and by the cron-reload path)."""
+    global _version
+    with _lock:
+        _version += 1
+        _cache.clear()

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -756,3 +756,79 @@ def stop_background_scheduler() -> None:
         pass
     _background_scheduler = None
     logger.info("Background scheduler stopped")
+
+
+def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, Any]:
+    """Tear down and re-create the cadence-tunable cron jobs (#52).
+
+    Invoked by the settings PUT handler after ``LP_PLAN_PUSH_HOUR``,
+    ``LP_PLAN_PUSH_MINUTE``, or ``LP_MPC_HOURS`` change. Jobs handled:
+
+    - ``bulletproof_plan_push``: single UTC-anchored push.
+    - ``bulletproof_mpc_*``: one per hour in ``LP_MPC_HOURS_LIST``.
+
+    The heartbeat thread and other jobs are untouched. When the background
+    scheduler is not yet started (e.g. tests, non-bulletproof mode), this is
+    a no-op that returns ``{"status": "inactive"}``.
+    """
+    if _background_scheduler is None or not config.USE_BULLETPROOF_ENGINE:
+        return {"status": "inactive", "reason": reason}
+
+    try:
+        from apscheduler.triggers.cron import CronTrigger
+    except Exception as e:  # pragma: no cover - only when apscheduler missing
+        logger.warning("reregister_cron_jobs: apscheduler import failed: %s", e)
+        return {"status": "error", "reason": reason, "error": str(e)}
+
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+
+    removed: list[str] = []
+    for job in list(_background_scheduler.get_jobs()):
+        jid = job.id
+        if jid == "bulletproof_plan_push" or jid.startswith("bulletproof_mpc_"):
+            try:
+                _background_scheduler.remove_job(jid)
+                removed.append(jid)
+            except Exception as e:
+                logger.warning("remove_job(%s) failed: %s", jid, e)
+
+    added: list[str] = []
+    for mpc_hour in config.LP_MPC_HOURS_LIST:
+        jid = f"bulletproof_mpc_{mpc_hour:02d}"
+        _background_scheduler.add_job(
+            bulletproof_mpc_job,
+            CronTrigger(hour=mpc_hour, minute=0, timezone=tz),
+            id=jid,
+        )
+        added.append(jid)
+
+    push_jid = "bulletproof_plan_push"
+    _background_scheduler.add_job(
+        bulletproof_plan_push_job,
+        CronTrigger(
+            hour=config.LP_PLAN_PUSH_HOUR,
+            minute=config.LP_PLAN_PUSH_MINUTE,
+            timezone=ZoneInfo("UTC"),
+        ),
+        id=push_jid,
+    )
+    added.append(push_jid)
+
+    logger.info(
+        "Cron jobs re-registered (reason=%s): removed=%s added=%s "
+        "plan_push=%02d:%02d UTC mpc_hours=%s",
+        reason,
+        removed,
+        added,
+        config.LP_PLAN_PUSH_HOUR,
+        config.LP_PLAN_PUSH_MINUTE,
+        config.LP_MPC_HOURS_LIST,
+    )
+    return {
+        "status": "ok",
+        "reason": reason,
+        "removed": removed,
+        "added": added,
+        "plan_push_utc": f"{config.LP_PLAN_PUSH_HOUR:02d}:{config.LP_PLAN_PUSH_MINUTE:02d}",
+        "mpc_hours": config.LP_MPC_HOURS_LIST,
+    }

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -1,0 +1,198 @@
+"""Runtime-tunable settings — PUT→property read round-trip, cron hot-reload (#52)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import db, runtime_settings as rts
+from src.config import config
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db.config, "DB_PATH", str(db_path))
+    db.init_db()
+    rts.clear_cache()
+    config._overrides.clear()  # in-memory config overrides leak across tests
+    yield db_path
+    rts.clear_cache()
+    config._overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rejects_unknown_key():
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("NOT_A_KNOB", 42)
+
+
+def test_validate_enforces_range():
+    # DHW_TEMP_COMFORT_C: 40..65
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("DHW_TEMP_COMFORT_C", 30)
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("DHW_TEMP_COMFORT_C", 80)
+
+
+def test_validate_enforces_enum():
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("OPTIMIZATION_PRESET", "noprep")
+
+
+def test_validate_coerces_int_list_from_csv():
+    rts.set_setting("LP_MPC_HOURS", "12,6,21,6")
+    assert rts.get_setting("LP_MPC_HOURS") == [6, 12, 21]
+
+
+def test_validate_coerces_int_list_from_python_list():
+    rts.set_setting("LP_MPC_HOURS", [21, 6, 12])
+    assert rts.get_setting("LP_MPC_HOURS") == [6, 12, 21]
+
+
+# ---------------------------------------------------------------------------
+# DB persistence + cache invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_get_setting_falls_back_to_env_default_when_db_empty(monkeypatch):
+    monkeypatch.delenv("DHW_TEMP_COMFORT_C", raising=False)
+    # Simulate "no override in DB" — default from the schema's env_default lambda.
+    rts.clear_cache()
+    assert rts.get_setting("DHW_TEMP_COMFORT_C") == 48.0  # schema default
+
+
+def test_put_then_get_round_trip():
+    rts.set_setting("DHW_TEMP_COMFORT_C", 52.0)
+    assert rts.get_setting("DHW_TEMP_COMFORT_C") == 52.0
+
+
+def test_put_invalidates_cache_via_version_counter(monkeypatch):
+    """Two successive PUTs within the TTL window must both be visible — the
+    version bump is what makes the cache invalidate, not the TTL."""
+    rts.set_setting("DHW_TEMP_COMFORT_C", 50.0)
+    assert rts.get_setting("DHW_TEMP_COMFORT_C") == 50.0
+    rts.set_setting("DHW_TEMP_COMFORT_C", 55.0)
+    assert rts.get_setting("DHW_TEMP_COMFORT_C") == 55.0
+
+
+def test_delete_reverts_to_env_default():
+    rts.set_setting("DHW_TEMP_COMFORT_C", 55.0)
+    assert rts.get_setting("DHW_TEMP_COMFORT_C") == 55.0
+    removed = rts.delete_setting("DHW_TEMP_COMFORT_C")
+    assert removed is True
+    assert rts.get_setting("DHW_TEMP_COMFORT_C") == 48.0  # env default
+
+
+def test_delete_returns_false_when_no_row():
+    assert rts.delete_setting("DHW_TEMP_COMFORT_C") is False
+
+
+# ---------------------------------------------------------------------------
+# Config property integration (no call-site churn)
+# ---------------------------------------------------------------------------
+
+
+def test_config_property_reads_runtime_value():
+    rts.set_setting("DHW_TEMP_COMFORT_C", 52.5)
+    assert config.DHW_TEMP_COMFORT_C == 52.5
+
+
+def test_config_property_reads_lp_mpc_hours_list():
+    rts.set_setting("LP_MPC_HOURS", "4,10,15")
+    assert config.LP_MPC_HOURS_LIST == [4, 10, 15]
+    # The legacy string form is derived from the canonical list.
+    assert config.LP_MPC_HOURS == "4,10,15"
+
+
+def test_config_enum_property_round_trip():
+    rts.set_setting("OPTIMIZATION_PRESET", "guests")
+    assert config.OPTIMIZATION_PRESET == "guests"
+    rts.set_setting("OPTIMIZATION_PRESET", "normal")
+    assert config.OPTIMIZATION_PRESET == "normal"
+
+
+# ---------------------------------------------------------------------------
+# list_settings shape
+# ---------------------------------------------------------------------------
+
+
+def test_list_settings_marks_overridden(monkeypatch):
+    rts.set_setting("DHW_TEMP_COMFORT_C", 53.0)
+    rows = {r["key"]: r for r in rts.list_settings()}
+    assert rows["DHW_TEMP_COMFORT_C"]["overridden"] is True
+    assert rows["DHW_TEMP_COMFORT_C"]["value"] == 53.0
+    # A key we haven't touched stays overridden=False.
+    assert rows["INDOOR_SETPOINT_C"]["overridden"] is False
+
+
+# ---------------------------------------------------------------------------
+# Cron hot-reload (LP_MPC_HOURS / LP_PLAN_PUSH_HOUR / LP_PLAN_PUSH_MINUTE)
+# ---------------------------------------------------------------------------
+
+
+def test_cron_reload_reregisters_jobs_when_active(monkeypatch):
+    """Simulate an active background scheduler and assert the job set is rebuilt
+    with the new LP_MPC_HOURS without tearing down the rest."""
+    from src.scheduler import runner
+
+    # Build a minimal fake scheduler with the jobs the function tears down.
+    class _Job:
+        def __init__(self, jid): self.id = jid
+
+    class _Sched:
+        def __init__(self, initial_ids):
+            self._jobs = [_Job(j) for j in initial_ids]
+            self.removed: list[str] = []
+            self.added: list[str] = []
+        def get_jobs(self):
+            return list(self._jobs)
+        def remove_job(self, jid):
+            self._jobs = [j for j in self._jobs if j.id != jid]
+            self.removed.append(jid)
+        def add_job(self, func, trigger, *, id):  # noqa: A002
+            self._jobs.append(_Job(id))
+            self.added.append(id)
+
+    fake = _Sched([
+        "bulletproof_octopus_fetch",   # unrelated — must be preserved
+        "bulletproof_plan_push",
+        "bulletproof_mpc_06",
+        "bulletproof_mpc_12",
+        "bulletproof_mpc_21",
+    ])
+    monkeypatch.setattr(runner, "_background_scheduler", fake)
+    monkeypatch.setattr(runner.config, "USE_BULLETPROOF_ENGINE", True)
+
+    rts.set_setting("LP_MPC_HOURS", [4, 10, 15])
+    result = runner.reregister_cron_jobs(reason="test")
+
+    assert result["status"] == "ok"
+    assert sorted(fake.removed) == sorted([
+        "bulletproof_plan_push",
+        "bulletproof_mpc_06",
+        "bulletproof_mpc_12",
+        "bulletproof_mpc_21",
+    ])
+    # New MPC jobs match the freshly-written setting; push job re-added too.
+    assert set(fake.added) == {
+        "bulletproof_mpc_04",
+        "bulletproof_mpc_10",
+        "bulletproof_mpc_15",
+        "bulletproof_plan_push",
+    }
+    # Unrelated job is untouched.
+    assert any(j.id == "bulletproof_octopus_fetch" for j in fake.get_jobs())
+
+
+def test_cron_reload_is_noop_when_scheduler_inactive(monkeypatch):
+    from src.scheduler import runner
+    monkeypatch.setattr(runner, "_background_scheduler", None)
+    result = runner.reregister_cron_jobs(reason="test")
+    assert result["status"] == "inactive"


### PR DESCRIPTION
## Summary

Closes #52. Eight LP / comfort / schedule knobs can now be tuned at runtime — takes effect within the 30 s cache TTL, no systemd restart required. The three cadence knobs (`LP_PLAN_PUSH_HOUR/MINUTE`, `LP_MPC_HOURS`) additionally trigger an APScheduler cron re-register (**user-chosen option (a)** from the issue's design question) so MPC / plan-push cadence changes apply live too.

## Architecture

- **Table `runtime_settings(key, value, updated_at)`** — V10 migration. String-only storage; the service layer coerces per-key via a schema dict.
- **`src/runtime_settings.py`** — schema with typed `env_default` lambdas, enum / min-max validators, TTL + monotonic-version cache (multiple PUTs within the TTL window are both visible without sleeping).
- **`config.X` stays the expression every call-site already uses.** Each runtime-tunable knob is a `@property` that reads through `runtime_settings.get_setting`. Setters write to an in-memory override dict on the singleton so legacy `setattr(config, X, v)` — notably `simulate_plan` and pytest `monkeypatch.setattr` — still round-trips cleanly without polluting the DB.
- **`db.get_runtime_setting`** tolerates a missing table so early-boot code and tests that read `config.*` before `init_db` runs don't blow up.

## Surface

**REST**:
- `GET /api/v1/settings` — list all keys with current value / env default / overridden flag / range.
- `GET /api/v1/settings/{key}` — single value.
- `PUT /api/v1/settings/{key}` — body `{value: ...}`. Validates, persists, returns `cron_status` when the key is cadence-class.
- `DELETE /api/v1/settings/{key}` — remove the override; env default reasserts on next read (zero-risk rollback).

**MCP tools**:
- `list_settings`, `get_setting`, `set_setting(confirmed=False)`.
- `set_setting` is **dry-run by default**: returns the post-validation canonical value plus `current` so an agent can diff before applying. Pass `confirmed=True` to actually persist.

## Cron hot-reload

New `scheduler.runner.reregister_cron_jobs(reason)` rebuilds `bulletproof_plan_push` + `bulletproof_mpc_*` from freshly-read config while leaving the heartbeat thread and unrelated jobs untouched. Returns a structured status dict so the PUT handler can surface it to the caller.

## Migrated knobs (v1)

| Group    | Knobs                                                    | cron_reload |
|----------|----------------------------------------------------------|-------------|
| Comfort  | `DHW_TEMP_COMFORT_C`, `DHW_TEMP_NORMAL_C`, `INDOOR_SETPOINT_C` | —      |
| Strategy | `OPTIMIZATION_PRESET`, `ENERGY_STRATEGY_MODE`            | —           |
| Schedule | `LP_PLAN_PUSH_HOUR`, `LP_PLAN_PUSH_MINUTE`, `LP_MPC_HOURS` | ✅         |

Adding further knobs later is just a schema entry + one `@property / @setter` pair.

## Test plan

- [x] **`tests/test_runtime_settings.py` (16 tests)**: validation (range, enum, type coercion for `list[int]`), cache + version-counter invalidation, env-default fallback, delete → revert, `config.*` property round-trip, `list_settings` shape, cron hot-reload adds/removes jobs, no-op when scheduler is inactive.
- [x] **Full suite**: **193 passed, 1 skipped** + 2 pre-existing `ZoneInfo` / `MagicMock` failures in `test_set_daikin_*` that also fail on clean `main`.

## Verification after deploy

```bash
# List + inspect
curl http://127.0.0.1:8000/api/v1/settings | jq '.settings[] | {key, value, overridden}'

# Tune DHW comfort live (takes effect ≤30s)
curl -X PUT http://127.0.0.1:8000/api/v1/settings/DHW_TEMP_COMFORT_C \
     -H 'Content-Type: application/json' -d '{"value": 52}'

# Change MPC cadence + watch cron re-register without restart
curl -X PUT http://127.0.0.1:8000/api/v1/settings/LP_MPC_HOURS \
     -H 'Content-Type: application/json' -d '{"value": [4,10,15]}' | jq '.cron_status'

# Roll back the override
curl -X DELETE http://127.0.0.1:8000/api/v1/settings/DHW_TEMP_COMFORT_C
```

## Follow-ups (not in this PR)

- Migrate more knobs from the issue's list (LWT/sauna guard, shower windows, comfort band, etc.) — one-line schema entries each.
- Wire `delete_setting` into the MCP tool surface (currently only the REST `DELETE` endpoint exposes it).