### PR TITLE
fix(cockpit): per-slot Daikin/Residual costs, settings rebuild, hot-reload

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -148,11 +148,34 @@ app = FastAPI(
 app.include_router(energy_providers_router.router)
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+# auto_reload=True picks up template edits without a service restart — important
+# because cockpit iteration shouldn't require systemctl restart. Only Python
+# code changes (this file, simulate_diffs, etc.) still need a restart.
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR), auto_reload=True)
 
 STATIC_DIR = Path(__file__).parent / "static"
 if STATIC_DIR.is_dir():
+    # StaticFiles reads from disk on each request — JS/CSS edits land instantly
+    # on `git pull`. To beat browser cache, templates can append the file mtime
+    # via the ``static_v`` Jinja global below.
     app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+
+def _static_v(rel_path: str) -> int:
+    """Cache-busting query-string version: file mtime as int.
+
+    Templates use it like ``<script src="/static/js/cockpit.js?v={{ static_v('js/cockpit.js') }}">``
+    so a `git pull` of just static/templates flips the URL → browser fetches
+    the new bytes immediately (no service restart, no hard-refresh needed).
+    """
+    fp = STATIC_DIR / rel_path
+    try:
+        return int(fp.stat().st_mtime)
+    except FileNotFoundError:
+        return 0
+
+
+templates.env.globals["static_v"] = _static_v
 
 
 def get_daikin_client() -> DaikinClient:

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -448,11 +448,73 @@ a { color: inherit; text-decoration: none; }
 .plan-table tr.kind-peak_export { background: rgba(239,68,68,0.06); }
 .plan-table tr.kind-negative { background: rgba(37,99,235,0.06); }
 .plan-table tr:hover { background: rgba(255,255,255,0.03); }
+.plan-table tfoot tr.totals-row {
+    background: rgba(59,130,246,0.06);
+    font-variant-numeric: tabular-nums;
+    border-top: 2px solid var(--accent);
+}
+.plan-table tfoot tr.totals-row td {
+    padding: 0.65rem 0.6rem;
+    border-bottom: none;
+}
 .plan-table .col-actual.is-positive { color: var(--ok); }
 .plan-table .col-actual.is-negative { color: var(--bad); }
 .plan-table .col-actual.is-pending { color: var(--text-mute); font-style: italic; }
 
