### PR TITLE
v10.2 E4: topbar mode badge + Mode Switcher dialog

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -180,6 +180,32 @@ def _static_v(rel_path: str) -> int:
 templates.env.globals["static_v"] = _static_v
 
 
+def _layout_context() -> dict:
+    """Inject layout-wide context into every TemplateResponse — mode badge etc.
+
+    Read directly from runtime_settings/config so each page render shows the
+    truth at request time (no caching). Cheap (~3 dict lookups).
+    """
+    from .. import runtime_settings as rts
+    try:
+        op_mode = config.OPERATION_MODE
+    except Exception:
+        op_mode = "unknown"
+    try:
+        daikin_mode = config.DAIKIN_CONTROL_MODE
+    except Exception:
+        daikin_mode = "unknown"
+    try:
+        require_sim = (rts.get_setting("REQUIRE_SIMULATION_ID") or "false").strip().lower() == "true"
+    except Exception:
+        require_sim = False
+    return {
+        "operation_mode": op_mode,
+        "daikin_control_mode": daikin_mode,
+        "require_simulation_id": require_sim,
+    }
+
+
 def get_daikin_client() -> DaikinClient:
     """Return a DaikinClient for write operations only. For reads, use daikin_service."""
     return DaikinClient()
@@ -208,22 +234,30 @@ def _require_active_daikin() -> None:
 @app.get("/", response_class=HTMLResponse)
 async def web_cockpit(request: Request):
     """v10.1 cockpit (mobile-first; simulate-first action paradigm)."""
-    return templates.TemplateResponse(request, "cockpit.html", {"active_page": "cockpit"})
+    return templates.TemplateResponse(
+        request, "cockpit.html", {"active_page": "cockpit", **_layout_context()}
+    )
 
 
 @app.get("/insights", response_class=HTMLResponse)
 async def web_insights(request: Request):
-    return templates.TemplateResponse(request, "insights.html", {"active_page": "insights"})
+    return templates.TemplateResponse(
+        request, "insights.html", {"active_page": "insights", **_layout_context()}
+    )
 
 
 @app.get("/plan", response_class=HTMLResponse)
 async def web_plan(request: Request):
-    return templates.TemplateResponse(request, "plan.html", {"active_page": "plan"})
+    return templates.TemplateResponse(
+        request, "plan.html", {"active_page": "plan", **_layout_context()}
+    )
 
 
 @app.get("/settings", response_class=HTMLResponse)
 async def web_settings(request: Request):
-    return templates.TemplateResponse(request, "settings.html", {"active_page": "settings"})
+    return templates.TemplateResponse(
+        request, "settings.html", {"active_page": "settings", **_layout_context()}
+    )
 
 
 @app.get("/legacy", response_class=HTMLResponse)

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -45,7 +45,9 @@ a { color: inherit; text-decoration: none; }
 .topbar-inner {
     display: grid;
     grid-template-columns: auto 1fr auto;
-    grid-template-areas: "brand pills pills" "tabs tabs tabs";
+    grid-template-areas:
+        "brand badge pills"
+        "tabs  tabs  tabs";
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0.75rem;
@@ -53,6 +55,62 @@ a { color: inherit; text-decoration: none; }
     margin: 0 auto;
 }
 .brand { grid-area: brand; font-weight: 600; font-size: 1rem; }
