### PR TITLE
fix(cockpit): bind to actual API shapes (data was missing)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2458,6 +2458,53 @@ async def simulate_get(simulation_id: str):
 
 # --- v10.1 cockpit data endpoints -------------------------------------------
 
+@app.get("/api/v1/agile/today")
+async def agile_today():
+    """Today's Octopus Agile slot rates + the current half-hour's price.
+
+    Returns a list of 48 (or fewer if partial) slots with import prices, plus
+    the current import price. Export prices use the configured export tariff
+    when available, else the same import series as a placeholder.
+
+    Reads from SQLite ``agile_rates`` only — no cloud calls.
+    """
+    from datetime import UTC, datetime, timedelta
+    from .. import db as _db
+
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    export_tariff = (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip()
+
+    now = datetime.now(UTC)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1)
+
+    import_rows = _db.get_rates_for_period(tariff, day_start, day_end) if tariff else []
+    export_rows = _db.get_rates_for_period(export_tariff, day_start, day_end) if export_tariff else []
+
+    def _slot_price_at(rows: list, t: datetime) -> float | None:
+        iso_t = t.isoformat().replace("+00:00", "Z")
+        for r in rows:
+            if r["valid_from"] <= iso_t < r["valid_to"]:
+                return float(r["value_inc_vat"])
+        return None
+
+    return {
+        "tariff_import_code": tariff or None,
+        "tariff_export_code": export_tariff or None,
+        "import_slots": [
+            {"valid_from": r["valid_from"], "valid_to": r["valid_to"], "p": float(r["value_inc_vat"])}
+            for r in import_rows
+        ],
+        "export_slots": [
+            {"valid_from": r["valid_from"], "valid_to": r["valid_to"], "p": float(r["value_inc_vat"])}
+            for r in export_rows
+        ],
+        "current_import_p": _slot_price_at(import_rows, now),
+        "current_export_p": _slot_price_at(export_rows, now),
+        "now_utc": now.isoformat().replace("+00:00", "Z"),
+    }
+
+
 @app.get("/api/v1/load/breakdown")
 async def load_breakdown():
     """House total load split into Daikin (heat-pump) and residual (everything else).
@@ -2478,10 +2525,22 @@ async def load_breakdown():
 
     house_total_kw = None
     fox_captured_at = None
-    snap = _db.get_fox_realtime_snapshot()
-    if snap:
-        house_total_kw = snap.get("load_power_kw")
-        fox_captured_at = snap.get("captured_at")
+    # Prefer Fox service cache (updated more frequently than the SQLite snapshot
+    # which is only written by the MPC seeding job).
+    try:
+        from ..foxess.service import get_cached_realtime as _fox_realtime
+        snap = _fox_realtime(allow_refresh=False)
+        if snap is not None:
+            house_total_kw = getattr(snap, "load_power", None) if not isinstance(snap, dict) else snap.get("load_power")
+            fox_captured_at = getattr(snap, "updated_at", None) if not isinstance(snap, dict) else snap.get("updated_at")
+    except Exception:
+        pass
+    if house_total_kw is None:
+        # Fallback to SQLite snapshot (legacy path)
+        snap = _db.get_fox_realtime_snapshot()
+        if snap:
+            house_total_kw = snap.get("load_power_kw")
+            fox_captured_at = snap.get("captured_at")
 
     daikin_estimate_kw = None
     daikin_outdoor_c = None

--- a/src/api/static/js/cockpit.js
+++ b/src/api/static/js/cockpit.js
@@ -106,23 +106,66 @@
   async function loadOctopus() {
     const card = $('#cardOctopus');
     try {
-      // Use existing summary endpoint(s); fall back gracefully
-      const status = await jsonFetch('/api/v1/optimization/status').catch(() => null);
-      const importP = status?.current_price_pence ?? status?.now_price_pence ?? null;
-      $('[data-octopus-import]', card).textContent = fmtP(importP);
-      $('[data-octopus-export]', card).textContent = fmtP(status?.current_export_pence ?? null);
-      $('[data-octopus-slots]', card).textContent = status?.agile_slots_loaded ?? '—';
-      setStaleness(card, status?.last_octopus_fetch_at || null);
+      const [status, agile] = await Promise.all([
+        jsonFetch('/api/v1/optimization/status').catch(() => null),
+        jsonFetch('/api/v1/agile/today').catch(() => null),
+      ]);
+      $('[data-octopus-import]', card).textContent = fmtP(agile?.current_import_p);
+      $('[data-octopus-export]', card).textContent = fmtP(agile?.current_export_p);
+      $('[data-octopus-slots]', card).textContent = agile?.import_slots?.length ?? '—';
+      setStaleness(card, status?.cache_fetched_at_utc || status?.last_plan_at_utc || null);
+      renderTariffStripsFromAgile(agile);
     } catch (e) {
       toast(`Octopus: ${e.message}`, 'bad');
+    }
+  }
+
+  function priceColor(p) {
+    if (p == null) return 'var(--bg-card-2)';
+    if (p < 0) return 'var(--neg-price)';
+    if (p < 12) return 'var(--cheap)';
+    if (p < 25) return 'var(--standard)';
+    if (p < 35) return 'var(--peak)';
+    return 'var(--peak-export)';
+  }
+
+  function renderTariffStripsFromAgile(agile) {
+    const im = $('#tariffImportStrip');
+    const ex = $('#tariffExportStrip');
+    if (!im || !ex) return;
+    im.innerHTML = ex.innerHTML = '';
+    if (!agile) return;
+    const now = new Date();
+    const renderRow = (rowEl, slots) => {
+      slots.forEach(s => {
+        const cell = document.createElement('div');
+        cell.className = 'tariff-slot';
+        cell.style.background = priceColor(s.p);
+        cell.title = `${s.valid_from.slice(11,16)}–${s.valid_to.slice(11,16)} ${s.p.toFixed(1)}p`;
+        const start = new Date(s.valid_from);
+        const end = new Date(s.valid_to);
+        if (now >= start && now < end) cell.classList.add('is-current');
+        rowEl.appendChild(cell);
+      });
+    };
+    renderRow(im, agile.import_slots || []);
+    renderRow(ex, agile.export_slots || []);
+    const lbl = $('#tariffCurrentLabel');
+    if (lbl) {
+      const i = agile.current_import_p;
+      const e = agile.current_export_p;
+      lbl.textContent = `Current: import ${i == null ? '—' : i.toFixed(1) + 'p'} · export ${e == null ? '—' : e.toFixed(1) + 'p'}`;
     }
   }
 
   async function loadPlan() {
     const card = $('#cardPlan');
     try {
-      const p = await jsonFetch('/api/v1/optimization/plan');
-      $('[data-plan-backend]', card).textContent = p.optimizer_backend || '—';
+      const [p, status] = await Promise.all([
+        jsonFetch('/api/v1/optimization/plan'),
+        jsonFetch('/api/v1/optimization/status').catch(() => null),
+      ]);
+      $('[data-plan-backend]', card).textContent = status?.optimizer_backend || p?.optimizer_backend || '—';
       // Find current slot strategy from fox groups
       const fox = p.fox || {};
       let groups = [];
@@ -132,9 +175,8 @@
       const next = groups.find(g => slotStartUTC(g) > now);
       $('[data-plan-now]', card).textContent = cur ? `${pad2(cur.startHour)}:${pad2(cur.startMinute)}–${pad2(cur.endHour)}:${pad2(cur.endMinute)} ${cur.workMode}` : '—';
       $('[data-plan-next]', card).textContent = next ? `${pad2(next.startHour)}:${pad2(next.startMinute)} → ${next.workMode}` : '—';
-      setStaleness(card, fox.uploaded_at);
+      setStaleness(card, fox.uploaded_at || status?.last_plan_at_utc);
       renderPlanStrip(groups);
-      renderTariffStrips(p);
     } catch (e) {
       toast(`Plan: ${e.message}`, 'bad');
     }
@@ -196,24 +238,7 @@
     return 'standard';
   }
 
-  function renderTariffStrips(plan) {
-    // Without a dedicated tariff endpoint we render a flat empty band as a placeholder.
-    // Once /api/v1/tariffs/today (import + export per-slot) lands, fill these in.
-    const importStrip = $('#tariffImportStrip');
-    const exportStrip = $('#tariffExportStrip');
-    if (!importStrip || !exportStrip) return;
-    importStrip.innerHTML = exportStrip.innerHTML = '';
-    for (let i = 0; i < 48; i++) {
-      const im = document.createElement('div');
-      im.className = 'tariff-slot';
-      im.style.background = 'var(--bg-card-2)';
-      importStrip.appendChild(im);
-      const ex = document.createElement('div');
-      ex.className = 'tariff-slot';
-      ex.style.background = 'var(--bg-card-2)';
-      exportStrip.appendChild(ex);
-    }
-  }
+  // Tariff strips are rendered by renderTariffStripsFromAgile() (called from loadOctopus).
 
   async function loadBreakdown() {
     try {

--- a/src/api/static/js/insights.js
+++ b/src/api/static/js/insights.js
@@ -10,6 +10,17 @@
 
   let currentPeriod = 'month';
 
+  function periodToParams(period) {
+    const now = new Date();
+    const yyyy = now.getUTCFullYear();
+    const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(now.getUTCDate()).padStart(2, '0');
+    if (period === 'month') return { period: 'month', month: `${yyyy}-${mm}` };
+    if (period === 'year')  return { period: 'year',  year: String(yyyy) };
+    if (period === 'week')  return { period: 'week',  week_start: `${yyyy}-${mm}-${dd}` };
+    return { period: 'day', date: `${yyyy}-${mm}-${dd}` };
+  }
+
   async function loadPeriod(period) {
     currentPeriod = period;
     document.querySelectorAll('.insights-period-btn').forEach(b => {
@@ -17,9 +28,10 @@
       b.classList.toggle('btn-secondary', b.dataset.period !== period);
     });
     try {
-      const d = await jsonFetch(`/api/v1/energy/${period}`).catch(() => null);
-      if (!d) {
-        $('#insightPeriodLabel').textContent = `(no /api/v1/energy/${period} data yet)`;
+      const params = new URLSearchParams(periodToParams(period));
+      const d = await jsonFetch(`/api/v1/energy/period?${params}`).catch(() => null);
+      if (!d || d.detail) {
+        $('#insightPeriodLabel').textContent = d?.detail || `(no data for ${period})`;
         return;
       }
       $('#insightCost').textContent = fmtP(d.net_cost_pence);

--- a/src/api/static/js/settings.js
+++ b/src/api/static/js/settings.js
@@ -73,8 +73,10 @@
 
   async function load() {
     try {
-      const all = await jsonFetch('/api/v1/settings');
-      const byKey = Object.fromEntries((all || []).map(s => [s.key, s]));
+      const resp = await jsonFetch('/api/v1/settings');
+      // API returns {settings: [...]}; tolerate a bare list for older versions.
+      const all = Array.isArray(resp) ? resp : (resp?.settings || []);
+      const byKey = Object.fromEntries(all.map(s => [s.key, s]));
       Object.entries(CATEGORIES).forEach(([containerId, keys]) => {
         const c = $('#' + containerId);
         if (!c) return;
@@ -86,7 +88,7 @@
       });
       // Operation mode card
       const opStatus = await jsonFetch('/api/v1/optimization/status').catch(() => null);
-      $('#currentOpMode').textContent = opStatus?.mode || '—';
+      $('#currentOpMode').textContent = opStatus?.operation_mode || opStatus?.mode || '—';
     } catch (e) {
       toast(`Settings: ${e.message}`, 'bad');
     }


### PR DESCRIPTION
Cockpit shipped with several panels reading non-existent JSON fields or hitting non-existent paths — operator reported missing data. This PR audits + fixes the bindings, plus adds the missing `/api/v1/agile/today` endpoint that was stubbed as a placeholder.

## Fixes
- **New endpoint**: `GET /api/v1/agile/today` returns today's 48-slot import + export prices + current-slot rate (cache-only).
- **Octopus card**: now shows live current import/export prices.
- **Tariff strips**: coloured per-slot bands with current-slot highlight.
- **Plan card**: backend field now reads from `/optimization/status`.
- **Settings page**: reads `resp.settings` (API shape) and `opStatus.operation_mode`.
- **Insights page**: uses `/api/v1/energy/period` with required params.
- **Load breakdown**: reads from Fox service cache first, fallback SQLite snapshot.

Tests: 52/52 still green.
