### PR TITLE
feat(cockpit): Live + History unified UX with durable LP snapshots

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -234,6 +234,18 @@ async def web_cockpit(request: Request):
     )
 
 
+@app.get("/forecast", response_class=HTMLResponse)
+async def web_forecast(request: Request):
+    """Phase 3: dedicated Forecast tab showing everything the next LP solve
+    will see — prices, weather forecast, initial state (with sources),
+    thresholds, config snapshot, and tomorrow's tariff preview when
+    Octopus has published it. Answers "what will the LP do next?".
+    """
+    return templates.TemplateResponse(
+        request, "forecast.html", {"active_page": "forecast", **_layout_context()}
+    )
+
+
 @app.get("/insights", response_class=HTMLResponse)
 async def web_insights(request: Request):
     return templates.TemplateResponse(
@@ -747,6 +759,183 @@ async def cockpit_now():
             "energy_strategy_mode": config.ENERGY_STRATEGY_MODE,
         },
         "plan_date": plan_block["plan_date"],
+    }
+
+
+@app.get("/api/v1/optimization/inputs")
+async def optimization_inputs(horizon_hours: int | None = None):
+    """Everything the next LP solve will see, merged from caches + SQLite.
+
+    The Forecast tab reads this in one call to answer "what will the LP do
+    next, and against which numbers?" without triggering cloud fetches.
+
+    Cache-only contract — mirror of the ``/cockpit/now`` discipline. Weather
+    rows come from ``meteo_forecast`` (latest-per-slot, written by the last
+    LP solve). Prices from ``agile_rates``. Initial state via
+    ``read_lp_initial_state(allow_daikin_refresh=False)`` so no Daikin quota
+    is burned on a page load.
+    """
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+    from datetime import timedelta as _td
+    from zoneinfo import ZoneInfo
+    from ..scheduler.lp_initial_state import read_lp_initial_state
+    from ..scheduler import lp_overrides
+
+    hz = int(horizon_hours or config.LP_HORIZON_HOURS)
+    hz = max(4, min(48, hz))
+    now = _dt.now(_UTC)
+    day_start = now.replace(minute=0, second=0, microsecond=0)
+    window_end = day_start + _td(hours=hz)
+
+    # --- Tariff rates (import + export) -------------------------------------
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    export_tariff = (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip()
+    import_rows = db.get_rates_for_period(tariff, day_start, window_end) if tariff else []
+    export_rows = db.get_rates_for_period(export_tariff, day_start, window_end) if export_tariff else []
+
+    # --- Meteo forecast (latest-per-slot, in the plan window) ---------------
+    conn = db.get_connection()
+    try:
+        cur = conn.execute(
+            """SELECT slot_time, temp_c, solar_w_m2 FROM meteo_forecast
+               WHERE slot_time >= ? AND slot_time < ?
+               ORDER BY slot_time""",
+            (day_start.isoformat(), window_end.isoformat()),
+        )
+        meteo_rows = [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+    # --- Base-load hour-of-day profile --------------------------------------
+    profile_limit = int(getattr(config, "LP_LOAD_PROFILE_SLOTS", 2016))
+    try:
+        load_profile = db.hourly_load_profile_kwh(limit=profile_limit)
+    except Exception:
+        load_profile = {}
+    try:
+        fox_mean = db.mean_fox_load_kwh_per_slot(limit=60)
+    except Exception:
+        fox_mean = None
+    try:
+        flat = fox_mean if fox_mean is not None else db.mean_consumption_kwh_from_execution_logs(limit=profile_limit)
+    except Exception:
+        flat = 0.4
+
+    # --- Initial state (quota-safe: no Daikin refresh) ----------------------
+    try:
+        initial = read_lp_initial_state(None, allow_daikin_refresh=False)
+        initial_block = {
+            "soc_kwh": round(float(initial.soc_kwh), 3),
+            "soc_pct": round(float(initial.soc_kwh) / float(config.BATTERY_CAPACITY_KWH) * 100.0, 1) if config.BATTERY_CAPACITY_KWH else None,
+            "tank_c": round(float(initial.tank_temp_c), 2),
+            "indoor_c": round(float(initial.indoor_temp_c), 2),
+            "soc_source": getattr(initial, "soc_source", "unknown"),
+            "tank_source": getattr(initial, "tank_source", "unknown"),
+            "indoor_source": getattr(initial, "indoor_source", "unknown"),
+        }
+    except Exception as e:
+        initial_block = {
+            "soc_kwh": None, "soc_pct": None, "tank_c": None, "indoor_c": None,
+            "soc_source": f"error:{e}", "tank_source": "unknown", "indoor_source": "unknown",
+        }
+
+    try:
+        micro_climate_offset = float(db.get_micro_climate_offset_c(config.DAIKIN_MICRO_CLIMATE_LOOKBACK))
+    except Exception:
+        micro_climate_offset = 0.0
+
+    # --- Thresholds from today's daily_targets (LP-derived) -----------------
+    tz_name = config.BULLETPROOF_TIMEZONE or "Europe/London"
+    try:
+        tz = ZoneInfo(tz_name)
+        plan_date_local = _dt.now(tz).date().isoformat()
+    except Exception:
+        plan_date_local = now.date().isoformat()
+    try:
+        tgt = db.get_daily_target(plan_date_local) or {}
+    except Exception:
+        tgt = {}
+
+    # --- Per-slot merged view (prices + weather + base_load, for the horizon)
+    slots_out: list[dict[str, Any]] = []
+    slot_len = _td(minutes=30)
+    weather_by_slot: dict[str, dict[str, Any]] = {}
+    for r in meteo_rows:
+        weather_by_slot[r["slot_time"]] = r
+    import_by_valid_from: dict[str, float] = {r["valid_from"]: float(r["value_inc_vat"]) for r in import_rows}
+    export_by_valid_from: dict[str, float] = {r["valid_from"]: float(r["value_inc_vat"]) for r in export_rows}
+    t = day_start
+    while t < window_end:
+        iso = t.isoformat().replace("+00:00", "+00:00")  # preserve offset
+        iso_norm = iso
+        # Agile rates land in SQLite with ±Z suffix; try both.
+        iso_candidates = {iso, iso.replace("+00:00", "Z")}
+        price_i = None
+        price_e = None
+        for k in iso_candidates:
+            if k in import_by_valid_from:
+                price_i = import_by_valid_from[k]; break
+        for k in iso_candidates:
+            if k in export_by_valid_from:
+                price_e = export_by_valid_from[k]; break
+        wx = weather_by_slot.get(iso_norm) or weather_by_slot.get(iso.replace("+00:00", ""))
+        try:
+            hr_local = t.astimezone(ZoneInfo(tz_name)).hour
+        except Exception:
+            hr_local = t.hour
+        bl = float(load_profile.get(hr_local, flat))
+        slots_out.append({
+            "t_utc": iso.replace("+00:00", "Z"),
+            "price_import_p": price_i,
+            "price_export_p": price_e,
+            "temp_c": float(wx["temp_c"]) if wx and wx.get("temp_c") is not None else None,
+            "solar_w_m2": float(wx["solar_w_m2"]) if wx and wx.get("solar_w_m2") is not None else None,
+            "base_load_kwh": round(bl, 4),
+        })
+        t = t + slot_len
+
+    # --- Config snapshot — the knobs the LP reads at solve time -------------
+    cfg_snap = {
+        "LP_HORIZON_HOURS": int(config.LP_HORIZON_HOURS),
+        "BATTERY_CAPACITY_KWH": float(config.BATTERY_CAPACITY_KWH),
+        "MIN_SOC_RESERVE_PERCENT": float(config.MIN_SOC_RESERVE_PERCENT),
+        "BATTERY_RT_EFFICIENCY": float(config.BATTERY_RT_EFFICIENCY),
+        "MAX_INVERTER_KW": float(config.MAX_INVERTER_KW),
+        "DAIKIN_CONTROL_MODE": str(config.DAIKIN_CONTROL_MODE),
+        "OPTIMIZATION_PRESET": str(config.OPTIMIZATION_PRESET),
+        "ENERGY_STRATEGY_MODE": str(config.ENERGY_STRATEGY_MODE),
+        "DHW_TEMP_COMFORT_C": float(config.DHW_TEMP_COMFORT_C),
+        "DHW_TEMP_NORMAL_C": float(config.DHW_TEMP_NORMAL_C),
+        "INDOOR_SETPOINT_C": float(config.INDOOR_SETPOINT_C),
+        "LP_PRICE_QUANTIZE_PENCE": float(getattr(config, "LP_PRICE_QUANTIZE_PENCE", 0.0)),
+        "LP_BATTERY_TV_PENALTY_PENCE_PER_KWH_DELTA": float(getattr(config, "LP_BATTERY_TV_PENALTY_PENCE_PER_KWH_DELTA", 0.0)),
+        "LP_IMPORT_TV_PENALTY_PENCE_PER_KWH_DELTA": float(getattr(config, "LP_IMPORT_TV_PENALTY_PENCE_PER_KWH_DELTA", 0.0)),
+    }
+
+    # --- Tomorrow's rates available? (Octopus publishes ~16:00 UTC) ---------
+    tomorrow_start = day_start + _td(days=1)
+    tomorrow_end = tomorrow_start + _td(days=1)
+    tomorrow_rows = db.get_rates_for_period(tariff, tomorrow_start, tomorrow_end) if tariff else []
+    tomorrow_available = len(tomorrow_rows) >= 4
+
+    return {
+        "now_utc": now.isoformat().replace("+00:00", "Z"),
+        "planner_tz": tz_name,
+        "horizon_hours": hz,
+        "slots": slots_out,
+        "initial": initial_block,
+        "micro_climate_offset_c": micro_climate_offset,
+        "thresholds": {
+            "cheap_p": (tgt or {}).get("cheap_threshold"),
+            "peak_p": (tgt or {}).get("peak_threshold"),
+        },
+        "config_snapshot": cfg_snap,
+        "target_vwap_pence": (tgt or {}).get("target_vwap"),
+        "estimated_cost_pence": (tgt or {}).get("estimated_cost_pence"),
+        "strategy_summary": (tgt or {}).get("strategy_summary"),
+        "tomorrow_rates_available": tomorrow_available,
+        "workbench_schema": lp_overrides.schema_for_response(),
     }
 
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -774,6 +774,70 @@ async def cockpit_now():
     }
 
 
+@app.get("/api/v1/attribution/day")
+async def attribution_day(date: str | None = None):
+    """Per-day energy attribution donut — Home Assistant Energy Dashboard idiom.
+
+    "Your solar went to: self-used X%, stored in battery Y%, exported Z%."
+    Reads from ``fox_energy_daily`` (populated daily by the Fox rollup job)
+    so it's historical-only — today's running totals are not included
+    until the rollup fires.
+    """
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+    from datetime import timedelta as _td
+
+    if date is None:
+        date = (_dt.now(_UTC).date() - _td(days=1)).isoformat()
+    row = db.get_fox_energy_daily_by_date(date)
+    if not row:
+        return {
+            "date": date,
+            "available": False,
+            "solar_kwh": None,
+            "load_kwh": None,
+            "import_kwh": None,
+            "export_kwh": None,
+            "charge_kwh": None,
+            "discharge_kwh": None,
+            "shares": None,
+        }
+    solar = float(row.get("solar_kwh") or 0.0)
+    exp = float(row.get("export_kwh") or 0.0)
+    chg = float(row.get("charge_kwh") or 0.0)
+    imp = float(row.get("import_kwh") or 0.0)
+    load = float(row.get("load_kwh") or 0.0)
+    dis = float(row.get("discharge_kwh") or 0.0)
+
+    # Solar destinations: export is clear. Charge comes partly from solar +
+    # partly from imported cheap slots; approximate with max(0, chg - imp)
+    # since a slot can't charge from grid AND solar simultaneously in meaningful
+    # excess. Self-use = solar - export - solar_to_battery.
+    solar_to_battery = max(0.0, chg - imp)
+    solar_to_export = min(solar, exp)
+    solar_self_use = max(0.0, solar - solar_to_export - solar_to_battery)
+    share_total = solar_self_use + solar_to_battery + solar_to_export
+    shares = None
+    if share_total > 0:
+        shares = {
+            "self_use_pct": round(100.0 * solar_self_use / share_total, 1),
+            "battery_pct": round(100.0 * solar_to_battery / share_total, 1),
+            "export_pct": round(100.0 * solar_to_export / share_total, 1),
+        }
+
+    return {
+        "date": date,
+        "available": True,
+        "solar_kwh": solar,
+        "load_kwh": load,
+        "import_kwh": imp,
+        "export_kwh": exp,
+        "charge_kwh": chg,
+        "discharge_kwh": dis,
+        "shares": shares,
+    }
+
+
 @app.get("/api/v1/cockpit/at")
 async def cockpit_at(when: str):
     """Reconstruct the same-shape payload as ``/cockpit/now`` but frozen at a

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -234,6 +234,18 @@ async def web_cockpit(request: Request):
     )
 
 
+@app.get("/history", response_class=HTMLResponse)
+async def web_history(request: Request):
+    """Phase 4: History replay — same hero-style layout as Cockpit but frozen
+    at a chosen past moment. Reads from the LP snapshot tables (Phase 0) so
+    every LP run's inputs, per-slot decision, and plan-vs-actual delta can be
+    replayed for any moment we have data for.
+    """
+    return templates.TemplateResponse(
+        request, "history.html", {"active_page": "history", **_layout_context()}
+    )
+
+
 @app.get("/forecast", response_class=HTMLResponse)
 async def web_forecast(request: Request):
     """Phase 3: dedicated Forecast tab showing everything the next LP solve
@@ -759,6 +771,123 @@ async def cockpit_now():
             "energy_strategy_mode": config.ENERGY_STRATEGY_MODE,
         },
         "plan_date": plan_block["plan_date"],
+    }
+
+
+@app.get("/api/v1/cockpit/at")
+async def cockpit_at(when: str):
+    """Reconstruct the same-shape payload as ``/cockpit/now`` but frozen at a
+    past moment. Reads exclusively from SQLite snapshots (Phase 0) —
+    ``execution_log`` for realised state, ``lp_solution_snapshot`` for the
+    LP's per-slot decision at the time, ``lp_inputs_snapshot`` for its
+    inputs, ``agile_rates`` for price-at-time, and ``meteo_forecast_history``
+    for the forecast version the LP run actually saw.
+    """
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+    from zoneinfo import ZoneInfo
+
+    try:
+        # Accept both 2026-04-24T14:00:00Z and 2026-04-24T14:00:00+00:00.
+        w = _dt.fromisoformat(when.replace("Z", "+00:00"))
+        if w.tzinfo is None:
+            w = w.replace(tzinfo=_UTC)
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"invalid ISO datetime: {when!r}")
+    when_iso = w.isoformat()
+
+    tz_name = config.BULLETPROOF_TIMEZONE or "Europe/London"
+
+    # --- Pick the LP run that was active at `when` ---------------------------
+    run_id = db.find_run_for_time(when_iso)
+    lp_inputs = db.get_lp_inputs(run_id) if run_id is not None else None
+    lp_slots = db.get_lp_solution_slots(run_id) if run_id is not None else []
+
+    # --- Price at the moment, from agile_rates -------------------------------
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    export_tariff = (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip()
+    import_rows = []
+    export_rows = []
+    if tariff:
+        from datetime import timedelta as _td
+        import_rows = db.get_rates_for_period(tariff, w - _td(hours=1), w + _td(hours=1))
+    if export_tariff:
+        from datetime import timedelta as _td
+        export_rows = db.get_rates_for_period(export_tariff, w - _td(hours=1), w + _td(hours=1))
+
+    def _price_at(rows: list) -> tuple[float | None, str | None, str | None]:
+        iso_w = when_iso.replace("+00:00", "Z")
+        for r in rows:
+            if r["valid_from"] <= iso_w < r["valid_to"]:
+                return float(r["value_inc_vat"]), r["valid_from"], r["valid_to"]
+        return None, None, None
+
+    price_i, slot_from, slot_to = _price_at(import_rows)
+    price_e, _, _ = _price_at(export_rows)
+
+    # --- Realised state from execution_log around `when` ---------------------
+    realised: dict[str, Any] = {}
+    try:
+        conn = db.get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT * FROM execution_log
+                   WHERE timestamp <= ?
+                   ORDER BY timestamp DESC LIMIT 1""",
+                (when_iso,),
+            )
+            row = cur.fetchone()
+            realised = dict(row) if row else {}
+        finally:
+            conn.close()
+    except Exception:
+        realised = {}
+
+    state_block = {
+        "soc_pct": realised.get("soc_percent"),
+        "soc_kwh": round(float(realised["soc_percent"]) / 100.0 * float(config.BATTERY_CAPACITY_KWH), 3)
+            if realised.get("soc_percent") is not None else None,
+        "solar_kw": None,       # Not tracked per-slot in execution_log
+        "load_kw": realised.get("consumption_kwh") is not None
+            and round(float(realised["consumption_kwh"]) / 0.5, 3) or None,
+        "grid_kw": None,
+        "battery_kw": None,
+        "fox_mode": realised.get("fox_mode"),
+        "tank_c": realised.get("daikin_tank_temp"),
+        "indoor_c": realised.get("daikin_room_temp"),
+        "outdoor_c": realised.get("daikin_outdoor_temp"),
+        "lwt_c": realised.get("daikin_lwt"),
+        "daikin_mode": None,
+    }
+
+    # --- LP plan for the slot containing `when` ------------------------------
+    planned_slot: dict[str, Any] | None = None
+    if lp_slots and slot_from:
+        iso_from = slot_from.replace("+00:00", "Z")
+        for s in lp_slots:
+            if s.get("slot_time_utc") in (iso_from, slot_from):
+                planned_slot = dict(s)
+                break
+
+    return {
+        "when_utc": when_iso.replace("+00:00", "Z"),
+        "planner_tz": tz_name,
+        "source": {
+            "run_id": run_id,
+            "lp_run_at_utc": (lp_inputs or {}).get("run_at_utc"),
+            "execution_log_timestamp": realised.get("timestamp"),
+        },
+        "current_slot": {
+            "t_utc": slot_from,
+            "t_end_utc": slot_to,
+            "price_import_p": price_i,
+            "price_export_p": price_e,
+            "fox_mode": realised.get("fox_mode"),
+        },
+        "state": state_block,
+        "planned_slot": planned_slot,  # LP's decision for that slot, or None
+        "lp_inputs": lp_inputs,        # Full inputs row at solve time, or None
+        "slot_kind": realised.get("slot_kind"),
     }
 
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -463,6 +463,34 @@ async def health():
     return {"status": "ok"}
 
 
+@app.get("/api/v1/system/timezone")
+async def system_timezone():
+    """Return the timezone the planner + cockpit should display times in.
+
+    ``planner_tz`` is ``config.BULLETPROOF_TIMEZONE`` (used for comfort
+    windows, MPC cron firing, Octopus fetch cron, load-profile hour-of-day
+    binning). ``plan_push_tz`` is fixed to UTC because the nightly plan-push
+    cron is UTC-anchored so the first dispatches of each new plan land on a
+    fresh Daikin quota day — this is not configurable and must stay that way.
+    ``now_utc`` / ``now_local`` let the frontend cross-check its own clock.
+    """
+    from zoneinfo import ZoneInfo
+    tz_name = config.BULLETPROOF_TIMEZONE or "Europe/London"
+    now_utc = datetime.now(UTC)
+    try:
+        now_local = now_utc.astimezone(ZoneInfo(tz_name))
+    except Exception:
+        # Fall back to UTC if the config string doesn't resolve.
+        now_local = now_utc
+        tz_name = "UTC"
+    return {
+        "planner_tz": tz_name,
+        "plan_push_tz": "UTC",
+        "now_utc": now_utc.isoformat().replace("+00:00", "Z"),
+        "now_local": now_local.isoformat(),
+    }
+
+
 @app.get("/api/v1/daikin/quota")
 async def daikin_quota():
     """Return Daikin API quota usage, cache age, and stale status.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -491,6 +491,265 @@ async def system_timezone():
     }
 
 
