### PR TITLE
fix(scheduler): rolling 24h plan window to stop Fox V3 wiping today

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -300,7 +300,10 @@ class Config:
     BATTERY_RT_EFFICIENCY: float = float(os.getenv("BATTERY_RT_EFFICIENCY", "0.92"))
     MAX_INVERTER_KW: float = float(os.getenv("MAX_INVERTER_KW", "6.0"))
     EXPORT_RATE_PENCE: float = float(os.getenv("EXPORT_RATE_PENCE", "15.0"))
-    LP_HORIZON_HOURS: int = int(os.getenv("LP_HORIZON_HOURS", "36"))
+    # Rolling-window length for the LP/Fox V3 dispatch. Default 24 h so every
+    # replan produces a "now → now + 24 h" schedule; truncated if Agile data
+    # ends sooner (Octopus publishes tomorrow ~16:00 UTC).
+    LP_HORIZON_HOURS: int = int(os.getenv("LP_HORIZON_HOURS", "24"))
     DAIKIN_POWER_BUCKETS_KW: str = (os.getenv("DAIKIN_POWER_BUCKETS_KW") or "0,0.5,1.0,1.5").strip()
     # Heat pump nameplate cap (kW) used in LP HP power bounds.
     DAIKIN_MAX_HP_KW: float = float(os.getenv("DAIKIN_MAX_HP_KW", "2.0"))

--- a/src/db.py
+++ b/src/db.py
@@ -1204,6 +1204,55 @@ def _preserve_daikin_pending_ids_for_replan(plan_date: str) -> set[int]:
     return preserve
 
 
+def _preserve_daikin_pending_ids_in_range(
+    start_utc_iso: str, end_utc_iso: str
+) -> set[int]:
+    """Range variant of :func:`_preserve_daikin_pending_ids_for_replan`.
+
+    Active-row restore pointers are scanned globally (not range-filtered) because
+    an in-flight action's *restore* row typically falls ahead of ``now`` and is
+    therefore inside the rolling clear window even when the active row itself is
+    not. In-flight pending preservation scans only the pending rows whose
+    ``start_time`` falls in ``[start_utc_iso, end_utc_iso)``.
+    """
+    now_utc = _now_utc()
+    preserve: set[int] = set()
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT restore_action_id FROM action_schedule
+                   WHERE device = 'daikin' AND status = 'active'
+                         AND restore_action_id IS NOT NULL"""
+            )
+            for row in cur.fetchall():
+                rid = row["restore_action_id"] if hasattr(row, "keys") else row[0]
+                if rid is not None:
+                    preserve.add(int(rid))
+
+            cur = conn.execute(
+                """SELECT id, start_time, end_time, restore_action_id
+                   FROM action_schedule
+                   WHERE device = 'daikin' AND status = 'pending'
+                         AND start_time >= ? AND start_time < ?""",
+                (start_utc_iso, end_utc_iso),
+            )
+            for row in cur.fetchall():
+                try:
+                    start = _parse_action_time_utc(str(row["start_time"]))
+                    end = _parse_action_time_utc(str(row["end_time"]))
+                except (ValueError, KeyError, TypeError):
+                    continue
+                if start <= now_utc < end:
+                    preserve.add(int(row["id"]))
+                    rid = row["restore_action_id"]
+                    if rid is not None:
+                        preserve.add(int(rid))
+        finally:
+            conn.close()
+    return preserve
+
+
 def clear_actions_for_date(plan_date: str, device: str | None = None) -> None:
     """Remove pending actions for a plan date (before re-optimizing).
 
@@ -1239,6 +1288,56 @@ def clear_actions_for_date(plan_date: str, device: str | None = None) -> None:
                     """DELETE FROM action_schedule
                        WHERE date = ? AND status = 'pending'""",
                     (plan_date,),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def clear_actions_in_range(
+    start_utc_iso: str,
+    end_utc_iso: str,
+    device: str | None = None,
+) -> None:
+    """Remove pending actions whose ``start_time`` falls in ``[start, end)``.
+
+    Used by the rolling 24 h planner: a plan written at, e.g., 18:00 today
+    straddles today and tomorrow, so clearing by a single ``plan_date`` leaves
+    the other date's stale rows in place. Daikin rows inherit the same
+    in-flight preservation semantics as :func:`clear_actions_for_date`.
+    """
+    preserve_ids: set[int] = set()
+    if device == "daikin":
+        preserve_ids = _preserve_daikin_pending_ids_in_range(start_utc_iso, end_utc_iso)
+    with _lock:
+        conn = get_connection()
+        try:
+            if device:
+                if preserve_ids:
+                    placeholders = ",".join("?" * len(preserve_ids))
+                    q = (
+                        f"""DELETE FROM action_schedule
+                            WHERE device = ? AND status = 'pending'
+                            AND start_time >= ? AND start_time < ?
+                            AND id NOT IN ({placeholders})"""
+                    )
+                    conn.execute(
+                        q,
+                        (device, start_utc_iso, end_utc_iso, *sorted(preserve_ids)),
+                    )
+                else:
+                    conn.execute(
+                        """DELETE FROM action_schedule
+                           WHERE device = ? AND status = 'pending'
+                           AND start_time >= ? AND start_time < ?""",
+                        (device, start_utc_iso, end_utc_iso),
+                    )
+            else:
+                conn.execute(
+                    """DELETE FROM action_schedule
+                       WHERE status = 'pending'
+                       AND start_time >= ? AND start_time < ?""",
+                    (start_utc_iso, end_utc_iso),
                 )
             conn.commit()
         finally:

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -293,8 +293,20 @@ def write_daikin_from_lp_plan(
     plan: LpPlan,
     forecast: list[HourlyForecast],
 ) -> int:
