### PR TITLE
feat(v10.2 E5): batch settings apply — one simulate-confirm for N changes

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2494,6 +2494,67 @@ async def settings_simulate(key: str, body: dict):
     return _register_diff(_diffs.diff_setting_change(key, body.get("value")))
 
 
+@app.post("/api/v1/settings/batch/simulate")
+async def settings_batch_simulate(body: dict):
+    """Simulate N settings changes in one diff. Body: ``{changes: {KEY: value, ...}}``."""
+    changes = body.get("changes") or {}
+    if not isinstance(changes, dict) or not changes:
+        raise HTTPException(status_code=400, detail="changes must be a non-empty object")
+    return _register_diff(_diffs.diff_settings_batch(changes))
+
+
+@app.post("/api/v1/settings/batch")
+async def settings_batch_apply(
+    body: dict,
+    x_simulation_id: str | None = Header(None, alias="X-Simulation-Id"),
+):
+    """Apply N settings changes atomically (best-effort rollback on failure).
+
+    Pair with ``/simulate`` above; pass ``X-Simulation-Id``. If any individual
+    ``set_setting`` fails mid-batch, we re-apply the previous values for the
+    keys that already succeeded, then surface a 409 with the per-key error.
+    """
+    _enforce_simulation_id("settings.batch", x_simulation_id)
+    changes = body.get("changes") or {}
+    if not isinstance(changes, dict) or not changes:
+        raise HTTPException(status_code=400, detail="changes must be a non-empty object")
+    from .. import runtime_settings as rts
+
+    applied: list[tuple[str, Any]] = []  # (key, prior_value) for rollback
+    results: list[dict] = []
+    for key, value in changes.items():
+        try:
+            prior = rts.get_setting(key)
+        except Exception:
+            prior = None
+        try:
+            canonical = rts.set_setting(key, value, actor="api_batch")
+            applied.append((key, prior))
+            results.append({"key": key, "ok": True, "value": canonical})
+        except Exception as exc:
+            # Rollback succeeded keys
+            rollback_errors: list[dict] = []
+            for ok_key, ok_prior in applied:
+                try:
+                    if ok_prior is not None:
+                        rts.set_setting(ok_key, ok_prior, actor="api_batch_rollback")
+                    else:
+                        rts.delete_setting(ok_key, actor="api_batch_rollback")
+                except Exception as rb_exc:
+                    rollback_errors.append({"key": ok_key, "error": str(rb_exc)})
+            results.append({"key": key, "ok": False, "error": str(exc)})
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "BatchPartialFailure",
+                    "failed_at_key": key,
+                    "results": results,
+                    "rollback_errors": rollback_errors,
+                },
+            )
+    return {"ok": True, "results": results}
+
+
 @app.post("/api/v1/scheduler/pause/simulate")
 async def scheduler_pause_simulate():
     return _register_diff(_diffs.diff_scheduler_pause())

--- a/src/api/simulate_diffs.py
+++ b/src/api/simulate_diffs.py
@@ -398,6 +398,52 @@ def diff_scheduler_resume() -> ActionDiff:
 # v10.2 — historic-cache refresh (Fox quota-burning action)
 # ---------------------------------------------------------------------------
 
