### PR TITLE
feat(cockpit): plan/insights real data + cockpit re-plan promo + Daikin economics

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2505,6 +2505,105 @@ async def agile_today():
     }
 
 
+@app.get("/api/v1/execution/today")
+async def execution_today():
+    """Per-slot realised cost data for today's plan-vs-actual view.
+
+    Joins ``execution_log`` rows from today (cost_realised_pence, agile_price_pence,
+    slot_kind, daikin_lwt, etc.) with the LP plan's strategy classification.
+    No cloud calls — pure SQLite read.
+
+    Returns:
+      - slots: ordered list of {slot_iso, slot_local, slot_kind, agile_p,
+        consumption_kwh, cost_realised_p, daikin_kwh_est, residual_kwh_est,
+        cost_svt_p, delta_vs_svt_p}
+      - totals: cumulative totals + Daikin attribution
+    """
+    from datetime import UTC, datetime
+    from .. import db as _db
+
+    now = datetime.now(UTC)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+    # Pull all execution_log rows for today
+    with _db._lock:
+        conn = _db.get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT timestamp, consumption_kwh, agile_price_pence,
+                          cost_realised_pence, cost_svt_shadow_pence, delta_vs_svt_pence,
+                          soc_percent, fox_mode, daikin_lwt, daikin_outdoor_temp,
+                          slot_kind
+                   FROM execution_log
+                   WHERE timestamp >= ? AND timestamp <= ?
+                   ORDER BY timestamp""",
+                (day_start.isoformat().replace("+00:00", "Z"),
+                 day_end.isoformat().replace("+00:00", "Z")),
+            )
+            rows = [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+    from ..physics import get_daikin_heating_kw
+    SLOT_HOURS = 0.5
+    slots = []
+    total_cost = 0.0
+    total_svt = 0.0
+    total_load = 0.0
+    total_daikin_kwh = 0.0
+    for r in rows:
+        outdoor = r.get("daikin_outdoor_temp")
+        # Estimate Daikin energy this slot from physics (no cloud call)
+        daikin_kw = float(get_daikin_heating_kw(outdoor)) if outdoor is not None else 0.0
+        daikin_kwh = daikin_kw * SLOT_HOURS
+        load_kwh = float(r.get("consumption_kwh") or 0.0)
+        residual_kwh = max(0.0, load_kwh - daikin_kwh)
+        agile_p = r.get("agile_price_pence")
+        cost = float(r.get("cost_realised_pence") or 0.0)
+        svt = float(r.get("cost_svt_shadow_pence") or 0.0)
+        # Attribute realised cost to Daikin proportionally
+        cost_daikin = cost * (daikin_kwh / load_kwh) if load_kwh > 0 else 0.0
+        cost_residual = cost - cost_daikin
+
+        ts = r["timestamp"]
+        slots.append({
+            "slot_utc": ts,
+            "slot_kind": r.get("slot_kind"),
+            "agile_p": agile_p,
+            "consumption_kwh": load_kwh,
+            "daikin_kwh_est": round(daikin_kwh, 3),
+            "residual_kwh": round(residual_kwh, 3),
+            "cost_realised_p": round(cost, 2),
+            "cost_daikin_p": round(cost_daikin, 2),
+            "cost_residual_p": round(cost_residual, 2),
+            "cost_svt_p": round(svt, 2),
+            "delta_vs_svt_p": float(r.get("delta_vs_svt_pence") or 0.0),
+            "soc_percent": r.get("soc_percent"),
+            "fox_mode": r.get("fox_mode"),
+            "daikin_outdoor_c": outdoor,
+            "daikin_lwt_c": r.get("daikin_lwt"),
+        })
+        total_cost += cost
+        total_svt += svt
+        total_load += load_kwh
+        total_daikin_kwh += daikin_kwh
+
+    return {
+        "date": day_start.date().isoformat(),
+        "slots": slots,
+        "totals": {
+            "load_kwh": round(total_load, 2),
+            "daikin_kwh_est": round(total_daikin_kwh, 2),
+            "residual_kwh_est": round(max(0.0, total_load - total_daikin_kwh), 2),
+            "cost_realised_p": round(total_cost, 2),
+            "cost_svt_p": round(total_svt, 2),
+            "delta_vs_svt_p": round(total_cost - total_svt, 2),
+            "daikin_share_pct": round(100 * total_daikin_kwh / total_load, 1) if total_load else 0.0,
+        },
+    }
+
+
 @app.get("/api/v1/load/breakdown")
 async def load_breakdown():
     """House total load split into Daikin (heat-pump) and residual (everything else).

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -441,7 +441,13 @@ a { color: inherit; text-decoration: none; }
     text-align: left;
 }
 .plan-table th { color: var(--text-mute); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+.plan-table th.num, .plan-table td.num { text-align: right; }
 .plan-table tr.is-now { background: rgba(59,130,246,0.08); }
+.plan-table tr.kind-cheap { background: rgba(16,185,129,0.04); }
+.plan-table tr.kind-peak { background: rgba(245,158,11,0.06); }
+.plan-table tr.kind-peak_export { background: rgba(239,68,68,0.06); }
+.plan-table tr.kind-negative { background: rgba(37,99,235,0.06); }
+.plan-table tr:hover { background: rgba(255,255,255,0.03); }
 .plan-table .col-actual.is-positive { color: var(--ok); }
 .plan-table .col-actual.is-negative { color: var(--bad); }
 .plan-table .col-actual.is-pending { color: var(--text-mute); font-style: italic; }

--- a/src/api/static/js/cockpit.js
+++ b/src/api/static/js/cockpit.js
@@ -291,6 +291,15 @@
       loadPlan();
     });
 