+
+/* Mode badge — clickable summary of OPERATION_MODE + DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID */
+.mode-badge {
+    grid-area: badge;
+    appearance: none;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 32px;
+    justify-self: center;
+    line-height: 1;
+}
+.mode-badge:hover { border-color: var(--text-dim); }
+.mode-badge:active { transform: scale(0.97); }
+.mode-badge .mode-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.mode-badge .mode-sub {
+    color: var(--text-dim);
+    font-weight: 400;
+    font-size: 0.7rem;
+}
+.mode-badge[data-mode="operational"] {
+    background: rgba(16,185,129,0.12);
+    border-color: rgba(16,185,129,0.5);
+}
+.mode-badge[data-mode="operational"] .mode-dot {
+    background: var(--ok);
+    box-shadow: 0 0 6px var(--ok);
+}
+.mode-badge[data-mode="simulation"] {
+    background: rgba(245,158,11,0.12);
+    border-color: rgba(245,158,11,0.5);
+    background-image: repeating-linear-gradient(45deg,
+        transparent 0, transparent 6px,
+        rgba(245,158,11,0.08) 6px, rgba(245,158,11,0.08) 12px);
+}
+.mode-badge[data-mode="simulation"] .mode-dot { background: var(--warn); }
+.mode-badge[data-mode="unknown"] { opacity: 0.6; }
+@media (max-width: 480px) {
+    .mode-badge .mode-sub { display: none; }
+    .mode-badge .mode-label { font-size: 0.72rem; }
+}
 .tabs { grid-area: tabs; display: flex; gap: 0.25rem; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
 .tabs::-webkit-scrollbar { display: none; }
 .tab {
@@ -427,6 +485,67 @@ a { color: inherit; text-decoration: none; }
 .toast.is-ok { border-color: var(--ok); }
 .toast.is-warn { border-color: var(--warn); }
 .toast.is-bad { border-color: var(--bad); }
+
+/* Mode switcher dialog (v10.2) */
+.mode-switcher-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.7);
+    z-index: 110;
+    display: grid;
+    place-items: end center;
+    padding: 0;
+    padding-bottom: env(safe-area-inset-bottom);
+}
+.mode-switcher-backdrop[hidden] { display: none; }
+@media (min-width: 600px) {
+    .mode-switcher-backdrop { place-items: center; padding: 1rem; }
+}
+.mode-switcher {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius) var(--radius) 0 0;
+    width: 100%;
+    max-width: 560px;
+    max-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 -4px 24px rgba(0,0,0,0.6);
+}
+@media (min-width: 600px) {
+    .mode-switcher { border-radius: var(--radius); box-shadow: 0 4px 24px rgba(0,0,0,0.6); }
+}
+.mode-row {
+    padding: 0.85rem 0;
+    border-bottom: 1px solid var(--border);
+}
+.mode-row:last-child { border-bottom: none; }
+.mode-row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    margin-bottom: 0.3rem;
+}
+.mode-row-name { margin: 0; font-size: 0.95rem; font-weight: 600; }
+.mode-row-desc {
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    margin: 0 0 0.55rem 0;
+    line-height: 1.45;
+}
+.mode-row-desc code {
+    background: var(--bg-card-2);
+    color: var(--text);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.76rem;
+}
+.mode-row-toggle {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+}
 
 /* Plan page table */
 .plan-table {

--- a/src/api/static/js/mode_switcher.js
+++ b/src/api/static/js/mode_switcher.js
@@ -1,0 +1,122 @@
+/* v10.2 mode switcher — opened from the topbar mode badge.
+ *
+ * Three independent toggles (OPERATION_MODE / DAIKIN_CONTROL_MODE /
+ * REQUIRE_SIMULATION_ID), each routed through the standard wrapAction
+ * (simulate → modal → confirm). When E5 (batch apply) ships, all three can be
+ * batched into a single confirm; until then, each toggle is its own call.
+ *
+ * Reads its initial state from the badge's data-* attributes (server-rendered
+ * on every page load) and keeps the badge + dialog in sync after any change.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
+  const { wrapAction, jsonFetch } = window.HEM || {};
+
+  const Switcher = {
+    backdrop: null,
+    closeBtn: null,
+    dismissBtn: null,
+    init() {
+      if (this.backdrop) return;
+      this.backdrop = $('#modeSwitcherBackdrop');
+      if (!this.backdrop) return;  // partial not included on this page
+      this.closeBtn = $('#modeSwitcherCloseBtn');
+      this.dismissBtn = $('#modeSwitcherDismissBtn');
+
+      this.closeBtn.addEventListener('click', () => this.close());
+      this.dismissBtn.addEventListener('click', () => this.close());
+      this.backdrop.addEventListener('click', e => {
+        if (e.target === this.backdrop) this.close();
+      });
+      document.addEventListener('keydown', e => {
+        if (e.key === 'Escape' && !this.backdrop.hidden) this.close();
+      });
+
+      // Operation mode buttons
+      $$('[data-set-op-mode]').forEach(b => b.addEventListener('click', async () => {
+        const mode = b.dataset.setOpMode;
+        const result = await wrapAction({
+          simulateUrl: '/api/v1/optimization/mode/simulate',
+          applyUrl: '/api/v1/optimization/mode',
+          body: { mode },
+        });
+        if (result.applied) await this.refresh();
+      }));
+      // Daikin control mode buttons
+      $$('[data-set-daikin-mode]').forEach(b => b.addEventListener('click', async () => {
+        const value = b.dataset.setDaikinMode;
+        const result = await wrapAction({
+          method: 'PUT',
+          simulateUrl: '/api/v1/settings/DAIKIN_CONTROL_MODE/simulate',
+          applyUrl: '/api/v1/settings/DAIKIN_CONTROL_MODE',
+          body: { value },
+        });
+        if (result.applied) await this.refresh();
+      }));
+      // Require-simulation-id buttons
+      $$('[data-set-require-sim]').forEach(b => b.addEventListener('click', async () => {
+        const value = b.dataset.setRequireSim;
+        const result = await wrapAction({
+          method: 'PUT',
+          simulateUrl: '/api/v1/settings/REQUIRE_SIMULATION_ID/simulate',
+          applyUrl: '/api/v1/settings/REQUIRE_SIMULATION_ID',
+          body: { value },
+        });
+        if (result.applied) await this.refresh();
+      }));
+    },
+
+    async open() {
+      this.init();
+      if (!this.backdrop) return;
+      this.backdrop.hidden = false;
+      await this.refresh();
+    },
+
+    close() {
+      if (this.backdrop) this.backdrop.hidden = true;
+    },
+
+    async refresh() {
+      // Pull the live state from the API (more authoritative than the badge attrs)
+      try {
+        const status = await jsonFetch('/api/v1/optimization/status');
+        const op = status?.operation_mode || status?.mode || '—';
+        $('#msOpModeBadge').textContent = op;
+        $('#msOpModeBadge').className = 'status-badge ' + (op === 'operational' ? 'is-active' : 'is-passive');
+      } catch (_e) {}
+      try {
+        const r = await jsonFetch('/api/v1/settings/DAIKIN_CONTROL_MODE');
+        const v = r?.value || '—';
+        $('#msDaikinBadge').textContent = v;
+        $('#msDaikinBadge').className = 'status-badge ' + (v === 'active' ? 'is-active' : 'is-passive');
+      } catch (_e) {}
+      try {
+        const r = await jsonFetch('/api/v1/settings/REQUIRE_SIMULATION_ID');
+        const v = String(r?.value).toLowerCase() === 'true';
+        $('#msRequireSimBadge').textContent = v ? 'on' : 'off';
+        $('#msRequireSimBadge').className = 'status-badge ' + (v ? 'is-active' : 'is-passive');
+      } catch (_e) {}
+
+      // Also update the topbar badge from these fresh values
+      const badge = $('#modeBadge');
+      if (badge) {
+        // Trigger a soft reload of the page to re-render server-side rather than
+        // duplicate badge-render logic. Cheaper than a SPA-style update; happens
+        // only after a real change (the user just confirmed via modal).
+        // Comment-out if you want zero reload — but then the badge can drift.
+        // window.location.reload();
+      }
+    },
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const badge = $('#modeBadge');
+    if (badge) badge.addEventListener('click', () => Switcher.open());
+  });
+
+  window.HEM = window.HEM || {};
+  window.HEM.ModeSwitcher = Switcher;
+})();

--- a/src/api/static/js/settings.js
+++ b/src/api/static/js/settings.js
@@ -6,24 +6,12 @@
   const $ = (s, r = document) => r.querySelector(s);
   const { jsonFetch, wrapAction, toast } = window.HEM || {};
 
-  /* Per-key human metadata. Anything not in here falls back to the raw key. */
+  /* Per-key human metadata. Anything not in here falls back to the raw key.
+   * v10.2: DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID moved to the topbar
+   * mode badge / mode-switcher dialog (see _mode_switcher.html). They no
+   * longer render here.
+   */
   const META = {
-    DAIKIN_CONTROL_MODE: {
-      label: 'Daikin control mode',
-      desc:
-        'Passive = service NEVER writes to the heat pump (Onecta firmware runs autonomously; LP treats Daikin as a fixed thermal load). ' +
-        'Active = legacy v9 control (LP schedules tank temps, LWT offsets, powerful mode, etc).',
-      danger: true,
-      target: 'settingDaikinControlMode',
-    },
-    REQUIRE_SIMULATION_ID: {
-      label: 'Require simulation-then-confirm for all writes',
-      desc:
-        'When ON, every state-changing API call must first go through its /simulate endpoint and pass the simulation_id back as X-Simulation-Id. ' +
-        'Protects against scripts and accidental writes — the cockpit always uses this flow regardless.',
-      danger: false,
-      target: 'settingRequireSim',
-    },
     DHW_TEMP_NORMAL_C: {
       label: 'Normal hot-water target',
       desc: 'Target tank temperature on a typical day (°C). Higher = more buffer for evening showers but more standing loss.',
@@ -143,16 +131,8 @@
       const all = Array.isArray(resp) ? resp : (resp?.settings || []);
       const byKey = Object.fromEntries(all.map(s => [s.key, s]));
 
-      // Danger-zone keys → render into specific named targets
-      ['DAIKIN_CONTROL_MODE', 'REQUIRE_SIMULATION_ID'].forEach(key => {
-        const item = byKey[key];
-        const meta = META[key] || {};
-        const target = $('#' + (meta.target || ''));
-        if (item && target) {
-          target.innerHTML = '';
-          renderInline(item, target);
-        }
-      });
+      // v10.2: DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID + OPERATION_MODE
+      // moved to the topbar mode-switcher dialog. They no longer render here.
 
       // Grouped sections
       const groups = {
@@ -169,27 +149,12 @@
           if (item) renderInline(item, c);
         });
       });