+def diff_settings_batch(changes: dict[str, Any]) -> ActionDiff:
+    """Roll N settings changes into one ``ActionDiff`` with ``sub_actions``.
+
+    Each key gets its own per-key diff via :func:`diff_setting_change`. Safety
+    flags are unioned. The umbrella diff's ``before``/``after`` are tabular
+    summaries — modal renders ``sub_actions`` as a proper table.
+
+    Use ``POST /api/v1/settings/batch/simulate`` to obtain a ``simulation_id``
+    for ``POST /api/v1/settings/batch``.
+    """
+    sub: list[dict[str, Any]] = []
+    flags: set[str] = set()
+    summaries: list[str] = []
+    before_table: dict[str, Any] = {}
+    after_table: dict[str, Any] = {}
+    for key, value in (changes or {}).items():
+        d = diff_setting_change(key, value)
+        sub.append({
+            "key": key,
+            "action": d.action,
+            "before": d.before,
+            "after": d.after,
+            "safety_flags": list(d.safety_flags),
+            "human_summary": d.human_summary,
+        })
+        flags.update(d.safety_flags)
+        summaries.append(d.human_summary)
+        # Flatten before/after into per-key tables for the rollup view.
+        for k, v in (d.before or {}).items():
+            before_table[k] = v
+        for k, v in (d.after or {}).items():
+            after_table[k] = v
+
+    return ActionDiff(
+        action="settings.batch",
+        before=before_table,
+        after=after_table,
+        safety_flags=sorted(flags),
+        sub_actions=sub,
+        human_summary=(
+            f"Apply {len(sub)} setting change(s) in one batch."
+            if sub else "No changes (empty batch)."
+        ),
+    )
+
+
 def diff_energy_refresh(dates: list[str]) -> ActionDiff:
     """Simulate diff for ``POST /api/v1/energy/refresh``.
 

--- a/src/api/simulation.py
+++ b/src/api/simulation.py
@@ -26,9 +26,13 @@ class ActionDiff:
     The frontend renders ``human_summary`` in the modal; ``before``/``after``
     populate a structured before/after panel; ``safety_flags`` raise a banner
     that requires explicit confirmation.
+
+    v10.2: ``sub_actions`` carries per-item diffs for batch actions. When
+    present, the modal renders a table; the umbrella diff's before/after
+    are aggregated rollups.
     """
 
-    action: str  # e.g. "foxess.set_mode", "daikin.set_lwt_offset"
+    action: str  # e.g. "foxess.set_mode", "daikin.set_lwt_offset", "settings.batch"
     before: dict[str, Any]
     after: dict[str, Any]
     affected_slots: list[str] = field(default_factory=list)
@@ -38,6 +42,7 @@ class ActionDiff:
     human_summary: str = ""
     simulation_id: str = ""
     expires_at_epoch: float = 0.0
+    sub_actions: list[dict[str, Any]] = field(default_factory=list)
 
     def to_response_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -449,6 +449,48 @@ a { color: inherit; text-decoration: none; }
     white-space: pre-wrap;
     word-break: break-word;
 }
+.modal-batch-table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-card-2);
+}
+.modal-batch-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+.modal-batch-table th,
+.modal-batch-table td {
+    padding: 0.45rem 0.65rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+.modal-batch-table thead th {
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    letter-spacing: 0.06em;
+    color: var(--text-mute);
+    background: var(--bg);
+    position: sticky;
+    top: 0;
+}
+.modal-batch-table tbody tr:last-child td { border-bottom: none; }
+.modal-batch-table .bcell-key code { color: var(--text); }
+.modal-batch-table .bcell-before { color: var(--text-dim); }
+.modal-batch-table .bcell-after  { color: var(--ok); }
+.modal-batch-table .bcell-safety { white-space: normal; }
+.batch-flag {
+    display: inline-block;
+    padding: 0.05rem 0.3rem;
+    border-radius: 4px;
+    margin-right: 0.2rem;
+    font-size: 0.7rem;
+}
+.batch-flag-soft { background: rgba(245,158,11,0.15); color: var(--warn); border: 1px solid rgba(245,158,11,0.4); }
+.batch-flag-hard { background: rgba(239,68,68,0.15); color: var(--bad); border: 1px solid rgba(239,68,68,0.5); }
 .flags-section { background: rgba(239,68,68,0.08); border: 1px solid rgba(239,68,68,0.4); border-radius: var(--radius); padding: 0.65rem; }
 .flags-heading { color: var(--bad); }
 .flags-list { margin: 0; padding-left: 1.2rem; font-size: 0.82rem; }
@@ -545,6 +587,17 @@ a { color: inherit; text-decoration: none; }
     display: flex;
     gap: 0.4rem;
     align-items: center;
+}
+.mode-row-toggle .btn.is-selected {
+    background: rgba(59,130,246,0.18);
+    border-color: var(--accent);
+    color: var(--text);
+}
+.mode-row-toggle .btn.is-pending {
+    background: rgba(245,158,11,0.18);
+    border-color: var(--warn);
+    color: var(--warn);
+    box-shadow: 0 0 0 1px var(--warn);
 }
 
 /* Plan page table */

--- a/src/api/static/js/modal.js
+++ b/src/api/static/js/modal.js
@@ -28,6 +28,22 @@
     }
   }
 