-    """Write merged Daikin ``action_schedule`` rows from LP solution."""
-    db.clear_actions_for_date(plan_date, device="daikin")
+    """Write merged Daikin ``action_schedule`` rows from LP solution.
+
+    Clearing is range-keyed on the LP's UTC slot window so a rolling 24 h plan
+    written at, e.g., 18:00 local (``plan_date`` = today, slots spanning into
+    tomorrow) correctly removes stale rows from *both* dates while the shared
+    in-flight preservation keeps any Daikin action currently executing.
+    """
+    if plan.slot_starts_utc:
+        window_start_iso = plan.slot_starts_utc[0].isoformat().replace("+00:00", "Z")
+        window_end = plan.slot_starts_utc[-1] + timedelta(minutes=30)
+        window_end_iso = window_end.isoformat().replace("+00:00", "Z")
+        db.clear_actions_in_range(window_start_iso, window_end_iso, device="daikin")
+    else:
+        db.clear_actions_for_date(plan_date, device="daikin")
     pairs = daikin_dispatch_preview(plan, forecast)
     count = 0
     for restore_row, action_row in pairs:

--- a/src/scheduler/lp_simulation.py
+++ b/src/scheduler/lp_simulation.py
@@ -30,7 +30,7 @@ class LpSimulationResult:
     ok: bool
     error: str | None = None
     plan_date: str = ""
-    plan_window: str = ""        # "full_day" | "today_remainder"
+    plan_window: str = ""        # "rolling_24h" | "rolling_partial"
     plan: LpPlan | None = None
     initial: LpInitialState | None = None
     mu_load_kwh: float = 0.0
@@ -70,10 +70,9 @@ def run_lp_simulation(
 ) -> LpSimulationResult:
     """Build the same inputs as ``_run_optimizer_lp``, solve, return plan — **no DB/Fox/Daikin writes**.
 
-    Automatically selects the best available planning window:
-    - Tomorrow (full day) if tomorrow's rates are published (≥40 slots).
-    - Today-remainder if only today's rates are present.
-    - Returns an error result if no rates exist at all.
+    Uses the rolling ``now → now + LP_HORIZON_HOURS`` window (truncated to the
+    last published Agile slot). Returns an error result if no rates exist or
+    fewer than the minimum usable slot count remain.
 
     Phase 4 review: ``allow_daikin_refresh=False`` forbids any cache refresh that
     would burn Daikin quota. The ``simulate_plan`` MCP tool relies on this to
@@ -92,7 +91,7 @@ def run_lp_simulation(
         )
 
     plan_date = window.plan_date
-    plan_window_label = "full_day" if window.is_full_day else "today_remainder"
+    plan_window_label = "rolling_24h" if window.horizon_hours >= 23.5 else "rolling_partial"
     day_start = window.day_start
     horizon_end = window.horizon_end
 

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -28,111 +28,118 @@ logger = logging.getLogger(__name__)
 
 TZ = lambda: ZoneInfo(config.BULLETPROOF_TIMEZONE)
 
-# Octopus publishes tomorrow's rates ~16:00 UK time.  We call the plan "full-day" when
-# we have at least this many half-hour slots for the target day.
-_MIN_FULL_DAY_SLOTS = 40
+# Rolling-window floor. Fewer than this many half-hour slots of Agile data ahead
+# of *now* means the LP has nothing meaningful to optimize — Self-Use fallback.
+_MIN_USABLE_SLOTS = 4  # 2 hours
 
 
 @dataclass
 class PlanWindow:
-    """Describes the time window the optimizer will plan for."""
+    """Describes the rolling time window the optimizer will plan for.
 