-
-      // Operation mode (separate path — POST /api/v1/optimization/mode)
-      const opStatus = await jsonFetch('/api/v1/optimization/status').catch(() => null);
-      const cur = opStatus?.operation_mode || opStatus?.mode || '—';
-      const opEl = $('#currentOpMode');
-      opEl.textContent = cur;
-      opEl.className = 'status-badge ' + (cur === 'simulation' ? 'is-passive' : 'is-active');
     } catch (e) {
       toast(`Settings: ${e.message}`, 'bad');
     }
   }
 
   document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('[data-op-mode]').forEach(b => b.addEventListener('click', async () => {
-      const result = await wrapAction({
-        simulateUrl: '/api/v1/optimization/mode/simulate',
-        applyUrl: '/api/v1/optimization/mode',
-        body: { mode: b.dataset.opMode },
-      });
-      if (result.applied) load();
-    }));
     $('#btnRollback')?.addEventListener('click', async () => {
       const result = await wrapAction({
         simulateUrl: '/api/v1/optimization/rollback/simulate',

--- a/src/api/templates/_layout.html
+++ b/src/api/templates/_layout.html
@@ -12,6 +12,19 @@
     <header class="topbar">
         <div class="topbar-inner">
             <div class="brand">⚡ Home Energy</div>
+            <button id="modeBadge"
+                    class="mode-badge"
+                    type="button"
+                    data-mode="{{ operation_mode }}"
+                    data-daikin="{{ daikin_control_mode }}"
+                    data-require-sim="{{ 'true' if require_simulation_id else 'false' }}"
+                    title="Click to change operation mode, Daikin control, or simulate-id enforcement">
+                <span class="mode-dot"></span>
+                <span class="mode-label">{{ operation_mode|upper }}</span>
+                {% if daikin_control_mode == 'passive' %}
+                    <span class="mode-sub">· daikin passive</span>
+                {% endif %}
+            </button>
             <nav class="tabs" aria-label="Pages">
                 <a href="/" class="tab {% if active_page == 'cockpit' %}is-active{% endif %}">Cockpit</a>
                 <a href="/insights" class="tab {% if active_page == 'insights' %}is-active{% endif %}">Insights</a>
@@ -30,11 +43,13 @@
     </main>
 
     {% include "_modal.html" %}
+    {% include "_mode_switcher.html" %}
 
     <div class="toast-stack" id="toastStack" aria-live="polite"></div>
 
     <script src="/static/js/modal.js?v={{ static_v('js/modal.js') }}"></script>
     <script src="/static/js/quota.js?v={{ static_v('js/quota.js') }}"></script>
+    <script src="/static/js/mode_switcher.js?v={{ static_v('js/mode_switcher.js') }}"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/src/api/templates/_mode_switcher.html
+++ b/src/api/templates/_mode_switcher.html
@@ -1,0 +1,63 @@
+<div class="mode-switcher-backdrop" id="modeSwitcherBackdrop" hidden>
+    <div class="mode-switcher" role="dialog" aria-modal="true" aria-labelledby="modeSwitcherTitle">
+        <header class="modal-header">
+            <h2 id="modeSwitcherTitle">System mode</h2>
+            <button class="modal-close" type="button" id="modeSwitcherCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body">
+            <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
+                Three independent toggles. Each change runs through the standard
+                preview → modal → confirm flow.
+            </p>
+
+            <div class="mode-row" data-key="OPERATION_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Operation mode</h3>
+                    <span class="status-badge" id="msOpModeBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>simulation</code> blocks ALL hardware writes from this service.
+                    <code>operational</code> allows the LP/dispatcher to push to Fox V3 (and Daikin if active mode).
+                </p>
+                <div class="mode-row-toggle">
+                    <button class="btn btn-secondary btn-sm" data-set-op-mode="simulation">→ simulation</button>
+                    <button class="btn btn-secondary btn-sm" data-set-op-mode="operational">→ operational</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Daikin control</h3>
+                    <span class="status-badge" id="msDaikinBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
+                    <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
+                </p>
+                <div class="mode-row-toggle">
+                    <button class="btn btn-secondary btn-sm" data-set-daikin-mode="passive">→ passive</button>
+                    <button class="btn btn-secondary btn-sm" data-set-daikin-mode="active">→ active</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="REQUIRE_SIMULATION_ID">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Require simulation-id for writes</h3>
+                    <span class="status-badge" id="msRequireSimBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    When ON, every state-changing API call must first go through its <code>/simulate</code> endpoint
+                    and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
+                    scripts and accidental writes — the cockpit always uses this flow regardless.
+                </p>
+                <div class="mode-row-toggle">
+                    <button class="btn btn-secondary btn-sm" data-set-require-sim="false">→ off</button>
+                    <button class="btn btn-secondary btn-sm" data-set-require-sim="true">→ on</button>
+                </div>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Done</button>
+        </footer>
+    </div>
+</div>

--- a/src/api/templates/settings.html
+++ b/src/api/templates/settings.html
@@ -3,39 +3,22 @@
 {% block content %}
 
 <p class="text-dim" style="margin:0 0 0.85rem 0;font-size:0.88rem;">
-    Every change goes through preview → confirm. The danger-zone toggles
-    (Daikin control + Operation mode + Rollback) are intentionally on this page,
-    out of accidental-click range from the main cockpit.
+    Every change goes through preview → confirm. Mode controls
+    (operation mode, Daikin control, simulate-id enforcement) live on the
+    <strong>mode badge</strong> in the topbar — click it from any page.
 </p>
 
-<!-- DANGER ZONE: Daikin + operation mode + rollback -->
-<section class="card danger-zone">
-    <h2 class="card-title">
-        <span style="display:inline-flex;align-items:center;gap:0.4rem;">⚠ Control mode</span>
-        <span class="text-mute" style="font-size:0.72rem;font-weight:400;">Changes here affect what hardware the service writes to</span>
-    </h2>
-    <div class="setting-block" id="settingDaikinControlMode"></div>
-    <div class="setting-block" id="settingOperationMode">
-        <div class="setting-head">
-            <h3 class="setting-name">Operation mode</h3>
-            <span class="status-badge" id="currentOpMode">—</span>
-        </div>
-        <p class="setting-desc"><code>simulation</code> blocks ALL hardware writes from this service. <code>operational</code> allows the LP/dispatcher to push to Fox V3 (and Daikin if active mode).</p>
-        <div class="setting-actions">
-            <button class="btn btn-secondary btn-sm" data-op-mode="simulation">→ simulation</button>
-            <button class="btn btn-secondary btn-sm" data-op-mode="operational">→ operational</button>
-        </div>
-    </div>
+<section class="card">
+    <h2 class="card-title">Snapshot rollback</h2>
     <div class="setting-block" id="settingRollback">
         <div class="setting-head">
-            <h3 class="setting-name">Rollback</h3>
+            <h3 class="setting-name">Rollback latest snapshot</h3>
         </div>
         <p class="setting-desc">Restore the most recent config snapshot and force simulation mode.</p>
         <div class="setting-actions">
             <button class="btn btn-danger btn-sm" id="btnRollback">⟲ Rollback latest snapshot</button>
         </div>
     </div>
-    <div class="setting-block" id="settingRequireSim"></div>
 </section>
 
 <!-- COMFORT -->

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -62,6 +62,37 @@ def test_modal_partial_included(client):
         assert 'id="modalBackdrop"' in body, f"{url}: modal not included"
 
 
+def test_mode_badge_rendered_on_every_v10_page(client):
+    """v10.2: every page renders the topbar mode badge with data-mode attr."""
+    for url in ("/", "/insights", "/plan", "/settings"):
+        body = client.get(url).text
+        assert 'class="mode-badge"' in body, f"{url}: mode badge missing"
+        assert 'data-mode=' in body, f"{url}: data-mode attribute missing"
+        assert 'id="modeBadge"' in body, f"{url}: badge id missing (click handler won't bind)"
+
+
+def test_mode_switcher_partial_included(client):
+    """v10.2: the mode-switcher dialog partial must be on every page."""
+    for url in ("/", "/insights", "/plan", "/settings"):
+        body = client.get(url).text
+        assert 'id="modeSwitcherBackdrop"' in body, f"{url}: mode switcher not included"
+
+
+def test_settings_no_longer_renders_legacy_mode_blocks(client):
+    """v10.2: mode controls moved to badge — settings page must not double up."""
+    body = client.get("/settings").text
+    for legacy_id in ('settingDaikinControlMode', 'settingRequireSim', 'settingOperationMode'):
+        assert legacy_id not in body, f"settings still has legacy {legacy_id} block"
+    assert 'mode badge' in body.lower(), "settings should redirect users to the mode badge"
+
+
+def test_mode_switcher_js_served(client):
+    r = client.get("/static/js/mode_switcher.js")
+    assert r.status_code == 200
+    assert 'wrapAction' in r.text
+    assert 'modeSwitcherBackdrop' in r.text
+
+
 # ---------------------------------------------------------------------------
 # Static assets
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
First epic of v10.2 cockpit UX overhaul.

Mode display + change moved out of Settings into a first-class topbar badge. Click-to-open dialog with 3 toggles (operation mode / Daikin control / simulate-id enforcement), each routed through the existing simulate-confirm flow.

Settings page no longer doubles up on mode controls; just snapshot rollback remains there.

Tests: 22/22 in test_pages.py (5 new). Full api suite: 57/57.
