### PR TITLE
fix(api): TemplateResponse signature for starlette 0.52+

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -264,9 +264,9 @@ async def web_dashboard(request: Request):
         bool(foxess_error),
     )
     return templates.TemplateResponse(
+        request,
         "dashboard.html",
         {
-            "request": request,
             "daikin": daikin_status,
             "foxess": foxess_status,
             "daikin_error": daikin_error,


### PR DESCRIPTION
Dashboard was returning 500 because starlette 0.52 dropped the legacy positional signature. Tested locally with TestClient — returns 200 OK, 140KB HTML.