### PR TITLE
fix: Forecast tab half-hour weather interpolation + global LP-running indicator

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1059,18 +1059,73 @@ async def optimization_inputs(horizon_hours: int | None = None):
     except Exception:
         tgt = {}
 
+    # --- Weather interpolation helpers --------------------------------------
+    # meteo_forecast is stored hourly (Open-Meteo only returns hourly data);
+    # half-hour slots landed between two hours have no row. The LP itself
+    # interpolates via weather._interp_hourly_scalar so it solves with
+    # continuous temp/solar values, but this endpoint previously did exact
+    # ISO lookups and returned None for the HH:30 slots — confusing users who
+    # assumed the LP was blind on those slots (it isn't). Mirror the LP's
+    # linear interpolation so the Forecast tab shows the same continuous
+    # series the solver actually consumes.
+    parsed_meteo: list[tuple[_dt, float | None, float | None]] = []
+    for r in meteo_rows:
+        try:
+            ts = _dt.fromisoformat((r["slot_time"] or "").replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=_UTC)
+            parsed_meteo.append((
+                ts,
+                float(r["temp_c"]) if r.get("temp_c") is not None else None,
+                float(r["solar_w_m2"]) if r.get("solar_w_m2") is not None else None,
+            ))
+        except Exception:
+            continue
+    parsed_meteo.sort(key=lambda x: x[0])
+
+    def _interp(t: _dt, idx: int) -> float | None:
+        """Linear interpolate meteo value (idx=1 temp_c, idx=2 solar_w_m2) at *t*.
+
+        Falls back to carry-last / carry-first when *t* is outside the
+        available range — mirrors weather._interp_hourly_scalar but returns
+        None instead of a magic default so the caller can decide whether to
+        surface "—" or a derived value.
+        """
+        if not parsed_meteo:
+            return None
+        before = None
+        after = None
+        for row in parsed_meteo:
+            if row[0] <= t:
+                before = row
+            elif after is None and row[0] > t:
+                after = row
+                break
+        if before is None:
+            return parsed_meteo[0][idx]
+        if after is None:
+            return before[idx]
+        va, vb = before[idx], after[idx]
+        if va is None and vb is None:
+            return None
+        if va is None:
+            return vb
+        if vb is None:
+            return va
+        ta, tb = before[0].timestamp(), after[0].timestamp()
+        if tb <= ta:
+            return va
+        w = (t.timestamp() - ta) / (tb - ta)
+        return va + w * (vb - va)
+
     # --- Per-slot merged view (prices + weather + base_load, for the horizon)
     slots_out: list[dict[str, Any]] = []
     slot_len = _td(minutes=30)
-    weather_by_slot: dict[str, dict[str, Any]] = {}
-    for r in meteo_rows:
-        weather_by_slot[r["slot_time"]] = r
     import_by_valid_from: dict[str, float] = {r["valid_from"]: float(r["value_inc_vat"]) for r in import_rows}
     export_by_valid_from: dict[str, float] = {r["valid_from"]: float(r["value_inc_vat"]) for r in export_rows}
     t = day_start
     while t < window_end:
         iso = t.isoformat().replace("+00:00", "+00:00")  # preserve offset
-        iso_norm = iso
         # Agile rates land in SQLite with ±Z suffix; try both.
         iso_candidates = {iso, iso.replace("+00:00", "Z")}
         price_i = None
@@ -1081,7 +1136,9 @@ async def optimization_inputs(horizon_hours: int | None = None):
         for k in iso_candidates:
             if k in export_by_valid_from:
                 price_e = export_by_valid_from[k]; break
-        wx = weather_by_slot.get(iso_norm) or weather_by_slot.get(iso.replace("+00:00", ""))
+        # Interpolated temp + solar — matches what the LP actually sees.
+        temp_c = _interp(t, 1)
+        solar = _interp(t, 2)
         try:
             hr_local = t.astimezone(ZoneInfo(tz_name)).hour
         except Exception:
@@ -1091,8 +1148,8 @@ async def optimization_inputs(horizon_hours: int | None = None):
             "t_utc": iso.replace("+00:00", "Z"),
             "price_import_p": price_i,
             "price_export_p": price_e,