+@app.get("/api/v1/cockpit/now")
+async def cockpit_now():
+    """One-call aggregator for the cockpit's "where are we now?" hero panel.
+
+    Never issues cloud calls — reads from in-memory caches, SQLite, and
+    runtime_settings only. Replaces four parallel GETs previously fanned out by
+    cockpit.js (foxess/status + daikin/status + agile/today +
+    optimization/status) so the hero panel renders from a single coherent
+    snapshot instead of four independently-timed fetches.
+
+    Freshness per source (agile / fox / daikin / plan) is surfaced so the
+    cockpit can render per-source refresh chips with real ages.
+    """
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+    from datetime import timedelta as _td
+    from zoneinfo import ZoneInfo
+
+    now = _dt.now(_UTC)
+
+    def _age(iso: str | None) -> float | None:
+        if not iso:
+            return None
+        try:
+            dt = _dt.fromisoformat(iso.replace("Z", "+00:00"))
+        except Exception:
+            return None
+        return round((now - dt).total_seconds(), 1)
+
+    # --- Agile tariff (SQLite only) ------------------------------------------
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    export_tariff = (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip()
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + _td(days=1)
+    import_rows = db.get_rates_for_period(tariff, day_start, day_end) if tariff else []
+    export_rows = db.get_rates_for_period(export_tariff, day_start, day_end) if export_tariff else []
+
+    def _price_at(rows: list, t: _dt) -> tuple[float | None, str | None, str | None]:
+        iso_t = t.isoformat().replace("+00:00", "Z")
+        for r in rows:
+            if r["valid_from"] <= iso_t < r["valid_to"]:
+                return float(r["value_inc_vat"]), r["valid_from"], r["valid_to"]
+        return None, None, None
+
+    cur_import_p, slot_from, slot_to = _price_at(import_rows, now)
+    cur_export_p, _, _ = _price_at(export_rows, now)
+
+    # Fetch timestamp of the Agile cache — AgileRateCache.fetched_at_utc when
+    # available; fall back to the optimizer-snapshot's last successful Octopus
+    # fetch state.
+    agile_cache_fetched_at = None
+    try:
+        cache = get_agile_cache()
+        if cache and cache.fetched_at_utc:
+            agile_cache_fetched_at = cache.fetched_at_utc.isoformat().replace("+00:00", "Z")
+    except Exception:
+        pass
+    if not agile_cache_fetched_at:
+        try:
+            ofs = db.get_octopus_fetch_state()
+            agile_cache_fetched_at = ofs.last_success_at if ofs else None
+        except Exception:
+            pass
+
+    # --- Fox ESS realtime (in-memory cache, read-only) -----------------------
+    fox_block: dict[str, Any] = {
+        "soc_pct": None,
+        "soc_kwh": None,
+        "solar_kw": None,
+        "load_kw": None,
+        "grid_kw": None,
+        "battery_kw": None,
+        "fox_mode": None,
+    }
+    fox_fresh: dict[str, Any] = {"fetched_at_utc": None, "age_s": None, "stale": None}
+    try:
+        rt = get_cached_realtime()
+        fox_block.update({
+            "soc_pct": float(rt.soc),
+            "soc_kwh": round(float(config.BATTERY_CAPACITY_KWH) * float(rt.soc) / 100.0, 3),
+            "solar_kw": round(float(rt.solar_power), 3),
+            "load_kw": round(float(rt.load_power), 3),
+            "grid_kw": round(float(rt.grid_power), 3),
+            "battery_kw": round(float(rt.battery_power), 3),
+            "fox_mode": str(rt.work_mode),
+        })
+    except Exception:
+        pass
+    try:
+        s = get_refresh_stats_extended()
+        last_wall = s.get("last_updated_epoch")
+        if last_wall:
+            iso = _dt.fromtimestamp(last_wall, tz=_UTC).isoformat().replace("+00:00", "Z")
+            fox_fresh = {
+                "fetched_at_utc": iso,
+                "age_s": _age(iso),
+                "stale": bool(s.get("stale", False)),
+            }
+    except Exception:
+        pass
+
+    # --- Daikin (cached only; quota-aware) -----------------------------------
+    dk_block: dict[str, Any] = {
+        "tank_c": None,
+        "indoor_c": None,
+        "outdoor_c": None,
+        "lwt_c": None,
+        "control_mode": config.DAIKIN_CONTROL_MODE,
+        "mode": None,
+    }
+    dk_fresh: dict[str, Any] = {"fetched_at_utc": None, "age_s": None, "stale": None}
+    try:
+        cached = daikin_service.get_cached_devices(allow_refresh=False, actor="cockpit_now")
+        if cached.devices:
+            d = cached.devices[0]
+            tank = getattr(d, "tank_temperature", None)
+            room = getattr(getattr(d, "temperature", None), "room_temperature", None)
+            outdoor = getattr(d, "outdoor_temperature", None)
+            lwt = getattr(d, "leaving_water_temperature", None)
+            if tank is not None:
+                dk_block["tank_c"] = float(tank)
+            if room is not None:
+                dk_block["indoor_c"] = float(room)
+            if outdoor is not None:
+                dk_block["outdoor_c"] = float(outdoor)
+            if lwt is not None:
+                dk_block["lwt_c"] = float(lwt)
+            dk_block["mode"] = getattr(d, "operation_mode", None)
+        if cached.fetched_at_wall:
+            iso = _dt.fromtimestamp(cached.fetched_at_wall, tz=_UTC).isoformat().replace("+00:00", "Z")
+            dk_fresh = {
+                "fetched_at_utc": iso,
+                "age_s": _age(iso),
+                "stale": bool(cached.stale),
+            }
+    except Exception:
+        pass
+
+    # --- Plan (current fox group, last plan timestamp) -----------------------
+    plan_block: dict[str, Any] = {
+        "current_fox_mode": None,
+        "current_slot_utc": slot_from,
+        "current_slot_end_utc": slot_to,
+        "next_transition_utc": None,
+        "next_fox_mode": None,
+        "plan_date": None,
+    }
+    plan_fresh: dict[str, Any] = {"fetched_at_utc": None, "age_s": None, "stale": None}
+    try:
+        fox_state = db.get_latest_fox_schedule_state() or {}
+        groups_json = fox_state.get("groups_json") or "[]"
+        import json as _json
+        groups = _json.loads(groups_json) if groups_json else []
+        # Fox groups are HH:MM cycles in UTC (Fox hardware clock). Match "now".
+        now_hm = (now.hour, now.minute)
+        def _start(g: dict) -> tuple[int, int]:
+            return int(g.get("startHour", 0)), int(g.get("startMinute", 0))
+        def _end(g: dict) -> tuple[int, int]:
+            return int(g.get("endHour", 0)), int(g.get("endMinute", 0))
+        cur = next(
+            (g for g in groups
+             if _start(g) <= now_hm < _end(g)
+             or (_start(g) > _end(g) and (now_hm >= _start(g) or now_hm < _end(g)))),
+            None,
+        )
+        upcoming = sorted(
+            (g for g in groups if _start(g) > now_hm),
+            key=lambda g: _start(g),
+        )
+        if cur:
+            plan_block["current_fox_mode"] = cur.get("workMode")
+        if upcoming:
+            nxt = upcoming[0]
+            plan_block["next_fox_mode"] = nxt.get("workMode")
+            plan_block["next_transition_utc"] = now.replace(
+                hour=_start(nxt)[0], minute=_start(nxt)[1], second=0, microsecond=0
+            ).isoformat().replace("+00:00", "Z")
+        uploaded_at = fox_state.get("uploaded_at")
+        if uploaded_at:
+            plan_fresh = {
+                "fetched_at_utc": uploaded_at,
+                "age_s": _age(uploaded_at),
+                "stale": False,
+            }
+    except Exception:
+        pass
+    try:
+        ofs = db.get_octopus_fetch_state()
+        if ofs and ofs.last_success_at and not plan_fresh.get("fetched_at_utc"):
+            plan_fresh = {
+                "fetched_at_utc": ofs.last_success_at,
+                "age_s": _age(ofs.last_success_at),
+                "stale": False,
+            }
+    except Exception:
+        pass
+
+    # --- Thresholds from daily_targets (LP's classification for today) -------
+    tz_name = config.BULLETPROOF_TIMEZONE or "Europe/London"
+    try:
+        tz = ZoneInfo(tz_name)
+        plan_date_local = _dt.now(tz).date().isoformat()
+    except Exception:
+        plan_date_local = now.date().isoformat()
+    plan_block["plan_date"] = plan_date_local
+    try:
+        tgt = db.get_daily_target(plan_date_local)
+    except Exception:
+        tgt = None
+    thresholds = {
+        "cheap_p": (tgt or {}).get("cheap_threshold"),
+        "peak_p": (tgt or {}).get("peak_threshold"),
+    }
+
+    # --- Compose ------------------------------------------------------------
+    return {
+        "now_utc": now.isoformat().replace("+00:00", "Z"),
+        "planner_tz": tz_name,
+        "current_slot": {
+            "t_utc": slot_from,
+            "t_end_utc": slot_to,
+            "price_import_p": cur_import_p,
+            "price_export_p": cur_export_p,
+            "fox_mode": plan_block["current_fox_mode"],
+        },
+        "next_transition": {
+            "t_utc": plan_block["next_transition_utc"],
+            "new_fox_mode": plan_block["next_fox_mode"],
+        },
+        "state": {
+            **fox_block,
+            **{
+                "tank_c": dk_block["tank_c"],
+                "indoor_c": dk_block["indoor_c"],
+                "outdoor_c": dk_block["outdoor_c"],
+                "lwt_c": dk_block["lwt_c"],
+                "daikin_mode": dk_block["mode"],
+            },
+        },
+        "freshness": {
+            "agile": {
+                "fetched_at_utc": agile_cache_fetched_at,
+                "age_s": _age(agile_cache_fetched_at),
+                "stale": None,
+            },
+            "fox": fox_fresh,
+            "daikin": dk_fresh,
+            "plan": plan_fresh,
+        },
+        "thresholds": thresholds,
+        "modes": {
+            "daikin_control_mode": config.DAIKIN_CONTROL_MODE,
+            "optimization_preset": config.OPTIMIZATION_PRESET,
+            "energy_strategy_mode": config.ENERGY_STRATEGY_MODE,
+        },
+        "plan_date": plan_block["plan_date"],
+    }
+
+
 @app.get("/api/v1/daikin/quota")
 async def daikin_quota():
     """Return Daikin API quota usage, cache age, and stale status.

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -393,6 +393,25 @@ a { color: inherit; text-decoration: none; }
 }
 .fc-slot-table td.num, .fc-slot-table th.num { text-align: right; }
 
+/* -----------------------------------------------------------------------
+ * Phase 4: History page
+ * ----------------------------------------------------------------------- */
+.history-picker {
+    background: var(--bg-card-2);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+}
+.history-source {
+    font-size: 0.74rem;
+    color: var(--text-dim);
+    font-family: monospace;
+    word-break: break-all;
+}
+
 /* Layout */
 .page {
     max-width: 960px;

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -272,6 +272,127 @@ a { color: inherit; text-decoration: none; }
     opacity: 0.7;
 }
 
+/* -----------------------------------------------------------------------
+ * Phase 3: Forecast tab
+ * ----------------------------------------------------------------------- */
+.forecast-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.6rem;
+}
+.fcs-kpi {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.4rem 0.5rem;
+    background: var(--bg-card-2);
+    border-radius: 6px;
+}
+.fcs-k {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+}
+.fcs-v {
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+}
+.fc-kv-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+.fc-kv-table th, .fc-kv-table td {
+    padding: 0.35rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+.fc-kv-table th {
+    color: var(--text-dim);
+    font-weight: 500;
+    width: 20%;
+}
+.fc-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+.fc-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    padding: 0.22rem 0.55rem;
+    background: var(--bg-card-2);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+}
+.fc-chip strong { color: var(--text-dim); font-weight: 500; }
+.fc-chip span { color: var(--text); }
+.fc-spark-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+.fc-spark-label {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+    margin-bottom: 0.25rem;
+}
+.fc-spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 50px;
+    background: var(--bg-card-2);
+    padding: 2px;
+    border-radius: 4px;
+}
+.fc-bar {
+    flex: 1;
+    min-width: 2px;
+    background: var(--standard);
+    border-radius: 1px;
+}
+.fc-bar.is-missing {
+    background: repeating-linear-gradient(
+        45deg,
+        var(--border), var(--border) 2px,
+        transparent 2px, transparent 4px
+    );
+    opacity: 0.6;
+    height: 100%;
+}
+.fc-slot-table-wrap {
+    max-height: 360px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+}
+.fc-slot-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+}
+.fc-slot-table th, .fc-slot-table td {
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+}
+.fc-slot-table th {
+    background: var(--bg-card-2);
+    position: sticky;
+    top: 0;
+    text-align: left;
+    color: var(--text-dim);
+    font-weight: 500;
+}
+.fc-slot-table td.num, .fc-slot-table th.num { text-align: right; }
+
 /* Layout */
 .page {
     max-width: 960px;

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -143,6 +143,135 @@ a { color: inherit; text-decoration: none; }
     cursor: help;
 }
 
+/* -----------------------------------------------------------------------
+ * Phase 2: cockpit hero — replaces the old four-card status grid.
+ * ----------------------------------------------------------------------- */
+.cockpit-hero {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.hero-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.6fr);
+    gap: 1rem;
+    align-items: start;
+}
+@media (max-width: 720px) {
+    .hero-main { grid-template-columns: 1fr; }
+}
+.hero-now, .hero-next {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.hero-kicker {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+}
+.hero-slot-line {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+.hero-slot-time {
+    font-size: 1.35rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+.hero-slot-kind {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    background: var(--bg-card-2);
+    color: var(--text-dim);
+}
+.hero-slot-kind.kind-cheap { background: var(--cheap); color: #08180a; }
+.hero-slot-kind.kind-peak { background: var(--peak); color: #180a08; }
+.hero-slot-kind.kind-negative { background: var(--neg-price); color: #fff; }
+.hero-slot-kind.kind-standard { background: var(--standard); color: #0b0f17; }
+.hero-slot-price {
+    font-size: 0.9rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+}
+.hero-state-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 0.35rem 0.75rem;
+    margin-top: 0.4rem;
+}
+.hero-kpi {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding: 0.3rem 0;
+    border-top: 1px solid var(--border);
+}
+.hero-kpi-label {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+}
+.hero-kpi-value {
+    font-size: 0.92rem;
+    font-variant-numeric: tabular-nums;
+}
+.hero-next {
+    background: var(--bg-card-2);
+    border-radius: 8px;
+    padding: 0.65rem 0.85rem;
+}
+.hero-next-count {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+.hero-next-label {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+/* --- Freshness ribbon --- */
+.freshness-ribbon {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding-top: 0.5rem;
+    border-top: 1px dashed var(--border);
+}
+.fresh-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.28rem 0.6rem;
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    cursor: pointer;
+    transition: border-color 120ms ease;
+}
+.fresh-chip:hover:not(:disabled) { border-color: var(--text-dim); }
+.fresh-chip:disabled { opacity: 0.5; cursor: progress; }
+.fresh-chip .fresh-chip-name {
+    font-weight: 600;
+    color: var(--text);
+}
+.fresh-chip.is-stale { border-color: var(--warn); color: var(--warn); }
+.fresh-chip.is-very-stale { border-color: var(--bad); color: var(--bad); }
+.fresh-chip .fresh-chip-refresh {
+    margin-left: 0.15rem;
+    font-size: 0.8rem;
+    opacity: 0.7;
+}
+
 /* Layout */
 .page {
     max-width: 960px;

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -412,6 +412,57 @@ a { color: inherit; text-decoration: none; }
     word-break: break-all;
 }
 
+/* Attribution donut (Phase 5) */
+.attribution-block {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 1rem;
+    align-items: center;
+}
+@media (max-width: 480px) {
+    .attribution-block { grid-template-columns: 1fr; }
+}
+.attribution-donut {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background: var(--bg-card-2);
+    /* Center hole so it reads as a donut rather than a pie. */
+    mask: radial-gradient(circle, transparent 42%, #000 43%);
+    -webkit-mask: radial-gradient(circle, transparent 42%, #000 43%);
+}
+.attribution-legend {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+}
+.attribution-legend .attr-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.attribution-legend .attr-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+}
+.attribution-legend .attr-totals {
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    margin-top: 0.25rem;
+}
+
+/* Simulating… busy state */
+.btn.is-busy {
+    opacity: 0.7;
+    cursor: progress;
+}
+body.is-simulating {
+    /* Subtle top progress hint while a simulate is running. */
+    box-shadow: inset 0 2px 0 0 var(--warn);
+}
+
 /* Layout */
 .page {
     max-width: 960px;

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -463,6 +463,18 @@ body.is-simulating {
     box-shadow: inset 0 2px 0 0 var(--warn);
 }
 
+/* Phase 6: daikin-controls grey-out when passive (not hidden — we want
+ * the user to see what's there and why it's disabled). */
+.daikin-controls.is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    filter: grayscale(0.4);
+}
+.daikin-controls.is-disabled input,
+.daikin-controls.is-disabled button {
+    pointer-events: none;
+}
+
 /* Layout */
 .page {
     max-width: 960px;

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -136,6 +136,12 @@ a { color: inherit; text-decoration: none; }
 }
 .pill.is-warn { color: var(--warn); }
 .pill.is-bad { color: var(--bad); }
+.pill.tz-pill {
+    /* Sits at the far right of the topbar next to the quota pills. */
+    margin-left: 0.35rem;
+    font-size: 0.7rem;
+    cursor: help;
+}
 
 /* Layout */
 .page {

--- a/src/api/static/js/cockpit.js
+++ b/src/api/static/js/cockpit.js
@@ -107,6 +107,21 @@
     $('#heroFoxMode').textContent = state.fox_mode || cur.fox_mode || '—';
     $('#heroDaikinMode').textContent = state.daikin_mode || n.modes?.daikin_control_mode || '—';
 
+    // Phase 6 gating: grey-out (not hide) the Daikin tank/LWT controls when
+    // DAIKIN_CONTROL_MODE is passive. The user sees they exist and understands
+    // *why* they're inert — flipping hidden made the controls silently vanish.
+    const dkMode = n.modes?.daikin_control_mode || 'passive';
+    const isPassive = dkMode === 'passive';
+    const passiveNote = $('#daikinOverridePassiveNote');
+    const daikinBlock = $('#daikinOverrideActive');
+    const modeText = $('[data-daikin-mode-text]');
+    if (modeText) modeText.textContent = dkMode;
+    if (passiveNote) passiveNote.hidden = !isPassive;
+    if (daikinBlock) {
+      daikinBlock.classList.toggle('is-disabled', isPassive);
+      daikinBlock.querySelectorAll('input, button').forEach(el => { el.disabled = isPassive; });
+    }
+
     // Next transition — countdown + label.
     const countdown = $('#heroNextCountdown');
     const nextLabel = $('#heroNextLabel');

--- a/src/api/static/js/cockpit.js
+++ b/src/api/static/js/cockpit.js
@@ -1,11 +1,10 @@
-/* v10.1 cockpit page logic.
+/* Cockpit page — Phase 2 rework.
  *
- * Reads from cached endpoints only — never triggers cloud refresh unless the
- * operator clicks the per-card ⟳ button (which routes through the same
- * endpoints; the backend decides whether to hit cloud APIs based on TTL +
- * quota).
- *
- * No auto-refresh. Operator triggers fresh data manually via per-card buttons.
+ * The old four-card layout (Octopus / Fox / Daikin / Plan) has been replaced
+ * by a single hero panel backed by /api/v1/cockpit/now — one coherent
+ * snapshot of where we are now, with a freshness ribbon per source. The
+ * tariff + plan strips and the house-load breakdown are still rendered below
+ * via their existing endpoints.
  */
 (function () {
   'use strict';
@@ -14,12 +13,12 @@
   const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
   const { jsonFetch, wrapAction, toast, refreshQuota } = window.HEM || {};
 
-  /* ----- Freshness rendering ----- */
+  // --- formatting helpers -------------------------------------------------
 
   function fmtAge(iso) {
-    if (!iso) return { text: 'never', class: 'is-very-stale' };
+    if (!iso) return { text: '—', class: 'is-very-stale' };
     const d = new Date(iso);
-    if (isNaN(d)) return { text: 'invalid', class: 'is-very-stale' };
+    if (isNaN(d)) return { text: '—', class: 'is-very-stale' };
     const sec = Math.floor((Date.now() - d.getTime()) / 1000);
     if (sec < 60) return { text: `${sec}s ago`, class: '' };
     if (sec < 3600) {
@@ -28,18 +27,6 @@
     }
     const h = Math.floor(sec / 3600);
     return { text: `${h}h ago`, class: 'is-very-stale' };
-  }
-
-  function setStaleness(card, iso) {
-    const el = card.querySelector('[data-staleness]');
-    const light = card.querySelector('.status-light');
-    if (!el || !light) return;
-    const a = fmtAge(iso);
-    el.textContent = a.text;
-    el.classList.remove('is-stale', 'is-very-stale');
-    if (a.class) el.classList.add(a.class);
-    light.classList.remove('is-ok', 'is-warn', 'is-bad');
-    light.classList.add(a.class === 'is-very-stale' ? 'is-bad' : (a.class === 'is-stale' ? 'is-warn' : 'is-ok'));
   }
 
   function fmtKwh(v, suffix) {
@@ -59,81 +46,110 @@
     return `${Number(v).toFixed(1)}p`;
   }
 
-  /* ----- Status cards ----- */
-
-  async function loadFox(forceRefresh) {
-    const card = $('#cardFox');
-    try {
-      const url = forceRefresh ? '/api/v1/foxess/status?refresh=true' : '/api/v1/foxess/status';
-      const d = await jsonFetch(url);
-      $('[data-fox-soc]', card).textContent = fmtPct(d.soc);
-      $('[data-fox-solar]', card).textContent = fmtKwh(d.solar_power);
-      $('[data-fox-load]', card).textContent = fmtKwh(d.load_power);
-      $('[data-fox-grid]', card).textContent = fmtKwh(d.grid_power);
-      $('[data-fox-mode]', card).textContent = d.work_mode || '—';
-      setStaleness(card, d.updated_at);
-    } catch (e) {
-      $('[data-fox-soc]', card).textContent = 'err';
-      toast(`Fox: ${e.message}`, 'bad');
-    }
+  function slotKindForPrice(p, thresholds) {
+    if (p == null) return 'standard';
+    if (p < 0) return 'negative';
+    const cheap = thresholds?.cheap_p;
+    const peak = thresholds?.peak_p;
+    if (cheap != null && p < cheap) return 'cheap';
+    if (peak != null && p > peak) return 'peak';
+    return 'standard';
   }
 
-  async function loadDaikin(forceRefresh) {
-    const card = $('#cardDaikin');
+  // --- Hero panel ---------------------------------------------------------
+
+  let _thresholds = { cheap_p: null, peak_p: null };
+
+  async function loadNow() {
+    let n;
     try {
-      const url = forceRefresh ? '/api/v1/daikin/status?refresh=true' : '/api/v1/daikin/status';
-      const arr = await jsonFetch(url);
-      const d = (arr && arr[0]) || {};
-      $('[data-daikin-tank]', card).textContent = fmtC(d.tank_temp);
-      $('[data-daikin-indoor]', card).textContent = fmtC(d.room_temp);
-      $('[data-daikin-outdoor]', card).textContent = fmtC(d.outdoor_temp);
-      $('[data-daikin-lwt]', card).textContent = fmtC(d.lwt);
-      const mode = d.control_mode || 'unknown';
-      const badge = $('[data-daikin-mode]', card);
-      badge.textContent = mode;
-      badge.className = 'status-badge ' + (mode === 'passive' ? 'is-passive' : 'is-active');
-      // Freshness comes from /api/v1/daikin/quota (cache_age_seconds, last_refresh_at_utc).
-      // Stamping "now" was misleading — the Daikin cache can be ≤30 min old.
-      try {
-        const q = await jsonFetch('/api/v1/daikin/quota');
-        setStaleness(card, q?.last_refresh_at_utc || null);
-      } catch (_e) {
-        setStaleness(card, null);
-      }
-      // Echo mode into the override panel
-      const tEl = $('[data-daikin-mode-text]');
-      if (tEl) tEl.textContent = mode;
-      $('#daikinOverridePassiveNote').hidden = (mode !== 'passive');
-      $('#daikinOverrideActive').hidden = (mode === 'passive');
+      n = await jsonFetch('/api/v1/cockpit/now');
     } catch (e) {
-      toast(`Daikin: ${e.message}`, 'bad');
+      toast(`Cockpit: ${e.message}`, 'bad');
+      return;
     }
+
+    _thresholds = n.thresholds || { cheap_p: null, peak_p: null };
+
+    const cur = n.current_slot || {};
+    const state = n.state || {};
+    const fresh = n.freshness || {};
+    const next = n.next_transition || {};
+
+    const kind = slotKindForPrice(cur.price_import_p, _thresholds);
+    const heroKind = $('#heroSlotKind');
+    if (heroKind) {
+      heroKind.textContent = kind;
+      heroKind.className = `hero-slot-kind kind-${kind}`;
+    }
+    const heroTime = $('#heroSlotTime');
+    if (heroTime) {
+      heroTime.textContent = (window.HEM && window.HEM.fmtSlotRange && cur.t_utc && cur.t_end_utc)
+        ? window.HEM.fmtSlotRange(cur.t_utc, cur.t_end_utc)
+        : '—';
+    }
+    const heroPrice = $('#heroSlotPrice');
+    if (heroPrice) {
+      const ip = cur.price_import_p != null ? `${cur.price_import_p.toFixed(1)}p` : '—';
+      const ep = cur.price_export_p != null ? `${cur.price_export_p.toFixed(1)}p` : '—';
+      heroPrice.textContent = `imp ${ip} · exp ${ep}`;
+    }
+
+    $('#heroSoc').textContent = state.soc_pct != null ? `${fmtPct(state.soc_pct)} · ${fmtKwh(state.soc_kwh, 'kWh')}` : '—';
+    $('#heroSolar').textContent = fmtKwh(state.solar_kw);
+    $('#heroLoad').textContent = fmtKwh(state.load_kw);
+    const grid = state.grid_kw;
+    $('#heroGrid').textContent = grid == null ? '—' : `${grid >= 0 ? '+' : ''}${Number(grid).toFixed(2)} kW`;
+    $('#heroTank').textContent = fmtC(state.tank_c);
+    $('#heroIndoor').textContent = fmtC(state.indoor_c);
+    $('#heroOutdoor').textContent = fmtC(state.outdoor_c);
+    $('#heroLwt').textContent = fmtC(state.lwt_c);
+    $('#heroFoxMode').textContent = state.fox_mode || cur.fox_mode || '—';
+    $('#heroDaikinMode').textContent = state.daikin_mode || n.modes?.daikin_control_mode || '—';
+
+    // Next transition — countdown + label.
+    const countdown = $('#heroNextCountdown');
+    const nextLabel = $('#heroNextLabel');
+    if (next.t_utc) {
+      const until = Math.max(0, Math.floor((new Date(next.t_utc).getTime() - Date.now()) / 1000));
+      const m = Math.floor(until / 60);
+      const h = Math.floor(m / 60);
+      countdown.textContent = h > 0 ? `in ${h}h ${m % 60}m` : `in ${m}m`;
+      const t = (window.HEM && window.HEM.fmtSlotTime) ? window.HEM.fmtSlotTime(next.t_utc) : '';
+      nextLabel.textContent = `${t} → ${next.new_fox_mode || '—'}`;
+    } else {
+      countdown.textContent = '—';
+      nextLabel.textContent = '—';
+    }
+
+    // Freshness ribbon — one chip per source.
+    ['agile', 'fox', 'daikin', 'plan'].forEach(k => {
+      const chip = $(`.fresh-chip[data-source="${k}"]`);
+      if (!chip) return;
+      const f = fresh[k] || {};
+      const a = fmtAge(f.fetched_at_utc);
+      const ageEl = chip.querySelector('[data-age]');
+      if (ageEl) ageEl.textContent = a.text;
+      chip.classList.remove('is-stale', 'is-very-stale');
+      if (a.class) chip.classList.add(a.class);
+    });
   }
 
-  async function loadOctopus() {
-    const card = $('#cardOctopus');
-    try {
-      const [status, agile] = await Promise.all([
-        jsonFetch('/api/v1/optimization/status').catch(() => null),
-        jsonFetch('/api/v1/agile/today').catch(() => null),
-      ]);
-      $('[data-octopus-import]', card).textContent = fmtP(agile?.current_import_p);
-      $('[data-octopus-export]', card).textContent = fmtP(agile?.current_export_p);
-      $('[data-octopus-slots]', card).textContent = agile?.import_slots?.length ?? '—';
-      setStaleness(card, status?.cache_fetched_at_utc || status?.last_plan_at_utc || null);
-      renderTariffStripsFromAgile(agile);
-    } catch (e) {
-      toast(`Octopus: ${e.message}`, 'bad');
-    }
-  }
+  // --- Tariff + Plan strips (reused; overlay now-cursor + thresholds) -----
 
   function priceColor(p) {
     if (p == null) return 'var(--bg-card-2)';
-    if (p < 0) return 'var(--neg-price)';
-    if (p < 12) return 'var(--cheap)';
-    if (p < 25) return 'var(--standard)';
-    if (p < 35) return 'var(--peak)';
-    return 'var(--peak-export)';
+    const kind = slotKindForPrice(p, _thresholds);
+    if (kind === 'negative') return 'var(--neg-price)';
+    if (kind === 'cheap') return 'var(--cheap)';
+    if (kind === 'peak') return 'var(--peak)';
+    return 'var(--standard)';
+  }
+
+  async function loadTariff() {
+    const agile = await jsonFetch('/api/v1/agile/today').catch(() => null);
+    renderTariffStripsFromAgile(agile);
+    updateTariffLabel(agile);
   }
 
   function renderTariffStripsFromAgile(agile) {
@@ -148,8 +164,6 @@
         const cell = document.createElement('div');
         cell.className = 'tariff-slot';
         cell.style.background = priceColor(s.p);
-        // Slot times formatted in the planner tz — not browser local — so a
-        // VPN/travel user sees the same labels as the LP planned against.
         const rangeLbl = (window.HEM && window.HEM.fmtSlotRange)
           ? window.HEM.fmtSlotRange(s.valid_from, s.valid_to)
           : `${s.valid_from.slice(11,16)}–${s.valid_to.slice(11,16)}`;
@@ -162,79 +176,63 @@
     };
     renderRow(im, agile.import_slots || []);
     renderRow(ex, agile.export_slots || []);
+  }
+
+  function updateTariffLabel(agile) {
     const lbl = $('#tariffCurrentLabel');
-    if (lbl) {
-      const i = agile.current_import_p;
-      const e = agile.current_export_p;
-      lbl.textContent = `Current: import ${i == null ? '—' : i.toFixed(1) + 'p'} · export ${e == null ? '—' : e.toFixed(1) + 'p'}`;
-    }
+    if (!lbl) return;
+    if (!agile) { lbl.textContent = '—'; return; }
+    const i = agile.current_import_p;
+    const e = agile.current_export_p;
+    const cheap = _thresholds.cheap_p != null ? `cheap<${_thresholds.cheap_p.toFixed(1)}p` : '';
+    const peak = _thresholds.peak_p != null ? `peak>${_thresholds.peak_p.toFixed(1)}p` : '';
+    const thr = [cheap, peak].filter(Boolean).join(' · ');
+    lbl.textContent = `Current: import ${fmtP(i)} · export ${fmtP(e)}${thr ? ' · ' + thr : ''}`;
   }
 
   async function loadPlan() {
-    const card = $('#cardPlan');
-    try {
-      const [p, status] = await Promise.all([
-        jsonFetch('/api/v1/optimization/plan'),
-        jsonFetch('/api/v1/optimization/status').catch(() => null),
-      ]);
-      $('[data-plan-backend]', card).textContent = status?.optimizer_backend || p?.optimizer_backend || '—';
-      // Find current slot strategy from fox groups
-      const fox = p.fox || {};
-      let groups = [];
-      try { groups = JSON.parse(fox.groups_json || '[]'); } catch (_e) {}
-      const now = new Date();
-      const cur = groups.find(g => slotContains(g, now));
-      const next = groups.find(g => slotStartUTC(g) > now);
-      $('[data-plan-now]', card).textContent = cur ? `${pad2(cur.startHour)}:${pad2(cur.startMinute)}–${pad2(cur.endHour)}:${pad2(cur.endMinute)} ${cur.workMode}` : '—';
-      $('[data-plan-next]', card).textContent = next ? `${pad2(next.startHour)}:${pad2(next.startMinute)} → ${next.workMode}` : '—';
-      setStaleness(card, fox.uploaded_at || status?.last_plan_at_utc);
-      renderPlanStrip(groups);
-    } catch (e) {
-      toast(`Plan: ${e.message}`, 'bad');
-    }
+    const p = await jsonFetch('/api/v1/optimization/plan').catch(() => null);
+    if (!p) return;
+    const fox = p.fox || {};
+    let groups = [];
+    try { groups = JSON.parse(fox.groups_json || '[]'); } catch (_e) {}
+    renderPlanStrip(groups);
   }
 
   function pad2(n) { return String(n).padStart(2, '0'); }
-  function slotStartUTC(g) {
-    const d = new Date();
-    d.setUTCHours(g.startHour || 0, g.startMinute || 0, 0, 0);
-    return d;
-  }
-  function slotContains(g, t) {
-    const s = slotStartUTC(g);
-    const e = new Date(s);
-    e.setUTCHours(g.endHour || 0, g.endMinute || 0, 0, 0);
-    return t >= s && t < e;
-  }
 
   function renderPlanStrip(groups) {
     const strip = $('#planStrip');
     if (!strip) return;
     strip.innerHTML = '';
     const now = new Date();
-    // Build 48 half-hour slots from local 00:00 today
+    // Fox groups are UTC-clock (hardware); build 48 UTC slots for the next 24h.
+    const dayStart = new Date(now);
+    dayStart.setUTCHours(0, 0, 0, 0);
     for (let i = 0; i < 48; i++) {
       const slot = document.createElement('div');
       slot.className = 'plan-slot';
       const hour = Math.floor(i / 2);
       const min = (i % 2) * 30;
-      const slotStart = new Date(now);
-      slotStart.setHours(hour, min, 0, 0);
+      const slotStart = new Date(dayStart);
+      slotStart.setUTCHours(hour, min, 0, 0);
       const slotEnd = new Date(slotStart);
-      slotEnd.setMinutes(slotEnd.getMinutes() + 30);
+      slotEnd.setUTCMinutes(slotEnd.getUTCMinutes() + 30);
 
-      // Find the group that covers this slot (using local time)
       const g = groups.find(g => {
-        const gs = new Date(now);
-        gs.setHours(g.startHour, g.startMinute || 0, 0, 0);
-        const ge = new Date(now);
-        ge.setHours(g.endHour, g.endMinute || 0, 0, 0);
+        const gs = new Date(dayStart);
+        gs.setUTCHours(g.startHour, g.startMinute || 0, 0, 0);
+        const ge = new Date(dayStart);
+        ge.setUTCHours(g.endHour, g.endMinute || 0, 0, 0);
         return slotStart >= gs && slotStart < ge;
       });
       const kind = workModeToKind(g);
       slot.classList.add(`kind-${kind}`);
       if (now >= slotStart && now < slotEnd) slot.classList.add('is-now');
-      slot.title = `${pad2(hour)}:${pad2(min)} · ${kind}` + (g ? ` (${g.workMode})` : '');
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(slotStart.toISOString())
+        : `${pad2(hour)}:${pad2(min)}`;
+      slot.title = `${lbl} · ${kind}` + (g ? ` (${g.workMode})` : '');
       slot.addEventListener('click', () => { window.location.href = '/plan'; });
       strip.appendChild(slot);
     }
@@ -250,8 +248,6 @@
     return 'standard';
   }
 
-  // Tariff strips are rendered by renderTariffStripsFromAgile() (called from loadOctopus).
-
   async function loadBreakdown() {
     try {
       const b = await jsonFetch('/api/v1/load/breakdown');
@@ -266,7 +262,35 @@
     }
   }
 
-  /* ----- Override panel ----- */
+  // --- Freshness chip handlers -------------------------------------------
+
+  function bindFreshnessChips() {
+    $$('.fresh-chip').forEach(chip => chip.addEventListener('click', async () => {
+      const source = chip.dataset.source;
+      chip.disabled = true;
+      try {
+        if (source === 'agile') {
+          await jsonFetch('/api/v1/optimization/refresh', { method: 'POST' });
+        } else if (source === 'fox') {
+          await jsonFetch('/api/v1/foxess/status?refresh=true');
+        } else if (source === 'daikin') {
+          await jsonFetch('/api/v1/daikin/status?refresh=true');
+        } else if (source === 'plan') {
+          // No side-effect endpoint — just a reload of the current plan view.
+        }
+        await loadNow();
+        if (source === 'agile') await loadTariff();
+        if (source === 'plan') await loadPlan();
+        if (refreshQuota) refreshQuota();
+      } catch (e) {
+        toast(`${source} refresh failed: ${e.message}`, 'bad');
+      } finally {
+        chip.disabled = false;
+      }
+    }));
+  }
+
+  // --- Manual override panel (unchanged from v10.1) -----------------------
 
   function bindOverride() {
     const toggle = $('#overrideToggle');
@@ -276,7 +300,6 @@
       toggle.setAttribute('aria-expanded', String(!open));
       body.hidden = open;
     });
-
     $$('.override-tab').forEach(t => t.addEventListener('click', () => {
       $$('.override-tab').forEach(x => x.classList.remove('is-active'));
       t.classList.add('is-active');
@@ -291,7 +314,7 @@
         applyUrl: '/api/v1/foxess/mode',
         body: { mode },
       });
-      loadFox();
+      loadNow();
       loadPlan();
     }));
 
@@ -301,15 +324,15 @@
         applyUrl: '/api/v1/optimization/propose',
       });
       loadPlan();
+      loadNow();
     });
 
-    // Promoted Re-plan button at the top of the Plan timeline card
     $('#btnSimulateRePlanCockpit')?.addEventListener('click', async () => {
       const result = await wrapAction({
         simulateUrl: '/api/v1/optimization/propose/simulate',
         applyUrl: '/api/v1/optimization/propose',
       });
-      if (result.applied) setTimeout(loadPlan, 4000);
+      if (result.applied) setTimeout(() => { loadPlan(); loadNow(); }, 4000);
     });
 
     $('#btnDaikinTank')?.addEventListener('click', async () => {
@@ -320,7 +343,7 @@
         applyUrl: '/api/v1/daikin/tank-temperature',
         body: { temperature: t },
       });
-      loadDaikin();
+      loadNow();
     });
 
     $('#btnDaikinLwt')?.addEventListener('click', async () => {
@@ -331,40 +354,19 @@
         applyUrl: '/api/v1/daikin/lwt-offset',
         body: { offset: off },
       });
-      loadDaikin();
+      loadNow();
     });
   }
 
-  /* ----- Per-card refresh buttons ----- */
-
-  function bindRefreshButtons() {
-    $$('[data-refresh]').forEach(btn => btn.addEventListener('click', async () => {
-      const which = btn.dataset.refresh;
-      btn.disabled = true;
-      try {
-        if (which === 'fox') await loadFox(true);
-        else if (which === 'daikin') await loadDaikin(true);
-        else if (which === 'octopus') await loadOctopus();
-        else if (which === 'plan') await loadPlan();
-        if (refreshQuota) refreshQuota();
-      } finally {
-        btn.disabled = false;
-      }
-    }));
-  }
-
-  /* ----- Boot ----- */
+  // --- Boot ---------------------------------------------------------------
 
   document.addEventListener('DOMContentLoaded', async () => {
     bindOverride();
-    bindRefreshButtons();
-    // Initial loads — all from cache, no cloud refresh.
-    // loadFox is awaited first because /api/v1/load/breakdown reads from the
-    // Fox service cache; calling loadFox warms it.
-    await loadFox(false);
-    loadBreakdown();
-    loadDaikin(false);
-    loadOctopus();
+    bindFreshnessChips();
+    // Load the hero first so thresholds are available when strips render.
+    await loadNow();
+    loadTariff();
     loadPlan();
+    loadBreakdown();
   });
 })();

--- a/src/api/static/js/cockpit.js
+++ b/src/api/static/js/cockpit.js
@@ -92,7 +92,14 @@
       const badge = $('[data-daikin-mode]', card);
       badge.textContent = mode;
       badge.className = 'status-badge ' + (mode === 'passive' ? 'is-passive' : 'is-active');
-      setStaleness(card, new Date().toISOString()); // Daikin status doesn't carry timestamp; stamp now
+      // Freshness comes from /api/v1/daikin/quota (cache_age_seconds, last_refresh_at_utc).
+      // Stamping "now" was misleading — the Daikin cache can be ≤30 min old.
+      try {
+        const q = await jsonFetch('/api/v1/daikin/quota');
+        setStaleness(card, q?.last_refresh_at_utc || null);
+      } catch (_e) {
+        setStaleness(card, null);
+      }
       // Echo mode into the override panel
       const tEl = $('[data-daikin-mode-text]');
       if (tEl) tEl.textContent = mode;
@@ -141,7 +148,12 @@
         const cell = document.createElement('div');
         cell.className = 'tariff-slot';
         cell.style.background = priceColor(s.p);
-        cell.title = `${s.valid_from.slice(11,16)}–${s.valid_to.slice(11,16)} ${s.p.toFixed(1)}p`;
+        // Slot times formatted in the planner tz — not browser local — so a
+        // VPN/travel user sees the same labels as the LP planned against.
+        const rangeLbl = (window.HEM && window.HEM.fmtSlotRange)
+          ? window.HEM.fmtSlotRange(s.valid_from, s.valid_to)
+          : `${s.valid_from.slice(11,16)}–${s.valid_to.slice(11,16)}`;
+        cell.title = `${rangeLbl} ${s.p.toFixed(1)}p`;
         const start = new Date(s.valid_from);
         const end = new Date(s.valid_to);
         if (now >= start && now < end) cell.classList.add('is-current');

--- a/src/api/static/js/forecast.js
+++ b/src/api/static/js/forecast.js
@@ -1,0 +1,141 @@
+/* Forecast page — renders /api/v1/optimization/inputs. Phase 3.
+ *
+ * Answers: "what will the LP see on its next run?". Pure read — opening
+ * the page never triggers a cloud fetch.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
+  const { jsonFetch, wrapAction, toast } = window.HEM || {};
+
+  function fmtP(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(1)}p`;
+  }
+  function fmtC(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(1)}°C`;
+  }
+  function fmtKwh(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(3)} kWh`;
+  }
+
+  /**
+   * Render a compact CSS-only sparkline: one vertical bar per slot, height
+   * scaled within [0, max]. Keeps the tab render fast without pulling a
+   * charting library.
+   */
+  function renderSpark(mount, values) {
+    if (!mount) return;
+    mount.innerHTML = '';
+    const cleaned = values.map(v => (v == null || isNaN(v) ? null : Number(v)));
+    const present = cleaned.filter(v => v != null);
+    if (!present.length) {
+      mount.textContent = '—';
+      return;
+    }
+    const min = Math.min(0, ...present);
+    const max = Math.max(...present);
+    const span = max - min || 1;
+    cleaned.forEach((v, i) => {
+      const bar = document.createElement('span');
+      bar.className = 'fc-bar' + (v == null ? ' is-missing' : '');
+      if (v != null) {
+        const h = Math.max(2, ((v - min) / span) * 100);
+        bar.style.height = `${h}%`;
+      }
+      mount.appendChild(bar);
+    });
+  }
+
+  function renderChips(mount, snapshot) {
+    if (!mount) return;
+    const entries = Object.entries(snapshot || {});
+    if (!entries.length) { mount.textContent = '—'; return; }
+    mount.innerHTML = '';
+    entries.forEach(([k, v]) => {
+      const chip = document.createElement('span');
+      chip.className = 'fc-chip';
+      const val = typeof v === 'number' ? (Number.isInteger(v) ? v : Number(v).toFixed(3)) : v;
+      chip.innerHTML = `<strong>${k}</strong> <span>${val}</span>`;
+      mount.appendChild(chip);
+    });
+  }
+
+  function renderSlotTable(rows) {
+    const tbody = $('#fcSlotTable tbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    if (!rows.length) {
+      tbody.innerHTML = '<tr><td colspan="6" class="text-mute">No slot data. Run the optimizer once to populate inputs.</td></tr>';
+      return;
+    }
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const t = (window.HEM && window.HEM.fmtSlotTime) ? window.HEM.fmtSlotTime(r.t_utc) : r.t_utc.slice(11, 16);
+      tr.innerHTML = `
+        <td>${t}</td>
+        <td class="num">${fmtP(r.price_import_p)}</td>
+        <td class="num">${fmtP(r.price_export_p)}</td>
+        <td class="num">${fmtC(r.temp_c)}</td>
+        <td class="num">${r.solar_w_m2 == null ? '—' : Number(r.solar_w_m2).toFixed(0)}</td>
+        <td class="num">${fmtKwh(r.base_load_kwh)}</td>`;
+      tbody.appendChild(tr);
+    });
+  }
+
+  async function load() {
+    let d;
+    try {
+      d = await jsonFetch('/api/v1/optimization/inputs');
+    } catch (e) {
+      toast(`Forecast: ${e.message}`, 'bad');
+      return;
+    }
+
+    $('#fcHorizon').textContent = `${d.horizon_hours} h`;
+    $('#fcTz').textContent = d.planner_tz || '—';
+    $('#fcTomorrow').textContent = d.tomorrow_rates_available ? 'published' : 'not yet';
+    $('#fcCheap').textContent = d.thresholds?.cheap_p != null ? fmtP(d.thresholds.cheap_p) : '—';
+    $('#fcPeak').textContent = d.thresholds?.peak_p != null ? fmtP(d.thresholds.peak_p) : '—';
+    $('#fcMicro').textContent = d.micro_climate_offset_c != null ? `${Number(d.micro_climate_offset_c).toFixed(2)} °C` : '—';
+
+    const init = d.initial || {};
+    $('#fcInitSoc').textContent = init.soc_kwh != null
+      ? `${Number(init.soc_kwh).toFixed(2)} kWh (${init.soc_pct != null ? init.soc_pct.toFixed(0) + '%' : '—'})`
+      : '—';
+    $('#fcInitSocSrc').textContent = init.soc_source || '—';
+    $('#fcInitTank').textContent = fmtC(init.tank_c);
+    $('#fcInitTankSrc').textContent = init.tank_source || '—';
+    $('#fcInitIndoor').textContent = fmtC(init.indoor_c);
+    $('#fcInitIndoorSrc').textContent = init.indoor_source || '—';
+
+    renderChips($('#fcConfigChips'), d.config_snapshot);
+
+    const rows = d.slots || [];
+    renderSpark($('#fcSparkPrice'), rows.map(r => r.price_import_p));
+    renderSpark($('#fcSparkTemp'), rows.map(r => r.temp_c));
+    renderSpark($('#fcSparkSolar'), rows.map(r => r.solar_w_m2));
+    renderSpark($('#fcSparkLoad'), rows.map(r => r.base_load_kwh));
+    renderSlotTable(rows);
+  }
+
+  function bind() {
+    $('#btnForecastReload')?.addEventListener('click', load);
+    $('#btnForecastReplan')?.addEventListener('click', async () => {
+      // Use the existing simulate→confirm flow via wrapAction, then reload.
+      const r = await wrapAction({
+        simulateUrl: '/api/v1/optimization/propose/simulate',
+        applyUrl: '/api/v1/optimization/propose',
+      });
+      if (r.applied) setTimeout(load, 4000);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    bind();
+    load();
+  });
+})();

--- a/src/api/static/js/history.js
+++ b/src/api/static/js/history.js
@@ -1,0 +1,124 @@
+/* History page — Phase 4.
+ *
+ * Drives the date-time picker, calls /api/v1/cockpit/at?when=..., and
+ * renders the same-shape hero + plan-vs-actual table from the LP snapshot
+ * tables. Zero cloud calls.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const { jsonFetch, toast } = window.HEM || {};
+
+  function fmtC(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(1)}°C`; }
+  function fmtP(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(1)}p`; }
+  function fmtKwh(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(3)} kWh`; }
+  function fmtPct(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(0)}%`; }
+
+  function inputToIso(val) {
+    // datetime-local gives "2026-04-24T10:00"; treat as UTC — the picker
+    // displays the wall-clock moment the user typed, interpreted as UTC.
+    if (!val) return null;
+    return val.length <= 16 ? val + ':00Z' : val + 'Z';
+  }
+
+  async function replay(whenIso) {
+    let data;
+    try {
+      data = await jsonFetch(`/api/v1/cockpit/at?when=${encodeURIComponent(whenIso)}`);
+    } catch (e) {
+      toast(`History: ${e.message}`, 'bad');
+      return;
+    }
+
+    const cur = data.current_slot || {};
+    const state = data.state || {};
+    const plan = data.planned_slot || {};
+    const li = data.lp_inputs || {};
+    const src = data.source || {};
+
+    // Source readout: which run + which log row fed this payload.
+    const srcEl = $('#historySource');
+    if (srcEl) {
+      const parts = [];
+      if (src.lp_run_at_utc) parts.push(`LP run ${src.lp_run_at_utc}`);
+      if (src.run_id != null) parts.push(`run_id=${src.run_id}`);
+      if (src.execution_log_timestamp) parts.push(`execution_log @ ${src.execution_log_timestamp}`);
+      srcEl.textContent = parts.length ? `Source: ${parts.join(' · ')}` : 'No snapshots available for that moment.';
+    }
+
+    // State row.
+    $('#hSoc').textContent = state.soc_pct != null ? `${fmtPct(state.soc_pct)} · ${fmtKwh(state.soc_kwh)}` : '—';
+    $('#hLoad').textContent = state.load_kw != null ? `${Number(state.load_kw).toFixed(2)} kW` : '—';
+    $('#hFoxMode').textContent = state.fox_mode || '—';
+    $('#hTank').textContent = fmtC(state.tank_c);
+    $('#hIndoor').textContent = fmtC(state.indoor_c);
+    $('#hOutdoor').textContent = fmtC(state.outdoor_c);
+    $('#hLwt').textContent = fmtC(state.lwt_c);
+    $('#hKind').textContent = data.slot_kind || '—';
+    $('#hPriceImp').textContent = fmtP(cur.price_import_p);
+    $('#hPriceExp').textContent = fmtP(cur.price_export_p);
+
+    // Plan vs actual (actuals come from state where telemetry exists).
+    $('#paPlanImport').textContent = fmtKwh(plan.import_kwh);
+    $('#paActImport').textContent = state.load_kw != null ? `~${Number(state.load_kw * 0.5).toFixed(3)} kWh` : '—';
+    $('#paPlanChg').textContent = fmtKwh(plan.charge_kwh);
+    $('#paPlanDis').textContent = fmtKwh(plan.discharge_kwh);
+    $('#paPlanDhw').textContent = fmtKwh(plan.dhw_kwh);
+    $('#paPlanSpace').textContent = fmtKwh(plan.space_kwh);
+    $('#paPlanTank').textContent = fmtC(plan.tank_temp_c);
+    $('#paActTank').textContent = fmtC(state.tank_c);
+    $('#paPlanIndoor').textContent = fmtC(plan.indoor_temp_c);
+    $('#paActIndoor').textContent = fmtC(state.indoor_c);
+    $('#paPlanSoc').textContent = plan.soc_kwh != null ? `${Number(plan.soc_kwh).toFixed(2)} kWh` : '—';
+    $('#paActSoc').textContent = state.soc_kwh != null ? `${Number(state.soc_kwh).toFixed(2)} kWh` : '—';
+
+    // LP inputs at solve time.
+    $('#liRunAt').textContent = li.run_at_utc || '—';
+    $('#liPlanDate').textContent = li.plan_date || '—';
+    $('#liHorizon').textContent = li.horizon_hours != null ? `${li.horizon_hours} h` : '—';
+    $('#liSoc').textContent = li.soc_initial_kwh != null
+      ? `${Number(li.soc_initial_kwh).toFixed(2)} kWh (source: ${li.soc_source || '?'})`
+      : '—';
+    $('#liTank').textContent = li.tank_initial_c != null
+      ? `${fmtC(li.tank_initial_c)} (source: ${li.tank_source || '?'})`
+      : '—';
+    $('#liIndoor').textContent = li.indoor_initial_c != null
+      ? `${fmtC(li.indoor_initial_c)} (source: ${li.indoor_source || '?'})`
+      : '—';
+    $('#liMicro').textContent = li.micro_climate_offset_c != null
+      ? `${Number(li.micro_climate_offset_c).toFixed(2)} °C`
+      : '—';
+    $('#liCheap').textContent = fmtP(li.cheap_threshold_p);
+    $('#liPeak').textContent = fmtP(li.peak_threshold_p);
+    $('#liDkMode').textContent = li.daikin_control_mode || '—';
+    $('#liPreset').textContent = li.optimization_preset || '—';
+  }
+
+  function bind() {
+    const picker = $('#historyWhen');
+    // Default to 1 hour ago, formatted for datetime-local input (no TZ).
+    const d = new Date(Date.now() - 60 * 60 * 1000);
+    const pad = n => String(n).padStart(2, '0');
+    if (picker) {
+      picker.value = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+    }
+    $('#btnHistoryJump')?.addEventListener('click', () => {
+      const iso = inputToIso(picker?.value);
+      if (iso) replay(iso);
+    });
+    $('#btnHistoryNow')?.addEventListener('click', async () => {
+      const now = new Date();
+      if (picker) {
+        picker.value = `${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}T${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}`;
+      }
+      replay(now.toISOString());
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    bind();
+    const picker = $('#historyWhen');
+    const iso = inputToIso(picker?.value);
+    if (iso) replay(iso);
+  });
+})();

--- a/src/api/static/js/history.js
+++ b/src/api/static/js/history.js
@@ -72,6 +72,15 @@
     $('#paPlanSoc').textContent = plan.soc_kwh != null ? `${Number(plan.soc_kwh).toFixed(2)} kWh` : '—';
     $('#paActSoc').textContent = state.soc_kwh != null ? `${Number(state.soc_kwh).toFixed(2)} kWh` : '—';
 
+    // Attribution donut — fetched separately for the date of replay.
+    try {
+      const whenDate = whenIso.slice(0, 10);  // "2026-04-24"
+      const a = await jsonFetch(`/api/v1/attribution/day?date=${whenDate}`);
+      renderAttribution(a);
+    } catch (_e) {
+      renderAttribution(null);
+    }
+
     // LP inputs at solve time.
     $('#liRunAt').textContent = li.run_at_utc || '—';
     $('#liPlanDate').textContent = li.plan_date || '—';
@@ -92,6 +101,36 @@
     $('#liPeak').textContent = fmtP(li.peak_threshold_p);
     $('#liDkMode').textContent = li.daikin_control_mode || '—';
     $('#liPreset').textContent = li.optimization_preset || '—';
+  }
+
+  /**
+   * Render a CSS conic-gradient donut showing how solar was split across
+   * self-use / battery / export for the replay date.
+   */
+  function renderAttribution(a) {
+    const donut = $('#attributionDonut');
+    const legend = $('#attributionLegend');
+    if (!donut || !legend) return;
+    if (!a || !a.available || !a.shares) {
+      donut.style.background = 'var(--bg-card-2)';
+      legend.textContent = a && !a.available
+        ? `No rollup yet for ${a.date} (Fox rollup runs overnight).`
+        : '—';
+      return;
+    }
+    const s = a.shares;
+    // conic-gradient sweep: self-use → battery → export.
+    const sCol = '#4caf50', bCol = '#2196f3', eCol = '#ff9800';
+    const end1 = s.self_use_pct;
+    const end2 = end1 + s.battery_pct;
+    donut.style.background =
+      `conic-gradient(${sCol} 0 ${end1}%, ${bCol} ${end1}% ${end2}%, ${eCol} ${end2}% 100%)`;
+    legend.innerHTML = `
+      <div class="attr-item"><span class="attr-swatch" style="background:${sCol}"></span> Self-use ${s.self_use_pct}%</div>
+      <div class="attr-item"><span class="attr-swatch" style="background:${bCol}"></span> Battery ${s.battery_pct}%</div>
+      <div class="attr-item"><span class="attr-swatch" style="background:${eCol}"></span> Export ${s.export_pct}%</div>
+      <div class="attr-totals">${Number(a.solar_kwh).toFixed(1)} kWh solar · ${Number(a.load_kwh).toFixed(1)} kWh load · ${Number(a.export_kwh).toFixed(1)} kWh export</div>
+    `;
   }
 
   function bind() {

--- a/src/api/static/js/plan_render.js
+++ b/src/api/static/js/plan_render.js
@@ -98,8 +98,11 @@
       sumRes    += s.cost_residual_p || 0;
       sumCost   += s.cost_realised_p || 0;
       sumSvt    += s.cost_svt_p || 0;
-      const d = new Date(s.slot_utc);
-      const lbl = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+      // Format in the planner timezone, not browser local — otherwise a
+      // VPN/travel user sees times shifted from what the LP actually planned.
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(s.slot_utc)
+        : (() => { const d = new Date(s.slot_utc); return `${pad(d.getHours())}:${pad(d.getMinutes())}`; })();
       const strategy = strategyForSlot(groups, s.slot_utc) + (s.slot_kind ? ` · ${s.slot_kind}` : '');
       const dvs = s.delta_vs_svt_p || 0;
       const dvsCls = dvs > 0 ? 'text-bad' : (dvs < 0 ? 'text-ok' : '');
@@ -150,8 +153,10 @@
       return;
     }
     const html = slots.map(s => {
-      const t = new Date(s.valid_from);
-      const lbl = `${pad(t.getHours())}:${pad(t.getMinutes())}`;
+      // Planner-tz formatting — see the equivalent comment in renderSlotTable.
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(s.valid_from)
+        : (() => { const t = new Date(s.valid_from); return `${pad(t.getHours())}:${pad(t.getMinutes())}`; })();
       const tooltip = `${lbl} · ${Number(s.p).toFixed(2)}p · ${s.kind || ''}`;
       return `<div class="tariff-day-cell kind-${s.kind || 'standard'}" title="${tooltip}"><span class="tariff-day-cell-time">${lbl}</span><span class="tariff-day-cell-price">${Number(s.p).toFixed(0)}p</span></div>`;
     }).join('');

--- a/src/api/static/js/tz.js
+++ b/src/api/static/js/tz.js
@@ -1,0 +1,123 @@
+/* Shared timezone helpers (Phase 1 of cockpit rework).
+ *
+ * The cockpit was previously doing `new Date(iso).getHours()` on UTC slot
+ * timestamps, which returns the BROWSER's local hour, not the planner's. If
+ * the user's browser is not in `Europe/London` (VPN, travel, wrong TZ),
+ * labels like "16:30" become wrong while the LP is still correctly planning
+ * in Europe/London.
+ *
+ * Every cockpit JS module formatting a slot time should now call
+ * `HEM.fmtSlotTime(iso)` or `HEM.fmtSlotRange(fromIso, toIso)`. Those
+ * delegate to Intl.DateTimeFormat with the planner_tz returned by
+ * `/api/v1/system/timezone`, cached for the lifetime of the page.
+ */
+(function () {
+  'use strict';
+  const { jsonFetch } = window.HEM || {};
+
+  // One in-flight fetch, memoized once resolved.
+  let _tzPromise = null;
+  let _tz = null;  // { planner_tz, plan_push_tz, now_utc, now_local }
+
+  function loadTz() {
+    if (_tz) return Promise.resolve(_tz);
+    if (_tzPromise) return _tzPromise;
+    _tzPromise = (jsonFetch ? jsonFetch('/api/v1/system/timezone') : fetch('/api/v1/system/timezone').then(r => r.json()))
+      .then(r => { _tz = r; return r; })
+      .catch(() => {
+        // Fallback so the page still renders if the endpoint fails.
+        _tz = { planner_tz: 'Europe/London', plan_push_tz: 'UTC' };
+        return _tz;
+      });
+    return _tzPromise;
+  }
+
+  function plannerTz() {
+    return (_tz && _tz.planner_tz) || 'Europe/London';
+  }
+
+  function _fmt(iso, opts) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '—';
+    try {
+      return new Intl.DateTimeFormat(undefined, Object.assign({ timeZone: plannerTz() }, opts)).format(d);
+    } catch (_e) {
+      return iso;
+    }
+  }
+
+  // Slot time like "16:30" in the planner tz.
+  function fmtSlotTime(iso) {
+    return _fmt(iso, { hour: '2-digit', minute: '2-digit', hour12: false });
+  }
+
+  // Slot range like "16:30–17:00" in the planner tz.
+  function fmtSlotRange(fromIso, toIso) {
+    return `${fmtSlotTime(fromIso)}–${fmtSlotTime(toIso)}`;
+  }
+
+  // Full local timestamp, e.g. "24/04/2026, 16:30:12".
+  function fmtLocal(iso) {
+    return _fmt(iso, {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+    });
+  }
+
+  // Produce a Date that represents "now in the planner tz but with local clock"
+  // — useful for hour-of-day bucket math without leaking the browser tz. Returns
+  // a Date whose Y/M/D/H/M fields match the planner clock; callers should use
+  // those fields (getFullYear/getHours etc.) rather than the raw timestamp.
+  function nowInPlannerTz() {
+    const now = new Date();
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: plannerTz(),
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+    }).formatToParts(now).reduce((acc, p) => { acc[p.type] = p.value; return acc; }, {});
+    return new Date(
+      `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`
+    );
+  }
+
+  // Hour + minute of the planner-tz clock for a given UTC ISO stamp.
+  function slotHM(iso) {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return { hour: 0, minute: 0 };
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: plannerTz(),
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(d);
+    const hour = Number(parts.find(p => p.type === 'hour')?.value || 0);
+    const minute = Number(parts.find(p => p.type === 'minute')?.value || 0);
+    return { hour, minute };
+  }
+
+  window.HEM = window.HEM || {};
+  window.HEM.Tz = {
+    loadTz,
+    plannerTz,
+    fmtSlotTime,
+    fmtSlotRange,
+    fmtLocal,
+    nowInPlannerTz,
+    slotHM,
+  };
+
+  // Shortcuts used widely.
+  window.HEM.fmtSlotTime = fmtSlotTime;
+  window.HEM.fmtSlotRange = fmtSlotRange;
+
+  // Kick off the fetch eagerly so callers who don't await loadTz() still
+  // converge quickly. Any early call formats in the fallback tz (Europe/London)
+  // which is correct for this single-home deployment anyway.
+  document.addEventListener('DOMContentLoaded', () => {
+    loadTz().then(tz => {
+      const badge = document.getElementById('tzBadge');
+      if (badge && tz && tz.planner_tz) {
+        badge.textContent = `🕒 ${tz.planner_tz}`;
+      }
+    });
+  });
+})();

--- a/src/api/static/js/workbench.js
+++ b/src/api/static/js/workbench.js
@@ -110,6 +110,17 @@
       toast('No overrides to simulate', 'warn');
       return;
     }
+    // Phase 5: loading-state feedback. The solver is typically sub-second
+    // but LP_HORIZON_HOURS=48 + many overrides can push into the 2-3s range,
+    // and a disabled button with "Simulating…" copy tells the user why.
+    const btn = document.getElementById('btnSimulate');
+    const originalLabel = btn ? btn.textContent : '';
+    if (btn) {
+      btn.disabled = true;
+      btn.textContent = 'Simulating…';
+      btn.classList.add('is-busy');
+    }
+    document.body.classList.add('is-simulating');
     try {
       const [sim, current] = await Promise.all([
         jsonFetch('/api/v1/workbench/simulate', { method: 'POST', body: { overrides: State.overrides } }),
@@ -126,6 +137,15 @@
       }
     } catch (e) {
       toast(`Simulate failed: ${e.message}`, 'bad');
+    } finally {
+      if (btn) {
+        btn.disabled = false;
+        btn.classList.remove('is-busy');
+        // Restore the label via the main refresh so N-change counter updates.
+        btn.textContent = originalLabel;
+        renderEditor();
+      }
+      document.body.classList.remove('is-simulating');
     }
   }
 
@@ -160,8 +180,10 @@
       return;
     }
     tbody.innerHTML = slots.map((s, i) => {
-      const t = new Date(s.t);
-      const lbl = `${String(t.getHours()).padStart(2,'0')}:${String(t.getMinutes()).padStart(2,'0')}`;
+      // Slot labels in planner tz so Workbench matches Cockpit / Forecast / History.
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(s.t)
+        : (() => { const t = new Date(s.t); return `${String(t.getHours()).padStart(2,'0')}:${String(t.getMinutes()).padStart(2,'0')}`; })();
       const simImp = s.import_kwh ?? 0;
       // We don't have current per-slot import in the same shape; show — for now.
       return `<tr>

--- a/src/api/templates/_layout.html
+++ b/src/api/templates/_layout.html
@@ -27,6 +27,7 @@
             </button>
             <nav class="tabs" aria-label="Pages">
                 <a href="/" class="tab {% if active_page == 'cockpit' %}is-active{% endif %}">Cockpit</a>
+                <a href="/forecast" class="tab {% if active_page == 'forecast' %}is-active{% endif %}">Forecast</a>
                 <a href="/insights" class="tab {% if active_page == 'insights' %}is-active{% endif %}">Insights</a>
                 <a href="/workbench" class="tab {% if active_page == 'workbench' %}is-active{% endif %}">Workbench</a>
                 <a href="/settings" class="tab {% if active_page == 'settings' %}is-active{% endif %}">Settings</a>

--- a/src/api/templates/_layout.html
+++ b/src/api/templates/_layout.html
@@ -35,6 +35,10 @@
                 <span class="pill" id="quotaDaikin" title="Daikin Onecta API requests today">D —/180</span>
                 <span class="pill" id="quotaFox" title="Fox ESS API requests today">F —/1200</span>
             </div>
+            <span class="pill tz-pill" id="tzBadge"
+                  title="Planning + cockpit use this timezone. The nightly plan-push cron is UTC-anchored so each new day&apos;s first dispatches land on a fresh Daikin quota day.">
+                🕒 —
+            </span>
         </div>
     </header>
 
@@ -48,6 +52,7 @@
     <div class="toast-stack" id="toastStack" aria-live="polite"></div>
 
     <script src="/static/js/modal.js?v={{ static_v('js/modal.js') }}"></script>
+    <script src="/static/js/tz.js?v={{ static_v('js/tz.js') }}"></script>
     <script src="/static/js/quota.js?v={{ static_v('js/quota.js') }}"></script>
     <script src="/static/js/mode_switcher.js?v={{ static_v('js/mode_switcher.js') }}"></script>
     {% block scripts %}{% endblock %}

--- a/src/api/templates/_layout.html
+++ b/src/api/templates/_layout.html
@@ -28,6 +28,7 @@
             <nav class="tabs" aria-label="Pages">
                 <a href="/" class="tab {% if active_page == 'cockpit' %}is-active{% endif %}">Cockpit</a>
                 <a href="/forecast" class="tab {% if active_page == 'forecast' %}is-active{% endif %}">Forecast</a>
+                <a href="/history" class="tab {% if active_page == 'history' %}is-active{% endif %}">History</a>
                 <a href="/insights" class="tab {% if active_page == 'insights' %}is-active{% endif %}">Insights</a>
                 <a href="/workbench" class="tab {% if active_page == 'workbench' %}is-active{% endif %}">Workbench</a>
                 <a href="/settings" class="tab {% if active_page == 'settings' %}is-active{% endif %}">Settings</a>

--- a/src/api/templates/cockpit.html
+++ b/src/api/templates/cockpit.html
@@ -2,65 +2,56 @@
 {% block title %}Cockpit · Home Energy{% endblock %}
 {% block content %}
 
-<section class="status-grid">
-    <div class="card status-card" id="cardOctopus">
-        <div class="header-row">
-            <span class="status-light is-warn"></span>
-            <span class="status-name">Octopus</span>
-            <span class="status-staleness" data-staleness>—</span>
-            <button class="btn-icon" title="Refresh now" data-refresh="octopus">⟳</button>
+<!-- Phase 2: "NOW" hero panel — one coherent snapshot from /api/v1/cockpit/now -->
+<section class="card cockpit-hero">
+    <div class="hero-main">
+        <div class="hero-now">
+            <span class="hero-kicker">Current slot</span>
+            <div class="hero-slot-line">
+                <span class="hero-slot-time" id="heroSlotTime">—</span>
+                <span class="hero-slot-kind" id="heroSlotKind">—</span>
+                <span class="hero-slot-price" id="heroSlotPrice">—</span>
+            </div>
+            <div class="hero-state-grid">
+                <div class="hero-kpi"><span class="hero-kpi-label">SoC</span><span class="hero-kpi-value" id="heroSoc">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Solar</span><span class="hero-kpi-value" id="heroSolar">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Load</span><span class="hero-kpi-value" id="heroLoad">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Grid</span><span class="hero-kpi-value" id="heroGrid">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Tank</span><span class="hero-kpi-value" id="heroTank">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Indoor</span><span class="hero-kpi-value" id="heroIndoor">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Outdoor</span><span class="hero-kpi-value" id="heroOutdoor">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">LWT</span><span class="hero-kpi-value" id="heroLwt">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Fox mode</span><span class="hero-kpi-value" id="heroFoxMode">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Daikin</span><span class="hero-kpi-value" id="heroDaikinMode">—</span></div>
+            </div>
         </div>
-        <div class="status-rows">
-            <span class="label">Import (now)</span><span class="value" data-octopus-import>—</span>
-            <span class="label">Export (now)</span><span class="value" data-octopus-export>—</span>
-            <span class="label">Slots loaded</span><span class="value" data-octopus-slots>—</span>
-        </div>
+        <aside class="hero-next">
+            <span class="hero-kicker">Next transition</span>
+            <div class="hero-next-count" id="heroNextCountdown">—</div>
+            <div class="hero-next-label" id="heroNextLabel">—</div>
+        </aside>
     </div>
-
-    <div class="card status-card" id="cardFox">
-        <div class="header-row">
-            <span class="status-light is-warn"></span>
-            <span class="status-name">Fox ESS</span>
-            <span class="status-staleness" data-staleness>—</span>
-            <button class="btn-icon" title="Refresh now" data-refresh="fox">⟳</button>
-        </div>
-        <div class="status-rows">
-            <span class="label">SoC</span><span class="value" data-fox-soc>—</span>
-            <span class="label">Solar</span><span class="value" data-fox-solar>—</span>
-            <span class="label">Load</span><span class="value" data-fox-load>—</span>
-            <span class="label">Grid</span><span class="value" data-fox-grid>—</span>
-            <span class="label">Mode</span><span class="value" data-fox-mode>—</span>
-        </div>
-    </div>
-
-    <div class="card status-card" id="cardDaikin">
-        <div class="header-row">
-            <span class="status-light is-warn"></span>
-            <span class="status-name">Daikin</span>
-            <span class="status-staleness" data-staleness>—</span>
-            <button class="btn-icon" title="Refresh now (consumes Onecta quota)" data-refresh="daikin">⟳</button>
-        </div>
-        <div class="status-rows">
-            <span class="label">Tank</span><span class="value" data-daikin-tank>—</span>
-            <span class="label">Indoor</span><span class="value" data-daikin-indoor>—</span>
-            <span class="label">Outdoor</span><span class="value" data-daikin-outdoor>—</span>
-            <span class="label">LWT</span><span class="value" data-daikin-lwt>—</span>
-            <span class="label">Mode</span><span class="value"><span class="status-badge" data-daikin-mode>—</span></span>
-        </div>
-    </div>
-
-    <div class="card status-card" id="cardPlan">
-        <div class="header-row">
-            <span class="status-light is-warn"></span>
-            <span class="status-name">Plan</span>
-            <span class="status-staleness" data-staleness>—</span>
-            <button class="btn-icon" title="Reload" data-refresh="plan">⟳</button>
-        </div>
-        <div class="status-rows">
-            <span class="label">Now slot</span><span class="value" data-plan-now>—</span>
-            <span class="label">Next change</span><span class="value" data-plan-next>—</span>
-            <span class="label">Backend</span><span class="value" data-plan-backend>—</span>
-        </div>
+    <div class="freshness-ribbon" id="freshnessRibbon" title="Click a chip to refresh just that source">
+        <button class="fresh-chip" type="button" data-source="agile">
+            <span class="fresh-chip-name">Agile</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
+        <button class="fresh-chip" type="button" data-source="fox">
+            <span class="fresh-chip-name">Fox</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
+        <button class="fresh-chip" type="button" data-source="daikin">
+            <span class="fresh-chip-name">Daikin</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
+        <button class="fresh-chip" type="button" data-source="plan">
+            <span class="fresh-chip-name">Plan</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
     </div>
 </section>
 

--- a/src/api/templates/cockpit.html
+++ b/src/api/templates/cockpit.html
@@ -118,7 +118,7 @@
 
 <section class="override-section">
     <button class="override-toggle" id="overrideToggle" aria-expanded="false">
-        Manual override · everything below requires preview &amp; confirm
+        Controls · everything below requires preview &amp; confirm
     </button>
     <div class="override-body" id="overrideBody" hidden>
         <div class="override-tabs" role="tablist">
@@ -147,11 +147,16 @@
             <p class="text-dim" style="font-size:0.85rem;margin:0;" id="daikinOverrideHint">
                 Daikin is in <code data-daikin-mode-text>—</code> mode.
             </p>
+            <!-- Phase 6: passive-mode gating grey-out (not hidden) + tooltip
+                 so the user sees *why* the controls are disabled rather than
+                 having them silently disappear. -->
             <div id="daikinOverridePassiveNote" class="text-warn" style="font-size:0.85rem;" hidden>
-                In passive mode the service never writes to Daikin. To control it, switch
-                <code>DAIKIN_CONTROL_MODE</code> to <code>active</code> on the Settings page.
+                In passive mode the service never writes to Daikin.
+                Flip <code>DAIKIN_CONTROL_MODE</code> to <code>active</code> via the top-bar mode badge to enable manual overrides.
             </div>
-            <div id="daikinOverrideActive" hidden>
+            <div id="daikinOverrideActive"
+                 class="daikin-controls"
+                 title="Daikin is in passive mode. Switch to active (topbar mode badge) to enable these controls.">
                 <div class="field">
                     <label>Tank target (°C)</label>
                     <input type="number" min="30" max="65" step="0.5" id="daikinTankInput" value="48">

--- a/src/api/templates/forecast.html
+++ b/src/api/templates/forecast.html
@@ -1,0 +1,96 @@
+{% extends "_layout.html" %}
+{% block title %}Forecast · Home Energy{% endblock %}
+{% block content %}
+
+<section class="card">
+    <h2 class="card-title">
+        LP inputs
+        <span class="card-actions">
+            <button class="btn btn-sm btn-secondary" id="btnForecastReload" title="Reload the cached inputs (no cloud calls)">Reload</button>
+            <button class="btn btn-sm btn-primary" id="btnForecastReplan" title="Fetch fresh Octopus + weather and re-solve">
+                Refresh data &amp; re-plan
+            </button>
+        </span>
+    </h2>
+    <p class="text-mute" style="font-size:0.78rem;margin:0 0 0.75rem 0;">
+        Everything the next LP solve will see, read from caches and the
+        <code>meteo_forecast</code> / <code>agile_rates</code> tables. No cloud calls are
+        triggered by opening this page.
+    </p>
+    <div class="forecast-summary" id="forecastSummary">
+        <div class="fcs-kpi"><span class="fcs-k">Horizon</span><span class="fcs-v" id="fcHorizon">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Planner tz</span><span class="fcs-v" id="fcTz">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Tomorrow rates</span><span class="fcs-v" id="fcTomorrow">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Cheap &lt;</span><span class="fcs-v" id="fcCheap">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Peak &gt;</span><span class="fcs-v" id="fcPeak">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Micro-climate Δ</span><span class="fcs-v" id="fcMicro">—</span></div>
+    </div>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Initial state (what the LP reads at solve time)</h3>
+    <table class="fc-kv-table">
+        <tbody>
+            <tr><th>SoC</th><td id="fcInitSoc">—</td><td class="text-dim" id="fcInitSocSrc">—</td></tr>
+            <tr><th>Tank</th><td id="fcInitTank">—</td><td class="text-dim" id="fcInitTankSrc">—</td></tr>
+            <tr><th>Indoor</th><td id="fcInitIndoor">—</td><td class="text-dim" id="fcInitIndoorSrc">—</td></tr>
+        </tbody>
+    </table>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        Source labels: <code>fox_realtime_cache</code> / <code>db_realtime_snapshot</code> (SoC);
+        <code>daikin_live</code> / <code>daikin_cache</code> / <code>daikin_estimate</code> (tank &amp; indoor);
+        <code>default</code> means config fallback.
+    </p>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Config snapshot</h3>
+    <div class="fc-chip-row" id="fcConfigChips">—</div>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        These are the knobs the LP will read on its next solve. Historical values live in the
+        <code>config_audit</code> table (tuning changes are logged there).
+    </p>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Per-slot inputs (next horizon)</h3>
+    <div class="fc-spark-grid">
+        <div>
+            <div class="fc-spark-label">Import price (p/kWh)</div>
+            <div class="fc-spark" id="fcSparkPrice"></div>
+        </div>
+        <div>
+            <div class="fc-spark-label">Outdoor temp (°C)</div>
+            <div class="fc-spark" id="fcSparkTemp"></div>
+        </div>
+        <div>
+            <div class="fc-spark-label">Solar W/m²</div>
+            <div class="fc-spark" id="fcSparkSolar"></div>
+        </div>
+        <div>
+            <div class="fc-spark-label">Base load (kWh/slot)</div>
+            <div class="fc-spark" id="fcSparkLoad"></div>
+        </div>
+    </div>
+    <div class="fc-slot-table-wrap">
+        <table class="fc-slot-table" id="fcSlotTable">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th class="num">Import p</th>
+                    <th class="num">Export p</th>
+                    <th class="num">Temp °C</th>
+                    <th class="num">Solar W/m²</th>
+                    <th class="num">Base load kWh</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</section>
+
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/forecast.js?v={{ static_v('js/forecast.js') }}"></script>
+{% endblock %}

--- a/src/api/templates/history.html
+++ b/src/api/templates/history.html
@@ -1,0 +1,85 @@
+{% extends "_layout.html" %}
+{% block title %}History · Home Energy{% endblock %}
+{% block content %}
+
+<section class="card">
+    <h2 class="card-title">
+        Replay a past moment
+        <span class="card-actions">
+            <input type="datetime-local" id="historyWhen" class="history-picker" />
+            <button class="btn btn-sm btn-secondary" id="btnHistoryJump" title="Replay the snapshot at the chosen moment">Replay</button>
+            <button class="btn btn-sm btn-secondary" id="btnHistoryNow" title="Jump to the latest run">Latest run</button>
+        </span>
+    </h2>
+    <p class="text-mute" style="font-size:0.78rem;margin:0 0 0.75rem 0;">
+        Reads from the LP snapshot tables — the same layout as the Cockpit NOW panel, frozen at the chosen moment.
+        Source labels below show exactly which <code>optimizer_log</code> run and which <code>execution_log</code>
+        row the data came from.
+    </p>
+    <div class="history-source" id="historySource">—</div>
+</section>
+
+<section class="card">
+    <h3 class="card-title">State at that moment</h3>
+    <div class="hero-state-grid">
+        <div class="hero-kpi"><span class="hero-kpi-label">SoC</span><span class="hero-kpi-value" id="hSoc">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Load</span><span class="hero-kpi-value" id="hLoad">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Fox mode</span><span class="hero-kpi-value" id="hFoxMode">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Tank</span><span class="hero-kpi-value" id="hTank">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Indoor</span><span class="hero-kpi-value" id="hIndoor">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Outdoor</span><span class="hero-kpi-value" id="hOutdoor">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">LWT</span><span class="hero-kpi-value" id="hLwt">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Slot kind</span><span class="hero-kpi-value" id="hKind">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Import p</span><span class="hero-kpi-value" id="hPriceImp">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Export p</span><span class="hero-kpi-value" id="hPriceExp">—</span></div>
+    </div>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Plan vs Actual (this slot)</h3>
+    <table class="fc-kv-table" id="histPlanActual">
+        <thead>
+            <tr><th>Metric</th><th>Plan</th><th>Actual</th></tr>
+        </thead>
+        <tbody>
+            <tr><th>Import kWh</th><td id="paPlanImport">—</td><td id="paActImport">—</td></tr>
+            <tr><th>Battery charge kWh</th><td id="paPlanChg">—</td><td class="text-dim">—</td></tr>
+            <tr><th>Battery discharge kWh</th><td id="paPlanDis">—</td><td class="text-dim">—</td></tr>
+            <tr><th>DHW kWh</th><td id="paPlanDhw">—</td><td class="text-dim">—</td></tr>
+            <tr><th>Space heat kWh</th><td id="paPlanSpace">—</td><td class="text-dim">—</td></tr>
+            <tr><th>Tank end °C</th><td id="paPlanTank">—</td><td id="paActTank">—</td></tr>
+            <tr><th>Indoor end °C</th><td id="paPlanIndoor">—</td><td id="paActIndoor">—</td></tr>
+            <tr><th>SoC end kWh</th><td id="paPlanSoc">—</td><td id="paActSoc">—</td></tr>
+        </tbody>
+    </table>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        Plan columns come from <code>lp_solution_snapshot</code> (the LP's per-slot decision at solve time).
+        Actual comes from <code>execution_log</code>. A row of dashes means we have no actual telemetry
+        for that metric (e.g. per-slot battery charge isn't logged yet).
+    </p>
+</section>
+
+<section class="card">
+    <h3 class="card-title">LP inputs at solve time</h3>
+    <table class="fc-kv-table">
+        <tbody>
+            <tr><th>Run at</th><td id="liRunAt">—</td></tr>
+            <tr><th>Plan date</th><td id="liPlanDate">—</td></tr>
+            <tr><th>Horizon</th><td id="liHorizon">—</td></tr>
+            <tr><th>Initial SoC</th><td id="liSoc">—</td></tr>
+            <tr><th>Initial tank</th><td id="liTank">—</td></tr>
+            <tr><th>Initial indoor</th><td id="liIndoor">—</td></tr>
+            <tr><th>Micro-climate Δ</th><td id="liMicro">—</td></tr>
+            <tr><th>Cheap threshold</th><td id="liCheap">—</td></tr>
+            <tr><th>Peak threshold</th><td id="liPeak">—</td></tr>
+            <tr><th>Daikin mode</th><td id="liDkMode">—</td></tr>
+            <tr><th>Preset</th><td id="liPreset">—</td></tr>
+        </tbody>
+    </table>
+</section>
+
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/history.js?v={{ static_v('js/history.js') }}"></script>
+{% endblock %}

--- a/src/api/templates/history.html
+++ b/src/api/templates/history.html
@@ -60,6 +60,17 @@
 </section>
 
 <section class="card">
+    <h3 class="card-title">Solar attribution (day of replay)</h3>
+    <div class="attribution-block" id="attributionBlock">
+        <div class="attribution-donut" id="attributionDonut" aria-hidden="true"></div>
+        <div class="attribution-legend" id="attributionLegend">—</div>
+    </div>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        Where today's solar went: self-used, stored in battery, or exported. Historical-only — today's running totals appear once the nightly Fox rollup fires.
+    </p>
+</section>
+
+<section class="card">
     <h3 class="card-title">LP inputs at solve time</h3>
     <table class="fc-kv-table">
         <tbody>

--- a/src/db.py
+++ b/src/db.py
@@ -406,6 +406,109 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         )"""
     )
 
