### PR TITLE
fix(scheduler): drop inner datetime import shadowing module-level one

### DIFF
--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -242,8 +242,6 @@ def bulletproof_mpc_job() -> None:
         # Store live snapshot in DB so the LP initial state reader picks it up
         if rt_soc_pct is not None:
             try:
-                from datetime import datetime
-
                 from .. import db as _db
 
                 _db.upsert_fox_realtime_snapshot(


### PR DESCRIPTION
## Summary

`bulletproof_mpc_job` imports `datetime` at module level (line 6) and again *inside* the function body via `from datetime import datetime`. Python binds the name as a function-local for the entire scope, so the earlier `now_local = datetime.now(tz)` at line 204 raises `UnboundLocalError` every time the cron fires. Remove the inner import — the module-level one already covers it.

## The incident

Observed on prod at 2026-04-23 06:00 local (APScheduler MPC cron):

```
File "/root/home-energy-manager/src/scheduler/runner.py", line 204, in bulletproof_mpc_job
    now_local = datetime.now(tz)
UnboundLocalError: cannot access local variable 'datetime' where it is not associated with a value
```

The MPC cron has been silently failing every hour since the offending line was introduced — the job body is wrapped in a broad `except Exception` that only `logger.warning`s, so this was only visible at the APScheduler-level traceback.

## Test plan

- [x] `python -c "import ast; ast.parse(open('src/scheduler/runner.py').read())"` — parse check
- [ ] Deploy, wait for next MPC cron tick (top-of-hour), confirm `journalctl -u home-energy-manager` logs `MPC re-optimise: ok=…` instead of the traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)