-            "temp_c": float(wx["temp_c"]) if wx and wx.get("temp_c") is not None else None,
-            "solar_w_m2": float(wx["solar_w_m2"]) if wx and wx.get("solar_w_m2") is not None else None,
+            "temp_c": float(temp_c) if temp_c is not None else None,
+            "solar_w_m2": float(solar) if solar is not None else None,
             "base_load_kwh": round(bl, 4),
         })
         t = t + slot_len

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -463,6 +463,45 @@ body.is-simulating {
     box-shadow: inset 0 2px 0 0 var(--warn);
 }
 
+/* Generalised busy state for any wrapAction simulate+apply flow */
+body.is-busy {
+    cursor: progress;
+}
+body.is-busy::before {
+    /* Indeterminate top progress bar. Appears for every simulate-apply
+     * round-trip so users always see "something is happening". */
+    content: "";
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    z-index: 9999;
+    background: linear-gradient(
+        90deg,
+        transparent 0%, var(--standard) 20%, var(--standard) 40%,
+        transparent 60%, transparent 100%
+    );
+    background-size: 250% 100%;
+    animation: hem-progress 1.1s linear infinite;
+    pointer-events: none;
+}
+@keyframes hem-progress {
+    0%   { background-position: 100% 0%; }
+    100% { background-position: -150% 0%; }
+}
+
+/* LP re-plan in flight — pulse the Plan freshness chip so the user
+ * connects "I clicked re-plan" to "the system is running the solver".
+ * Fires via body.is-optimizing (set by wrapAction when the simulate URL
+ * is an optimisation endpoint). */
+body.is-optimizing .fresh-chip[data-source="plan"] {
+    animation: hem-chip-pulse 1.2s ease-in-out infinite;
+    border-color: var(--standard);
+}
+@keyframes hem-chip-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(var(--standard-rgb, 100, 149, 237), 0.4); }
+    50%      { box-shadow: 0 0 0 6px rgba(var(--standard-rgb, 100, 149, 237), 0.05); }
+}
+
 /* Phase 6: daikin-controls grey-out when passive (not hidden — we want
  * the user to see what's there and why it's disabled). */
 .daikin-controls.is-disabled {

--- a/src/api/static/js/forecast.js
+++ b/src/api/static/js/forecast.js
@@ -97,7 +97,12 @@
 
     $('#fcHorizon').textContent = `${d.horizon_hours} h`;
     $('#fcTz').textContent = d.planner_tz || '—';
-    $('#fcTomorrow').textContent = d.tomorrow_rates_available ? 'published' : 'not yet';
+    // Octopus publishes next-day rates around 16:00 UTC. Until then, horizon
+    // slots landing in "tomorrow" will have null import/export prices — the
+    // LP solves a shorter effective window, which is expected, not broken.
+    $('#fcTomorrow').textContent = d.tomorrow_rates_available
+      ? 'published'
+      : 'not yet (Octopus publishes around 16:00 UTC)';
     $('#fcCheap').textContent = d.thresholds?.cheap_p != null ? fmtP(d.thresholds.cheap_p) : '—';
     $('#fcPeak').textContent = d.thresholds?.peak_p != null ? fmtP(d.thresholds.peak_p) : '—';
     $('#fcMicro').textContent = d.micro_climate_offset_c != null ? `${Number(d.micro_climate_offset_c).toFixed(2)} °C` : '—';

--- a/src/api/static/js/modal.js
+++ b/src/api/static/js/modal.js
@@ -258,32 +258,46 @@
   async function wrapAction(opts) {
     const method = opts.method || 'POST';
     const body = opts.body || {};
+    // Generalised busy state — `is-busy` fires on EVERY wrapAction flow so
+    // users always see "something is happening" during simulate + apply.
+    // CSS hooks on body.is-busy add a thin top progress bar + cursor: progress.
+    // Separately, `is-optimizing` fires only when the action is an LP propose
+    // (so the Plan freshness chip can pulse distinctively vs a generic write).
+    const isOptimise = (opts.simulateUrl || "").includes("optimization/propose")
+                    || (opts.simulateUrl || "").includes("workbench/simulate");
+    document.body.classList.add('is-busy');
+    if (isOptimise) document.body.classList.add('is-optimizing');
     let diff;
     try {
-      diff = await jsonFetch(opts.simulateUrl, { method, body });
-    } catch (e) {
-      toast(`Simulate failed: ${e.message}`, 'bad');
-      return { applied: false };
-    }
-    if (!diff || !diff.simulation_id) {
-      toast('Simulate returned no diff — refusing to apply', 'bad');
-      return { applied: false };
-    }
-    const confirmed = await Modal.show(diff);
-    if (!confirmed) return { applied: false };
+      try {
+        diff = await jsonFetch(opts.simulateUrl, { method, body });
+      } catch (e) {
+        toast(`Simulate failed: ${e.message}`, 'bad');
+        return { applied: false };
+      }
+      if (!diff || !diff.simulation_id) {
+        toast('Simulate returned no diff — refusing to apply', 'bad');
+        return { applied: false };
+      }
+      const confirmed = await Modal.show(diff);
+      if (!confirmed) return { applied: false };
 
-    try {
-      const response = await jsonFetch(opts.applyUrl, {
-        method,
-        body,
-        headers: { 'X-Simulation-Id': diff.simulation_id },
-      });
-      toast(`Applied: ${diff.action || 'change'}`, 'ok');
-      return { applied: true, response };
-    } catch (e) {
-      const status = e.status || '?';
-      toast(`Apply failed (${status}): ${e.message}`, 'bad');
-      return { applied: false };
+      try {
+        const response = await jsonFetch(opts.applyUrl, {
+          method,
+          body,
+          headers: { 'X-Simulation-Id': diff.simulation_id },
+        });
+        toast(`Applied: ${diff.action || 'change'}`, 'ok');
+        return { applied: true, response };
+      } catch (e) {
+        const status = e.status || '?';
+        toast(`Apply failed (${status}): ${e.message}`, 'bad');
+        return { applied: false };
+      }
+    } finally {
+      document.body.classList.remove('is-busy');
+      document.body.classList.remove('is-optimizing');
     }
   }
 

--- a/tests/api/test_inputs_interpolation.py
+++ b/tests/api/test_inputs_interpolation.py
@@ -1,0 +1,100 @@
+"""Forecast tab — half-hour slots now interpolate between hourly weather rows.
+
+The bug: Open-Meteo returns hourly data, meteo_forecast stores it at HH:00
+timestamps, and /api/v1/optimization/inputs used to do exact-ISO lookup —
+so HH:30 slots showed "—" for temp + solar. Users thought the LP solved
+against sparse inputs. Actually the LP interpolates internally via
+weather._interp_hourly_scalar, so the bug was purely display.
+
+Fix: mirror the LP's linear interpolation in the endpoint so the Forecast
+tab shows the same continuous series the solver consumes.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+    # Clean any leftover meteo rows so our seed is deterministic.
+    conn = db.get_connection()
+    try:
+        conn.execute("DELETE FROM meteo_forecast")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _seed_three_hours(start: datetime) -> None:
+    """Seed temp+solar at start, start+1h, start+2h — spanning the first 3 hours
+    of the rolling horizon. Half-hour slots between them should interpolate."""
+    rows = [
+        {"slot_time": start.isoformat(),                                 "temp_c": 10.0, "solar_w_m2": 100.0},
+        {"slot_time": start.replace(hour=start.hour + 1).isoformat(),    "temp_c": 12.0, "solar_w_m2": 200.0},
+        {"slot_time": start.replace(hour=start.hour + 2).isoformat(),    "temp_c": 14.0, "solar_w_m2": 300.0},
+    ]
+    db.save_meteo_forecast(rows, start.date().isoformat())
+
+
+def test_half_hour_slot_interpolates_linearly(client):
+    # Anchor the horizon so our seed rows land inside it. The endpoint's
+    # day_start is the hour floor of "now", so we must seed at that hour.
+    now = datetime.now(UTC)
+    anchor = now.replace(minute=0, second=0, microsecond=0)
+    _seed_three_hours(anchor)
+
+    r = client.get(f"/api/v1/optimization/inputs?horizon_hours=4")
+    assert r.status_code == 200
+    slots = r.json()["slots"]
+    by_time = {s["t_utc"].rstrip("Z"): s for s in slots}
+
+    anchor_key = anchor.isoformat().replace("+00:00", "")
+    # The HH:00 slot has the raw value, the HH:30 slot must be the linear
+    # midpoint between this hour and the next hour's raw values.
+    hh00 = by_time.get(anchor_key) or {}
+    hh30_key = anchor.replace(minute=30).isoformat().replace("+00:00", "")
+    hh30 = by_time.get(hh30_key) or {}
+
+    # Raw anchors came through.
+    assert hh00.get("temp_c") == pytest.approx(10.0)
+    assert hh00.get("solar_w_m2") == pytest.approx(100.0)
+    # Interpolated midpoint of 10↔12 and 100↔200.
+    assert hh30.get("temp_c") is not None, f"HH:30 missing temp_c: {hh30}"
+    assert hh30["temp_c"] == pytest.approx(11.0, abs=0.01)
+    assert hh30["solar_w_m2"] == pytest.approx(150.0, abs=0.01)
+
+
+def test_slots_beyond_last_seed_carry_last_forward(client):
+    anchor = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    _seed_three_hours(anchor)
+
+    r = client.get("/api/v1/optimization/inputs?horizon_hours=6")
+    slots = r.json()["slots"]
+    # The last seeded row was anchor+2h; slots beyond that must carry that
+    # value forward rather than flip to None (the LP's interp does the same).
+    tail = [s for s in slots if s["t_utc"] > anchor.replace(hour=anchor.hour + 2).isoformat().replace("+00:00", "Z")]
+    assert tail, "need at least one post-seed slot"
+    for s in tail:
+        assert s["temp_c"] == pytest.approx(14.0), f"slot {s['t_utc']} should carry 14.0 forward, got {s['temp_c']}"
+
+
+def test_no_seed_rows_returns_nulls_gracefully(client):
+    # Empty meteo_forecast table — endpoint must still 200 with None fields.
+    r = client.get("/api/v1/optimization/inputs")
+    assert r.status_code == 200
+    slots = r.json()["slots"]
+    assert slots  # rolling horizon always emits slots
+    # At least the temp field is None when no weather data exists.
+    assert all(s["temp_c"] is None for s in slots)


### PR DESCRIPTION
## Summary
Two targeted data-quality fixes surfaced from a user screenshot of the Forecast table.

### Bug 1: half-hour slots missing temp + solar
Open-Meteo returns hourly data → `meteo_forecast` stores only HH:00 rows → `/api/v1/optimization/inputs` did exact ISO-timestamp lookup → every HH:30 slot showed \"—\" for both temp and solar.

This **looked** like the LP was blind on half-hour slots. Actually the LP interpolates internally via `weather._interp_hourly_scalar` (weather.py:359), so the solver was fine — the bug was purely in the display endpoint.

**Fix**: mirror the LP's linear interpolation at the endpoint, with carry-last-forward at the tail (same as the LP). The Forecast tab now shows exactly what the solver sees.

Before:
```
10:00   10.4°C   607 W/m²
10:30   —        —
11:00   12.3°C   725 W/m²
```

After:
```
10:00   10.4°C   607 W/m²
10:30   11.35°C  666 W/m²    ← linear midpoint
11:00   12.3°C   725 W/m²
```

### Bug 2: no \"LP is running\" indicator
User feedback: \"I don't see a motion saying that it's running the plan.\"

**Fix**: every `wrapAction()` flow now sets `body.is-busy` → thin animated progress bar at the top of the page + `cursor: progress`. LP-specific flows (`optimization/propose`, `workbench/simulate`) also set `body.is-optimizing` → pulsing animation on the Plan freshness chip in the cockpit. Both classes clear in a `finally` block so a thrown request can't leave a ghost state.

### Polish
Forecast tab's \"tomorrow rates\" copy clarified: explains Octopus publishes ~16:00 UTC, so null prices in trailing slots are expected, not a bug.

## Test plan
- [x] `pytest tests/ -x -q --ignore=tests/integration` — 419 passed, 1 skipped (+3 new)
- [ ] After deploy: Forecast tab at /forecast shows temp + solar on every half-hour slot
- [ ] After deploy: click \"Refresh data & re-plan\" → thin top progress bar visible during simulate+apply; Plan chip pulses distinctively

🤖 Generated with [Claude Code](https://claude.com/claude-code)