+    # V11: durable LP snapshots (cockpit History replay).
+    #
+    # lp_solution_snapshot holds the per-slot decision vector of each solve so
+    # the History view can render "what the LP decided" for any past run.
+    # lp_inputs_snapshot holds the scalar inputs + JSON-encoded base_load and
+    # config snapshot that fed that solve.
+    # Both reference optimizer_log.id as run_id (optimizer_log is written after
+    # every successful _run_optimizer_lp with lastrowid returned).
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS lp_solution_snapshot (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id          INTEGER NOT NULL,
+            slot_index      INTEGER NOT NULL,
+            slot_time_utc   TEXT NOT NULL,
+            price_p         REAL,
+            import_kwh      REAL,
+            export_kwh      REAL,
+            charge_kwh      REAL,
+            discharge_kwh   REAL,
+            pv_use_kwh      REAL,
+            pv_curtail_kwh  REAL,
+            dhw_kwh         REAL,
+            space_kwh       REAL,
+            soc_kwh         REAL,
+            tank_temp_c     REAL,
+            indoor_temp_c   REAL,
+            outdoor_temp_c  REAL,
+            lwt_offset_c    REAL,
+            UNIQUE(run_id, slot_index)
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_solution_snapshot_run ON lp_solution_snapshot(run_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_solution_snapshot_slot ON lp_solution_snapshot(slot_time_utc)"
+    )
+
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS lp_inputs_snapshot (
+            run_id                   INTEGER PRIMARY KEY,
+            run_at_utc               TEXT NOT NULL,
+            plan_date                TEXT,
+            horizon_hours            INTEGER,
+            soc_initial_kwh          REAL,
+            tank_initial_c           REAL,
+            indoor_initial_c         REAL,
+            soc_source               TEXT,
+            tank_source              TEXT,
+            indoor_source            TEXT,
+            base_load_json           TEXT,
+            micro_climate_offset_c   REAL,
+            config_snapshot_json     TEXT,
+            price_quantize_p         REAL,
+            peak_threshold_p         REAL,
+            cheap_threshold_p        REAL,
+            daikin_control_mode      TEXT,
+            optimization_preset      TEXT,
+            energy_strategy_mode     TEXT
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_plan_date ON lp_inputs_snapshot(plan_date)"
+    )
+
+    # V11b: meteo_forecast_history — append-only audit log of every forecast
+    # fetch. The existing meteo_forecast table is latest-per-slot (overwrites on
+    # UNIQUE(slot_time)) so heartbeat + LP reads stay simple; this companion
+    # table preserves the full fetch history so the cockpit can show "what did
+    # the LP think the weather would be on date D when it ran at 10:00?".
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS meteo_forecast_history (
+            id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+            forecast_fetch_at_utc TEXT NOT NULL,
+            slot_time             TEXT NOT NULL,
+            temp_c                REAL,
+            solar_w_m2            REAL,
+            UNIQUE(forecast_fetch_at_utc, slot_time)
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_meteo_forecast_history_slot ON meteo_forecast_history(slot_time)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_meteo_forecast_history_fetch ON meteo_forecast_history(forecast_fetch_at_utc)"
+    )
+
+    # V11c: config_audit — append-only log of runtime_settings changes so a
+    # past plan can always be explained even if a tunable was changed later.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS config_audit (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            key            TEXT NOT NULL,
+            value          TEXT,
+            op             TEXT NOT NULL,
+            actor          TEXT,
+            changed_at_utc TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_config_audit_key_ts ON config_audit(key, changed_at_utc DESC)"
+    )
+
 
 def init_db() -> None:
     """Create tables if missing and apply lightweight migrations."""