-    plan_date: str           # ISO date string (YYYY-MM-DD)
-    day_start: datetime      # local-tz midnight (or now rounded to next HH slot)
-    horizon_end: datetime    # end of planning horizon
-    is_full_day: bool        # True = tomorrow's full day, False = today-remainder
+    All datetimes are UTC. The window is computed as
+    ``[day_start, horizon_end)`` where ``day_start = now`` rounded up to the
+    next half-hour boundary and ``horizon_end = min(day_start + LP_HORIZON_HOURS,
+    last known Agile slot end)``. The field name ``day_start`` is preserved for
+    historical reasons — it is the *window* start, not a local-midnight anchor.
+    """
+
+    plan_date: str           # ISO date of local(day_start) — tag for logs/consent, not a clear key
+    day_start: datetime      # UTC — start of rolling window (next HH:30 boundary)
+    horizon_end: datetime    # UTC — end of rolling window, truncated to data availability
     rates: list              # raw rate rows covering the window
+
+    @property
+    def horizon_hours(self) -> float:
+        return (self.horizon_end - self.day_start).total_seconds() / 3600.0
+
+
+def _now_utc() -> datetime:
+    """Wall clock for the rolling-window resolver (monkeypatch target in tests)."""
+    return datetime.now(UTC)
+
+
+def _ceil_to_half_hour_utc(dt: datetime) -> datetime:
+    """Round *dt* up to the next :00 or :30 boundary in UTC."""
+    dt = dt.astimezone(UTC).replace(second=0, microsecond=0)
+    if dt.minute == 0 or dt.minute == 30:
+        # Already on a half-hour boundary — advance to the NEXT one so the
+        # currently-live slot isn't re-dispatched (Daikin quota integrity).
+        return dt + timedelta(minutes=30)
+    if dt.minute < 30:
+        return dt.replace(minute=30)
+    return (dt + timedelta(hours=1)).replace(minute=0)
 
 
 def _resolve_plan_window(tariff: str) -> PlanWindow | None:
-    """Determine the best available planning window given what rates are in the DB.
+    """Compute a rolling ``now → now + LP_HORIZON_HOURS`` window.
 
-    Resolution order:
-    1. Tomorrow's full-day rates present (≥ _MIN_FULL_DAY_SLOTS) → plan tomorrow midnight to LP_HORIZON_HOURS.
-    2. Today's partial/full rates present → plan from *now* (next half-hour boundary) to local midnight.
-    3. No usable rates → return None (caller should activate Self-Use fallback).
+    The window always starts at the *next* half-hour boundary after ``now`` so
+    the currently-running slot is never re-dispatched (quota integrity, see
+    ADR-002). The end is capped by the last known Agile ``valid_to`` so a 09:00
+    call before Octopus publishes tomorrow cleanly produces a shorter window
+    ending at today's last slot.
 
-    This makes the optimizer work correctly whether called at 09:00 (today's rates only),
-    16:30 (just after Octopus published tomorrow), or on-demand at any time.
+    Returns ``None`` when fewer than ``_MIN_USABLE_SLOTS`` of Agile data remain
+    — caller should fall back to Self-Use.
     """
     tz = TZ()
-    now_local = datetime.now(tz)
+    now_utc = _now_utc()
+    start_utc = _ceil_to_half_hour_utc(now_utc)
+    target_end_utc = start_utc + timedelta(hours=int(config.LP_HORIZON_HOURS))
 
-    # ── Try TOMORROW first ────────────────────────────────────────────────────
-    tomorrow = (now_local + timedelta(days=1)).date()
-    tmr_start = datetime.combine(tomorrow, datetime.min.time()).replace(tzinfo=tz)
-    tmr_end = tmr_start + timedelta(hours=int(config.LP_HORIZON_HOURS))
+    # Query with small overlap so overlapping rate rows at the boundary are included.
+    q_from = start_utc - timedelta(minutes=30)
+    q_to = target_end_utc + timedelta(hours=1)
+    rates = db.get_rates_for_period(tariff, q_from, q_to) or []
 
