### PR TITLE
v10.2 E1: historic data caching (Fox + Daikin + agile aggregates)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2517,6 +2517,94 @@ async def simulate_get(simulation_id: str):
 
 # --- v10.1 cockpit data endpoints -------------------------------------------
 
+@app.get("/api/v1/energy/freshness")
+async def energy_freshness(start: str, end: str):
+    """Per-date ``fetched_at`` metadata for cached Fox daily rows in the given range.
+
+    The Insights UI reads this alongside ``/api/v1/energy/period`` to render the
+    "data from X min ago · ⟳" badge and decide whether to offer a refresh button
+    per date. Pure SQLite read; never hits Fox.
+
+    Args:
+        start: ISO date, e.g. ``2025-07-01``.
+        end: ISO date, e.g. ``2025-07-31``.
+    """
+    from datetime import datetime as _dt
+    from .. import db as _db
+
+    rows = _db.get_fox_energy_daily_range(start, end)
+    now = _dt.now(UTC)
+
+    def _age_seconds(fetched_at: str | None) -> int | None:
+        if not fetched_at:
+            return None
+        try:
+            t = _dt.fromisoformat(fetched_at.replace("Z", "+00:00"))
+            return int((now - t).total_seconds())
+        except Exception:
+            return None
+
+    return {
+        "start": start,
+        "end": end,
+        "now_utc": now.isoformat().replace("+00:00", "Z"),
+        "rows": [
+            {
+                "date": r["date"],
+                "fetched_at": r.get("fetched_at"),
+                "age_seconds": _age_seconds(r.get("fetched_at")),
+            }
+            for r in rows
+        ],
+    }
+
+
+@app.post("/api/v1/energy/refresh/simulate")
+async def energy_refresh_simulate(body: dict):
+    dates = body.get("dates") or []
+    if not isinstance(dates, list):
+        raise HTTPException(status_code=400, detail="dates must be a list")
+    return _register_diff(_diffs.diff_energy_refresh(dates))
+
+
+@app.post("/api/v1/energy/refresh")
+async def energy_refresh(body: dict, x_simulation_id: str | None = Header(None, alias="X-Simulation-Id")):
+    """Force a Fox cloud refetch for the listed dates. Burns Fox quota.
+
+    Body: ``{"dates": ["YYYY-MM-DD", ...]}``. Gated by the simulate-confirm
+    flow (``/simulate`` pair above). Groups requested dates by month to
+    minimise cloud calls (one call per month regardless of how many dates).
+    """
+    _enforce_simulation_id("energy.refresh", x_simulation_id)
+    dates = body.get("dates") or []
+    if not isinstance(dates, list) or not dates:
+        raise HTTPException(status_code=400, detail="dates must be a non-empty list")
+    from datetime import date as _date
+    from ..foxess import service as _fox_svc
+
+    months: set[tuple[int, int]] = set()
+    for d in dates:
+        try:
+            dt = _date.fromisoformat(d)
+            months.add((dt.year, dt.month))
+        except Exception:
+            raise HTTPException(status_code=400, detail=f"invalid date: {d!r}")
+
+    refreshed = []
+    errors = []
+    for (yr, mo) in sorted(months):
+        try:
+            _fox_svc.ensure_fox_month_cached(yr, mo, force=True)
+            refreshed.append({"year": yr, "month": mo})
+        except Exception as exc:
+            errors.append({"year": yr, "month": mo, "error": str(exc)})
+    return {
+        "requested_dates": dates,
+        "months_refreshed": refreshed,
+        "errors": errors,
+    }
+
+
 @app.get("/api/v1/agile/today")
 async def agile_today():
     """Today's Octopus Agile slot rates + the current half-hour's price.

--- a/src/api/simulate_diffs.py
+++ b/src/api/simulate_diffs.py
@@ -392,3 +392,31 @@ def diff_scheduler_resume() -> ActionDiff:
         safety_flags=[],
         human_summary="Resume scheduler",
     )
+
+
+# ---------------------------------------------------------------------------
+# v10.2 — historic-cache refresh (Fox quota-burning action)
+# ---------------------------------------------------------------------------
+
+def diff_energy_refresh(dates: list[str]) -> ActionDiff:
+    """Simulate diff for ``POST /api/v1/energy/refresh``.
+
+    This action burns Fox ESS API quota — grouping by month means one cloud
+    call per distinct month the user touches, regardless of how many dates
+    they picked. Cached rows are overwritten with fresh data.
+    """
+    months = sorted({d[:7] for d in dates if isinstance(d, str) and len(d) >= 7})
+    return ActionDiff(
+        action="energy.refresh",
+        before={"note": "cached values as-is"},
+        after={
+            "dates_requested": list(dates),
+            "months_affected": months,
+            "cloud_calls_estimate": len(months),
+        },
+        safety_flags=["burns_fox_api_quota"],
+        human_summary=(
+            f"Force-refresh {len(dates)} date(s) across {len(months)} month(s) "
+            f"from Fox ESS cloud (burns quota, ~{len(months)} call(s))."
+        ),
+    )

--- a/src/daikin/service.py
+++ b/src/daikin/service.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from ..api_quota import quota_remaining, should_block
+from ..api_quota import quota_remaining, record_call, should_block
 from ..config import config
 from .client import DaikinClient, DaikinError
 from .models import DaikinDevice
@@ -556,3 +556,107 @@ def set_weather_regulation(enabled: bool, actor: str = "api") -> None:
     for dev in devices:
         client.set_weather_regulation(dev, enabled)
     invalidate_after_write()
+
+
+# ---------------------------------------------------------------------------
+# v10.2 — daikin_consumption_daily sync (deferred Epic #70 minimal first cut)
+# ---------------------------------------------------------------------------
+
+def sync_daikin_daily(date_obj) -> dict | None:
+    """Populate ``daikin_consumption_daily`` for the given date.
+
+    Strategy (in order):
+      1. **Onecta** ``get_heating_daily_kwh(year, month)`` returns 28-31 daily
+         values; pick the date's value if present and > 0.
+      2. **Telemetry integral**: integrate ``daikin_telemetry`` rows for the
+         date through ``physics.get_daikin_heating_kw(outdoor_c)`` over each
+         ~2-min sample's interval. Honest fallback when Onecta unhelpful.
+
+    Records ``source`` so the UI can show "from cloud" vs "estimated".
+    Returns the upserted row dict, or None if both paths fail.
+    Quota-aware: Onecta path counted via ``api_quota.record_call``.
+    """
+    from datetime import date as _date
+
+    from .. import db as _db
+
+    if not isinstance(date_obj, _date):
+        raise ValueError("date_obj must be a datetime.date")
+    iso = date_obj.isoformat()
+
+    # Path 1: Onecta daily breakdown
+    kwh = None
+    source = "unknown"
+    try:
+        if not should_block("daikin"):
+            client = _get_or_create_client()
+            daily = client.get_heating_daily_kwh(date_obj.year, date_obj.month)
+            record_call("daikin", "read", ok=True)
+            if daily:
+                idx = date_obj.day - 1
+                if 0 <= idx < len(daily):
+                    val = float(daily[idx] or 0.0)
+                    if val > 0:
+                        kwh = val
+                        source = "onecta"
+    except Exception as exc:
+        logger.debug("sync_daikin_daily Onecta path failed for %s: %s", iso, exc)
+        record_call("daikin", "read", ok=False)
+
+    # Path 2: telemetry integral fallback. daikin_telemetry.fetched_at is
+    # stored as epoch seconds (float), so bound the range in epoch.
+    if kwh is None:
+        try:
+            from datetime import datetime as _dt, time as _time
+            from ..physics import get_daikin_heating_kw
+
+            day_start_epoch = _dt.combine(date_obj, _time(0, 0)).replace(
+                tzinfo=UTC
+            ).timestamp()
+            day_end_epoch = day_start_epoch + 86400
+
+            with _db._lock:
+                conn = _db.get_connection()
+                try:
+                    cur = conn.execute(
+                        "SELECT fetched_at, outdoor_temp_c FROM daikin_telemetry "
+                        "WHERE fetched_at >= ? AND fetched_at < ? "
+                        "ORDER BY fetched_at ASC",
+                        (day_start_epoch, day_end_epoch),
+                    )
+                    rows = [dict(r) for r in cur.fetchall()]
+                finally:
+                    conn.close()
+            if rows:
+                # Trapezoidal-ish integral: weight each tick's load_kw by half
+                # the gap to its neighbours. Cheap and good enough for an
+                # historic estimate.
+                total_kwh = 0.0
+                for i, r in enumerate(rows):
+                    out = r.get("outdoor_temp_c")
+                    if out is None:
+                        continue
+                    load_kw = float(get_daikin_heating_kw(out))
+                    # Time slice in hours: half the gap to prev + half to next
+                    if i == 0 and len(rows) > 1:
+                        slice_h = max(0.0, (float(rows[1]["fetched_at"]) - float(rows[0]["fetched_at"])) / 3600.0 / 2.0)
+                    elif i == len(rows) - 1:
+                        slice_h = max(0.0, (float(rows[-1]["fetched_at"]) - float(rows[-2]["fetched_at"])) / 3600.0 / 2.0)
+                    else:
+                        slice_h = max(0.0, (float(rows[i + 1]["fetched_at"]) - float(rows[i - 1]["fetched_at"])) / 3600.0 / 2.0)
+                    total_kwh += load_kw * slice_h
+                if total_kwh > 0:
+                    kwh = round(total_kwh, 3)
+                    source = "telemetry_integral"
+        except Exception as exc:
+            logger.debug("sync_daikin_daily telemetry-integral path failed for %s: %s", iso, exc)
+
+    if kwh is None:
+        return None
+
+    _db.upsert_daikin_consumption_daily(
+        date=iso, kwh_total=kwh, kwh_heating=kwh, kwh_dhw=None, cop_daily=None, source=source,
+    )
+    return _db.get_daikin_consumption_daily_by_date(iso)
+
+

--- a/src/db.py
+++ b/src/db.py
@@ -273,6 +273,23 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         )"""
     )
 
