### PR TITLE
chore: drop dead OPTIMIZATION_ENGINE_ENABLED field + legionella notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,14 +49,11 @@ DAIKIN_ALERT_TEMP_DEVIATION=2
 OPENCLAW_READ_ONLY=true
 
 # Optimization engine (room/DHW targets; export product for LP/analytics)
-OPTIMIZATION_ENGINE_ENABLED=true
 OPTIMIZATION_PRESET=normal
 # Daikin control mode (v10): passive = service never writes to Daikin, treats it
 # as a fixed thermal load (firmware autonomous). active = legacy v9 control path.
 # Flip via PUT /api/v1/settings/DAIKIN_CONTROL_MODE without restart.
 DAIKIN_CONTROL_MODE=passive
-# Legacy / optional — may be ignored depending on build; see CHANGELOG if unset has no effect
-# TARGET_PRICE_PENCE=12.0
 TARGET_ROOM_TEMP_MIN_C=20.0
 TARGET_ROOM_TEMP_MAX_C=23.0
 TARGET_DHW_TEMP_MIN_NORMAL_C=45.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ EOF
 
 ### Legionella thermal-shock cycle
 
-Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously (Sunday ~11:00 local). **The LP and dispatch layer do not schedule or override this cycle** — the `DHW_LEGIONELLA_*` env vars are deprecated (kept only so stale `.env` files don't error on load) and will be removed in a follow-up. If a `shutdown` or `max_heat` action happens to overlap the cycle window, Onecta firmware arbitrates.
+Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously (Sunday ~11:00 local). **The LP and dispatch layer do not schedule or override this cycle** — the `DHW_LEGIONELLA_*` env vars are gone from the code. Python ignores unrecognised keys in `.env` so lingering entries are harmless; delete them on your next `.env` touch. If a `shutdown` or `max_heat` action happens to overlap the cycle window, Onecta firmware arbitrates.
 
 ---
 

--- a/docs/DAIKIN/README.md
+++ b/docs/DAIKIN/README.md
@@ -127,7 +127,7 @@ Our LP respects this via `LP_HP_MIN_ON_SLOTS` (default 2 = 1 hour minimum run); 
 
 ## Legionella thermal-shock cycle
 
-Onecta firmware runs the weekly thermal-shock autonomously (Sunday ~11:00 local). **The LP / dispatch layer does not schedule or override this cycle.** The legacy `DHW_LEGIONELLA_*` env vars are deprecated and slated for removal (see CLAUDE.md). If a `shutdown` or `max_heat` action overlaps the cycle, Onecta arbitrates.
+Onecta firmware runs the weekly thermal-shock autonomously (Sunday ~11:00 local). **The LP / dispatch layer does not schedule or override this cycle.** The legacy `DHW_LEGIONELLA_*` env vars are gone from the code; Python ignores unknown `.env` keys so lingering entries are harmless and can be deleted on your next `.env` touch. If a `shutdown` or `max_heat` action overlaps the cycle, Onecta arbitrates.
 
 ---
 

--- a/src/config.py
+++ b/src/config.py
@@ -249,10 +249,6 @@ class Config:
     SCHEDULER_PEAK_END: str = os.getenv("SCHEDULER_PEAK_END", "19:00")
     SCHEDULER_PREHEAT_LWT_BOOST: float = float(os.getenv("SCHEDULER_PREHEAT_LWT_BOOST", "2"))
 
-    # V7 Optimization engine (Agile watchdog + 48-block solver + dispatch hints)
-    OPTIMIZATION_ENGINE_ENABLED: bool = os.getenv(
-        "OPTIMIZATION_ENGINE_ENABLED", "false"
-    ).lower() in ("true", "1", "yes")
     # OPTIMIZATION_PRESET + ENERGY_STRATEGY_MODE are runtime-tunable via
     # /api/v1/settings (#52) — see the @property definitions below.
     # savings_first (default): import/savings focus; peak grid export (force discharge) only when


### PR DESCRIPTION
## Summary

Cleanup follow-up to #130. Removes dead config fields and updates stale deprecation notes.

- **`OPTIMIZATION_ENGINE_ENABLED`** — declared in \`src/config.py\` but never referenced anywhere in \`src/\` or \`tests/\`. V7-era flag; the bulletproof engine now uses \`USE_BULLETPROOF_ENGINE\`. Also removed the stale line from \`.env.example\`.
- **`DHW_LEGIONELLA_*` notes** — the old "kept only so stale .env files don't error on load" shim comment in \`CLAUDE.md\` and \`docs/DAIKIN/README.md\` is wrong: Python silently ignores unknown env keys. Updated the wording to reflect reality (vars already removed from code; stale \`.env\` entries are harmless, delete on next touch).

## Prod .env follow-up (applied separately)

The following keys are dead in the code and should be removed from prod \`.env\`:
- \`OPERATION_MODE\` (retired in #130)
- \`OPTIMIZATION_ENGINE_ENABLED\` (this PR)
- \`TARGET_PRICE_PENCE\` (removed long ago per CHANGELOG; never cleaned from prod env)

Will edit prod \`.env\` via SSH after this PR merges.

## Test plan

- [x] \`pytest -q tests/test_daikin_passive_mode.py\` — 17 passed (asserts DHW_LEGIONELLA attrs gone from config)
- [x] \`py_compile src/config.py\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)