+  function fmtScalar(v) {
+    // Pull a single scalar out of a {key: value} dict (per-row before/after
+    // entries from diff_settings_batch); fall back to JSON for nested shapes.
+    if (v == null) return '—';
+    if (typeof v === 'object') {
+      const keys = Object.keys(v);
+      if (keys.length === 1) return fmtScalar(v[keys[0]]);
+      if (keys.length === 0) return '—';
+      try { return JSON.stringify(v); } catch (_e) { return String(v); }
+    }
+    if (typeof v === 'number') {
+      return Math.abs(v) < 0.01 || Math.abs(v) >= 1000 ? String(v) : (Math.round(v * 1000) / 1000).toString();
+    }
+    return String(v);
+  }
+
   function classifyFlag(flag) {
     // Flags that require typed-confirmation are the most dangerous ones.
     const HARD = new Set([
@@ -46,6 +62,10 @@
     summaryEl: null,
     beforeEl: null,
     afterEl: null,
+    beforeSection: null,
+    afterSection: null,
+    batchSection: null,
+    batchBody: null,
     flagsSection: null,
     flagsList: null,
     flagsConfirmLabel: null,
@@ -65,6 +85,10 @@
       this.summaryEl = $('#modalSummary');
       this.beforeEl = $('#modalBefore');
       this.afterEl = $('#modalAfter');
+      this.beforeSection = $('#modalBeforeSection');
+      this.afterSection = $('#modalAfterSection');
+      this.batchSection = $('#modalBatchSection');
+      this.batchBody = $('#modalBatchBody');
       this.flagsSection = $('#modalFlagsSection');
       this.flagsList = $('#modalFlags');
       this.flagsConfirmLabel = $('#modalFlagsConfirmLabel');
@@ -94,8 +118,29 @@
       this._diff = diff;
       this.titleEl.textContent = diff.action || 'Confirm';
       this.summaryEl.textContent = diff.human_summary || '';
-      this.beforeEl.textContent = fmtJson(diff.before);
-      this.afterEl.textContent = fmtJson(diff.after);
+
+      const subs = Array.isArray(diff.sub_actions) ? diff.sub_actions : [];
+      if (subs.length) {
+        // Batch mode: render table, hide raw before/after blocks.
+        this.batchBody.innerHTML = subs.map(s => {
+          const safety = (s.safety_flags || []).map(f => `<code class="batch-flag batch-flag-${classifyFlag(f)}">${escapeHtml(f)}</code>`).join(' ') || '<span class="text-dim">—</span>';
+          return `<tr>
+              <td class="bcell-key"><code>${escapeHtml(s.key || s.action || '?')}</code></td>
+              <td class="bcell-before">${escapeHtml(fmtScalar(s.before))}</td>
+              <td class="bcell-after">${escapeHtml(fmtScalar(s.after))}</td>
+              <td class="bcell-safety">${safety}</td>
+          </tr>`;
+        }).join('');
+        this.batchSection.hidden = false;
+        this.beforeSection.hidden = true;
+        this.afterSection.hidden = true;
+      } else {
+        this.batchSection.hidden = true;
+        this.beforeSection.hidden = false;
+        this.afterSection.hidden = false;
+        this.beforeEl.textContent = fmtJson(diff.before);
+        this.afterEl.textContent = fmtJson(diff.after);
+      }
 
       const cost = diff.cost_delta_pence;
       const slots = diff.affected_slots || [];

--- a/src/api/static/js/mode_switcher.js
+++ b/src/api/static/js/mode_switcher.js
@@ -1,12 +1,9 @@
 /* v10.2 mode switcher — opened from the topbar mode badge.
  *
- * Three independent toggles (OPERATION_MODE / DAIKIN_CONTROL_MODE /
- * REQUIRE_SIMULATION_ID), each routed through the standard wrapAction
- * (simulate → modal → confirm). When E5 (batch apply) ships, all three can be
- * batched into a single confirm; until then, each toggle is its own call.
- *
- * Reads its initial state from the badge's data-* attributes (server-rendered
- * on every page load) and keeps the badge + dialog in sync after any change.
+ * The dialog stages pending toggles for OPERATION_MODE / DAIKIN_CONTROL_MODE /
+ * REQUIRE_SIMULATION_ID; clicking "Review changes" sends them all through the
+ * batch settings endpoint as ONE simulate → modal → confirm. Single-toggle
+ * usage still works — the batch endpoint accepts a 1-key payload too.
  */
 (function () {
   'use strict';
@@ -18,12 +15,17 @@
     backdrop: null,
     closeBtn: null,
     dismissBtn: null,
+    reviewBtn: null,
+    pending: {},   // { KEY: stagedValue } — only diverges-from-current entries
+    current: {},   // { KEY: livedValue from API }
+
     init() {
       if (this.backdrop) return;
       this.backdrop = $('#modeSwitcherBackdrop');
-      if (!this.backdrop) return;  // partial not included on this page
+      if (!this.backdrop) return;
       this.closeBtn = $('#modeSwitcherCloseBtn');
       this.dismissBtn = $('#modeSwitcherDismissBtn');
+      this.reviewBtn = $('#modeSwitcherReviewBtn');
 
       this.closeBtn.addEventListener('click', () => this.close());
       this.dismissBtn.addEventListener('click', () => this.close());
@@ -34,81 +36,107 @@
         if (e.key === 'Escape' && !this.backdrop.hidden) this.close();
       });
 
-      // Operation mode buttons
-      $$('[data-set-op-mode]').forEach(b => b.addEventListener('click', async () => {
-        const mode = b.dataset.setOpMode;
-        const result = await wrapAction({
-          simulateUrl: '/api/v1/optimization/mode/simulate',
-          applyUrl: '/api/v1/optimization/mode',
-          body: { mode },
-        });
-        if (result.applied) await this.refresh();
+      $$('[data-stage-key]').forEach(b => b.addEventListener('click', () => {
+        this.stage(b.dataset.stageKey, b.dataset.stageValue);
       }));
-      // Daikin control mode buttons
-      $$('[data-set-daikin-mode]').forEach(b => b.addEventListener('click', async () => {
-        const value = b.dataset.setDaikinMode;
-        const result = await wrapAction({
-          method: 'PUT',
-          simulateUrl: '/api/v1/settings/DAIKIN_CONTROL_MODE/simulate',
-          applyUrl: '/api/v1/settings/DAIKIN_CONTROL_MODE',
-          body: { value },
-        });
-        if (result.applied) await this.refresh();
-      }));
-      // Require-simulation-id buttons
-      $$('[data-set-require-sim]').forEach(b => b.addEventListener('click', async () => {
-        const value = b.dataset.setRequireSim;
-        const result = await wrapAction({
-          method: 'PUT',
-          simulateUrl: '/api/v1/settings/REQUIRE_SIMULATION_ID/simulate',
-          applyUrl: '/api/v1/settings/REQUIRE_SIMULATION_ID',
-          body: { value },
-        });
-        if (result.applied) await this.refresh();
-      }));
+
+      this.reviewBtn.addEventListener('click', () => this.submit());
     },
 
     async open() {
       this.init();
       if (!this.backdrop) return;
+      this.pending = {};
       this.backdrop.hidden = false;
       await this.refresh();
+      this.repaint();
     },
 
     close() {
       if (this.backdrop) this.backdrop.hidden = true;
+      this.pending = {};
+    },
+
+    stage(key, rawValue) {
+      const current = this.current[key];
+      const value = this._coerceForCompare(key, rawValue);
+      const cur = this._coerceForCompare(key, current);
+      if (String(value) === String(cur)) {
+        delete this.pending[key];
+      } else {
+        this.pending[key] = this._coerceForSubmit(key, rawValue);
+      }
+      this.repaint();
+    },
+
+    _coerceForCompare(key, v) {
+      if (key === 'REQUIRE_SIMULATION_ID') return String(v).toLowerCase() === 'true';
+      return v;
+    },
+
+    _coerceForSubmit(key, v) {
+      if (key === 'REQUIRE_SIMULATION_ID') return String(v).toLowerCase() === 'true';
+      return v;
+    },
+
+    repaint() {
+      // Highlight active button (matches current OR pending state)
+      $$('[data-pending-key]').forEach(group => {
+        const key = group.dataset.pendingKey;
+        const staged = key in this.pending ? this.pending[key] : null;
+        const current = this.current[key];
+        const effective = staged !== null ? staged : current;
+        $$('[data-stage-key]', group).forEach(b => {
+          const matches = String(this._coerceForCompare(key, b.dataset.stageValue))
+                       === String(this._coerceForCompare(key, effective));
+          b.classList.toggle('is-selected', matches);
+          b.classList.toggle('is-pending', matches && staged !== null);
+        });
+      });
+      const n = Object.keys(this.pending).length;
+      this.reviewBtn.disabled = (n === 0);
+      this.reviewBtn.textContent = n === 0 ? 'Review changes' : `Review ${n} change${n === 1 ? '' : 's'}`;
+    },
+
+    async submit() {
+      const changes = { ...this.pending };
+      if (Object.keys(changes).length === 0) return;
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/settings/batch/simulate',
+        applyUrl: '/api/v1/settings/batch',
+        body: { changes },
+      });
+      if (result.applied) {
+        this.pending = {};
+        await this.refresh();
+        this.repaint();
+        // Soft reload so the topbar badge re-renders from the new server-side context.
+        setTimeout(() => window.location.reload(), 400);
+      }
     },
 
     async refresh() {
-      // Pull the live state from the API (more authoritative than the badge attrs)
       try {
         const status = await jsonFetch('/api/v1/optimization/status');
         const op = status?.operation_mode || status?.mode || '—';
+        this.current.OPERATION_MODE = op;
         $('#msOpModeBadge').textContent = op;
         $('#msOpModeBadge').className = 'status-badge ' + (op === 'operational' ? 'is-active' : 'is-passive');
       } catch (_e) {}
       try {
         const r = await jsonFetch('/api/v1/settings/DAIKIN_CONTROL_MODE');
         const v = r?.value || '—';
+        this.current.DAIKIN_CONTROL_MODE = v;
         $('#msDaikinBadge').textContent = v;
         $('#msDaikinBadge').className = 'status-badge ' + (v === 'active' ? 'is-active' : 'is-passive');
       } catch (_e) {}
       try {
         const r = await jsonFetch('/api/v1/settings/REQUIRE_SIMULATION_ID');
         const v = String(r?.value).toLowerCase() === 'true';
+        this.current.REQUIRE_SIMULATION_ID = v;
         $('#msRequireSimBadge').textContent = v ? 'on' : 'off';
         $('#msRequireSimBadge').className = 'status-badge ' + (v ? 'is-active' : 'is-passive');
       } catch (_e) {}
-
-      // Also update the topbar badge from these fresh values
-      const badge = $('#modeBadge');
-      if (badge) {
-        // Trigger a soft reload of the page to re-render server-side rather than
-        // duplicate badge-render logic. Cheaper than a SPA-style update; happens
-        // only after a real change (the user just confirmed via modal).
-        // Comment-out if you want zero reload — but then the badge can drift.
-        // window.location.reload();
-      }
     },
   };
 

--- a/src/api/templates/_modal.html
+++ b/src/api/templates/_modal.html
@@ -7,12 +7,24 @@
         <section class="modal-body" id="modalBody">
             <p class="modal-summary" id="modalSummary"></p>
 
-            <div class="modal-section">
+            <div class="modal-section" id="modalBatchSection" hidden>
+                <h3>Changes</h3>
+                <div class="modal-batch-table-wrap">
+                    <table class="modal-batch-table">
+                        <thead>
+                            <tr><th>Key</th><th>Before</th><th>After</th><th>Safety</th></tr>
+                        </thead>
+                        <tbody id="modalBatchBody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="modal-section" id="modalBeforeSection">
                 <h3>Before</h3>
                 <pre class="kv-block" id="modalBefore"></pre>
             </div>
 
-            <div class="modal-section">
+            <div class="modal-section" id="modalAfterSection">
                 <h3>After</h3>
                 <pre class="kv-block" id="modalAfter"></pre>
             </div>

--- a/src/api/templates/_mode_switcher.html
+++ b/src/api/templates/_mode_switcher.html
@@ -6,8 +6,8 @@
         </header>
         <section class="modal-body">
             <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
-                Three independent toggles. Each change runs through the standard
-                preview → modal → confirm flow.
+                Stage one or more toggles, then <strong>Review changes</strong> opens a single
+                preview → modal → confirm — all applied as one batch.
             </p>
 
             <div class="mode-row" data-key="OPERATION_MODE">
@@ -19,9 +19,9 @@
                     <code>simulation</code> blocks ALL hardware writes from this service.
                     <code>operational</code> allows the LP/dispatcher to push to Fox V3 (and Daikin if active mode).
                 </p>
-                <div class="mode-row-toggle">
-                    <button class="btn btn-secondary btn-sm" data-set-op-mode="simulation">→ simulation</button>
-                    <button class="btn btn-secondary btn-sm" data-set-op-mode="operational">→ operational</button>
+                <div class="mode-row-toggle" data-pending-key="OPERATION_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="OPERATION_MODE" data-stage-value="simulation">simulation</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="OPERATION_MODE" data-stage-value="operational">operational</button>
                 </div>
             </div>
 
@@ -34,9 +34,9 @@
                     <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
                     <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
                 </p>
-                <div class="mode-row-toggle">
-                    <button class="btn btn-secondary btn-sm" data-set-daikin-mode="passive">→ passive</button>
-                    <button class="btn btn-secondary btn-sm" data-set-daikin-mode="active">→ active</button>
+                <div class="mode-row-toggle" data-pending-key="DAIKIN_CONTROL_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="passive">passive</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="active">active</button>
                 </div>
             </div>
 
@@ -50,14 +50,15 @@
                     and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
                     scripts and accidental writes — the cockpit always uses this flow regardless.
                 </p>
-                <div class="mode-row-toggle">
-                    <button class="btn btn-secondary btn-sm" data-set-require-sim="false">→ off</button>
-                    <button class="btn btn-secondary btn-sm" data-set-require-sim="true">→ on</button>
+                <div class="mode-row-toggle" data-pending-key="REQUIRE_SIMULATION_ID">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="false">off</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="true">on</button>
                 </div>
             </div>
         </section>
         <footer class="modal-footer">
-            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Done</button>
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modeSwitcherReviewBtn" disabled>Review changes</button>
         </footer>
     </div>
 </div>

--- a/tests/api/test_settings_batch.py
+++ b/tests/api/test_settings_batch.py
@@ -1,0 +1,152 @@
+"""v10.2 E5 — batch settings simulate + apply.
+
+Covers:
+- /simulate returns one ActionDiff with sub_actions for N keys
+- /apply (X-Simulation-Id) writes all keys atomically
+- Empty / non-dict body rejected with 400
+- Single-key payload still works (mode_switcher fallback)
+- Invalid key in batch surfaces a 409 BatchPartialFailure with rollback details
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+from src.api.simulation import reset_store_for_tests
+from src.runtime_settings import clear_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_store():
+    from src import db as _db
+    _db.init_db()
+    reset_store_for_tests()
+    clear_cache()
+    yield
+    reset_store_for_tests()
+    clear_cache()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def require_sim_off(monkeypatch):
+    monkeypatch.setenv("REQUIRE_SIMULATION_ID", "false")
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def require_sim_on(monkeypatch):
+    monkeypatch.setenv("REQUIRE_SIMULATION_ID", "true")
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class TestBatchSimulate:
+    def test_returns_sub_actions_for_each_key(self, client):
+        r = client.post(
+            "/api/v1/settings/batch/simulate",
+            json={"changes": {"DHW_TEMP_NORMAL_C": 50.0, "INDOOR_SETPOINT_C": 21.0}},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["action"] == "settings.batch"
+        assert body["simulation_id"]
+        subs = body.get("sub_actions") or []
+        assert len(subs) == 2
+        keys = {s["key"] for s in subs}
+        assert keys == {"DHW_TEMP_NORMAL_C", "INDOOR_SETPOINT_C"}
+
+    def test_single_key_payload_works(self, client):
+        # mode_switcher routes 1-key changes through the same endpoint.
+        r = client.post(
+            "/api/v1/settings/batch/simulate",
+            json={"changes": {"DHW_TEMP_NORMAL_C": 48.0}},
+        )
+        assert r.status_code == 200
+        assert len(r.json()["sub_actions"]) == 1
+
+    def test_rejects_empty_changes(self, client):
+        r = client.post("/api/v1/settings/batch/simulate", json={"changes": {}})
+        assert r.status_code == 400
+
+    def test_rejects_non_dict_changes(self, client):
+        r = client.post("/api/v1/settings/batch/simulate", json={"changes": ["x"]})
+        assert r.status_code == 400
+
+    def test_aggregates_safety_flags(self, client, monkeypatch):
+        # DAIKIN_CONTROL_MODE: passive → active is a hard flag.
+        monkeypatch.setenv("DAIKIN_CONTROL_MODE", "passive")
+        clear_cache()
+        r = client.post(
+            "/api/v1/settings/batch/simulate",
+            json={"changes": {
+                "DAIKIN_CONTROL_MODE": "active",
+                "DHW_TEMP_NORMAL_C": 50.0,
+            }},
+        )
+        assert r.status_code == 200
+        flags = r.json().get("safety_flags") or []
+        assert "enables_daikin_writes" in flags
+
+
+class TestBatchApply:
+    def test_apply_with_sim_id_writes_all_keys(self, client, require_sim_on):
+        r = client.post(
+            "/api/v1/settings/batch/simulate",
+            json={"changes": {"DHW_TEMP_NORMAL_C": 49.5, "INDOOR_SETPOINT_C": 20.5}},
+        )
+        sid = r.json()["simulation_id"]
+        r = client.post(
+            "/api/v1/settings/batch",
+            json={"changes": {"DHW_TEMP_NORMAL_C": 49.5, "INDOOR_SETPOINT_C": 20.5}},
+            headers={"X-Simulation-Id": sid},
+        )
+        assert r.status_code == 200, r.text
+        results = r.json()["results"]
+        assert all(r["ok"] for r in results)
+        # Verify they actually persisted
+        r = client.get("/api/v1/settings/DHW_TEMP_NORMAL_C")
+        assert r.status_code == 200
+
+    def test_apply_without_sim_id_when_required(self, client, require_sim_on):
+        r = client.post(
+            "/api/v1/settings/batch",
+            json={"changes": {"DHW_TEMP_NORMAL_C": 50.0}},
+        )
+        assert r.status_code == 409
+        assert r.json()["detail"]["error"] == "SimulationIdRequired"
+
+    def test_invalid_key_mid_batch_rolls_back(self, client, require_sim_off):
+        # Seed two valid keys to known values first.
+        from src import runtime_settings as rts
+        rts.set_setting("DHW_TEMP_NORMAL_C", 45.0, actor="test_setup")
+        prior = rts.get_setting("DHW_TEMP_NORMAL_C")
+
+        r = client.post(
+            "/api/v1/settings/batch",
+            json={"changes": {
+                "DHW_TEMP_NORMAL_C": 49.0,
+                "DEFINITELY_NOT_A_REAL_KEY": "boom",
+            }},
+        )
+        # Validation may catch this in simulate or in apply; either way it
+        # must NOT leave DHW_TEMP_NORMAL_C at the new value when the second
+        # key was rejected.
+        if r.status_code == 409:
+            detail = r.json()["detail"]
+            assert detail["error"] == "BatchPartialFailure"
+            assert detail["failed_at_key"] == "DEFINITELY_NOT_A_REAL_KEY"
+            # Rollback restored the prior value
+            assert rts.get_setting("DHW_TEMP_NORMAL_C") == prior
+        else:
+            # If validated upfront (400), nothing was written
+            assert r.status_code in (400, 422)
+            assert rts.get_setting("DHW_TEMP_NORMAL_C") == prior


### PR DESCRIPTION
## Summary

- `ActionDiff.sub_actions` carries per-key entries; `diff_settings_batch()` rolls N changes into one umbrella diff with aggregated `safety_flags`.
- New `POST /api/v1/settings/batch[/simulate]` — atomic apply with best-effort rollback on partial failure (`409 BatchPartialFailure` with per-key results).
- Modal renders a `Key / Before / After / Safety` table when `sub_actions` is present; hard-flag typed-confirmation still triggers if any sub-action carries a hard flag.
- Mode switcher rebuilt around **staged-pending toggles** + a single **Review N changes** button → routes through the batch endpoint. One confirm now flips all three mode toggles together.

## Why

Plan v10.2 sequencing (E4 → E1 → **E5** → E2 → E3): E5 unblocks E3's "promote N LP knobs in one confirm" flow and removes the 1-toggle-at-a-time friction users hit in E4's mode switcher.

## Test plan

- [x] 8 new tests in `tests/api/test_settings_batch.py` cover: sub_actions shape, single-key fallback, validation (empty/non-dict body), safety-flag aggregation, atomic apply with sim-id, sim-id enforcement, mid-batch invalid key → rollback.
- [x] Full suite green: `325 passed, 1 skipped`.
- [x] End-to-end smoke: `simulate` returns `simulation_id` + `sub_actions[2]`; `apply` writes both keys; `apply` without sim-id returns 409; empty changes → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)