-    tmr_q_from = tmr_start.astimezone(UTC) - timedelta(hours=1)
-    tmr_q_to = tmr_end.astimezone(UTC) + timedelta(hours=2)
-    logger.info(
-        "TZ-AUDIT: tomorrow DB query | local midnight %s (%s) | UTC query %s → %s",
-        tmr_start.strftime("%a %d %b %H:%M %Z"),
-        tmr_start.astimezone(UTC).strftime("%Y-%m-%dT%H:%MZ"),
-        tmr_q_from.strftime("%Y-%m-%dT%H:%MZ"),
-        tmr_q_to.strftime("%Y-%m-%dT%H:%MZ"),
-    )
-    tmr_rates = db.get_rates_for_period(tariff, tmr_q_from, tmr_q_to)
-    tmr_slots_preview = _build_half_hour_slots(tmr_rates or [], tmr_start, tmr_end)
-    if len(tmr_slots_preview) >= _MIN_FULL_DAY_SLOTS:
-        logger.info(
-            "Plan window: tomorrow %s (%d slots, full-day)",
-            tomorrow.isoformat(),
-            len(tmr_slots_preview),
+    last_valid_to: datetime | None = None
+    for r in rates:
+        try:
+            vt = _parse_ts(str(r["valid_to"]))
+        except (ValueError, KeyError, TypeError):
+            continue
+        if last_valid_to is None or vt > last_valid_to:
+            last_valid_to = vt
+
+    if last_valid_to is None or last_valid_to <= start_utc:
+        logger.warning(
+            "Plan window: no future Agile rates available "
+            "(start=%s, last_valid_to=%s) — Self-Use fallback",
+            start_utc.strftime("%Y-%m-%dT%H:%MZ"),
+            last_valid_to.strftime("%Y-%m-%dT%H:%MZ") if last_valid_to else "None",
         )
-        return PlanWindow(
-            plan_date=tomorrow.isoformat(),
-            day_start=tmr_start,
-            horizon_end=tmr_end,
-            is_full_day=True,
-            rates=tmr_rates,
-        )
-
-    # ── Fall back to TODAY-REMAINDER ─────────────────────────────────────────
-    today = now_local.date()
-    # Round up to the next half-hour boundary
-    mins = now_local.minute
-    if mins < 30:
-        today_start = now_local.replace(minute=30, second=0, microsecond=0)
-    else:
-        today_start = (now_local + timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
-    today_end = datetime.combine(today + timedelta(days=1), datetime.min.time()).replace(tzinfo=tz)
-
-    if today_start >= today_end:
-        # Past midnight — nothing left to plan today
-        logger.warning("Plan window: no usable rates (past midnight, tomorrow not published yet)")
         return None
 
-    today_q_from = today_start.astimezone(UTC) - timedelta(minutes=30)
-    today_q_to = today_end.astimezone(UTC) + timedelta(hours=1)
-    logger.info(
-        "TZ-AUDIT: today-remainder DB query | local start %s (%s) end %s (%s) | UTC query %s → %s",
-        today_start.strftime("%H:%M %Z"),
-        today_start.astimezone(UTC).strftime("%Y-%m-%dT%H:%MZ"),
-        today_end.strftime("%H:%M %Z"),
-        today_end.astimezone(UTC).strftime("%Y-%m-%dT%H:%MZ"),
-        today_q_from.strftime("%Y-%m-%dT%H:%MZ"),
-        today_q_to.strftime("%Y-%m-%dT%H:%MZ"),
-    )
-    today_rates = db.get_rates_for_period(tariff, today_q_from, today_q_to)
-    today_slots_preview = _build_half_hour_slots(today_rates or [], today_start, today_end)
-    if today_slots_preview:
-        logger.info(
-            "Plan window: today-remainder %s from %s (%d slots, partial-day)",
-            today.isoformat(),
-            today_start.strftime("%H:%M"),
-            len(today_slots_preview),
+    horizon_end_utc = min(target_end_utc, last_valid_to)
+    slots_preview = _build_half_hour_slots(rates, start_utc, horizon_end_utc)
+    if len(slots_preview) < _MIN_USABLE_SLOTS:
+        logger.warning(
+            "Plan window: only %d slots usable (< %d minimum) — Self-Use fallback",
+            len(slots_preview),
+            _MIN_USABLE_SLOTS,
         )
-        return PlanWindow(
-            plan_date=today.isoformat(),
-            day_start=today_start,
-            horizon_end=today_end,
-            is_full_day=False,
-            rates=today_rates,
-        )
+        return None
 
-    logger.warning("Plan window: no usable rates in DB for today or tomorrow — Self-Use fallback")
-    return None
+    start_local = start_utc.astimezone(tz)
+    end_local = horizon_end_utc.astimezone(tz)
+    horizon_h = (horizon_end_utc - start_utc).total_seconds() / 3600.0
+    logger.info(
+        "TZ-AUDIT: rolling plan window | %.1fh | UTC %s → %s | local %s → %s | %d slots",
+        horizon_h,
+        start_utc.strftime("%Y-%m-%dT%H:%MZ"),
+        horizon_end_utc.strftime("%Y-%m-%dT%H:%MZ"),
+        start_local.strftime("%a %d %b %H:%M %Z"),
+        end_local.strftime("%a %d %b %H:%M %Z"),
+        len(slots_preview),
+    )
+
+    return PlanWindow(
+        plan_date=start_local.date().isoformat(),
+        day_start=start_utc,
+        horizon_end=horizon_end_utc,
+        rates=rates,
+    )
 
 
 @dataclass
@@ -326,6 +333,50 @@ def _bulletproof_allow_peak_export_discharge() -> bool:
     return soc >= float(config.EXPORT_DISCHARGE_MIN_SOC_PERCENT)
 
 
+def _count_midnight_crossings(
+    merged: list[tuple[datetime, datetime, tuple]],
+    tz: ZoneInfo,
+) -> int:
+    """Count merged windows whose local ``[ls, le)`` strictly crosses a local
+    midnight boundary — each will become two Fox V3 groups after the split.
+    """
+    n = 0
+    for start_utc, end_utc, _ in merged:
+        ls = start_utc.astimezone(tz)
+        le = end_utc.astimezone(tz)
+        next_midnight = datetime.combine(
+            ls.date() + timedelta(days=1), datetime.min.time()
+        ).replace(tzinfo=ls.tzinfo)
+        if le > next_midnight:
+            n += 1
+    return n
+
+
+def _split_at_local_midnight(
+    merged: list[tuple[datetime, datetime, tuple]],
+    tz: ZoneInfo,
+) -> list[tuple[datetime, datetime, tuple]]:
+    """Split any merged window that crosses local midnight into two
+    same-key halves. Fox V3 groups are ``HH:MM`` within a single 24 h
+    cycle (no date), so a range like 22:00 → 02:00 is undefined; emitting
+    two groups 22:00 → 23:59 and 00:00 → 02:00 preserves the intent.
+    """
+    out: list[tuple[datetime, datetime, tuple]] = []
+    for start_utc, end_utc, key in merged:
+        ls = start_utc.astimezone(tz)
+        le = end_utc.astimezone(tz)
+        next_midnight = datetime.combine(
+            ls.date() + timedelta(days=1), datetime.min.time()
+        ).replace(tzinfo=ls.tzinfo)
+        if le > next_midnight:
+            mid_utc = next_midnight.astimezone(UTC)
+            out.append((start_utc, mid_utc, key))
+            out.append((mid_utc, end_utc, key))
+        else:
+            out.append((start_utc, end_utc, key))
+    return out
+
+
 def _merge_fox_groups(
     slots: list[HalfHourSlot],
     max_groups: int = 8,
@@ -352,11 +403,18 @@ def _merge_fox_groups(
 
     merged = _merge_adjacent_force_charge_rows(merged)
 
+    # Reserve a slot for each window that will be split at local midnight
+    # (Fox V3 groups are dateless HH:MM within a 24 h cycle, so cross-midnight
+    # windows get split into two same-key groups before dispatch).
     guard = 0
-    while len(merged) > max_groups and len(merged) >= 2 and guard < 64:
+    while (
+        len(merged) + _count_midnight_crossings(merged, tz) > max_groups
+        and len(merged) >= 2
+        and guard < 64
+    ):
         guard += 1
         merged = _coarse_merge_fox(merged)
-        if len(merged) <= max_groups:
+        if len(merged) + _count_midnight_crossings(merged, tz) <= max_groups:
             break
         merged_pair = False
         for j in range(len(merged) - 1):
@@ -382,6 +440,8 @@ def _merge_fox_groups(
             nk = ("SelfUse", None, None, int(config.MIN_SOC_RESERVE_PERCENT))
         merged[0] = (a, d, nk)
         del merged[1]
+
+    merged = _split_at_local_midnight(merged, tz)
 
     groups: list[SchedulerGroup] = []
     for start_utc, end_utc, (wm, fds, fdp, msg) in merged:
@@ -603,7 +663,12 @@ def _normal_params() -> dict[str, Any]:
 
 
 def _write_daikin_schedule(plan_date: str, slots: list[HalfHourSlot], forecast: list[HourlyForecast]) -> int:
-    db.clear_actions_for_date(plan_date, device="daikin")
+    if slots:
+        window_start_iso = slots[0].start_utc.isoformat().replace("+00:00", "Z")
+        window_end_iso = slots[-1].end_utc.isoformat().replace("+00:00", "Z")
+        db.clear_actions_in_range(window_start_iso, window_end_iso, device="daikin")
+    else:
+        db.clear_actions_for_date(plan_date, device="daikin")
     tz = TZ()
     count = 0
     away_like = _optimization_preset_away_like()

--- a/tests/test_clear_actions_in_range.py
+++ b/tests/test_clear_actions_in_range.py
@@ -1,0 +1,150 @@
+"""Range-keyed action clear: rolling 24 h replans must clear the exact window,
+preserving in-flight pending rows and the restore partners of active rows.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def test_removes_only_rows_whose_start_falls_in_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    before = datetime(2026, 6, 1, 11, 0, tzinfo=UTC)
+    in_range = datetime(2026, 6, 1, 13, 0, tzinfo=UTC)
+    after = datetime(2026, 6, 2, 18, 0, tzinfo=UTC)
+
+    rid_b = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(before), end_time=_iso(before + timedelta(minutes=30)),
+        device="daikin", action_type="pre_heat", params={}, status="pending",
+    )
+    rid_in = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(in_range), end_time=_iso(in_range + timedelta(minutes=30)),
+        device="daikin", action_type="pre_heat", params={}, status="pending",
+    )
+    rid_a = db.upsert_action(
+        plan_date="2026-06-02",
+        start_time=_iso(after), end_time=_iso(after + timedelta(minutes=30)),
+        device="daikin", action_type="pre_heat", params={}, status="pending",
+    )
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 12, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 12, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(rid_b) is not None
+    assert db.get_action_by_id(rid_in) is None
+    assert db.get_action_by_id(rid_a) is not None
+
+
+def test_preserves_in_flight_pending_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pending pair with start ≤ now < end must survive an overlapping clear."""
+    now = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t0 = datetime(2026, 6, 1, 16, 0, tzinfo=UTC)
+    t1 = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)
+    t_restore_end = t1 + timedelta(minutes=1)
+
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t1), end_time=_iso(t_restore_end),
+        device="daikin", action_type="restore", params={}, status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t0), end_time=_iso(t1),
+        device="daikin", action_type="shutdown", params={}, status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 15, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 15, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(aid) is not None
+    assert db.get_action_by_id(rid) is not None
+
+
+def test_preserves_restore_of_active_row_outside_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Active row's restore partner must survive even when the active row itself
+    is outside the clear range (started earlier)."""
+    now = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t0 = datetime(2026, 6, 1, 16, 0, tzinfo=UTC)  # active main — BEFORE clear range
+    t1 = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)  # restore start — INSIDE clear range
+
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t1), end_time=_iso(t1 + timedelta(minutes=1)),
+        device="daikin", action_type="restore", params={}, status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t0), end_time=_iso(t1),
+        device="daikin", action_type="shutdown", params={}, status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+    db.mark_action(aid, "active")
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 17, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 17, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(rid) is not None, "restore of active row must be preserved"
+    assert db.get_action_by_id(aid) is not None  # active outside range anyway, but sanity
+
+
+def test_removes_purely_future_pending_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pending pair with both rows in the future (inside the clear range) is removed."""
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t0 = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+    t1 = datetime(2026, 6, 1, 21, 0, tzinfo=UTC)
+
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t1), end_time=_iso(t1 + timedelta(minutes=1)),
+        device="daikin", action_type="restore", params={}, status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t0), end_time=_iso(t1),
+        device="daikin", action_type="pre_heat", params={}, status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 12, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 12, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(aid) is None
+    assert db.get_action_by_id(rid) is None

--- a/tests/test_fox_groups_midnight_split.py
+++ b/tests/test_fox_groups_midnight_split.py
@@ -1,0 +1,91 @@
+"""Fox V3 groups: cross-midnight windows are split into two same-key halves.
+
+Fox Scheduler V3 groups are ``HH:MM`` on a single 24 h cycle with no date field,
+so a range like 22:00 → 02:00 is undefined. The rolling 24 h planner almost
+always produces at least one window that crosses local midnight; the splitter
+emits two groups (22:00 → 23:59 and 00:00 → 02:00) so the on-device schedule
+is unambiguous.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.config import config as app_config
+from src.scheduler.optimizer import HalfHourSlot, _merge_fox_groups
+
+
+@pytest.fixture(autouse=True)
+def _london_tz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+
+
+def _fc_slot(start_utc: datetime) -> HalfHourSlot:
+    return HalfHourSlot(
+        start_utc=start_utc,
+        end_utc=start_utc + timedelta(minutes=30),
+        price_pence=-1.0,
+        kind="negative",
+        lp_grid_import_w=6000,
+        target_soc_pct=100,
+    )
+
+
+def test_forcecharge_spanning_local_midnight_splits_in_two() -> None:
+    """In GMT (winter), UTC 22:00 → 02:00 next day IS local 22:00 → 02:00.
+
+    Expect two ForceCharge groups: 22:00 → 23:59 and 00:00 → 01:59 (end minute
+    rolled back from :00 per the existing Fox V3 end-of-hour convention), with
+    identical ``fd_soc`` / ``fd_pwr`` / ``min_soc_on_grid`` on both halves.
+    """
+    base = datetime(2026, 1, 15, 22, 0, tzinfo=UTC)
+    slots = [_fc_slot(base + timedelta(minutes=30 * i)) for i in range(8)]
+    groups = _merge_fox_groups(slots)
+
+    assert len(groups) == 2, f"expected 2 groups from cross-midnight window, got {len(groups)}"
+    g1, g2 = groups
+    assert (g1.start_hour, g1.start_minute) == (22, 0)
+    assert (g1.end_hour, g1.end_minute) == (23, 59)
+    assert (g2.start_hour, g2.start_minute) == (0, 0)
+    assert (g2.end_hour, g2.end_minute) == (1, 59)
+    assert g1.work_mode == "ForceCharge"
+    assert g2.work_mode == "ForceCharge"
+    assert g1.fd_soc == g2.fd_soc
+    assert g1.fd_pwr == g2.fd_pwr
+    assert g1.min_soc_on_grid == g2.min_soc_on_grid
+
+
+def test_window_ending_exactly_at_local_midnight_stays_single_group() -> None:
+    """Endpoint at 00:00 local is NOT a crossing — keep one group with end 23:59."""
+    base = datetime(2026, 1, 15, 22, 0, tzinfo=UTC)
+    slots = [_fc_slot(base + timedelta(minutes=30 * i)) for i in range(4)]  # 22:00 → 00:00
+    groups = _merge_fox_groups(slots)
+    assert len(groups) == 1
+    g = groups[0]
+    assert (g.start_hour, g.start_minute) == (22, 0)
+    assert (g.end_hour, g.end_minute) == (23, 59)
+
+
+def test_midnight_split_during_bst_uses_local_wallclock() -> None:
+    """During BST (UTC+1), UTC 21:00 → 01:00 is local 22:00 → 02:00 → still splits at local midnight."""
+    base = datetime(2026, 4, 22, 21, 0, tzinfo=UTC)
+    slots = [_fc_slot(base + timedelta(minutes=30 * i)) for i in range(8)]  # 21:00 → 01:00 UTC
+    groups = _merge_fox_groups(slots)
+    assert len(groups) == 2
+    g1, g2 = groups
+    assert (g1.start_hour, g1.start_minute) == (22, 0)  # local BST
+    assert (g1.end_hour, g1.end_minute) == (23, 59)
+    assert (g2.start_hour, g2.start_minute) == (0, 0)
+    assert (g2.end_hour, g2.end_minute) == (1, 59)  # 02:00 local rolled back
+
+
+def test_no_split_for_same_day_window() -> None:
+    """A morning-only ForceCharge window does not trigger the splitter."""
+    base = datetime(2026, 1, 15, 9, 0, tzinfo=UTC)  # GMT → 09:00 local
+    slots = [_fc_slot(base + timedelta(minutes=30 * i)) for i in range(4)]  # 09:00 → 11:00
+    groups = _merge_fox_groups(slots)
+    assert len(groups) == 1
+    g = groups[0]
+    assert (g.start_hour, g.start_minute) == (9, 0)
+    assert (g.end_hour, g.end_minute) == (10, 59)  # 11:00 rolled back per convention

--- a/tests/test_plan_window_rolling.py
+++ b/tests/test_plan_window_rolling.py
@@ -1,0 +1,113 @@
+"""Rolling 24 h planning window: start = now ceil-to-HH:30 UTC, end = min(now + LP_HORIZON_HOURS, last Agile slot)."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.scheduler import optimizer
+from src.scheduler.optimizer import _resolve_plan_window
+
+TARIFF = "E-1R-AGILE-TEST-A"
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _london_tz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", TARIFF)
+    monkeypatch.setattr(app_config, "LP_HORIZON_HOURS", 24)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _seed_rates(valid_from: datetime, count: int, price: float = 10.0) -> None:
+    rows: list[dict[str, object]] = []
+    vf = valid_from
+    for _ in range(count):
+        vt = vf + timedelta(minutes=30)
+        rows.append({"valid_from": _iso(vf), "valid_to": _iso(vt), "value_inc_vat": price})
+        vf = vt
+    db.save_agile_rates(rows, TARIFF)
+
+
+def test_rolling_24h_when_full_tomorrow_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """At 18:00 UTC with tomorrow fully published, window is 18:30 UTC today → 18:30 UTC tomorrow."""
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_rates(datetime(2026, 4, 22, 0, 0, tzinfo=UTC), 96)
+
+    w = _resolve_plan_window(TARIFF)
+    assert w is not None
+    assert w.day_start == datetime(2026, 4, 22, 18, 30, tzinfo=UTC)
+    assert w.horizon_end == datetime(2026, 4, 23, 18, 30, tzinfo=UTC)
+    assert w.horizon_hours == pytest.approx(24.0)
+
+
+def test_rolling_partial_when_tomorrow_not_published(monkeypatch: pytest.MonkeyPatch) -> None:
+    """At 09:00 UTC with only today's rates (ending 23:00 UTC), window truncates to last slot."""
+    now = datetime(2026, 4, 22, 9, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_rates(datetime(2026, 4, 22, 0, 0, tzinfo=UTC), 46)  # 23 h, last valid_to = 23:00 UTC
+
+    w = _resolve_plan_window(TARIFF)
+    assert w is not None
+    assert w.day_start == datetime(2026, 4, 22, 9, 30, tzinfo=UTC)
+    assert w.horizon_end == datetime(2026, 4, 22, 23, 0, tzinfo=UTC)
+    assert w.horizon_hours == pytest.approx(13.5)
+
+
+def test_start_advances_past_currently_live_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When 'now' lands exactly on a half-hour boundary, start moves to the *next* one."""
+    now = datetime(2026, 4, 22, 14, 30, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_rates(datetime(2026, 4, 22, 0, 0, tzinfo=UTC), 96)
+
+    w = _resolve_plan_window(TARIFF)
+    assert w is not None
+    assert w.day_start == datetime(2026, 4, 22, 15, 0, tzinfo=UTC)
+
+
+def test_returns_none_when_no_rates(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime(2026, 4, 22, 9, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    assert _resolve_plan_window(TARIFF) is None
+
+
+def test_returns_none_below_min_usable_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    """< 4 future half-hour slots (2 h) → Self-Use fallback."""
+    now = datetime(2026, 4, 22, 22, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_rates(datetime(2026, 4, 22, 22, 0, tzinfo=UTC), 3)  # 22:00–23:30 → 1 slot after 22:30 ceil
+    assert _resolve_plan_window(TARIFF) is None
+
+
+def test_plan_date_tags_local_start_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """plan_date is the local date of the window start — 23:00 UTC in BST lands on the next local date."""
+    # BST (UTC+1): 23:00 UTC = 00:00 next local day
+    now = datetime(2026, 4, 22, 23, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_rates(datetime(2026, 4, 22, 0, 0, tzinfo=UTC), 96)
+
+    w = _resolve_plan_window(TARIFF)
+    assert w is not None
+    # start_utc rounds up to 23:30 UTC → local 00:30 BST on 2026-04-23
+    assert w.plan_date == "2026-04-23"
+
+
+def test_horizon_hours_property_matches_window() -> None:
+    w = optimizer.PlanWindow(
+        plan_date="2026-04-22",
+        day_start=datetime(2026, 4, 22, 12, 0, tzinfo=UTC),
+        horizon_end=datetime(2026, 4, 23, 0, 0, tzinfo=UTC),
+        rates=[],
+    )
+    assert w.horizon_hours == pytest.approx(12.0)


### PR DESCRIPTION
## Summary

- Replace the "tomorrow full-day / today-remainder" branches in `_resolve_plan_window` with a single rolling `now → now+24h` window (UTC, truncated to the last Agile slot available). DST-safe.
- Split Fox Scheduler V3 groups at local midnight so the dateless `HH:MM` model stays well-formed when the plan crosses midnight; reserve 1 group per midnight crossing during the ≤8-group coarsening pass.
- Daikin replan now clears by time range (`clear_actions_in_range`) instead of by `plan_date` string, so a rolling window that spans today+tomorrow no longer leaves stale rows behind. In-flight pending rows are preserved (ADR-002 quota-integrity invariant).
- `LP_HORIZON_HOURS` default 36 → 24.

## The bug

Fox Scheduler V3 replaces the entire on-device schedule atomically (no date field, single 24 h cycle). At 16:05 the Octopus fetch triggered an LP for "tomorrow full-day" and pushed it to Fox V3 — wiping today's remaining hours. Early-morning re-plans had the mirror problem. With a rolling 24 h window, every run keeps the near-term hours and extends forward.

## Test plan

- [x] `pytest tests/test_plan_window_rolling.py` — 7 cases: full tomorrow, no-tomorrow truncation, start-advances-past-live, no rates, below-min-slots, plan_date tag, horizon_hours property
- [x] `pytest tests/test_fox_groups_midnight_split.py` — cross-midnight, end-at-midnight no-op, BST split, same-day no-op
- [x] `pytest tests/test_clear_actions_in_range.py` — range removal, in-flight preservation, active-row restore preservation, future-only
- [x] Full suite: 210 passed, 1 skipped (2 pre-existing MCP failures unrelated to this change, confirmed via `git stash`)
- [ ] Staging: trigger `/api/v1/lp/run` at 10:00, 14:00, 16:10, 22:00 local; verify via `fox_get_scheduler_v3` that uploaded groups cover rolling 24 h and don't wipe in-flight hours
- [ ] Daikin quota after a day of rolling re-plans — should stay well below 180/day ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)