@@ -2227,6 +2330,203 @@ def list_runtime_settings() -> list[dict[str, Any]]:
             cur = conn.execute(
                 "SELECT key, value, updated_at FROM runtime_settings ORDER BY key"
             )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# V11: LP snapshots + forecast history + config audit (cockpit History replay)
+# ---------------------------------------------------------------------------
+
+def save_lp_snapshots(
+    run_id: int,
+    inputs_row: dict[str, Any],
+    solution_rows: list[dict[str, Any]],
+) -> None:
+    """Persist one LP run's inputs + per-slot solution in a single transaction.
+
+    ``run_id`` is ``optimizer_log.id`` returned by :func:`log_optimizer_run`.
+    ``inputs_row`` keys map 1:1 onto ``lp_inputs_snapshot`` columns.
+    Each element of ``solution_rows`` maps 1:1 onto ``lp_solution_snapshot`` columns
+    (excluding ``id`` and ``run_id`` which are filled here).
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT OR REPLACE INTO lp_inputs_snapshot
+                   (run_id, run_at_utc, plan_date, horizon_hours,
+                    soc_initial_kwh, tank_initial_c, indoor_initial_c,
+                    soc_source, tank_source, indoor_source,
+                    base_load_json, micro_climate_offset_c, config_snapshot_json,
+                    price_quantize_p, peak_threshold_p, cheap_threshold_p,
+                    daikin_control_mode, optimization_preset, energy_strategy_mode)
+                   VALUES (:run_id, :run_at_utc, :plan_date, :horizon_hours,
+                           :soc_initial_kwh, :tank_initial_c, :indoor_initial_c,
+                           :soc_source, :tank_source, :indoor_source,
+                           :base_load_json, :micro_climate_offset_c, :config_snapshot_json,
+                           :price_quantize_p, :peak_threshold_p, :cheap_threshold_p,
+                           :daikin_control_mode, :optimization_preset, :energy_strategy_mode)""",
+                {"run_id": run_id, **inputs_row},
+            )
+            for row in solution_rows:
+                conn.execute(
+                    """INSERT OR REPLACE INTO lp_solution_snapshot
+                       (run_id, slot_index, slot_time_utc, price_p,
+                        import_kwh, export_kwh, charge_kwh, discharge_kwh,
+                        pv_use_kwh, pv_curtail_kwh, dhw_kwh, space_kwh,
+                        soc_kwh, tank_temp_c, indoor_temp_c, outdoor_temp_c, lwt_offset_c)
+                       VALUES (:run_id, :slot_index, :slot_time_utc, :price_p,
+                               :import_kwh, :export_kwh, :charge_kwh, :discharge_kwh,
+                               :pv_use_kwh, :pv_curtail_kwh, :dhw_kwh, :space_kwh,
+                               :soc_kwh, :tank_temp_c, :indoor_temp_c, :outdoor_temp_c, :lwt_offset_c)""",
+                    {"run_id": run_id, **row},
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def get_lp_solution_slots(run_id: int) -> list[dict[str, Any]]:
+    """Return all slot rows for a given run_id, ordered by slot_index."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM lp_solution_snapshot WHERE run_id = ? ORDER BY slot_index",
+                (run_id,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def get_lp_inputs(run_id: int) -> dict[str, Any] | None:
+    """Return the inputs row for a run_id, or None if absent."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM lp_inputs_snapshot WHERE run_id = ?", (run_id,)
+            )
+            r = cur.fetchone()
+            return dict(r) if r else None
+        finally:
+            conn.close()
+
+
+def find_run_for_time(when_utc: str) -> int | None:
+    """Return the most recent optimizer_log.id whose run_at <= when_utc.
+
+    Used by the History endpoint to pick which LP run's snapshot to display
+    for a given past moment.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT id FROM optimizer_log
+                   WHERE run_at <= ?
+                   ORDER BY run_at DESC
+                   LIMIT 1""",
+                (when_utc,),
+            )
+            r = cur.fetchone()
+            return int(r[0]) if r else None
+        finally:
+            conn.close()
+
+
+def save_meteo_forecast_history(
+    forecast_fetch_at_utc: str,
+    rows: list[dict[str, Any]],
+) -> None:
+    """Append a forecast fetch's per-slot rows to the history table.
+
+    Companion to :func:`save_meteo_forecast` (which is latest-per-slot). This
+    table preserves every fetch so the History view can show forecasts as they
+    were at past LP runs.
+    """
+    if not rows:
+        return
+    with _lock:
+        conn = get_connection()
+        try:
+            for r in rows:
+                conn.execute(
+                    """INSERT OR IGNORE INTO meteo_forecast_history
+                       (forecast_fetch_at_utc, slot_time, temp_c, solar_w_m2)
+                       VALUES (?, ?, ?, ?)""",
+                    (
+                        forecast_fetch_at_utc,
+                        r.get("slot_time"),
+                        r.get("temp_c"),
+                        r.get("solar_w_m2"),
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def get_meteo_forecast_at(fetch_at_utc: str) -> list[dict[str, Any]]:
+    """Return the forecast rows stored for a specific fetch timestamp."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT slot_time, temp_c, solar_w_m2
+                   FROM meteo_forecast_history
+                   WHERE forecast_fetch_at_utc = ?
+                   ORDER BY slot_time""",
+                (fetch_at_utc,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def log_config_change(
+    key: str,
+    value: str | None,
+    op: str,
+    actor: str | None = None,
+) -> None:
+    """Append one row to ``config_audit``.
+
+    ``op`` is ``"set"`` or ``"delete"``. Called from
+    ``runtime_settings.set_setting`` / ``delete_setting``.
+    """
+    ts = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT INTO config_audit (key, value, op, actor, changed_at_utc)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (key, value, op, actor, ts),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def get_config_audit(key: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    """Return recent config_audit rows, optionally filtered by key."""
+    with _lock:
+        conn = get_connection()
+        try:
+            if key is None:
+                cur = conn.execute(
+                    "SELECT * FROM config_audit ORDER BY changed_at_utc DESC LIMIT ?",
+                    (limit,),
+                )
+            else:
+                cur = conn.execute(
+                    "SELECT * FROM config_audit WHERE key = ? ORDER BY changed_at_utc DESC LIMIT ?",
+                    (key, limit),
+                )
             return [dict(r) for r in cur.fetchall()]
         finally:
             conn.close()

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -291,6 +291,12 @@ def set_setting(key: str, value: Any, *, actor: str = "api") -> Any:
     canonical = _validate(spec, value)
     serialized = _serialize(spec, canonical)
     db.set_runtime_setting(key, serialized)
+    # V11: append-only audit trail so a past LP run can be explained even
+    # after a knob is changed. Non-fatal — never block the setting write.
+    try:
+        db.log_config_change(key, serialized, op="set", actor=actor)
+    except Exception as e:
+        logger.debug("config_audit insert failed (non-fatal): %s", e)
     global _version
     with _lock:
         _version += 1
@@ -314,6 +320,11 @@ def delete_setting(key: str, *, actor: str = "api") -> bool:
     if spec is None:
         raise SettingValidationError(f"unknown runtime setting: {key!r}")
     removed = db.delete_runtime_setting(key)
+    if removed:
+        try:
+            db.log_config_change(key, None, op="delete", actor=actor)
+        except Exception as e:
+            logger.debug("config_audit delete insert failed (non-fatal): %s", e)
     global _version
     with _lock:
         _version += 1

--- a/src/scheduler/lp_initial_state.py
+++ b/src/scheduler/lp_initial_state.py
@@ -53,6 +53,8 @@ def read_lp_initial_state(
 
     tank = float(config.DHW_TEMP_NORMAL_C)
     indoor = float(config.INDOOR_SETPOINT_C)
+    tank_source = "default"
+    indoor_source = "default"
 
     try:
         # #55 — use the cached/estimator wrapper so LP still seeds sensibly
@@ -83,10 +85,13 @@ def read_lp_initial_state(
                 ),
                 "source": result.source,
             }
+        src = str(state.get("source") or "daikin_unknown")
         if state.get("tank_temp_c") is not None:
             tank = float(state["tank_temp_c"])
+            tank_source = src
         if state.get("indoor_temp_c") is not None:
             indoor = float(state["indoor_temp_c"])
+            indoor_source = src
         logger.debug(
             "LP Daikin seed: tank=%.1f°C indoor=%.1f°C source=%s",
             tank,
@@ -103,7 +108,15 @@ def read_lp_initial_state(
             r = rows[0].get("daikin_room_temp")
             if r is not None:
                 indoor = float(r)
+                indoor_source = "execution_log"
     except Exception:
         pass
 
-    return LpInitialState(soc_kwh=soc_kwh, tank_temp_c=tank, indoor_temp_c=indoor)
+    return LpInitialState(
+        soc_kwh=soc_kwh,
+        tank_temp_c=tank,
+        indoor_temp_c=indoor,
+        soc_source=soc_source,
+        tank_source=tank_source,
+        indoor_source=indoor_source,
+    )

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -42,6 +42,14 @@ class LpInitialState:
     soc_kwh: float
     tank_temp_c: float
     indoor_temp_c: float
+    # Provenance strings ("fox_realtime_cache", "db_realtime_snapshot",
+    # "daikin_live", "daikin_cache", "daikin_estimate", "execution_log",
+    # "default"). Persisted to lp_inputs_snapshot so the History view can show
+    # "SoC came from Fox live cache (1m ago)" etc. Defaults preserve
+    # backwards-compat for callers that construct LpInitialState directly.
+    soc_source: str = "unknown"
+    tank_source: str = "unknown"
+    indoor_source: str = "unknown"
 
 
 @dataclass

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1,6 +1,7 @@
 """Target VWAP engine, Fox Scheduler V3 builder, Daikin action_schedule writer."""
 from __future__ import annotations
 
+import json
 import logging
 import time
 from dataclasses import dataclass
@@ -876,6 +877,99 @@ def _run_optimizer_heuristic(fox: FoxESSClient | None, daikin: Any | None = None
     }
 
 
+def _persist_lp_snapshots(
+    *,
+    run_id: int,
+    run_at_iso: str,
+    plan_date: str,
+    plan: Any,  # LpPlan — typed-as-Any to avoid an import cycle at module load
+    initial: Any,  # LpInitialState
+    base_load: list[float],
+    micro_climate_offset: float,
+) -> None:
+    """Build and persist the inputs + per-slot rows for this LP run.
+
+    The shape of ``lp_inputs_snapshot`` + ``lp_solution_snapshot`` is the
+    cockpit History replay source of truth. Config fields captured here are
+    the LP-relevant tunables; other knobs can be recovered from
+    ``config_audit`` joined by timestamp if needed.
+    """
+    # Config snapshot — everything the LP meaningfully conditioned on. Keep
+    # compact; dashboards read this directly from the JSON.
+    cfg_snap = {
+        "LP_HORIZON_HOURS": int(config.LP_HORIZON_HOURS),
+        "BATTERY_CAPACITY_KWH": float(config.BATTERY_CAPACITY_KWH),
+        "MIN_SOC_RESERVE_PERCENT": float(config.MIN_SOC_RESERVE_PERCENT),
+        "BATTERY_RT_EFFICIENCY": float(config.BATTERY_RT_EFFICIENCY),
+        "MAX_INVERTER_KW": float(config.MAX_INVERTER_KW),
+        "DAIKIN_MAX_HP_KW": float(config.DAIKIN_MAX_HP_KW),
+        "DHW_TANK_LITRES": float(config.DHW_TANK_LITRES),
+        "DHW_TANK_UA_W_PER_K": float(config.DHW_TANK_UA_W_PER_K),
+        "BUILDING_UA_W_PER_K": float(config.BUILDING_UA_W_PER_K),
+        "BUILDING_THERMAL_MASS_KWH_PER_K": float(config.BUILDING_THERMAL_MASS_KWH_PER_K),
+        "DHW_TEMP_COMFORT_C": float(config.DHW_TEMP_COMFORT_C),
+        "DHW_TEMP_MAX_C": float(config.DHW_TEMP_MAX_C),
+        "LP_CYCLE_PENALTY_PENCE_PER_KWH": float(config.LP_CYCLE_PENALTY_PENCE_PER_KWH),
+        "LP_COMFORT_SLACK_PENCE_PER_DEGC_SLOT": float(config.LP_COMFORT_SLACK_PENCE_PER_DEGC_SLOT),
+        "LP_INVERTER_STRESS_COST_PENCE": float(config.LP_INVERTER_STRESS_COST_PENCE),
+        "LP_PRICE_QUANTIZE_PENCE": float(getattr(config, "LP_PRICE_QUANTIZE_PENCE", 0.0)),
+        "LP_BATTERY_TV_PENALTY_PENCE_PER_KWH_DELTA": float(
+            getattr(config, "LP_BATTERY_TV_PENALTY_PENCE_PER_KWH_DELTA", 0.0)
+        ),
+        "LP_IMPORT_TV_PENALTY_PENCE_PER_KWH_DELTA": float(
+            getattr(config, "LP_IMPORT_TV_PENALTY_PENCE_PER_KWH_DELTA", 0.0)
+        ),
+    }
+
+    inputs_row = {
+        "run_at_utc": run_at_iso,
+        "plan_date": plan_date,
+        "horizon_hours": int(config.LP_HORIZON_HOURS),
+        "soc_initial_kwh": float(initial.soc_kwh),
+        "tank_initial_c": float(initial.tank_temp_c),
+        "indoor_initial_c": float(initial.indoor_temp_c),
+        "soc_source": getattr(initial, "soc_source", "unknown"),
+        "tank_source": getattr(initial, "tank_source", "unknown"),
+        "indoor_source": getattr(initial, "indoor_source", "unknown"),
+        "base_load_json": json.dumps([round(float(x), 4) for x in base_load]),
+        "micro_climate_offset_c": float(micro_climate_offset or 0.0),
+        "config_snapshot_json": json.dumps(cfg_snap),
+        "price_quantize_p": float(getattr(config, "LP_PRICE_QUANTIZE_PENCE", 0.0)),
+        "peak_threshold_p": float(plan.peak_threshold_pence),
+        "cheap_threshold_p": float(plan.cheap_threshold_pence),
+        "daikin_control_mode": str(config.DAIKIN_CONTROL_MODE),
+        "optimization_preset": str(config.OPTIMIZATION_PRESET),
+        "energy_strategy_mode": str(config.ENERGY_STRATEGY_MODE),
+    }
+
+    # tank_temp_c, indoor_temp_c, soc_kwh are length N+1 (include initial);
+    # we persist the end-of-slot state (index i+1) to match how slot results
+    # are naturally interpreted. lwt_offset_c / temp_outdoor_c are length N.
+    n = len(plan.slot_starts_utc)
+    solution_rows: list[dict[str, Any]] = []
+    for i in range(n):
+        solution_rows.append({
+            "slot_index": i,
+            "slot_time_utc": plan.slot_starts_utc[i].isoformat(),
+            "price_p": float(plan.price_pence[i]) if i < len(plan.price_pence) else None,
+            "import_kwh": float(plan.import_kwh[i]) if i < len(plan.import_kwh) else None,
+            "export_kwh": float(plan.export_kwh[i]) if i < len(plan.export_kwh) else None,
+            "charge_kwh": float(plan.battery_charge_kwh[i]) if i < len(plan.battery_charge_kwh) else None,
+            "discharge_kwh": float(plan.battery_discharge_kwh[i]) if i < len(plan.battery_discharge_kwh) else None,
+            "pv_use_kwh": float(plan.pv_use_kwh[i]) if i < len(plan.pv_use_kwh) else None,
+            "pv_curtail_kwh": float(plan.pv_curtail_kwh[i]) if i < len(plan.pv_curtail_kwh) else None,
+            "dhw_kwh": float(plan.dhw_electric_kwh[i]) if i < len(plan.dhw_electric_kwh) else None,
+            "space_kwh": float(plan.space_electric_kwh[i]) if i < len(plan.space_electric_kwh) else None,
+            "soc_kwh": float(plan.soc_kwh[i + 1]) if (i + 1) < len(plan.soc_kwh) else None,
+            "tank_temp_c": float(plan.tank_temp_c[i + 1]) if (i + 1) < len(plan.tank_temp_c) else None,
+            "indoor_temp_c": float(plan.indoor_temp_c[i + 1]) if (i + 1) < len(plan.indoor_temp_c) else None,
+            "outdoor_temp_c": float(plan.temp_outdoor_c[i]) if i < len(plan.temp_outdoor_c) else None,
+            "lwt_offset_c": float(plan.lwt_offset_c[i]) if i < len(plan.lwt_offset_c) else None,
+        })
+
+    db.save_lp_snapshots(run_id=int(run_id), inputs_row=inputs_row, solution_rows=solution_rows)
+
+
 def _run_optimizer_lp(fox: FoxESSClient | None, daikin: Any | None = None) -> dict[str, Any]:
     """PuLP MILP horizon planner (V8). Falls back to heuristic if solve is not optimal."""
     from .lp_dispatch import (
@@ -920,16 +1014,22 @@ def _run_optimizer_lp(fox: FoxESSClient | None, daikin: Any | None = None) -> di
     # Persist forecast to DB so heartbeat can read real Open-Meteo temp (vs Daikin sensor)
     if forecast:
         _today = datetime.now(UTC).date().isoformat()
-        db.save_meteo_forecast(
-            [
-                {
-                    "slot_time": f.time_utc.isoformat(),
-                    "temp_c": f.temperature_c,
-                    "solar_w_m2": f.shortwave_radiation_wm2,
-                }
-                for f in forecast
-            ],
-            _today,
+        forecast_rows = [
+            {
+                "slot_time": f.time_utc.isoformat(),
+                "temp_c": f.temperature_c,
+                "solar_w_m2": f.shortwave_radiation_wm2,
+            }
+            for f in forecast
+        ]
+        db.save_meteo_forecast(forecast_rows, _today)
+        # V11: append-only fetch history keyed by UTC fetch timestamp so a
+        # later LP run (or the History view) can see which forecast was active
+        # at any past moment, even after newer fetches have overwritten the
+        # latest-per-slot table.
+        db.save_meteo_forecast_history(
+            datetime.now(UTC).isoformat(),
+            forecast_rows,
         )
     # PV calibration: Fox actual vs Open-Meteo archive to correct systematic bias
     from ..weather import compute_pv_calibration_factor
@@ -1011,9 +1111,10 @@ def _run_optimizer_lp(fox: FoxESSClient | None, daikin: Any | None = None) -> di
     fox_ok = upload_fox_if_operational(fox, groups)
     daikin_n = write_daikin_from_lp_plan(plan_date, plan, forecast)
 
-    db.log_optimizer_run(
+    run_at_iso = datetime.now(UTC).isoformat()
+    run_id = db.log_optimizer_run(
         {
-            "run_at": datetime.now(UTC).isoformat(),
+            "run_at": run_at_iso,
             "rates_count": len(slots),
             "cheap_slots": counts.get("cheap", 0),
             "peak_slots": counts.get("peak", 0) + counts.get("peak_export", 0),
@@ -1027,6 +1128,22 @@ def _run_optimizer_lp(fox: FoxESSClient | None, daikin: Any | None = None) -> di
             "daikin_actions_count": daikin_n,
         }
     )
+
+    # V11: durable per-slot snapshot so the History view can replay "what the
+    # LP decided at this moment". Failures here must not bring down the solve
+    # — wrap defensively.
+    try:
+        _persist_lp_snapshots(
+            run_id=run_id,
+            run_at_iso=run_at_iso,
+            plan_date=plan_date,
+            plan=plan,
+            initial=initial,
+            base_load=base_load,
+            micro_climate_offset=micro_climate_offset,
+        )
+    except Exception as e:
+        logger.warning("LP snapshot persistence failed (non-fatal): %s", e)
 
     _write_plan_consent(plan_date, strategy)
 

--- a/tests/api/test_attribution.py
+++ b/tests/api/test_attribution.py
@@ -1,0 +1,59 @@
+"""Phase 5 — GET /api/v1/attribution/day shares computation."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _upsert_day(date_str: str, *, solar: float, load: float, imp: float,
+                exp: float, chg: float, dis: float) -> None:
+    db.upsert_fox_energy_daily([{
+        "date": date_str,
+        "solar_kwh": solar, "load_kwh": load,
+        "import_kwh": imp, "export_kwh": exp,
+        "charge_kwh": chg, "discharge_kwh": dis,
+        "fetched_at": datetime.now(UTC).isoformat(),
+    }])
+
+
+def test_attribution_returns_unavailable_when_no_row(client):
+    r = client.get("/api/v1/attribution/day?date=1999-01-01")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["available"] is False
+    assert body["shares"] is None
+
+
+def test_attribution_shares_sum_to_100(client):
+    _upsert_day("2026-04-20",
+                solar=20.0, load=15.0, imp=2.0, exp=5.0, chg=6.0, dis=3.0)
+    r = client.get("/api/v1/attribution/day?date=2026-04-20")
+    body = r.json()
+    assert body["available"] is True
+    s = body["shares"]
+    total = s["self_use_pct"] + s["battery_pct"] + s["export_pct"]
+    assert abs(total - 100.0) < 0.2, f"shares sum to {total}"
+
+
+def test_attribution_defaults_to_yesterday(client):
+    yday = (datetime.now(UTC).date() - timedelta(days=1)).isoformat()
+    _upsert_day(yday, solar=10.0, load=8.0, imp=1.0, exp=3.0, chg=2.0, dis=1.0)
+    r = client.get("/api/v1/attribution/day")
+    assert r.status_code == 200
+    assert r.json()["date"] == yday
+    assert r.json()["available"] is True

--- a/tests/api/test_cockpit_at.py
+++ b/tests/api/test_cockpit_at.py
@@ -1,0 +1,116 @@
+"""Phase 4 — GET /api/v1/cockpit/at?when=... replay from LP snapshots.
+
+The History page reads this to rehydrate past moments. The endpoint joins
+optimizer_log (via find_run_for_time) with lp_solution_snapshot,
+lp_inputs_snapshot, agile_rates, and execution_log.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _seed_run_with_slot(run_at: datetime, slot_time: datetime) -> int:
+    """Create an optimizer_log row + inputs + one solution slot at slot_time."""
+    run_id = db.log_optimizer_run({
+        "run_at": run_at.isoformat(),
+        "rates_count": 48, "cheap_slots": 5, "peak_slots": 3,
+        "standard_slots": 36, "negative_slots": 0,
+        "target_vwap": 18.0, "actual_agile_mean": 20.0, "battery_warning": False,
+        "strategy_summary": "seed", "fox_schedule_uploaded": True, "daikin_actions_count": 0,
+    })
+    db.save_lp_snapshots(
+        run_id,
+        {
+            "run_at_utc": run_at.isoformat(), "plan_date": slot_time.date().isoformat(),
+            "horizon_hours": 24,
+            "soc_initial_kwh": 5.0, "tank_initial_c": 46.0, "indoor_initial_c": 20.5,
+            "soc_source": "fox_realtime_cache", "tank_source": "daikin_cache",
+            "indoor_source": "daikin_cache",
+            "base_load_json": "[]", "micro_climate_offset_c": 0.0,
+            "config_snapshot_json": "{}",
+            "price_quantize_p": 0.0, "peak_threshold_p": 25.0, "cheap_threshold_p": 12.0,
+            "daikin_control_mode": "passive", "optimization_preset": "normal",
+            "energy_strategy_mode": "savings_first",
+        },
+        [
+            {
+                "slot_index": 0,
+                "slot_time_utc": slot_time.isoformat().replace("+00:00", "+00:00"),
+                "price_p": 15.0, "import_kwh": 0.5, "export_kwh": 0.0,
+                "charge_kwh": 0.2, "discharge_kwh": 0.0, "pv_use_kwh": 0.0,
+                "pv_curtail_kwh": 0.0, "dhw_kwh": 0.1, "space_kwh": 0.0,
+                "soc_kwh": 5.2, "tank_temp_c": 46.5, "indoor_temp_c": 20.6,
+                "outdoor_temp_c": 12.0, "lwt_offset_c": 0.0,
+            },
+        ],
+    )
+    return run_id
+
+
+def test_at_rejects_bad_iso(client):
+    r = client.get("/api/v1/cockpit/at?when=not-a-date")
+    assert r.status_code == 400
+
+
+def test_at_returns_none_source_when_no_snapshots(client):
+    r = client.get("/api/v1/cockpit/at?when=2026-04-24T12:00:00Z")
+    assert r.status_code == 200
+    body = r.json()
+    # Shape check — source block present but run_id/lp_run_at null.
+    assert "source" in body
+    assert body["source"]["run_id"] is None
+    assert body["source"]["lp_run_at_utc"] is None
+    assert "state" in body
+    assert "current_slot" in body
+
+
+def test_at_rehydrates_from_snapshot(client):
+    run_at = datetime(2026, 4, 24, 6, 0, tzinfo=UTC)
+    slot_time = datetime(2026, 4, 24, 6, 30, tzinfo=UTC)
+    run_id = _seed_run_with_slot(run_at, slot_time)
+
+    r = client.get("/api/v1/cockpit/at?when=2026-04-24T06:30:00Z")
+    assert r.status_code == 200
+    body = r.json()
+
+    assert body["source"]["run_id"] == run_id
+    assert body["source"]["lp_run_at_utc"] is not None
+    # lp_inputs block carries the provenance strings we seeded.
+    li = body.get("lp_inputs") or {}
+    assert li.get("soc_source") == "fox_realtime_cache"
+    assert li.get("tank_source") == "daikin_cache"
+
+
+def test_history_page_renders(client):
+    r = client.get("/history")
+    assert r.status_code == 200
+    assert b"Replay a past moment" in r.content
+    assert b"history.js" in r.content
+
+
+def test_at_picks_most_recent_run_when_multiple(client):
+    run_early = datetime(2026, 4, 24, 6, 0, tzinfo=UTC)
+    run_late = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    slot = datetime(2026, 4, 24, 14, 0, tzinfo=UTC)
+    _seed_run_with_slot(run_early, slot)
+    rid_late = _seed_run_with_slot(run_late, slot)
+    # At 15:00 both runs are historic; endpoint should pick the later one.
+    r = client.get("/api/v1/cockpit/at?when=2026-04-24T15:00:00Z")
+    assert r.status_code == 200
+    assert r.json()["source"]["run_id"] == rid_late

--- a/tests/api/test_cockpit_now.py
+++ b/tests/api/test_cockpit_now.py
@@ -1,0 +1,93 @@
+"""Phase 2 — GET /api/v1/cockpit/now aggregator contract.
+
+The hero panel reads from a single coherent snapshot instead of four
+parallel fetches. This test pins the payload shape so frontend refactors
+don't silently break it. Functional correctness (price matching, current
+fox-group detection) is exercised in other layers — here we just confirm
+the contract and that the endpoint NEVER raises even when every upstream
+source is cold.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_cockpit_now_shape(client):
+    r = client.get("/api/v1/cockpit/now")
+    assert r.status_code == 200
+    body = r.json()
+
+    # Top-level keys.
+    assert set(body.keys()) == {
+        "now_utc", "planner_tz", "current_slot", "next_transition",
+        "state", "freshness", "thresholds", "modes", "plan_date",
+    }
+
+    # current_slot always has the 5-key shape.
+    assert set(body["current_slot"].keys()) == {
+        "t_utc", "t_end_utc", "price_import_p", "price_export_p", "fox_mode",
+    }
+
+    # state has the 12 fields the hero panel reads.
+    assert set(body["state"].keys()) == {
+        "soc_pct", "soc_kwh", "solar_kw", "load_kw", "grid_kw", "battery_kw",
+        "fox_mode", "tank_c", "indoor_c", "outdoor_c", "lwt_c", "daikin_mode",
+    }
+
+    # freshness — one block per source.
+    assert set(body["freshness"].keys()) == {"agile", "fox", "daikin", "plan"}
+    for block in body["freshness"].values():
+        assert set(block.keys()) == {"fetched_at_utc", "age_s", "stale"}
+
+    # thresholds.
+    assert set(body["thresholds"].keys()) == {"cheap_p", "peak_p"}
+
+    # modes.
+    assert set(body["modes"].keys()) == {
+        "daikin_control_mode", "optimization_preset", "energy_strategy_mode",
+    }
+
+
+def test_cockpit_now_returns_iso_utc_and_planner_tz(client):
+    r = client.get("/api/v1/cockpit/now")
+    body = r.json()
+    assert body["now_utc"].endswith("Z")
+    assert isinstance(body["planner_tz"], str) and len(body["planner_tz"]) > 0
+
+
+def test_cockpit_now_survives_cold_state(client):
+    # With no cached Fox/Daikin/Octopus data, the endpoint should still 200 and
+    # return None in all state slots rather than raising.
+    r = client.get("/api/v1/cockpit/now")
+    assert r.status_code == 200
+    body = r.json()
+    for key in ("soc_pct", "soc_kwh", "solar_kw", "load_kw", "tank_c", "indoor_c"):
+        # Either populated (if the test env has live caches) or None.
+        assert body["state"][key] is None or isinstance(body["state"][key], (int, float))
+
+
+def test_cockpit_now_never_triggers_cloud_calls(client):
+    # Contract: this endpoint MUST be cache-only. If it ever goes async-heavy
+    # on cloud calls the quota pills would burn silently. A smoke check on
+    # response time guards the worst regressions.
+    import time
+    t0 = time.monotonic()
+    r = client.get("/api/v1/cockpit/now")
+    elapsed = time.monotonic() - t0
+    assert r.status_code == 200
+    # Cold call should be well under a second — no network waits allowed.
+    assert elapsed < 1.5, f"endpoint took {elapsed:.2f}s — possible cloud call leak"

--- a/tests/api/test_optimization_inputs.py
+++ b/tests/api/test_optimization_inputs.py
@@ -1,0 +1,82 @@
+"""Phase 3 — GET /api/v1/optimization/inputs contract.
+
+The Forecast tab renders everything here. Pins the shape and the cache-only
+contract (response must be fast and never crash when sources are cold).
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_inputs_shape(client):
+    r = client.get("/api/v1/optimization/inputs")
+    assert r.status_code == 200
+    body = r.json()
+    expected = {
+        "now_utc", "planner_tz", "horizon_hours", "slots", "initial",
+        "micro_climate_offset_c", "thresholds", "config_snapshot",
+        "target_vwap_pence", "estimated_cost_pence", "strategy_summary",
+        "tomorrow_rates_available", "workbench_schema",
+    }
+    assert set(body.keys()) == expected
+
+
+def test_inputs_slots_have_expected_columns(client):
+    r = client.get("/api/v1/optimization/inputs")
+    slots = r.json()["slots"]
+    if slots:
+        assert set(slots[0].keys()) == {
+            "t_utc", "price_import_p", "price_export_p",
+            "temp_c", "solar_w_m2", "base_load_kwh",
+        }
+
+
+def test_inputs_initial_has_source_fields(client):
+    r = client.get("/api/v1/optimization/inputs")
+    init = r.json()["initial"]
+    for key in ("soc_kwh", "soc_pct", "tank_c", "indoor_c",
+                "soc_source", "tank_source", "indoor_source"):
+        assert key in init
+
+
+def test_inputs_honours_horizon_hours_clamp(client):
+    # Out-of-range horizon gets clamped into [4, 48]
+    r = client.get("/api/v1/optimization/inputs?horizon_hours=200")
+    assert r.status_code == 200
+    assert r.json()["horizon_hours"] == 48
+
+    r = client.get("/api/v1/optimization/inputs?horizon_hours=1")
+    assert r.status_code == 200
+    assert r.json()["horizon_hours"] == 4
+
+
+def test_inputs_never_hits_network_on_cold_state(client):
+    # Cache-only contract — should return fast even with empty DB.
+    t0 = time.monotonic()
+    r = client.get("/api/v1/optimization/inputs")
+    elapsed = time.monotonic() - t0
+    assert r.status_code == 200
+    assert elapsed < 2.0, f"endpoint took {elapsed:.2f}s — possible cloud call"
+
+
+def test_forecast_page_renders(client):
+    r = client.get("/forecast")
+    assert r.status_code == 200
+    assert b"LP inputs" in r.content
+    assert b"forecast.js" in r.content

--- a/tests/api/test_system_timezone.py
+++ b/tests/api/test_system_timezone.py
@@ -1,0 +1,79 @@
+"""Phase 1 — GET /api/v1/system/timezone contract + defaults.
+
+The cockpit JS fetches this once per page load to format slot times in the
+planner's timezone rather than the browser's local tz. The contract is:
+
+* ``planner_tz`` is the config.BULLETPROOF_TIMEZONE (default Europe/London).
+* ``plan_push_tz`` is fixed UTC (documented in CLAUDE.md — not configurable).
+* ``now_utc`` / ``now_local`` are ISO strings, ``now_utc`` ends in ``Z``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_timezone_endpoint_default_shape(client):
+    r = client.get("/api/v1/system/timezone")
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body.keys()) == {"planner_tz", "plan_push_tz", "now_utc", "now_local"}
+    assert body["plan_push_tz"] == "UTC"
+    # planner_tz defaults to Europe/London per config; unit tests honour that.
+    assert body["planner_tz"] == "Europe/London"
+
+
+def test_timezone_endpoint_returns_z_suffixed_utc(client):
+    r = client.get("/api/v1/system/timezone")
+    assert r.status_code == 200
+    assert r.json()["now_utc"].endswith("Z")
+    # now_local should be a parseable ISO string
+    local = r.json()["now_local"]
+    datetime.fromisoformat(local)  # raises on bad format
+
+
+def test_timezone_endpoint_respects_config_override(client, monkeypatch):
+    # Force a different tz on the live config singleton.
+    import src.config as config_mod
+    monkeypatch.setattr(config_mod.config, "BULLETPROOF_TIMEZONE", "America/New_York")
+    r = client.get("/api/v1/system/timezone")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["planner_tz"] == "America/New_York"
+    # plan_push_tz is not configurable — still UTC.
+    assert body["plan_push_tz"] == "UTC"
+
+
+def test_timezone_endpoint_falls_back_to_utc_on_bad_config(client, monkeypatch):
+    import src.config as config_mod
+    monkeypatch.setattr(config_mod.config, "BULLETPROOF_TIMEZONE", "Not/A/Real/Zone")
+    r = client.get("/api/v1/system/timezone")
+    assert r.status_code == 200
+    assert r.json()["planner_tz"] == "UTC"
+
+
+def test_now_utc_and_now_local_are_the_same_moment(client):
+    r = client.get("/api/v1/system/timezone")
+    body = r.json()
+    utc = datetime.fromisoformat(body["now_utc"].replace("Z", "+00:00"))
+    local = datetime.fromisoformat(body["now_local"])
+    # They represent the same instant within a small solve window.
+    local_as_utc = local.astimezone(ZoneInfo("UTC"))
+    delta = abs((local_as_utc - utc).total_seconds())
+    assert delta < 2.0

--- a/tests/test_db_snapshots.py
+++ b/tests/test_db_snapshots.py
@@ -1,0 +1,269 @@
+"""Phase 0 — LP snapshots, forecast history, and config audit.
+
+Covers:
+* Migrations create the three new V11 tables with the right columns.
+* ``save_lp_snapshots`` round-trips inputs + per-slot rows and ``find_run_for_time``
+  picks the right run.
+* ``save_meteo_forecast_history`` preserves each fetch separately (unlike
+  ``save_meteo_forecast`` which overwrites by ``slot_time``).
+* ``log_config_change`` appends and ``get_config_audit`` reads back in
+  reverse-chronological order, filterable by key.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+
+
+@pytest.fixture(autouse=True)
+def _db_ready():
+    db.init_db()
+    yield
+
+
+def _isoformat(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _columns(table: str) -> set[str]:
+    conn = db.get_connection()
+    try:
+        cur = conn.execute(f"PRAGMA table_info({table})")
+        return {str(r[1]) for r in cur.fetchall()}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+def test_lp_solution_snapshot_has_expected_columns():
+    cols = _columns("lp_solution_snapshot")
+    for expected in (
+        "id", "run_id", "slot_index", "slot_time_utc", "price_p",
+        "import_kwh", "export_kwh", "charge_kwh", "discharge_kwh",
+        "pv_use_kwh", "pv_curtail_kwh", "dhw_kwh", "space_kwh",
+        "soc_kwh", "tank_temp_c", "indoor_temp_c", "outdoor_temp_c",
+        "lwt_offset_c",
+    ):
+        assert expected in cols, f"missing column {expected}"
+
+
+def test_lp_inputs_snapshot_has_expected_columns():
+    cols = _columns("lp_inputs_snapshot")
+    for expected in (
+        "run_id", "run_at_utc", "plan_date", "horizon_hours",
+        "soc_initial_kwh", "tank_initial_c", "indoor_initial_c",
+        "soc_source", "tank_source", "indoor_source",
+        "base_load_json", "micro_climate_offset_c", "config_snapshot_json",
+        "price_quantize_p", "peak_threshold_p", "cheap_threshold_p",
+        "daikin_control_mode", "optimization_preset", "energy_strategy_mode",
+    ):
+        assert expected in cols, f"missing column {expected}"
+
+
+def test_meteo_forecast_history_has_expected_columns():
+    cols = _columns("meteo_forecast_history")
+    for expected in ("id", "forecast_fetch_at_utc", "slot_time", "temp_c", "solar_w_m2"):
+        assert expected in cols
+
+
+def test_config_audit_has_expected_columns():
+    cols = _columns("config_audit")
+    for expected in ("id", "key", "value", "op", "actor", "changed_at_utc"):
+        assert expected in cols
+
+
+def test_init_db_is_idempotent():
+    # Second init must not raise — migrations use CREATE TABLE IF NOT EXISTS.
+    db.init_db()
+    db.init_db()
+
+
+# ---------------------------------------------------------------------------
+# save_lp_snapshots round-trip
+# ---------------------------------------------------------------------------
+
+def _mk_run() -> int:
+    """Create one optimizer_log row and return its id."""
+    return db.log_optimizer_run({
+        "run_at": datetime.now(UTC).isoformat(),
+        "rates_count": 48,
+        "cheap_slots": 5,
+        "peak_slots": 3,
+        "standard_slots": 36,
+        "negative_slots": 0,
+        "target_vwap": 18.5,
+        "actual_agile_mean": 20.1,
+        "battery_warning": False,
+        "strategy_summary": "test run",
+        "fox_schedule_uploaded": True,
+        "daikin_actions_count": 6,
+    })
+
+
+def _mk_inputs_row() -> dict:
+    return {
+        "run_at_utc": datetime.now(UTC).isoformat(),
+        "plan_date": "2026-04-24",
+        "horizon_hours": 24,
+        "soc_initial_kwh": 5.1,
+        "tank_initial_c": 46.0,
+        "indoor_initial_c": 20.8,
+        "soc_source": "fox_realtime_cache",
+        "tank_source": "daikin_cache",
+        "indoor_source": "daikin_cache",
+        "base_load_json": json.dumps([0.4] * 48),
+        "micro_climate_offset_c": 0.3,
+        "config_snapshot_json": json.dumps({"LP_HORIZON_HOURS": 24, "BATTERY_CAPACITY_KWH": 10.0}),
+        "price_quantize_p": 1.0,
+        "peak_threshold_p": 25.0,
+        "cheap_threshold_p": 12.0,
+        "daikin_control_mode": "passive",
+        "optimization_preset": "normal",
+        "energy_strategy_mode": "savings_first",
+    }
+
+
+def _mk_solution_rows(n: int = 4) -> list[dict]:
+    t0 = datetime(2026, 4, 24, 0, 0, tzinfo=UTC)
+    rows = []
+    for i in range(n):
+        rows.append({
+            "slot_index": i,
+            "slot_time_utc": (t0 + timedelta(minutes=30 * i)).isoformat(),
+            "price_p": 15.0 + i,
+            "import_kwh": 0.1 * i,
+            "export_kwh": 0.0,
+            "charge_kwh": 0.2 if i < 2 else 0.0,
+            "discharge_kwh": 0.0 if i < 2 else 0.1,
+            "pv_use_kwh": 0.0,
+            "pv_curtail_kwh": 0.0,
+            "dhw_kwh": 0.0,
+            "space_kwh": 0.0,
+            "soc_kwh": 5.0 + 0.1 * i,
+            "tank_temp_c": 46.0,
+            "indoor_temp_c": 20.5,
+            "outdoor_temp_c": 12.0,
+            "lwt_offset_c": 0.0,
+        })
+    return rows
+
+
+def test_save_lp_snapshots_round_trip():
+    run_id = _mk_run()
+    db.save_lp_snapshots(run_id, _mk_inputs_row(), _mk_solution_rows(4))
+
+    inputs = db.get_lp_inputs(run_id)
+    assert inputs is not None
+    assert inputs["plan_date"] == "2026-04-24"
+    assert inputs["soc_initial_kwh"] == pytest.approx(5.1)
+    assert inputs["daikin_control_mode"] == "passive"
+    # JSON fields survive the round-trip intact
+    assert json.loads(inputs["config_snapshot_json"])["LP_HORIZON_HOURS"] == 24
+    assert len(json.loads(inputs["base_load_json"])) == 48
+
+    slots = db.get_lp_solution_slots(run_id)
+    assert len(slots) == 4
+    assert [s["slot_index"] for s in slots] == [0, 1, 2, 3]
+    assert slots[0]["price_p"] == pytest.approx(15.0)
+    assert slots[3]["soc_kwh"] == pytest.approx(5.3)
+
+
+def test_save_lp_snapshots_replaces_on_same_run_id_and_slot_index():
+    run_id = _mk_run()
+    db.save_lp_snapshots(run_id, _mk_inputs_row(), _mk_solution_rows(2))
+    # Re-run with different values for the same slot indices.
+    updated = _mk_solution_rows(2)
+    updated[0]["price_p"] = 99.0
+    db.save_lp_snapshots(run_id, _mk_inputs_row(), updated)
+
+    slots = db.get_lp_solution_slots(run_id)
+    assert len(slots) == 2
+    assert slots[0]["price_p"] == pytest.approx(99.0)
+
+
+def test_find_run_for_time_picks_most_recent_before_when():
+    t_first = datetime(2026, 4, 24, 6, 0, tzinfo=UTC)
+    t_second = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    rid1 = db.log_optimizer_run({
+        "run_at": t_first.isoformat(), "rates_count": 48,
+        "cheap_slots": 0, "peak_slots": 0, "standard_slots": 48, "negative_slots": 0,
+        "target_vwap": 18.0, "actual_agile_mean": 20.0, "battery_warning": False,
+        "strategy_summary": "t1", "fox_schedule_uploaded": True, "daikin_actions_count": 0,
+    })
+    rid2 = db.log_optimizer_run({
+        "run_at": t_second.isoformat(), "rates_count": 48,
+        "cheap_slots": 0, "peak_slots": 0, "standard_slots": 48, "negative_slots": 0,
+        "target_vwap": 18.0, "actual_agile_mean": 20.0, "battery_warning": False,
+        "strategy_summary": "t2", "fox_schedule_uploaded": True, "daikin_actions_count": 0,
+    })
+    # At 10:00 we should see the 06:00 run.
+    assert db.find_run_for_time(datetime(2026, 4, 24, 10, 0, tzinfo=UTC).isoformat()) == rid1
+    # At 14:00 we should see the 12:00 run.
+    assert db.find_run_for_time(datetime(2026, 4, 24, 14, 0, tzinfo=UTC).isoformat()) == rid2
+    # Before any run → None.
+    assert db.find_run_for_time(datetime(2026, 4, 24, 5, 0, tzinfo=UTC).isoformat()) is None
+
+
+# ---------------------------------------------------------------------------
+# meteo_forecast_history
+# ---------------------------------------------------------------------------
+
+def test_meteo_forecast_history_preserves_multiple_fetches_per_slot():
+    slot = datetime(2026, 4, 24, 14, 0, tzinfo=UTC).isoformat()
+    fetch_a = datetime(2026, 4, 24, 6, 0, tzinfo=UTC).isoformat()
+    fetch_b = datetime(2026, 4, 24, 12, 0, tzinfo=UTC).isoformat()
+
+    db.save_meteo_forecast_history(fetch_a, [{"slot_time": slot, "temp_c": 12.0, "solar_w_m2": 250.0}])
+    db.save_meteo_forecast_history(fetch_b, [{"slot_time": slot, "temp_c": 13.5, "solar_w_m2": 180.0}])
+
+    at_a = db.get_meteo_forecast_at(fetch_a)
+    at_b = db.get_meteo_forecast_at(fetch_b)
+    assert len(at_a) == 1 and at_a[0]["temp_c"] == pytest.approx(12.0)
+    assert len(at_b) == 1 and at_b[0]["temp_c"] == pytest.approx(13.5)
+
+
+def test_meteo_forecast_history_ignores_duplicate_fetch_slot():
+    slot = datetime(2026, 4, 24, 14, 0, tzinfo=UTC).isoformat()
+    fetch = datetime(2026, 4, 24, 6, 0, tzinfo=UTC).isoformat()
+    db.save_meteo_forecast_history(fetch, [{"slot_time": slot, "temp_c": 10.0, "solar_w_m2": 100.0}])
+    # INSERT OR IGNORE: the second write must not raise, and the first value stays.
+    db.save_meteo_forecast_history(fetch, [{"slot_time": slot, "temp_c": 99.9, "solar_w_m2": 999.0}])
+    rows = db.get_meteo_forecast_at(fetch)
+    assert len(rows) == 1
+    assert rows[0]["temp_c"] == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# config_audit
+# ---------------------------------------------------------------------------
+
+def test_log_config_change_appends_and_reads_back():
+    db.log_config_change("DHW_TEMP_NORMAL_C", "45.0", op="set", actor="test")
+    db.log_config_change("DHW_TEMP_NORMAL_C", "46.0", op="set", actor="test")
+    rows = db.get_config_audit(key="DHW_TEMP_NORMAL_C")
+    assert len(rows) >= 2
+    # DESC order — newest first
+    assert rows[0]["value"] == "46.0"
+    assert rows[1]["value"] == "45.0"
+    assert rows[0]["op"] == "set"
+
+
+def test_log_config_change_delete_op_stores_null_value():
+    db.log_config_change("OPTIMIZATION_PRESET", None, op="delete", actor="test")
+    rows = db.get_config_audit(key="OPTIMIZATION_PRESET")
+    assert rows[0]["value"] is None
+    assert rows[0]["op"] == "delete"
+
+
+def test_config_audit_global_list_respects_limit():
+    for i in range(5):
+        db.log_config_change("K", str(i), op="set", actor="test")
+    rows = db.get_config_audit(limit=3)
+    assert len(rows) == 3


### PR DESCRIPTION
## Summary
Cockpit rework benchmarked against OpenEMS / EVCC / HA Energy. Seven
phased commits on one branch so each phase is independently revertable.

**What ships:**
- Phase 0: Durable LP snapshots — `lp_solution_snapshot`, `lp_inputs_snapshot`, `config_audit`, `meteo_forecast_history`. Unblocks History replay.
- Phase 1: Timezone correctness — `/api/v1/system/timezone` + shared `HEM.fmtSlotTime` helper + topbar tz badge. Fixes the VPN/travel "16:30 means 17:30 actually" bug in three JS files.
- Phase 2: NOW hero panel + `/api/v1/cockpit/now` aggregator + 4-chip freshness ribbon. Replaces the four parallel status cards with one coherent snapshot.
- Phase 3: `/forecast` tab + `/api/v1/optimization/inputs` — everything the next LP solve will see, with per-field source labels and CSS sparklines.
- Phase 4: `/history` tab + `/api/v1/cockpit/at?when=ISO-UTC` — replay any past moment by joining the Phase 0 snapshots with `execution_log`.
- Phase 5: Workbench "Simulating…" state + planner-tz slot labels + HA-Energy-style attribution donut (`/api/v1/attribution/day`).
- Phase 6: "Manual override" → "Controls", Daikin controls grey out (not hidden) when passive.

## Files changed
23 files, +3074 / −242:
- 4 new DB tables + 7 new write/read helpers (`src/db.py`)
- 4 new endpoints (`/system/timezone`, `/cockpit/now`, `/cockpit/at`, `/optimization/inputs`, `/attribution/day`)
- 3 new pages (`/forecast`, `/history`) + shared tz.js helper
- 29 new tests: DB snapshot round-trips, tz endpoint shape, cockpit aggregators cache-only contract, cockpit-at replay, attribution shares, page smoke tests

## Benchmarks applied
See plan file `/home/stkoverflow/.claude/plans/i-want-to-check-lazy-barto.md` for full notes.
- **OpenEMS**: strict Live/History split, flat-widget → modal-chart pattern, adaptive rendering.
- **EVCC**: dedicated Forecast tab, energy-flow hero, automation-first philosophy.
- **HA Energy**: attribution framing (solar self-used vs battery vs export), period nav.

## Test plan
- [x] `pytest tests/ -x -q --ignore=tests/integration` — 393 passed, 1 skipped (+23 new tests)
- [x] Workbench API tests still green (96 passed)
- [ ] After deploy: visit `/cockpit`, toggle browser TZ in devtools → slot labels unchanged
- [ ] After deploy: click Daikin freshness chip → refreshes only Daikin
- [ ] After deploy: `/forecast` shows sparklines with live LP inputs
- [ ] After deploy: `/history` with "Latest run" rehydrates from Phase 0 snapshots
- [ ] After deploy: flip `DAIKIN_CONTROL_MODE` to passive via topbar → tank/LWT controls grey out with tooltip
- [ ] After deploy: one MPC cycle should grow `lp_solution_snapshot` by one horizon's worth of rows

## Rollback
Each commit is independently revertable. Phase 0 migration is additive —
reverting write callers leaves tables dormant, no data lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)