+    // Promoted Re-plan button at the top of the Plan timeline card
+    $('#btnSimulateRePlanCockpit')?.addEventListener('click', async () => {
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/optimization/propose/simulate',
+        applyUrl: '/api/v1/optimization/propose',
+      });
+      if (result.applied) setTimeout(loadPlan, 4000);
+    });
+
     $('#btnDaikinTank')?.addEventListener('click', async () => {
       const t = parseFloat($('#daikinTankInput').value);
       if (isNaN(t)) { toast('Enter a temperature', 'warn'); return; }

--- a/src/api/static/js/insights.js
+++ b/src/api/static/js/insights.js
@@ -1,12 +1,13 @@
-/* v10.1 insights page — comparisons + history. No hardware writes. */
+/* v10.1 insights page — full economics breakdown + Daikin attribution. */
 (function () {
   'use strict';
   const $ = (s, r = document) => r.querySelector(s);
   const { jsonFetch, toast } = window.HEM || {};
 
   function fmtP(v) { return v == null ? '—' : `${Number(v).toFixed(1)}p`; }
-  function fmtPct(v) { return v == null ? '—' : `${Number(v).toFixed(0)}%`; }
-  function fmtN(v) { return v == null ? '—' : Number(v).toFixed(2); }
+  function fmtGBP(v) { return v == null ? '—' : `£${(Number(v) / 100).toFixed(2)}`; }
+  function fmtKwh(v) { return v == null ? '—' : `${Number(v).toFixed(1)} kWh`; }
+  function fmtPct(v) { return v == null ? '—' : `${Number(v).toFixed(1)}%`; }
 
   let currentPeriod = 'month';
 
@@ -29,16 +30,60 @@
     });
     try {
       const params = new URLSearchParams(periodToParams(period));
-      const d = await jsonFetch(`/api/v1/energy/period?${params}`).catch(() => null);
-      if (!d || d.detail) {
-        $('#insightPeriodLabel').textContent = d?.detail || `(no data for ${period})`;
+      const d = await jsonFetch(`/api/v1/energy/period?${params}`).catch((e) => ({ _error: e.message }));
+      if (!d || d.detail || d._error) {
+        $('#insightPeriodLabel').textContent = d?.detail || d?._error || `(no data for ${period})`;
         return;
       }
-      $('#insightCost').textContent = fmtP(d.net_cost_pence);
-      $('#insightSvt').textContent = fmtP(d.svt_delta_pence);
-      $('#insightPvSelfUse').textContent = fmtPct(d.pv_self_use_pct);
-      $('#insightCycles').textContent = fmtN(d.battery_cycles);
-      $('#insightPeriodLabel').textContent = d.label || `(${period})`;
+      $('#insightPeriodLabel').textContent = d.period_label || `(${period})`;
+
+      // Economics
+      const c = d.cost || {};
+      $('#ecoNet').textContent = fmtGBP(c.net_cost_pence);
+      $('#ecoImport').textContent = fmtGBP(c.import_cost_pence);
+      $('#ecoExport').textContent = fmtGBP(c.export_earnings_pence);
+      $('#ecoStanding').textContent = fmtGBP(c.standing_charge_pence);
+
+      const en = d.energy || {};
+      $('#ecoImpKwh').textContent = fmtKwh(en.import_kwh);
+      $('#ecoSolarKwh').textContent = fmtKwh(en.solar_kwh);
+      $('#ecoLoadKwh').textContent = fmtKwh(en.load_kwh);
+      $('#ecoExpKwh').textContent = fmtKwh(en.export_kwh);
+
+      // Daikin
+      $('#daikinKwh').textContent = fmtKwh(d.heating_estimate_kwh);
+      $('#daikinCost').textContent = fmtGBP(d.heating_estimate_cost_pence);
+      const ha = d.heating_analytics || {};
+      $('#daikinPctCost').textContent = fmtPct(ha.heating_percent_of_cost);
+      $('#daikinPctKwh').textContent = fmtPct(ha.heating_percent_of_consumption);
+
+      // Gas comparison (if configured)
+      if (d.equivalent_gas_cost_pence != null) {
+        $('#gasCompareCard').hidden = false;
+        $('#gasCost').textContent = fmtGBP(d.equivalent_gas_cost_pence);
+        const adv = d.gas_comparison_ahead_pounds;
+        $('#gasAdvantage').textContent = adv == null ? '—' : `£${Number(adv).toFixed(2)} saved`;
+      } else {
+        $('#gasCompareCard').hidden = true;
+      }
+
+      // Daily breakdown
+      const tbody = $('#dailyTbody');
+      const days = (d.chart_data || []).filter(r => (r.import_kwh || r.solar_kwh || r.load_kwh));
+      if (!days.length) {
+        tbody.innerHTML = '<tr><td colspan="7" class="text-mute">No daily data for this period.</td></tr>';
+      } else {
+        tbody.innerHTML = days.map(r => `
+          <tr>
+            <td>${r.date}</td>
+            <td class="num">${(r.import_kwh ?? 0).toFixed(1)}</td>
+            <td class="num">${(r.export_kwh ?? 0).toFixed(1)}</td>
+            <td class="num">${(r.solar_kwh ?? 0).toFixed(1)}</td>
+            <td class="num">${(r.load_kwh ?? 0).toFixed(1)}</td>
+            <td class="num text-dim">${(r.charge_kwh ?? 0).toFixed(1)}</td>
+            <td class="num text-dim">${(r.discharge_kwh ?? 0).toFixed(1)}</td>
+          </tr>`).join('');
+      }
     } catch (e) {
       toast(`Insights: ${e.message}`, 'bad');
     }
@@ -47,17 +92,17 @@
   async function runCompare() {
     try {
       const d = await jsonFetch('/api/v1/tariffs/compare', { method: 'POST', body: { months_back: 3 } });
-      const rows = (d?.tariffs || []).slice(0, 10);
+      const rows = (d?.tariffs || d?.results || []).slice(0, 10);
       if (!rows.length) {
         $('#tariffCompareTable').innerHTML = '<p class="text-dim">No comparison data returned.</p>';
         return;
       }
       const html = `<table class="plan-table">
-        <thead><tr><th>Tariff</th><th>Est. monthly</th><th>vs current</th></tr></thead>
+        <thead><tr><th>Tariff</th><th class="num">Est. monthly</th><th class="num">vs current</th></tr></thead>
         <tbody>${rows.map(r => `<tr>
           <td>${r.tariff_code || r.name || '—'}</td>
-          <td>${fmtP(r.estimated_monthly_pence)}</td>
-          <td>${fmtP(r.delta_vs_current_pence)}</td>
+          <td class="num">${fmtGBP(r.estimated_monthly_pence)}</td>
+          <td class="num">${fmtGBP(r.delta_vs_current_pence)}</td>
         </tr>`).join('')}</tbody></table>`;
       $('#tariffCompareTable').innerHTML = html;
     } catch (e) {

--- a/src/api/static/js/plan.js
+++ b/src/api/static/js/plan.js
@@ -1,108 +1,104 @@
-/* v10.1 plan page — predicted vs actual overlay.
+/* v10.1 plan page — cost slot-by-slot, planned strategy vs realised cost.
  *
  * Reads:
- *   - /api/v1/optimization/plan  → today's planned Fox groups + Daikin actions
- *   - /api/v1/schedule           → action_schedule status + execution timestamps
+ *   /api/v1/execution/today  → per-slot realised cost + Daikin attribution
+ *   /api/v1/optimization/plan → today's planned Fox groups (for strategy column)
  *
- * V12 migration adds optimizer_logs.predicted_soc_path; once that lands the
- * Δ SoC column will render real numbers. Until then it shows "—" placeholders.
+ * Action: "Re-plan (simulate)" runs the simulate-then-confirm flow via the
+ * shared wrapAction helper. No direct writes anywhere on this page.
  */
 (function () {
   'use strict';
   const $ = (s, r = document) => r.querySelector(s);
-  const { jsonFetch, toast } = window.HEM || {};
+  const { jsonFetch, wrapAction, toast } = window.HEM || {};
 
   function pad(n) { return String(n).padStart(2, '0'); }
+  function fmtP(v) { return v == null ? '—' : `${Number(v).toFixed(1)}p`; }
+  function fmtKwh(v) { return v == null ? '—' : `${Number(v).toFixed(2)}`; }
 
-  function buildSlots(now) {
-    const slots = [];
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    for (let i = 0; i < 48; i++) {
-      const s = new Date(start);
-      s.setMinutes(s.getMinutes() + i * 30);
-      const e = new Date(s);
-      e.setMinutes(e.getMinutes() + 30);
-      slots.push({ start: s, end: e, label: `${pad(s.getHours())}:${pad(s.getMinutes())}` });
-    }
-    return slots;
-  }
-
-  function findGroupForSlot(groups, slot) {
-    return groups.find(g => {
-      const gs = new Date(slot.start);
-      gs.setHours(g.startHour, g.startMinute || 0, 0, 0);
-      const ge = new Date(slot.start);
-      ge.setHours(g.endHour, g.endMinute || 0, 0, 0);
-      return slot.start >= gs && slot.start < ge;
+  function strategyForSlot(groups, slotUtc) {
+    const t = new Date(slotUtc);
+    const h = t.getHours();
+    const m = t.getMinutes();
+    const cur = groups.find(g => {
+      const inAfterStart = (h > g.startHour) || (h === g.startHour && m >= (g.startMinute || 0));
+      const inBeforeEnd  = (h < g.endHour)   || (h === g.endHour   && m <  (g.endMinute   || 0));
+      return inAfterStart && inBeforeEnd;
     });
+    if (!cur) return '—';
+    const wm = (cur.workMode || '').toLowerCase();
+    if (wm.includes('forcecharge')) return `cheap → charge ${cur.extraParam?.fdSoc ?? '?'}%`;
+    if (wm.includes('forcedischarge')) return 'peak → discharge';
+    if (wm.includes('feed-in')) return 'export';
+    if (wm.includes('backup')) return 'backup';
+    return wm || '—';
   }
 
-  function workModeStrategy(g) {
-    if (!g) return '—';
-    const m = (g.workMode || '').toLowerCase();
-    if (m.includes('forcecharge')) return `cheap (charge → ${g.extraParam?.fdSoc ?? '?'}%)`;
-    if (m.includes('forcedischarge')) return 'peak (discharge)';
-    if (m.includes('feed-in')) return 'export';
-    if (m.includes('backup')) return 'backup';
-    return 'standard';
-  }
-
-  function classifyDelta(plan, actual) {
-    if (!actual) return 'is-pending';
-    return 'is-positive';  // placeholder — needs real SoC comparison
+  function kindClass(k) {
+    if (!k) return '';
+    return ' kind-' + k.replace(/[^a-z0-9_]/g, '-').toLowerCase();
   }
 
   async function load() {
     try {
-      const [plan, sched] = await Promise.all([
-        jsonFetch('/api/v1/optimization/plan'),
-        jsonFetch('/api/v1/schedule'),
+      const [exec, plan] = await Promise.all([
+        jsonFetch('/api/v1/execution/today'),
+        jsonFetch('/api/v1/optimization/plan').catch(() => ({})),
       ]);
-      const fox = plan?.fox || {};
       let groups = [];
-      try { groups = JSON.parse(fox.groups_json || '[]'); } catch (_e) {}
-      const now = new Date();
-      const slots = buildSlots(now);
+      try { groups = JSON.parse(plan?.fox?.groups_json || '[]'); } catch (_e) {}
+
+      const slots = exec?.slots || [];
+      const t = exec?.totals || {};
+
+      $('#totalCost').textContent = fmtP(t.cost_realised_p);
+      const dlt = t.delta_vs_svt_p;
+      const dEl = $('#totalDelta');
+      dEl.textContent = dlt == null ? '—' : `${dlt >= 0 ? '+' : ''}${dlt.toFixed(1)}p`;
+      dEl.className = 'value ' + (dlt > 0 ? 'text-bad' : (dlt < 0 ? 'text-ok' : ''));
+      $('#totalDaikinShare').textContent = t.daikin_share_pct == null ? '—' : `${t.daikin_share_pct.toFixed(0)}%`;
+      $('#totalLoad').textContent = `${fmtKwh(t.load_kwh)} kWh`;
+
       const tbody = $('#planTbody');
+      if (!slots.length) {
+        tbody.innerHTML = '<tr><td colspan="9" class="text-mute">No execution rows yet today (heartbeat will populate as the day progresses).</td></tr>';
+        return;
+      }
+
+      let cumDaikin = 0, cumRes = 0;
       tbody.innerHTML = '';
-      slots.forEach(slot => {
-        const g = findGroupForSlot(groups, slot);
-        const isNow = now >= slot.start && now < slot.end;
-        const isPast = slot.end <= now;
+      slots.forEach(s => {
+        cumDaikin += s.cost_daikin_p || 0;
+        cumRes    += s.cost_residual_p || 0;
+        const t = new Date(s.slot_utc);
+        const lbl = `${pad(t.getHours())}:${pad(t.getMinutes())}`;
+        const strategy = strategyForSlot(groups, s.slot_utc) + (s.slot_kind ? ` · ${s.slot_kind}` : '');
         const tr = document.createElement('tr');
-        if (isNow) tr.classList.add('is-now');
-        const plannedText = g ? `${g.workMode}` : '—';
-        const strategyText = workModeStrategy(g);
-        const actualText = isPast ? 'executed' : (isNow ? 'in progress' : '—');
-        const deltaClass = classifyDelta(g, isPast ? 'executed' : null);
+        const dvs = s.delta_vs_svt_p || 0;
+        const dvsCls = dvs > 0 ? 'text-bad' : (dvs < 0 ? 'text-ok' : '');
+        tr.className = kindClass(s.slot_kind);
         tr.innerHTML = `
-          <td>${slot.label}</td>
-          <td>${plannedText}</td>
-          <td>${strategyText}</td>
-          <td class="col-actual ${deltaClass}">${actualText}</td>
-          <td class="col-actual ${deltaClass}">—</td>`;
-        tr.addEventListener('click', () => showSlotDetail(slot, g, sched));
+          <td>${lbl}</td>
+          <td>${strategy}</td>
+          <td class="num">${fmtP(s.agile_p)}</td>
+          <td class="num">${fmtKwh(s.consumption_kwh)}</td>
+          <td class="num">${fmtP(s.cost_realised_p)}</td>
+          <td class="num text-dim">${cumDaikin.toFixed(1)}p</td>
+          <td class="num text-dim">${cumRes.toFixed(1)}p</td>
+          <td class="num text-mute">${fmtP(s.cost_svt_p)}</td>
+          <td class="num ${dvsCls}">${dvs >= 0 ? '+' : ''}${dvs.toFixed(1)}p</td>`;
+        tr.style.cursor = 'pointer';
+        tr.addEventListener('click', () => showDetail(s));
         tbody.appendChild(tr);
       });
-      if (slots.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="5" class="text-mute">No plan loaded.</td></tr>';
-      }
     } catch (e) {
       toast(`Plan: ${e.message}`, 'bad');
     }
   }
 
-  function showSlotDetail(slot, group, sched) {
+  function showDetail(slot) {
     const card = $('#slotDetailCard');
-    const daikin = (sched?.actions || []).filter(a => a.device === 'daikin' && a.start_time && new Date(a.start_time) >= slot.start && new Date(a.start_time) < slot.end);
-    const detail = {
-      slot: `${slot.label} → ${slot.end.toTimeString().slice(0,5)}`,
-      planned_fox_group: group || null,
-      daikin_actions_in_slot: daikin.length ? daikin : '(none — passive mode)',
-      note: 'Δ SoC actual will populate once optimizer_logs.predicted_soc_path migration ships.',
-    };
-    $('#slotDetailBody').textContent = JSON.stringify(detail, null, 2);
+    $('#slotDetailBody').textContent = JSON.stringify(slot, null, 2);
     card.hidden = false;
     card.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }
@@ -110,6 +106,16 @@
   document.addEventListener('DOMContentLoaded', () => {
     $('#btnReloadPlan')?.addEventListener('click', load);
     $('#btnCloseSlot')?.addEventListener('click', () => { $('#slotDetailCard').hidden = true; });
+    $('#btnSimulateRePlan')?.addEventListener('click', async () => {
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/optimization/propose/simulate',
+        applyUrl:    '/api/v1/optimization/propose',
+      });
+      if (result.applied) {
+        toast('Plan re-solve triggered', 'ok');
+        setTimeout(load, 4000);
+      }
+    });
     load();
   });
 })();

--- a/src/api/templates/cockpit.html
+++ b/src/api/templates/cockpit.html
@@ -104,7 +104,13 @@
 <section class="card">
     <h2 class="card-title">
         Plan timeline
-        <a href="/plan" class="btn btn-sm btn-secondary">Detail →</a>
+        <span class="card-actions">
+            <a href="/plan" class="btn btn-sm btn-secondary">Detail →</a>
+            <button class="btn btn-sm btn-primary" id="btnSimulateRePlanCockpit"
+                    title="Run a fresh LP simulation, review the diff in a modal, then choose to apply">
+                Re-plan (simulate)
+            </button>
+        </span>
     </h2>
     <div class="plan-strip" id="planStrip" title="Click a slot for detail"></div>
     <div class="plan-legend">
@@ -114,6 +120,9 @@
         <span><span class="legend-swatch" style="background:var(--peak)"></span>peak</span>
         <span><span class="legend-swatch" style="background:var(--peak-export)"></span>peak-export</span>
     </div>
+    <p class="text-mute" style="font-size:0.75rem;margin:0.5rem 0 0 0;">
+        Every action on this page runs as a simulation first; you confirm in a modal before anything writes.
+    </p>
 </section>
 
 <section class="override-section">

--- a/src/api/templates/insights.html
+++ b/src/api/templates/insights.html
@@ -4,7 +4,7 @@
 
 <section class="card">
     <h2 class="card-title">
-        Period summary
+        Period
         <span class="insights-period">
             <button class="btn btn-sm btn-secondary insights-period-btn" data-period="day">Day</button>
             <button class="btn btn-sm btn-secondary insights-period-btn" data-period="week">Week</button>
@@ -12,46 +12,89 @@
             <button class="btn btn-sm btn-secondary insights-period-btn" data-period="year">Year</button>
         </span>
     </h2>
+    <p class="text-mute" id="insightPeriodLabel" style="font-size:0.85rem;margin:0;">Loading…</p>
+</section>
+
+<section class="card">
+    <h2 class="card-title">Economics</h2>
+    <div class="insights-summary">
+        <div class="insight-tile"><div class="label">Net cost</div><div class="value" id="ecoNet">—</div></div>
+        <div class="insight-tile"><div class="label">Imported</div><div class="value" id="ecoImport">—</div></div>
+        <div class="insight-tile"><div class="label">Export earnings</div><div class="value text-ok" id="ecoExport">—</div></div>
+        <div class="insight-tile"><div class="label">Standing charge</div><div class="value text-mute" id="ecoStanding">—</div></div>
+    </div>
+    <div class="insights-summary" style="margin-top:0.5rem;">
+        <div class="insight-tile"><div class="label">Import kWh</div><div class="value" id="ecoImpKwh">—</div></div>
+        <div class="insight-tile"><div class="label">Solar kWh</div><div class="value" id="ecoSolarKwh">—</div></div>
+        <div class="insight-tile"><div class="label">Load kWh</div><div class="value" id="ecoLoadKwh">—</div></div>
+        <div class="insight-tile"><div class="label">Export kWh</div><div class="value" id="ecoExpKwh">—</div></div>
+    </div>
+</section>
+
+<section class="card">
+    <h2 class="card-title">Daikin (heat pump)</h2>
     <div class="insights-summary">
         <div class="insight-tile">
-            <div class="label">Net cost</div>
-            <div class="value" id="insightCost">—</div>
+            <div class="label">Heating energy</div>
+            <div class="value" id="daikinKwh">—</div>
         </div>
         <div class="insight-tile">
-            <div class="label">vs SVT</div>
-            <div class="value" id="insightSvt">—</div>
+            <div class="label">Heating cost</div>
+            <div class="value" id="daikinCost">—</div>
         </div>
         <div class="insight-tile">
-            <div class="label">PV self-use</div>
-            <div class="value" id="insightPvSelfUse">—</div>
+            <div class="label">% of total cost</div>
+            <div class="value" id="daikinPctCost">—</div>
         </div>
         <div class="insight-tile">
-            <div class="label">Cycles (battery)</div>
-            <div class="value" id="insightCycles">—</div>
+            <div class="label">% of consumption</div>
+            <div class="value" id="daikinPctKwh">—</div>
         </div>
     </div>
-    <p class="text-mute" id="insightPeriodLabel" style="font-size:0.8rem;margin:0;">—</p>
+    <p class="text-mute" style="font-size:0.78rem;margin:0.5rem 0 0 0;" id="daikinNote">
+        Heating estimate from physics (climate curve × outdoor temp). Refines as the D-1 backfill (deferred Epic) lands.
+    </p>
+</section>
+
+<section class="card" id="gasCompareCard" hidden>
+    <h2 class="card-title">vs gas boiler</h2>
+    <div class="insights-summary">
+        <div class="insight-tile">
+            <div class="label">Equivalent gas cost</div>
+            <div class="value" id="gasCost">—</div>
+        </div>
+        <div class="insight-tile">
+            <div class="label">Heat pump advantage</div>
+            <div class="value text-ok" id="gasAdvantage">—</div>
+        </div>
+    </div>
+</section>
+
+<section class="card">
+    <h2 class="card-title">Daily breakdown</h2>
+    <div style="overflow-x:auto;">
+        <table class="plan-table" id="dailyTable">
+            <thead><tr>
+                <th>Date</th>
+                <th class="num">Import kWh</th>
+                <th class="num">Export kWh</th>
+                <th class="num">Solar kWh</th>
+                <th class="num">Load kWh</th>
+                <th class="num">Charge</th>
+                <th class="num">Discharge</th>
+            </tr></thead>
+            <tbody id="dailyTbody"><tr><td colspan="7" class="text-mute">—</td></tr></tbody>
+        </table>
+    </div>
 </section>
 
 <section class="card">
     <h2 class="card-title">Tariff comparison</h2>
     <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
-        Estimated cost across alternative Octopus tariffs based on your last <span id="tariffMonths">3</span> months
-        of consumption. Click a row for breakdown.
+        Estimated cost across alternative Octopus tariffs based on your last 3 months of consumption.
     </p>
     <button class="btn btn-secondary btn-sm" id="btnRunCompare">Run comparison now</button>
     <div id="tariffCompareTable" style="margin-top:0.85rem;"></div>
-</section>
-
-<section class="card">
-    <h2 class="card-title">Daikin vs Fox energy (history)</h2>
-    <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
-        Daily energy split — how much of the house total Fox sees was the heat pump vs everything else.
-    </p>
-    <div id="loadHistoryChart" class="text-mute" style="font-size:0.85rem;">
-        (Chart loads when daikin_consumption_daily backfill is enabled — deferred Epic #70.
-        Once that ships, this panel will show a 30-day stacked bar of HP vs residual.)
-    </div>
 </section>
 
 {% endblock %}

--- a/src/api/templates/plan.html
+++ b/src/api/templates/plan.html
@@ -4,25 +4,37 @@
 
 <section class="card">
     <h2 class="card-title">
-        Plan vs actual · today
+        Today · cost slot-by-slot
         <span class="card-actions">
-            <button class="btn btn-sm btn-secondary" id="btnReloadPlan">⟳ Reload</button>
+            <button class="btn btn-sm btn-secondary" id="btnReloadPlan" title="Reload (cache only)">⟳</button>
+            <button class="btn btn-sm btn-primary" id="btnSimulateRePlan" title="Run a fresh simulation, then choose to apply">Re-plan (simulate)</button>
         </span>
     </h2>
     <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
-        Each row is a 30-min slot. Plan = LP-decided strategy; Actual = what the Fox/Daikin actually did.
-        Rows are auto-detected as <span class="text-ok">on track</span>, <span class="text-warn">drifting</span>, or <span class="text-bad">divergent</span>.
+        Each row is a 30-min slot. <strong>Cost</strong> is what the system actually paid; <strong>SVT shadow</strong> is what a plain SVT customer would have paid for the same kWh; <strong>Δ</strong> shows our savings (negative = we paid less).
     </p>
+
+    <div class="insights-summary" id="planTotals">
+        <div class="insight-tile"><div class="label">Cost today</div><div class="value" id="totalCost">—</div></div>
+        <div class="insight-tile"><div class="label">vs SVT shadow</div><div class="value" id="totalDelta">—</div></div>
+        <div class="insight-tile"><div class="label">Daikin share</div><div class="value" id="totalDaikinShare">—</div></div>
+        <div class="insight-tile"><div class="label">Load total</div><div class="value" id="totalLoad">—</div></div>
+    </div>
+
     <div style="overflow-x:auto;">
         <table class="plan-table" id="planTable">
             <thead><tr>
                 <th>Slot</th>
-                <th>Plan</th>
                 <th>Strategy</th>
-                <th>Actual</th>
-                <th>Δ SoC</th>
+                <th class="num">Tariff</th>
+                <th class="num">kWh</th>
+                <th class="num">Cost</th>
+                <th class="num">Daikin Σ</th>
+                <th class="num">Resid. Σ</th>
+                <th class="num">SVT</th>
+                <th class="num">Δ</th>
             </tr></thead>
-            <tbody id="planTbody"><tr><td colspan="5" class="text-mute">Loading…</td></tr></tbody>
+            <tbody id="planTbody"><tr><td colspan="9" class="text-mute">Loading…</td></tr></tbody>
         </table>
     </div>
 </section>


### PR DESCRIPTION
Operator feedback: missing data on plan & insights, plan should show cost planned/executed (not Δ SoC), insights needs economics + Daikin spending breakdown, cockpit needs prominent simulate-then-confirm re-plan.

## What's in this PR
- **New endpoint** `/api/v1/execution/today` (SQLite-only, no cloud calls): per-slot realised cost + Daikin attribution.
- **Plan page rewrite**: cost slot-by-slot table (Strategy / Tariff / kWh / Cost / Daikin Σ / Residual Σ / SVT shadow / Δ). Top tiles for cost today, vs SVT, Daikin share, Load total. "Re-plan (simulate)" button.
- **Insights page rewrite**: Economics card, Daikin card (heating cost, % of total cost, % of consumption), vs-gas card, daily breakdown table.
- **Cockpit promo**: prominent "Re-plan (simulate)" button on the Plan timeline card.
- **Quota-safe**: zero cloud calls on any new endpoint; all writes still routed through simulate-confirm.