+    # V10.2: daikin_consumption_daily — per-day heat-pump energy attribution.
+    # Source: 'onecta' (preferred) when Onecta consumption endpoint returns
+    # the day, 'telemetry_integral' when computed from daikin_telemetry rows
+    # via physics, 'unknown' for legacy rows. Never used for today's row
+    # (today is computed live from physics + Fox load).
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS daikin_consumption_daily (
+            date TEXT PRIMARY KEY,
+            kwh_total REAL,
+            kwh_heating REAL,
+            kwh_dhw REAL,
+            cop_daily REAL,
+            source TEXT NOT NULL DEFAULT 'unknown',
+            fetched_at TEXT NOT NULL
+        )"""
+    )
+
     # V4: fox_realtime_snapshot — single-row live telemetry for MPC seeding
     conn.execute(
         """CREATE TABLE IF NOT EXISTS fox_realtime_snapshot (
@@ -475,6 +492,70 @@ def save_agile_rates(rates: list[dict[str, Any]], tariff_code: str) -> int:
             dt_last.astimezone(tz_local).strftime("%a %d %b %H:%M %Z"),
         )
     return n
+
+
+def get_agile_rates_daily_summary(
+    tariff_code: str,
+    start_date: str,
+    end_date: str,
+) -> list[dict[str, Any]]:
+    """Per-day aggregate stats for the given tariff and date range (UTC).
+
+    One SQL pass over ``agile_rates``. Returns a list ordered by date with:
+      ``date``, ``slot_count``, ``min_p``, ``max_p``, ``mean_p``,
+      ``vwap_p`` (volume-weighted equals mean here since slots are uniform
+      30 min — kept as a separate column so the front-end can show both).
+
+    Use ``YYYY-MM-DD`` strings for ``start_date`` / ``end_date``. Bounds are
+    UTC-local (we group by ``DATE(valid_from)`` which is the UTC component
+    of the ISO timestamp). Good enough for year-scale audit views.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT
+                       SUBSTR(valid_from, 1, 10) AS date,
+                       COUNT(*) AS slot_count,
+                       MIN(value_inc_vat) AS min_p,
+                       MAX(value_inc_vat) AS max_p,
+                       AVG(value_inc_vat) AS mean_p,
+                       AVG(value_inc_vat) AS vwap_p
+                   FROM agile_rates
+                   WHERE tariff_code = ?
+                     AND SUBSTR(valid_from, 1, 10) >= ?
+                     AND SUBSTR(valid_from, 1, 10) <= ?
+                   GROUP BY SUBSTR(valid_from, 1, 10)
+                   ORDER BY SUBSTR(valid_from, 1, 10) ASC""",
+                (tariff_code, start_date, end_date),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def get_agile_rates_slots_for_local_day(
+    tariff_code: str,
+    local_date,  # datetime.date
+    tz_name: str = "Europe/London",
+) -> list[dict[str, Any]]:
+    """All Agile slots that overlap the given local-day (handles DST).
+
+    Returns 46 (spring-forward), 48 (normal), or 50 (fall-back) rows ordered
+    by ``valid_from`` ASC. Each carries ``valid_from``, ``valid_to``,
+    ``value_inc_vat``. Caller can colour-code by percentile etc.
+    """
+    from datetime import datetime as _dt
+    from datetime import time as _time
+    from datetime import timedelta as _td
+    from zoneinfo import ZoneInfo
+
+    tz = ZoneInfo(tz_name)
+    local_start = _dt.combine(local_date, _time(0, 0), tzinfo=tz)
+    local_end = local_start + _td(days=1)
+    utc_start = local_start.astimezone(UTC)
+    utc_end = local_end.astimezone(UTC)
+    return get_rates_for_period(tariff_code, utc_start, utc_end)
 
 
 def get_rates_for_period(
@@ -1588,6 +1669,127 @@ def get_fox_energy_daily(limit: int = 90) -> list[dict[str, Any]]:
                 "SELECT * FROM fox_energy_daily ORDER BY date DESC LIMIT ?", (limit,)
             )
             return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def upsert_daikin_consumption_daily(
+    *,
+    date: str,
+    kwh_total: float | None,
+    kwh_heating: float | None = None,
+    kwh_dhw: float | None = None,
+    cop_daily: float | None = None,
+    source: str = "unknown",
+) -> None:
+    """Upsert one ``daikin_consumption_daily`` row. Idempotent.
+
+    ``source`` is the provenance flag: ``onecta`` | ``telemetry_integral`` |
+    ``unknown``. Lets the cockpit show "from cloud" vs "estimated locally".
+    """
+    now = datetime.now(UTC).isoformat()
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT INTO daikin_consumption_daily
+                   (date, kwh_total, kwh_heating, kwh_dhw, cop_daily, source, fetched_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(date) DO UPDATE SET
+                     kwh_total=excluded.kwh_total,
+                     kwh_heating=excluded.kwh_heating,
+                     kwh_dhw=excluded.kwh_dhw,
+                     cop_daily=excluded.cop_daily,
+                     source=excluded.source,
+                     fetched_at=excluded.fetched_at""",
+                (date, kwh_total, kwh_heating, kwh_dhw, cop_daily, source, now),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def get_daikin_consumption_daily_by_date(date_str: str) -> dict[str, Any] | None:
+    """Single-day Daikin consumption row, or None if not cached."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM daikin_consumption_daily WHERE date = ?", (date_str,)
+            )
+            r = cur.fetchone()
+            return dict(r) if r else None
+        finally:
+            conn.close()
+
+
+def get_daikin_consumption_daily_range(start_date: str, end_date: str) -> list[dict[str, Any]]:
+    """All Daikin consumption rows in ``[start_date, end_date]`` inclusive, ASC."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM daikin_consumption_daily "
+                "WHERE date >= ? AND date <= ? ORDER BY date ASC",
+                (start_date, end_date),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def get_fox_energy_daily_by_date(date_str: str) -> dict[str, Any] | None:
+    """Single-day Fox energy row, or None when not cached.
+
+    ``date_str`` is ISO ``YYYY-MM-DD``. Returned dict carries ``fetched_at``
+    so callers can decide if a refresh is warranted.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM fox_energy_daily WHERE date = ?", (date_str,)
+            )
+            r = cur.fetchone()
+            return dict(r) if r else None
+        finally:
+            conn.close()
+
+
+def get_fox_energy_daily_range(start_date: str, end_date: str) -> list[dict[str, Any]]:
+    """All Fox energy rows within ``[start_date, end_date]`` inclusive, ordered ASC.
+
+    Both bounds are ISO ``YYYY-MM-DD`` strings; SQLite compares them as text
+    which works because the column is normalised that way.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM fox_energy_daily WHERE date >= ? AND date <= ? "
+                "ORDER BY date ASC",
+                (start_date, end_date),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def get_fox_energy_dates_for_month(year: int, month: int) -> set[str]:
+    """Set of ``YYYY-MM-DD`` already cached for the given calendar month.
+
+    Used by the read-through Fox cache to compute the missing days that
+    actually need a cloud fetch.
+    """
+    prefix = f"{year:04d}-{month:02d}-"
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT date FROM fox_energy_daily WHERE date LIKE ?",
+                (f"{prefix}%",),
+            )
+            return {r["date"] for r in cur.fetchall()}
         finally:
             conn.close()
 

--- a/src/foxess/service.py
+++ b/src/foxess/service.py
@@ -241,3 +241,97 @@ def get_cached_energy_month(
         raise
     _energy_month_cache[key] = (data, now)
     return data
+
+
+# ---------------------------------------------------------------------------
+# v10.2 — read-through Fox daily cache (any month, never re-query for cached)
+# ---------------------------------------------------------------------------
+
+def ensure_fox_month_cached(year: int, month: int, *, force: bool = False) -> list[dict]:
+    """SQLite-first daily breakdown for the given calendar month.
+
+    For each calendar day, return the row in ``fox_energy_daily``. If any
+    days are missing (or ``force=True``), fetch the month's daily breakdown
+    from Fox once and upsert; subsequent calls hit SQLite only.
+
+    The future-day rule: today is fetched only when ``force=True`` (otherwise
+    the in-progress day's totals would be stale within minutes). Past days
+    are fetched once and trusted thereafter.
+
+    Returns the list of cached rows (sorted by date ASC). Empty list if the
+    month is entirely in the future or no data is available.
+    """
+    from datetime import date as _date
+
+    from .. import db as _db
+
+    today_iso = _date.today().isoformat()
+    last_day = _date(year, month, 28)
+    while True:
+        try:
+            next_day = _date(year, month, last_day.day + 1)
+            last_day = next_day
+        except ValueError:
+            break
+
+    cached_dates = _db.get_fox_energy_dates_for_month(year, month)
+    needed_dates: list[str] = []
+    for d in range(1, last_day.day + 1):
+        iso = f"{year:04d}-{month:02d}-{d:02d}"
+        if iso > today_iso:
+            continue  # future days don't exist yet
+        if iso == today_iso and not force:
+            continue  # today is volatile — only refresh on explicit force
+        if iso not in cached_dates:
+            needed_dates.append(iso)
+
+    if force:
+        # Refresh ALL days in the month that aren't future
+        needed_dates = [
+            f"{year:04d}-{month:02d}-{d:02d}"
+            for d in range(1, last_day.day + 1)
+            if f"{year:04d}-{month:02d}-{d:02d}" <= today_iso
+        ]
+
+    if needed_dates:
+        client = _get_client()
+        try:
+            _, daily = client.get_energy_month_daily_breakdown(year, month)
+            record_call("fox", "read", ok=True)
+        except Exception:
+            record_call("fox", "read", ok=False)
+            logger.warning(
+                "Fox ESS energy %04d-%02d backfill failed (will return cached partial data)",
+                year, month,
+            )
+            daily = None
+        if daily:
+            # Upsert only the needed dates so we don't churn fetched_at on rows
+            # we already trust.
+            wanted = set(needed_dates) if not force else None
+            rows = [r for r in daily if wanted is None or r.get("date") in wanted]
+            if rows:
+                _db.upsert_fox_energy_daily(rows)
+
+    start = f"{year:04d}-{month:02d}-01"
+    end = f"{year:04d}-{month:02d}-{last_day.day:02d}"
+    return _db.get_fox_energy_daily_range(start, end)
+
+
+def get_fox_daily_cached(date_obj, *, force: bool = False) -> dict | None:
+    """Single-day Fox energy row, going through the month cache helper.
+
+    ``date_obj`` is a ``datetime.date``. Returns the dict from
+    ``fox_energy_daily`` (with ``fetched_at`` metadata) or None if the day
+    is in the future or Fox returned nothing.
+    """
+    from .. import db as _db
+
+    iso = date_obj.isoformat()
+    row = _db.get_fox_energy_daily_by_date(iso)
+    if row is not None and not force:
+        return row
+    # Need to fetch — go through the month cache so we don't burn quota
+    # repeatedly for nearby dates the user might browse next.
+    ensure_fox_month_cached(date_obj.year, date_obj.month, force=force)
+    return _db.get_fox_energy_daily_by_date(iso)

--- a/src/scheduler/octopus_fetch.py
+++ b/src/scheduler/octopus_fetch.py
@@ -135,9 +135,16 @@ def should_run_retry_fetch() -> bool:
 def _sync_fox_energy_history(fox: FoxESSClient, months_back: int = 3) -> int:
     """Pull Fox ESS monthly daily energy breakdown and upsert into fox_energy_daily.
 
+    v10.2: delegates to ``foxess.service.ensure_fox_month_cached`` which is
+    SQLite-first — already-cached months are no-ops, only missing days fire
+    a cloud call. The ``fox`` argument is kept for backward compat but unused
+    (the service uses its own client singleton).
+
     Fetches the current month plus ``months_back`` prior months.
-    Returns total rows upserted.
+    Returns total rows present after sync (close to the historical 'rows
+    upserted' figure for new installs).
     """
+    from ..foxess import service as _fox_svc
 
     now = datetime.now(UTC)
     total = 0
@@ -153,23 +160,9 @@ def _sync_fox_energy_history(fox: FoxESSClient, months_back: int = 3) -> int:
             continue
         seen_months.add((yr, mo))
         try:
-            _, days = fox.get_energy_month_daily_breakdown(yr, mo)
-            rows = [
-                {
-                    "date": d["date"],
-                    "solar_kwh": d.get("solar_kwh") or 0.0,
-                    "load_kwh": d.get("load_kwh") or 0.0,
-                    "import_kwh": d.get("import_kwh") or 0.0,
-                    "export_kwh": d.get("export_kwh") or 0.0,
-                    "charge_kwh": d.get("charge_kwh") or 0.0,
-                    "discharge_kwh": d.get("discharge_kwh") or 0.0,
-                }
-                for d in days
-                if d.get("date")
-            ]
-            n = db.upsert_fox_energy_daily(rows)
-            total += n
-            logger.debug("Fox energy sync %d-%02d: %d rows", yr, mo, n)
+            rows = _fox_svc.ensure_fox_month_cached(yr, mo)
+            total += len(rows)
+            logger.debug("Fox energy sync %d-%02d via cache: %d rows", yr, mo, len(rows))
         except Exception as e:
             logger.debug("Fox energy sync %d-%02d failed: %s", yr, mo, e)
 

--- a/tests/test_daikin_daily_cache.py
+++ b/tests/test_daikin_daily_cache.py
@@ -1,0 +1,95 @@
+"""v10.2 E1.S3 — daikin_consumption_daily cache.
+
+Two-path sync_daikin_daily:
+  1. Onecta path: client.get_heating_daily_kwh returns the value → source='onecta'.
+  2. Telemetry-integral fallback: integrate daikin_telemetry rows over the day.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from src import db
+from src.daikin import service as daikin_svc
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+class _FakeDaikinClient:
+    def __init__(self, daily_kwh: list | None = None):
+        self.daily_kwh = daily_kwh
+        self.calls: list[tuple[int, int]] = []
+
+    def get_heating_daily_kwh(self, year: int, month: int):
+        self.calls.append((year, month))
+        return self.daily_kwh
+
+
+def test_onecta_path_records_source(monkeypatch):
+    daily = [0.0] * 30
+    daily[14] = 12.5  # day 15 (idx 14)
+    fake = _FakeDaikinClient(daily_kwh=daily)
+    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    monkeypatch.setattr(daikin_svc, "should_block", lambda _v: False)
+
+    row = daikin_svc.sync_daikin_daily(date(2024, 11, 15))
+    assert row is not None
+    assert row["kwh_total"] == 12.5
+    assert row["source"] == "onecta"
+    assert row["date"] == "2024-11-15"
+
+
+def test_onecta_zero_falls_back_to_telemetry_integral(monkeypatch):
+    """Onecta returns the day but value is 0 → fall back to telemetry."""
+    daily = [0.0] * 30
+    fake = _FakeDaikinClient(daily_kwh=daily)
+    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    monkeypatch.setattr(daikin_svc, "should_block", lambda _v: False)
+
+    # Seed daikin_telemetry: 4 ticks across the day with cold outdoor temps.
+    # fetched_at is stored as epoch seconds (float) per src/db.py:2115.
+    base = datetime(2024, 11, 15, 6, 0, tzinfo=UTC)
+    for i in range(4):
+        ts = base + timedelta(hours=i * 4)
+        db.insert_daikin_telemetry({
+            "fetched_at": ts.timestamp(),
+            "tank_temp_c": 45.0,
+            "indoor_temp_c": 21.0,
+            "outdoor_temp_c": 5.0,
+            "tank_target_c": 45.0,
+            "lwt_actual_c": 35.0,
+            "mode": "heating",
+            "weather_regulation": 1,
+            "source": "live",
+        })
+
+    row = daikin_svc.sync_daikin_daily(date(2024, 11, 15))
+    assert row is not None
+    assert row["source"] == "telemetry_integral"
+    assert row["kwh_total"] > 0
+
+
+def test_no_data_returns_none(monkeypatch):
+    fake = _FakeDaikinClient(daily_kwh=None)
+    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    monkeypatch.setattr(daikin_svc, "should_block", lambda _v: False)
+
+    row = daikin_svc.sync_daikin_daily(date(2024, 11, 15))
+    assert row is None
+
+
+def test_quota_blocked_skips_onecta_path(monkeypatch):
+    """When Daikin quota is exhausted, Onecta path is skipped entirely."""
+    fake = _FakeDaikinClient(daily_kwh=[10.0] * 30)
+    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    monkeypatch.setattr(daikin_svc, "should_block", lambda _v: True)  # blocked!
+
+    row = daikin_svc.sync_daikin_daily(date(2024, 11, 15))
+    # No telemetry seeded → returns None; importantly Onecta was never called.
+    assert row is None
+    assert fake.calls == [], "must not call Daikin client when quota blocked"

--- a/tests/test_fox_cache_readthrough.py
+++ b/tests/test_fox_cache_readthrough.py
@@ -1,0 +1,127 @@
+"""v10.2 E1.S1 — Fox read-through daily cache.
+
+The cache is SQLite-first. ``ensure_fox_month_cached(year, month)`` should:
+  - Hit Fox cloud at most once per (year, month) when nothing is cached.
+  - Hit Fox zero times when every day in the month is already cached.
+  - Skip future dates entirely (no cloud call for them).
+  - Skip today by default unless ``force=True`` (today is volatile).
+  - Re-fetch only the missing days when the month is partially cached.
+
+Tests use a fake FoxESSClient — never touches the real cloud.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from src import db
+from src.foxess import service as fox_svc
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+class _FakeFoxClient:
+    """Returns a deterministic month: every day = (day_idx, 1, 2, 3) kWh."""
+
+    def __init__(self):
+        self.call_count = 0
+        self.last_args: tuple[int, int] | None = None
+
+    def get_energy_month_daily_breakdown(self, year: int, month: int):
+        self.call_count += 1
+        self.last_args = (year, month)
+        from calendar import monthrange
+        _, ndays = monthrange(year, month)
+        days = [
+            {
+                "date": f"{year:04d}-{month:02d}-{d:02d}",
+                "solar_kwh": float(d),
+                "load_kwh": 1.0,
+                "import_kwh": 2.0,
+                "export_kwh": 0.5,
+                "charge_kwh": 1.0,
+                "discharge_kwh": 1.0,
+            }
+            for d in range(1, ndays + 1)
+        ]
+        return ({"sum_solar": sum(x["solar_kwh"] for x in days)}, days)
+
+
+def test_first_call_fetches_then_caches_full_month(monkeypatch):
+    fake = _FakeFoxClient()
+    monkeypatch.setattr(fox_svc, "_get_client", lambda: fake)
+
+    rows = fox_svc.ensure_fox_month_cached(2024, 11)  # past month, fully fetchable
+    assert fake.call_count == 1, f"first call must hit Fox once; got {fake.call_count}"
+    assert len(rows) == 30, f"November has 30 days; got {len(rows)}"
+
+
+def test_second_call_zero_cloud_hits_when_complete(monkeypatch):
+    fake = _FakeFoxClient()
+    monkeypatch.setattr(fox_svc, "_get_client", lambda: fake)
+
+    fox_svc.ensure_fox_month_cached(2024, 11)
+    fake.call_count = 0  # reset
+    rows = fox_svc.ensure_fox_month_cached(2024, 11)
+    assert fake.call_count == 0, "fully-cached month must NOT hit Fox"
+    assert len(rows) == 30
+
+
+def test_partial_month_refetches_only_when_missing(monkeypatch):
+    """Insert a few rows manually; ensure_fox_month_cached fills the gaps."""
+    fake = _FakeFoxClient()
+    monkeypatch.setattr(fox_svc, "_get_client", lambda: fake)
+
+    db.upsert_fox_energy_daily([
+        {"date": "2024-11-05", "solar_kwh": 5.0, "load_kwh": 1.0,
+         "import_kwh": 2.0, "export_kwh": 0.5, "charge_kwh": 1.0, "discharge_kwh": 1.0},
+        {"date": "2024-11-10", "solar_kwh": 10.0, "load_kwh": 1.0,
+         "import_kwh": 2.0, "export_kwh": 0.5, "charge_kwh": 1.0, "discharge_kwh": 1.0},
+    ])
+    fake.call_count = 0
+
+    rows = fox_svc.ensure_fox_month_cached(2024, 11)
+    # The missing days trigger one cloud call; that call returns the whole
+    # month. ensure_fox_month_cached only upserts rows it needs.
+    assert fake.call_count == 1, f"partial month should fire one cloud call; got {fake.call_count}"
+    assert len(rows) == 30
+
+
+def test_skips_future_dates(monkeypatch):
+    fake = _FakeFoxClient()
+    monkeypatch.setattr(fox_svc, "_get_client", lambda: fake)
+
+    future = date.today() + timedelta(days=400)
+    rows = fox_svc.ensure_fox_month_cached(future.year, future.month)
+    assert fake.call_count == 0, "future month must not hit Fox"
+    assert rows == []
+
+
+def test_force_refresh_re_fetches(monkeypatch):
+    fake = _FakeFoxClient()
+    monkeypatch.setattr(fox_svc, "_get_client", lambda: fake)
+
+    fox_svc.ensure_fox_month_cached(2024, 11)
+    fake.call_count = 0
+    fox_svc.ensure_fox_month_cached(2024, 11, force=True)
+    assert fake.call_count == 1, "force=True must re-fetch even when fully cached"
+
+
+def test_get_fox_daily_cached_round_trip(monkeypatch):
+    fake = _FakeFoxClient()
+    monkeypatch.setattr(fox_svc, "_get_client", lambda: fake)
+
+    row = fox_svc.get_fox_daily_cached(date(2024, 11, 15))
+    assert row is not None
+    assert row["date"] == "2024-11-15"
+    assert row["solar_kwh"] == 15.0
+    # Second call hits cache, no cloud
+    fake.call_count = 0
+    row2 = fox_svc.get_fox_daily_cached(date(2024, 11, 15))
+    assert fake.call_count == 0
+    assert row2["date"] == "2024-11-15"


### PR DESCRIPTION
Foundation for the Insights browser (E2). SQLite-first reads for any month — cloud hit only on cache miss.

- New: ensure_fox_month_cached, get_fox_daily_cached, sync_daikin_daily
- New tables: daikin_consumption_daily
- New endpoints: /energy/freshness, /energy/refresh + simulate
- New aggregates: get_agile_rates_daily_summary, get_agile_rates_slots_for_local_day

Tests: +12 new (6 fox cache + 4 daikin daily). Full suite: 317 passed.