### PR TITLE
feat(workbench): preview Daikin control mode + retire OPERATION_MODE row

### DIFF
--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -56,7 +56,7 @@ a { color: inherit; text-decoration: none; }
 }
 .brand { grid-area: brand; font-weight: 600; font-size: 1rem; }
 
-/* Mode badge — clickable summary of OPERATION_MODE + DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID */
+/* Mode badge — clickable summary of DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID */
 .mode-badge {
     grid-area: badge;
     appearance: none;

--- a/src/api/static/js/mode_switcher.js
+++ b/src/api/static/js/mode_switcher.js
@@ -1,6 +1,6 @@
 /* v10.2 mode switcher — opened from the topbar mode badge.
  *
- * The dialog stages pending toggles for OPERATION_MODE / DAIKIN_CONTROL_MODE /
+ * The dialog stages pending toggles for DAIKIN_CONTROL_MODE /
  * REQUIRE_SIMULATION_ID; clicking "Review changes" sends them all through the
  * batch settings endpoint as ONE simulate → modal → confirm. Single-toggle
  * usage still works — the batch endpoint accepts a 1-key payload too.
@@ -116,13 +116,6 @@
     },
 
     async refresh() {
-      try {
-        const status = await jsonFetch('/api/v1/optimization/status');
-        const op = status?.operation_mode || status?.mode || '—';
-        this.current.OPERATION_MODE = op;
-        $('#msOpModeBadge').textContent = op;
-        $('#msOpModeBadge').className = 'status-badge ' + (op === 'operational' ? 'is-active' : 'is-passive');
-      } catch (_e) {}
       try {
         const r = await jsonFetch('/api/v1/settings/DAIKIN_CONTROL_MODE');
         const v = r?.value || '—';

--- a/src/api/static/js/settings.js
+++ b/src/api/static/js/settings.js
@@ -131,8 +131,8 @@
       const all = Array.isArray(resp) ? resp : (resp?.settings || []);
       const byKey = Object.fromEntries(all.map(s => [s.key, s]));
 
-      // v10.2: DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID + OPERATION_MODE
-      // moved to the topbar mode-switcher dialog. They no longer render here.
+      // v10.2: DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID moved to the
+      // topbar mode-switcher dialog. They no longer render here.
 
       // Grouped sections
       const groups = {

--- a/src/api/templates/_mode_switcher.html
+++ b/src/api/templates/_mode_switcher.html
@@ -10,21 +10,6 @@
                 preview → modal → confirm — all applied as one batch.
             </p>
 
-            <div class="mode-row" data-key="OPERATION_MODE">
-                <div class="mode-row-head">
-                    <h3 class="mode-row-name">Operation mode</h3>
-                    <span class="status-badge" id="msOpModeBadge">—</span>
-                </div>
-                <p class="mode-row-desc">
-                    <code>simulation</code> blocks ALL hardware writes from this service.
-                    <code>operational</code> allows the LP/dispatcher to push to Fox V3 (and Daikin if active mode).
-                </p>
-                <div class="mode-row-toggle" data-pending-key="OPERATION_MODE">
-                    <button class="btn btn-secondary btn-sm" data-stage-key="OPERATION_MODE" data-stage-value="simulation">simulation</button>
-                    <button class="btn btn-secondary btn-sm" data-stage-key="OPERATION_MODE" data-stage-value="operational">operational</button>
-                </div>
-            </div>
-
             <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
                 <div class="mode-row-head">
                     <h3 class="mode-row-name">Daikin control</h3>

--- a/src/scheduler/lp_overrides.py
+++ b/src/scheduler/lp_overrides.py
@@ -235,6 +235,14 @@ WHITELIST: dict[str, OverrideSpec] = {
         description="Allow peak-export discharge or never.",
         group="mode", promotable=True,
     ),
+    "DAIKIN_CONTROL_MODE": OverrideSpec(
+        key="DAIKIN_CONTROL_MODE",
+        config_attr="DAIKIN_CONTROL_MODE",
+        type_name="str",
+        enum=("passive", "active"),
+        description="passive = firmware autonomous (LP load-follows HP); active = LP schedules tank + LWT.",
+        group="mode", promotable=True,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Adds `DAIKIN_CONTROL_MODE` to the Workbench `WHITELIST` — the simulate-without-commit flow now covers passive↔active so you can preview the cost/comfort impact before flipping the live runtime toggle.
- Retires the stale `OPERATION_MODE` row from the mode switcher (template + JS + doc comments). The lifecycle was retired in #130; the UI row was the last reference.

## Context
Triggered by a post-v10.2 LP tuning audit. The runtime toggle itself already exists (`src/runtime_settings.py:117`, 30 s cache, no restart) — this PR closes the missing "simulate before flipping" gap.

## Test plan
- [x] `.venv/bin/python -m pytest tests/ -x -q --ignore=tests/integration` — 357 passed, 1 skipped
- [x] `validate_overrides({"DAIKIN_CONTROL_MODE": "passive"|"active"})` succeeds; `"banana"` rejected with `OverrideValidationError`
- [x] `schema_for_response()` surfaces the new entry with correct enum + group + current value
- [ ] After deploy: cockpit → top-bar mode badge opens switcher without `OPERATION_MODE` row; Workbench lists Daikin control knob in the mode group

🤖 Generated with [Claude Code](https://claude.com/claude-code)