-/* Settings page */
+/* Settings page — v10.1 iteration 2 */
+.danger-zone {
+    border-color: rgba(239,68,68,0.4);
+    background: linear-gradient(180deg, rgba(239,68,68,0.04) 0%, var(--bg-card) 30%);
+}
+.setting-block {
+    padding: 0.85rem 0;
+    border-bottom: 1px solid var(--border);
+}
+.setting-block:last-child { border-bottom: none; }
+.setting-block.is-danger {
+    background: rgba(239,68,68,0.04);
+    border-radius: 6px;
+    padding: 0.85rem;
+    margin: 0.5rem 0;
+}
+.setting-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    margin-bottom: 0.3rem;
+}
+.setting-name { margin: 0; font-size: 0.95rem; font-weight: 600; }
+.setting-desc {
+    color: var(--text-dim);
+    font-size: 0.82rem;
+    margin: 0 0 0.55rem 0;
+    line-height: 1.45;
+}
+.setting-desc code {
+    background: var(--bg-card-2);
+    color: var(--text);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.78rem;
+}
+.setting-actions {
+    display: flex;
+    gap: 0.45rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+.setting-actions input, .setting-actions select {
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.45rem 0.65rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    min-height: 38px;
+}
+
+/* Settings page (legacy block patterns kept for old dashboard) */
 .settings-group { display: grid; gap: 0.7rem; }
 .settings-row {
     display: grid;

--- a/src/api/static/js/plan.js
+++ b/src/api/static/js/plan.js
@@ -60,16 +60,21 @@
       $('#totalLoad').textContent = `${fmtKwh(t.load_kwh)} kWh`;
 
       const tbody = $('#planTbody');
+      const tfoot = $('#planTfoot');
+      tfoot.innerHTML = '';
       if (!slots.length) {
         tbody.innerHTML = '<tr><td colspan="9" class="text-mute">No execution rows yet today (heartbeat will populate as the day progresses).</td></tr>';
         return;
       }
 
-      let cumDaikin = 0, cumRes = 0;
+      // Per-slot costs only — NOT cumulative. Each row sums Daikin+Residual = Cost.
       tbody.innerHTML = '';
+      let sumDaikin = 0, sumRes = 0, sumCost = 0, sumSvt = 0;
       slots.forEach(s => {
-        cumDaikin += s.cost_daikin_p || 0;
-        cumRes    += s.cost_residual_p || 0;
+        sumDaikin += s.cost_daikin_p || 0;
+        sumRes    += s.cost_residual_p || 0;
+        sumCost   += s.cost_realised_p || 0;
+        sumSvt    += s.cost_svt_p || 0;
         const t = new Date(s.slot_utc);
         const lbl = `${pad(t.getHours())}:${pad(t.getMinutes())}`;
         const strategy = strategyForSlot(groups, s.slot_utc) + (s.slot_kind ? ` · ${s.slot_kind}` : '');
@@ -83,14 +88,29 @@
           <td class="num">${fmtP(s.agile_p)}</td>
           <td class="num">${fmtKwh(s.consumption_kwh)}</td>
           <td class="num">${fmtP(s.cost_realised_p)}</td>
-          <td class="num text-dim">${cumDaikin.toFixed(1)}p</td>
-          <td class="num text-dim">${cumRes.toFixed(1)}p</td>
+          <td class="num text-dim">${fmtP(s.cost_daikin_p)}</td>
+          <td class="num text-dim">${fmtP(s.cost_residual_p)}</td>
           <td class="num text-mute">${fmtP(s.cost_svt_p)}</td>
           <td class="num ${dvsCls}">${dvs >= 0 ? '+' : ''}${dvs.toFixed(1)}p</td>`;
         tr.style.cursor = 'pointer';
         tr.addEventListener('click', () => showDetail(s));
         tbody.appendChild(tr);
       });
+
+      // Totals row in <tfoot>
+      const totalDelta = sumCost - sumSvt;
+      const totalDeltaCls = totalDelta > 0 ? 'text-bad' : (totalDelta < 0 ? 'text-ok' : '');
+      tfoot.innerHTML = `<tr class="totals-row">
+        <td><strong>Total</strong></td>
+        <td class="text-dim">${slots.length} slots</td>
+        <td class="num"></td>
+        <td class="num"><strong>${fmtKwh(t.load_kwh)}</strong></td>
+        <td class="num"><strong>${fmtP(sumCost)}</strong></td>
+        <td class="num"><strong>${fmtP(sumDaikin)}</strong></td>
+        <td class="num"><strong>${fmtP(sumRes)}</strong></td>
+        <td class="num text-mute"><strong>${fmtP(sumSvt)}</strong></td>
+        <td class="num ${totalDeltaCls}"><strong>${totalDelta >= 0 ? '+' : ''}${totalDelta.toFixed(1)}p</strong></td>
+      </tr>`;
     } catch (e) {
       toast(`Plan: ${e.message}`, 'bad');
     }

--- a/src/api/static/js/settings.js
+++ b/src/api/static/js/settings.js
@@ -1,4 +1,4 @@
-/* v10.1 settings page — categorised runtime knobs.
+/* v10.1 settings page — categorised, human-labelled, simulate-confirm.
  * Every change flows through wrapAction (simulate → modal → apply).
  */
 (function () {
@@ -6,52 +6,118 @@
   const $ = (s, r = document) => r.querySelector(s);
   const { jsonFetch, wrapAction, toast } = window.HEM || {};
 
-  const CATEGORIES = {
-    settingsDaikin: ['DAIKIN_CONTROL_MODE', 'REQUIRE_SIMULATION_ID'],
-    settingsStrategy: ['OPTIMIZATION_PRESET', 'ENERGY_STRATEGY_MODE'],
-    settingsSchedule: ['LP_PLAN_PUSH_HOUR', 'LP_PLAN_PUSH_MINUTE', 'LP_MPC_HOURS'],
-    settingsComfort: ['DHW_TEMP_COMFORT_C', 'DHW_TEMP_NORMAL_C', 'INDOOR_SETPOINT_C'],
+  /* Per-key human metadata. Anything not in here falls back to the raw key. */
+  const META = {
+    DAIKIN_CONTROL_MODE: {
+      label: 'Daikin control mode',
+      desc:
+        'Passive = service NEVER writes to the heat pump (Onecta firmware runs autonomously; LP treats Daikin as a fixed thermal load). ' +
+        'Active = legacy v9 control (LP schedules tank temps, LWT offsets, powerful mode, etc).',
+      danger: true,
+      target: 'settingDaikinControlMode',
+    },
+    REQUIRE_SIMULATION_ID: {
+      label: 'Require simulation-then-confirm for all writes',
+      desc:
+        'When ON, every state-changing API call must first go through its /simulate endpoint and pass the simulation_id back as X-Simulation-Id. ' +
+        'Protects against scripts and accidental writes — the cockpit always uses this flow regardless.',
+      danger: false,
+      target: 'settingRequireSim',
+    },
+    DHW_TEMP_NORMAL_C: {
+      label: 'Normal hot-water target',
+      desc: 'Target tank temperature on a typical day (°C). Higher = more buffer for evening showers but more standing loss.',
+      group: 'settingsComfort',
+    },
+    DHW_TEMP_COMFORT_C: {
+      label: 'Plunge ceiling for hot water',
+      desc: 'Maximum tank temperature when the LP wants to absorb a cheap-price slot (°C). Only reached when it actively pays to do so.',
+      group: 'settingsComfort',
+    },
+    INDOOR_SETPOINT_C: {
+      label: 'Indoor target temperature',
+      desc: 'Target room temperature used for the LP comfort constraint (°C).',
+      group: 'settingsComfort',
+    },
+    OPTIMIZATION_PRESET: {
+      label: 'Occupancy preset',
+      desc:
+        'normal = standard household. guests = higher hot water + warmer rooms. travel/away = frost protection only, max battery export. ' +
+        '(BOOST retired in v10 — silently aliased to normal.)',
+      group: 'settingsStrategy',
+    },
+    ENERGY_STRATEGY_MODE: {
+      label: 'Energy strategy mode',
+      desc: 'savings_first = LP allows discharging the battery to the grid during peak tariff (peak-export). strict_savings = never discharge to grid.',
+      group: 'settingsStrategy',
+    },
+    LP_PLAN_PUSH_HOUR: {
+      label: 'Nightly plan push hour (UTC)',
+      desc: 'UTC hour when the next-day plan is force-pushed (anchored to Daikin quota rollover at 00:00 UTC).',
+      group: 'settingsSchedule',
+    },
+    LP_PLAN_PUSH_MINUTE: {
+      label: 'Nightly plan push minute',
+      desc: 'UTC minute (paired with the hour above).',
+      group: 'settingsSchedule',
+    },
+    LP_MPC_HOURS: {
+      label: 'Re-solve hours (local)',
+      desc: 'Comma-separated local hours when the LP runs an intra-day re-solve (e.g. 6,12,21).',
+      group: 'settingsSchedule',
+    },
   };
 
-  function renderRow(item) {
-    const wrap = document.createElement('div');
-    wrap.className = 'settings-row';
-    wrap.innerHTML = `
-      <div>
-        <div class="label">${item.key}</div>
-        <div class="description">${item.description || ''}</div>
-      </div>
-      <div class="control">
-        <span class="current">${formatValue(item.value)}</span>
-        ${renderControl(item)}
-      </div>`;
-    bindControl(wrap, item);
-    return wrap;
-  }
-
-  function formatValue(v) {
+  function fmtCurrent(item) {
+    const v = item.value;
     if (v == null) return '—';
-    if (Array.isArray(v)) return v.join(',');
+    if (Array.isArray(v)) return v.join(', ');
+    if (typeof v === 'number') return v.toString();
     return String(v);
   }
 
-  function renderControl(item) {
+  function controlFor(item) {
     if (item.enum) {
       return `<select data-key="${item.key}">
         ${item.enum.map(o => `<option value="${o}" ${String(item.value) === String(o) ? 'selected' : ''}>${o}</option>`).join('')}
-      </select>
-      <button class="btn btn-secondary btn-sm" data-apply="${item.key}">Apply</button>`;
+      </select>`;
     }
     if (item.type === 'int' || item.type === 'float') {
       const step = item.type === 'int' ? '1' : '0.5';
       return `<input type="number" data-key="${item.key}" value="${item.value ?? ''}" step="${step}"
               ${item.min != null ? `min="${item.min}"` : ''}
               ${item.max != null ? `max="${item.max}"` : ''}
-              style="width:5.5rem;">
-      <button class="btn btn-secondary btn-sm" data-apply="${item.key}">Apply</button>`;
+              style="width:5.5rem;">`;
     }
-    return `<input type="text" data-key="${item.key}" value="${formatValue(item.value)}" style="width:8rem;">
-            <button class="btn btn-secondary btn-sm" data-apply="${item.key}">Apply</button>`;
+    return `<input type="text" data-key="${item.key}" value="${fmtCurrent(item)}" style="width:8rem;">`;
+  }
+
+  function badgeClass(item) {
+    if (item.key === 'DAIKIN_CONTROL_MODE') {
+      return item.value === 'passive' ? 'is-passive' : 'is-active';
+    }
+    if (item.key === 'REQUIRE_SIMULATION_ID') {
+      return String(item.value) === 'true' ? 'is-active' : 'is-passive';
+    }
+    return '';
+  }
+
+  function renderInline(item, container) {
+    const meta = META[item.key] || {};
+    const block = document.createElement('div');
+    block.className = 'setting-block' + (meta.danger ? ' is-danger' : '');
+    block.innerHTML = `
+      <div class="setting-head">
+        <h3 class="setting-name">${meta.label || item.key}</h3>
+        <span class="status-badge ${badgeClass(item)}">${fmtCurrent(item)}</span>
+      </div>
+      <p class="setting-desc">${meta.desc || item.description || ''}</p>
+      <div class="setting-actions">
+        ${controlFor(item)}
+        <button class="btn btn-secondary btn-sm" data-apply="${item.key}">Change…</button>
+      </div>`;
+    bindControl(block, item);
+    container.appendChild(block);
   }
 
   function bindControl(wrap, item) {
@@ -74,21 +140,42 @@
   async function load() {
     try {
       const resp = await jsonFetch('/api/v1/settings');
-      // API returns {settings: [...]}; tolerate a bare list for older versions.
       const all = Array.isArray(resp) ? resp : (resp?.settings || []);
       const byKey = Object.fromEntries(all.map(s => [s.key, s]));
-      Object.entries(CATEGORIES).forEach(([containerId, keys]) => {
+
+      // Danger-zone keys → render into specific named targets
+      ['DAIKIN_CONTROL_MODE', 'REQUIRE_SIMULATION_ID'].forEach(key => {
+        const item = byKey[key];
+        const meta = META[key] || {};
+        const target = $('#' + (meta.target || ''));
+        if (item && target) {
+          target.innerHTML = '';
+          renderInline(item, target);
+        }
+      });
+
+      // Grouped sections
+      const groups = {
+        settingsComfort: ['DHW_TEMP_NORMAL_C', 'DHW_TEMP_COMFORT_C', 'INDOOR_SETPOINT_C'],
+        settingsStrategy: ['OPTIMIZATION_PRESET', 'ENERGY_STRATEGY_MODE'],
+        settingsSchedule: ['LP_PLAN_PUSH_HOUR', 'LP_PLAN_PUSH_MINUTE', 'LP_MPC_HOURS'],
+      };
+      Object.entries(groups).forEach(([containerId, keys]) => {
         const c = $('#' + containerId);
         if (!c) return;
         c.innerHTML = '';
         keys.forEach(k => {
           const item = byKey[k];
-          if (item) c.appendChild(renderRow(item));
+          if (item) renderInline(item, c);
         });
       });
-      // Operation mode card
+
+      // Operation mode (separate path — POST /api/v1/optimization/mode)
       const opStatus = await jsonFetch('/api/v1/optimization/status').catch(() => null);
-      $('#currentOpMode').textContent = opStatus?.operation_mode || opStatus?.mode || '—';
+      const cur = opStatus?.operation_mode || opStatus?.mode || '—';
+      const opEl = $('#currentOpMode');
+      opEl.textContent = cur;
+      opEl.className = 'status-badge ' + (cur === 'simulation' ? 'is-passive' : 'is-active');
     } catch (e) {
       toast(`Settings: ${e.message}`, 'bad');
     }
@@ -96,19 +183,19 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('[data-op-mode]').forEach(b => b.addEventListener('click', async () => {
-      await wrapAction({
+      const result = await wrapAction({
         simulateUrl: '/api/v1/optimization/mode/simulate',
         applyUrl: '/api/v1/optimization/mode',
         body: { mode: b.dataset.opMode },
       });
-      load();
+      if (result.applied) load();
     }));
     $('#btnRollback')?.addEventListener('click', async () => {
-      await wrapAction({
+      const result = await wrapAction({
         simulateUrl: '/api/v1/optimization/rollback/simulate',
         applyUrl: '/api/v1/optimization/rollback',
       });
-      load();
+      if (result.applied) load();
     });
     load();
   });

--- a/src/api/templates/_layout.html
+++ b/src/api/templates/_layout.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="theme-color" content="#0b0f17">
     <title>{% block title %}Home Energy Manager{% endblock %}</title>
-    <link rel="stylesheet" href="/static/css/cockpit.css">
+    <link rel="stylesheet" href="/static/css/cockpit.css?v={{ static_v('css/cockpit.css') }}">
     {% block head_extra %}{% endblock %}
 </head>
 <body>
@@ -33,8 +33,8 @@
 
     <div class="toast-stack" id="toastStack" aria-live="polite"></div>
 
-    <script src="/static/js/modal.js"></script>
-    <script src="/static/js/quota.js"></script>
+    <script src="/static/js/modal.js?v={{ static_v('js/modal.js') }}"></script>
+    <script src="/static/js/quota.js?v={{ static_v('js/quota.js') }}"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/src/api/templates/cockpit.html
+++ b/src/api/templates/cockpit.html
@@ -179,5 +179,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/cockpit.js"></script>
+<script src="/static/js/cockpit.js?v={{ static_v('js/cockpit.js') }}"></script>
 {% endblock %}

--- a/src/api/templates/insights.html
+++ b/src/api/templates/insights.html
@@ -100,5 +100,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/insights.js"></script>
+<script src="/static/js/insights.js?v={{ static_v('js/insights.js') }}"></script>
 {% endblock %}

--- a/src/api/templates/plan.html
+++ b/src/api/templates/plan.html
@@ -26,15 +26,16 @@
             <thead><tr>
                 <th>Slot</th>
                 <th>Strategy</th>
-                <th class="num">Tariff</th>
-                <th class="num">kWh</th>
-                <th class="num">Cost</th>
-                <th class="num">Daikin Σ</th>
-                <th class="num">Resid. Σ</th>
-                <th class="num">SVT</th>
-                <th class="num">Δ</th>
+                <th class="num" title="Octopus Agile import price (p/kWh)">Tariff</th>
+                <th class="num" title="kWh consumed in this 30-min slot">kWh</th>
+                <th class="num" title="Total cost paid in this slot (p)">Cost</th>
+                <th class="num" title="Cost attributed to Daikin heat pump in this slot (p)">Daikin</th>
+                <th class="num" title="Cost attributed to everything-but-Daikin in this slot (p)">Residual</th>
+                <th class="num" title="What an SVT customer would have paid for the same kWh">SVT</th>
+                <th class="num" title="Saving vs SVT (negative = saved)">Δ</th>
             </tr></thead>
             <tbody id="planTbody"><tr><td colspan="9" class="text-mute">Loading…</td></tr></tbody>
+            <tfoot id="planTfoot"></tfoot>
         </table>
     </div>
 </section>
@@ -50,5 +51,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/plan.js"></script>
+<script src="/static/js/plan.js?v={{ static_v('js/plan.js') }}"></script>
 {% endblock %}

--- a/src/api/templates/settings.html
+++ b/src/api/templates/settings.html
@@ -3,58 +3,64 @@
 {% block content %}
 
 <p class="text-dim" style="margin:0 0 0.85rem 0;font-size:0.88rem;">
-    Every change goes through preview → confirm. The mode switch (simulation vs operational) and snapshot rollback live here on purpose — out of accidental-click range.
+    Every change goes through preview → confirm. The danger-zone toggles
+    (Daikin control + Operation mode + Rollback) are intentionally on this page,
+    out of accidental-click range from the main cockpit.
 </p>
 
-<section class="card">
-    <h2 class="card-title">Daikin control</h2>
-    <div class="settings-group" id="settingsDaikin"></div>
-</section>
-
-<section class="card">
-    <h2 class="card-title">Strategy</h2>
-    <div class="settings-group" id="settingsStrategy"></div>
-</section>
-
-<section class="card">
-    <h2 class="card-title">Schedule cadence</h2>
-    <div class="settings-group" id="settingsSchedule"></div>
-</section>
-
-<section class="card">
-    <h2 class="card-title">Comfort</h2>
-    <div class="settings-group" id="settingsComfort"></div>
-</section>
-
-<section class="card">
-    <h2 class="card-title">Operation mode &amp; rollback</h2>
-    <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
-        The system holds snapshots before any operational/simulation transition. Rollback restores the most recent and forces simulation mode.
-    </p>
-    <div class="settings-row">
-        <div>
-            <div class="label">Operation mode</div>
-            <div class="description">simulation = no hardware writes; operational = live</div>
+<!-- DANGER ZONE: Daikin + operation mode + rollback -->
+<section class="card danger-zone">
+    <h2 class="card-title">
+        <span style="display:inline-flex;align-items:center;gap:0.4rem;">⚠ Control mode</span>
+        <span class="text-mute" style="font-size:0.72rem;font-weight:400;">Changes here affect what hardware the service writes to</span>
+    </h2>
+    <div class="setting-block" id="settingDaikinControlMode"></div>
+    <div class="setting-block" id="settingOperationMode">
+        <div class="setting-head">
+            <h3 class="setting-name">Operation mode</h3>
+            <span class="status-badge" id="currentOpMode">—</span>
         </div>
-        <div class="control">
-            <span class="current" id="currentOpMode">—</span>
+        <p class="setting-desc"><code>simulation</code> blocks ALL hardware writes from this service. <code>operational</code> allows the LP/dispatcher to push to Fox V3 (and Daikin if active mode).</p>
+        <div class="setting-actions">
             <button class="btn btn-secondary btn-sm" data-op-mode="simulation">→ simulation</button>
             <button class="btn btn-secondary btn-sm" data-op-mode="operational">→ operational</button>
         </div>
     </div>
-    <div class="settings-row">
-        <div>
-            <div class="label">Rollback</div>
-            <div class="description">Restore last snapshot &amp; force simulation</div>
+    <div class="setting-block" id="settingRollback">
+        <div class="setting-head">
+            <h3 class="setting-name">Rollback</h3>
         </div>
-        <div class="control">
-            <button class="btn btn-danger btn-sm" id="btnRollback">⟲ Rollback latest</button>
+        <p class="setting-desc">Restore the most recent config snapshot and force simulation mode.</p>
+        <div class="setting-actions">
+            <button class="btn btn-danger btn-sm" id="btnRollback">⟲ Rollback latest snapshot</button>
         </div>
     </div>
+    <div class="setting-block" id="settingRequireSim"></div>
+</section>
+
+<!-- COMFORT -->
+<section class="card">
+    <h2 class="card-title">Comfort targets</h2>
+    <div id="settingsComfort"></div>
+</section>
+
+<!-- STRATEGY -->
+<section class="card">
+    <h2 class="card-title">Optimization strategy</h2>
+    <div id="settingsStrategy"></div>
+</section>
+
+<!-- SCHEDULE -->
+<section class="card">
+    <h2 class="card-title">Schedule cadence</h2>
+    <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
+        When the LP re-solves the plan. Cron jobs are re-registered automatically when these change.
+    </p>
+    <div id="settingsSchedule"></div>
 </section>
 
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/settings.js"></script>
+<script src="/static/js/settings.js?v={{ static_v('js/settings.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Operator feedback fixes:
1. Plan page Daikin/Residual columns now show **per-slot interval costs** (not cumulative Σ) + a totals row in tfoot.
2. Settings page rebuilt: human-labelled blocks with descriptions, danger zone at top (Daikin control / Require sim / Operation mode / Rollback).
3. Hot-reload: `Jinja2Templates(auto_reload=True)` + `static_v` cache-buster — HTML/JS/CSS deploys with `git pull` only, no restart.
