### PR TITLE
feat(ux): cockpit settings drawer + neutral topbar badge + time/hours pickers + Fox landmines doc

### DIFF
--- a/docs/FOXESS/WORK_MODES_AND_SOC.md
+++ b/docs/FOXESS/WORK_MODES_AND_SOC.md
@@ -1,0 +1,83 @@
+# Fox ESS — work modes, SoC keys, scheduler groups
+
+Reference for the Fox Open API quirks we actually hit in this codebase.
+Keep this living — update when a new shape shows up.
+
+## TL;DR landmines
+
+1. **Two different string conventions for `workMode`** depending on endpoint:
+   - Global inverter setting (`/device/setting/set` with `key=workMode`): **spaced** strings → `"Self Use"`, `"Feed-in Priority"`, `"Back Up"`, `"Force charge"`, `"Force discharge"`.
+   - Scheduler V3 group's `workMode` field (`/op/v3/device/scheduler/enable`): **camelCase, no spaces** → `"SelfUse"`, `"ForceCharge"`, `"ForceDischarge"`, `"Feedin"`, `"Backup"`.
+   - Getting this wrong returns `errno 40257 "Parameters do not meet expectations"`.
+2. **Two different SoC keys**:
+   - `minSocOnGrid` — the on-grid battery reserve floor. Accepted in **scheduler group `extraParam`** (V3) AND we currently also use it as a global setting via `set_device_setting("minSocOnGrid", …)`. The latter is device-dependent — some models 40257 on this.
+   - `minSoc` — the inverter's **true global** min-SoC setting on some firmwares. Docstring in `client.py:401` mentions it as an example. We do NOT currently call this directly; `set_min_soc` only writes `minSocOnGrid`.
+3. **`get_device_list` is POST, not GET** — a GET returns 40257 (see comment at `client.py:271`).
+
+## Work modes — full table
+
+| Global setting (spaces) | Scheduler V3 (no space) | Behavior | When the LP picks this |
+|---|---|---|---|
+| `Self Use` | `SelfUse` | Default. Use PV first, charge battery from surplus, import from grid to cover load shortfall. Never force-exports. | Standard slots (neither cheap enough to force-charge nor peak enough to export). |
+| `Feed-in Priority` | `Feedin` | Send PV **directly to grid** at full capacity; battery only covers load shortfall. | Not currently used by the LP dispatcher (would need Outgoing Agile + surplus). |
+| `Back Up` | `Backup` | Keep battery at/above a floor for outage resilience; charge from grid if needed. No discharge below floor. | Used for negative-price holds where we want to keep capacity reserved. |
+| `Force charge` | `ForceCharge` | **Charge battery from the grid** at the specified `fdPwr` until `fdSoc` is reached. Respects `minSocOnGrid` as a lower bound but `fdSoc` is the target ceiling for this window. | Negative-price slots + cheap-price slots ahead of a forecasted peak. |
+| `Force discharge` | `ForceDischarge` | **Discharge battery to grid** (peak-export) until `fdSoc` is reached or battery hits `minSocOnGrid`. | Only when `ENERGY_STRATEGY_MODE=savings_first` AND preset is `travel`/`away` AND SoC ≥ `EXPORT_DISCHARGE_MIN_SOC_PERCENT`. Very rarely. |
+
+### Group `extraParam` fields (V3)
+
+`SchedulerGroup.to_api_dict()` (`models.py:53-73`) packs these into `extraParam`:
+
+- `minSocOnGrid` (always present, default `10`) — discharge floor during this window.
+- `fdSoc` — **target SoC** for `ForceCharge` / `ForceDischarge`. For ForceCharge: "charge until battery reaches this %". For ForceDischarge: "discharge until battery reaches this % or minSocOnGrid, whichever is higher".
+- `fdPwr` — **power in watts**. For ForceCharge: charge rate. For ForceDischarge: discharge rate. Bounded by `FOX_FORCE_CHARGE_MAX_PWR` (default 6000 = the inverter's AC cap on our 6 kW hybrid).
+- `maxSoc` — rarely used, ceiling for SelfUse charging.
+- `importLimit` / `exportLimit` — in watts. Peak-shaving knobs; not wired into the LP dispatcher today.
+
+## Known issue: `set_min_soc(10)` failing with 40257 on shutdown
+
+The `apply_safe_defaults` shutdown path (`state_machine.py:85`) calls:
+1. `set_scheduler_flag(False)` — OK
+2. `set_work_mode("Self Use")` — OK
+3. `set_min_soc(10)` → `set_device_setting("minSocOnGrid", 10)` — **40257**
+
+Observed on every prod restart. The inter-write pacing (PR #134) didn't fix it because it's not a timing issue — the key/value combo is rejected.
+
+### Hypotheses (to verify)
+
+1. **Wrong key name** — this device might require `minSoc` instead of `minSocOnGrid` for a global setting. `minSocOnGrid` may only be valid inside a scheduler group's `extraParam`, not as a top-level device setting.
+2. **Value format** — Fox might expect a string, a nested object, or a different numeric range.
+3. **Already at 10%** — device might reject a no-op write.
+
+### Verification plan (next time we touch Fox)
+
+Try, in isolation, against a dev account:
+```python
+# Hypothesis 1
+fox.set_device_setting("minSoc", 10)
+# Hypothesis 2
+fox.set_device_setting("minSocOnGrid", {"value": 10})
+# Hypothesis 3 — omit the write; just rely on the scheduler group's minSocOnGrid
+```
+
+The scheduler group already sets `minSocOnGrid` per window via `extraParam` — the shutdown-path call is probably redundant with that.
+
+### Workaround (non-urgent)
+
+The shutdown error is cosmetic: logged at WARN, doesn't affect the subsequent startup. Filing as `TODO(fox-minsoc-40257)`. If anyone touches `apply_safe_defaults` next, try removing the `set_min_soc(10)` call and see if anything notices.
+
+## Realtime `workMode` parsing
+
+`get_realtime()` may return `workMode` as:
+- a **numeric code** (`"0"` / `"1"` / …) — mapped via `WORK_MODE_BY_CODE` at `client.py:32`.
+- a **spaced string** (`"Self Use"`).
+- an **unknown string** — left as-is.
+
+Always treat `RealTimeData.work_mode` as a display string; don't match it exactly to the `set_work_mode` input list.
+
+## References
+
+- `src/foxess/client.py` — HTTP layer, all writers
+- `src/foxess/models.py` — `SchedulerGroup`, `RealTimeData`
+- TonyM1958/FoxESS-Cloud — reference Python client (inspired our 2s inter-write pacing, see PR #134)
+- Fox Open API docs: https://www.foxesscloud.com/public/i18n/en/OpenApiDocument.html

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -550,6 +550,118 @@ body.is-optimizing .fresh-chip[data-source="plan"] {
     font-weight: 600;
 }
 
+/* Controls section header — was a plain-text button that didn't read as
+ * clickable. Now a proper row with an expand arrow + subtitle. */
+.override-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.55rem 0.85rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text);
+    font-size: 0.85rem;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 120ms ease, background 120ms ease;
+}
+.override-toggle:hover { border-color: var(--text-dim); }
+.override-toggle-left {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+}
+.override-toggle-icon {
+    display: inline-block;
+    transition: transform 160ms ease;
+    color: var(--text-dim);
+}
+.override-toggle[aria-expanded="true"] .override-toggle-icon { transform: rotate(90deg); }
+.override-toggle-right {
+    font-size: 0.74rem;
+    font-weight: 400;
+}
+@media (max-width: 480px) {
+    .override-toggle-right { display: none; }
+}
+
+/* Settings drawer — opens from the ⚙ chip in the hero ribbon. Right-side
+ * slide-in so the underlying cockpit stays visible (users can flip a knob
+ * and immediately see the effect on the live view). */
+.fresh-chip-settings {
+    margin-left: auto;
+}
+body.drawer-open { overflow: hidden; }
+.drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 80;
+    display: flex;
+    justify-content: flex-end;
+}
+.drawer-backdrop[hidden] { display: none; }
+.drawer {
+    width: min(100%, 480px);
+    max-width: 100%;
+    height: 100%;
+    background: var(--bg);
+    border-left: 1px solid var(--border);
+    box-shadow: -8px 0 24px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    animation: drawer-slide-in 180ms ease;
+}
+@keyframes drawer-slide-in {
+    from { transform: translateX(100%); }
+    to   { transform: translateX(0); }
+}
+.drawer-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 0.95rem;
+    border-bottom: 1px solid var(--border);
+}
+.drawer-header h2 {
+    flex: 1;
+    margin: 0;
+    font-size: 1rem;
+}
+.drawer-close {
+    appearance: none;
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.3rem;
+}
+.drawer-close:hover { color: var(--text); }
+.drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.85rem;
+}
+.drawer-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.7rem 0.85rem;
+    margin-bottom: 0.75rem;
+}
+.drawer-card-title {
+    margin: 0 0 0.45rem 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-dim);
+}
+
 /* Layout */
 .page {
     max-width: 960px;

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -56,27 +56,34 @@ a { color: inherit; text-decoration: none; }
 }
 .brand { grid-area: brand; font-weight: 600; font-size: 1rem; }
 
-/* Mode badge — clickable summary of DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID */
+/* Mode badge — compact clickable Daikin-control indicator.
+ *
+ * Passive is the default + *desired* state (firmware runs the heat pump
+ * on its own curve); the old pill used a warning-orange "simulation"
+ * style which read as "something is wrong". Now: neutral chip always,
+ * subtle dot colour to hint at the mode, and a terse "Daikin: passive"
+ * label so first-time viewers understand what they're looking at.
+ */
 .mode-badge {
     grid-area: badge;
     appearance: none;
     background: var(--bg-card);
     border: 1px solid var(--border);
-    color: var(--text);
-    padding: 0.35rem 0.7rem;
+    color: var(--text-dim);
+    padding: 0.3rem 0.65rem;
     border-radius: 999px;
-    font-size: 0.78rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
+    font-size: 0.74rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    min-height: 32px;
+    min-height: 30px;
     justify-self: center;
     line-height: 1;
 }
-.mode-badge:hover { border-color: var(--text-dim); }
+.mode-badge:hover { border-color: var(--text-dim); color: var(--text); }
 .mode-badge:active { transform: scale(0.97); }
 .mode-badge .mode-dot {
     display: inline-block;
@@ -84,32 +91,31 @@ a { color: inherit; text-decoration: none; }
     height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
+    background: var(--text-dim);
 }
-.mode-badge .mode-sub {
-    color: var(--text-dim);
-    font-weight: 400;
-    font-size: 0.7rem;
-}
-.mode-badge[data-mode="operational"] {
-    background: rgba(16,185,129,0.12);
-    border-color: rgba(16,185,129,0.5);
-}
-.mode-badge[data-mode="operational"] .mode-dot {
-    background: var(--ok);
-    box-shadow: 0 0 6px var(--ok);
-}
-.mode-badge[data-mode="simulation"] {
-    background: rgba(245,158,11,0.12);
+.mode-badge .mode-label { color: var(--text-dim); font-weight: 500; }
+.mode-badge .mode-value { color: var(--text); font-weight: 600; font-variant: small-caps; }
+
+/* Passive = firmware autonomous (normal). Neutral blue dot to say "this is
+ * the default; nothing is wrong." Active = LP controls the HP: warmer tone
+ * to flag that the service is writing to the device. */
+.mode-badge[data-daikin="passive"] .mode-dot { background: #5b9bd5; }
+.mode-badge[data-daikin="active"] {
     border-color: rgba(245,158,11,0.5);
-    background-image: repeating-linear-gradient(45deg,
-        transparent 0, transparent 6px,
-        rgba(245,158,11,0.08) 6px, rgba(245,158,11,0.08) 12px);
 }
-.mode-badge[data-mode="simulation"] .mode-dot { background: var(--warn); }
-.mode-badge[data-mode="unknown"] { opacity: 0.6; }
+.mode-badge[data-daikin="active"] .mode-dot {
+    background: var(--warn);
+    box-shadow: 0 0 6px var(--warn);
+}
+/* Simulate-id enforcement on: show a tiny 🔒 after the label. */
+.mode-badge[data-require-sim="true"]::after {
+    content: "🔒";
+    font-size: 0.72rem;
+    opacity: 0.75;
+}
 @media (max-width: 480px) {
-    .mode-badge .mode-sub { display: none; }
-    .mode-badge .mode-label { font-size: 0.72rem; }
+    .mode-badge .mode-label { display: none; }
+    .mode-badge { padding: 0.3rem 0.55rem; }
 }
 .tabs { grid-area: tabs; display: flex; gap: 0.25rem; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
 .tabs::-webkit-scrollbar { display: none; }
@@ -512,6 +518,36 @@ body.is-optimizing .fresh-chip[data-source="plan"] {
 .daikin-controls.is-disabled input,
 .daikin-controls.is-disabled button {
     pointer-events: none;
+}
+
+/* MPC hours 24-cell toggle grid (replaces the CSV text input). */
+.mpc-grid {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 3px;
+    margin: 0.55rem 0;
+}
+@media (max-width: 480px) {
+    .mpc-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+}
+.mpc-cell {
+    appearance: none;
+    border: 1px solid var(--border);
+    background: var(--bg-card-2);
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    padding: 0.35rem 0;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+.mpc-cell:hover { border-color: var(--text-dim); color: var(--text); }
+.mpc-cell.is-on {
+    background: var(--cheap);
+    border-color: var(--cheap);
+    color: #08180a;
+    font-weight: 600;
 }
 
 /* Layout */

--- a/src/api/static/js/cockpit.js
+++ b/src/api/static/js/cockpit.js
@@ -375,9 +375,29 @@
 
   // --- Boot ---------------------------------------------------------------
 
+  // --- Settings drawer ---------------------------------------------------
+  // The drawer reuses settings.js — the container IDs on the cockpit page
+  // (#settingsComfort / #settingsStrategy / #settingsSchedule) match the
+  // full /settings page, so settings.js's own load() populates both.
+  function bindSettingsDrawer() {
+    const open = $('#btnSettingsDrawer');
+    const backdrop = $('#settingsDrawerBackdrop');
+    const closeBtn = $('#btnSettingsDrawerClose');
+    if (!backdrop) return;
+    const show = () => { backdrop.hidden = false; document.body.classList.add('drawer-open'); };
+    const hide = () => { backdrop.hidden = true; document.body.classList.remove('drawer-open'); };
+    open?.addEventListener('click', show);
+    closeBtn?.addEventListener('click', hide);
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) hide(); });
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape' && !backdrop.hidden) hide();
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', async () => {
     bindOverride();
     bindFreshnessChips();
+    bindSettingsDrawer();
     // Load the hero first so thresholds are available when strips render.
     await loadNow();
     loadTariff();

--- a/src/api/static/js/settings.js
+++ b/src/api/static/js/settings.js
@@ -125,6 +125,89 @@
     });
   }
 
+  /* ---------------------------------------------------------------------
+   * Composite controls — two pain points from user feedback:
+   *   1. Hour + minute as two separate spinbox fields was awful. Renders
+   *      as a single <input type="time"> and applies both keys in one
+   *      batch so simulate → confirm fires only once.
+   *   2. LP_MPC_HOURS was a CSV text input. Renders as a 24-cell
+   *      hour-of-day toggle grid; users click the hours they want.
+   * ---------------------------------------------------------------------
+   */
+
+  function renderPlanPushTime(hourItem, minuteItem, container) {
+    const hh = String(hourItem.value ?? 0).padStart(2, '0');
+    const mm = String(minuteItem.value ?? 0).padStart(2, '0');
+    const block = document.createElement('div');
+    block.className = 'setting-block';
+    block.innerHTML = `
+      <div class="setting-head">
+        <h3 class="setting-name">Nightly plan push (UTC)</h3>
+        <span class="status-badge">${hh}:${mm}</span>
+      </div>
+      <p class="setting-desc">When the next-day plan is pushed to Fox + Daikin. Anchored to UTC so it always lands just after the Daikin quota rollover at 00:00 UTC. Default 00:05 UTC.</p>
+      <div class="setting-actions">
+        <input type="time" id="planPushTime" value="${hh}:${mm}" step="60" style="width:8rem;">
+        <button class="btn btn-secondary btn-sm" id="btnApplyPlanPushTime">Change…</button>
+      </div>`;
+    container.appendChild(block);
+    block.querySelector('#btnApplyPlanPushTime').addEventListener('click', async () => {
+      const raw = block.querySelector('#planPushTime').value || '00:05';
+      const [h, m] = raw.split(':').map(n => parseInt(n, 10));
+      if (isNaN(h) || isNaN(m)) { toast('Invalid time', 'warn'); return; }
+      // Batch-apply both keys in one simulate → confirm round-trip so the
+      // user sees a single diff, not two.
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/settings/batch/simulate',
+        applyUrl: '/api/v1/settings/batch',
+        body: { changes: { LP_PLAN_PUSH_HOUR: h, LP_PLAN_PUSH_MINUTE: m } },
+      });
+      if (result.applied) load();
+    });
+  }
+
+  function renderMpcHours(item, container) {
+    const current = new Set((item.value || []).map(Number));
+    const block = document.createElement('div');
+    block.className = 'setting-block';
+    block.innerHTML = `
+      <div class="setting-head">
+        <h3 class="setting-name">Intra-day re-solve hours (local)</h3>
+        <span class="status-badge" id="mpcHoursBadge">${current.size} slot${current.size === 1 ? '' : 's'}</span>
+      </div>
+      <p class="setting-desc">Hours (local, ${item.description || 'planner tz'}) when the LP re-solves mid-day with fresh SoC + forecast. Click to toggle. Zero selected disables intra-day re-solves.</p>
+      <div class="mpc-grid" role="group" aria-label="Re-solve hours">
+        ${Array.from({length: 24}, (_, h) => `
+          <button type="button" class="mpc-cell ${current.has(h) ? 'is-on' : ''}" data-hour="${h}">
+            ${String(h).padStart(2, '0')}
+          </button>
+        `).join('')}
+      </div>
+      <div class="setting-actions">
+        <button class="btn btn-secondary btn-sm" id="btnApplyMpcHours">Change…</button>
+      </div>`;
+    container.appendChild(block);
+    const pending = new Set(current);
+    const badge = block.querySelector('#mpcHoursBadge');
+    block.querySelectorAll('.mpc-cell').forEach(b => b.addEventListener('click', () => {
+      const h = parseInt(b.dataset.hour, 10);
+      if (pending.has(h)) { pending.delete(h); b.classList.remove('is-on'); }
+      else { pending.add(h); b.classList.add('is-on'); }
+      const n = pending.size;
+      badge.textContent = `${n} slot${n === 1 ? '' : 's'}`;
+    }));
+    block.querySelector('#btnApplyMpcHours').addEventListener('click', async () => {
+      const hours = Array.from(pending).sort((a, b) => a - b);
+      const result = await wrapAction({
+        method: 'PUT',
+        simulateUrl: `/api/v1/settings/${item.key}/simulate`,
+        applyUrl: `/api/v1/settings/${item.key}`,
+        body: { value: hours },
+      });
+      if (result.applied) load();
+    });
+  }
+
   async function load() {
     try {
       const resp = await jsonFetch('/api/v1/settings');
@@ -134,13 +217,13 @@
       // v10.2: DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID moved to the
       // topbar mode-switcher dialog. They no longer render here.
 
-      // Grouped sections
-      const groups = {
+      // Grouped sections — schedule uses composite renderers for its two
+      // awkward inputs (hour/minute pair → time picker; CSV hours → 24-cell grid).
+      const simple = {
         settingsComfort: ['DHW_TEMP_NORMAL_C', 'DHW_TEMP_COMFORT_C', 'INDOOR_SETPOINT_C'],
         settingsStrategy: ['OPTIMIZATION_PRESET', 'ENERGY_STRATEGY_MODE'],
-        settingsSchedule: ['LP_PLAN_PUSH_HOUR', 'LP_PLAN_PUSH_MINUTE', 'LP_MPC_HOURS'],
       };
-      Object.entries(groups).forEach(([containerId, keys]) => {
+      Object.entries(simple).forEach(([containerId, keys]) => {
         const c = $('#' + containerId);
         if (!c) return;
         c.innerHTML = '';
@@ -149,6 +232,17 @@
           if (item) renderInline(item, c);
         });
       });
+
+      const sched = $('#settingsSchedule');
+      if (sched) {
+        sched.innerHTML = '';
+        if (byKey.LP_PLAN_PUSH_HOUR && byKey.LP_PLAN_PUSH_MINUTE) {
+          renderPlanPushTime(byKey.LP_PLAN_PUSH_HOUR, byKey.LP_PLAN_PUSH_MINUTE, sched);
+        }
+        if (byKey.LP_MPC_HOURS) {
+          renderMpcHours(byKey.LP_MPC_HOURS, sched);
+        }
+      }
     } catch (e) {
       toast(`Settings: ${e.message}`, 'bad');
     }

--- a/src/api/templates/_layout.html
+++ b/src/api/templates/_layout.html
@@ -15,15 +15,12 @@
             <button id="modeBadge"
                     class="mode-badge"
                     type="button"
-                    data-mode="{{ operation_mode }}"
                     data-daikin="{{ daikin_control_mode }}"
                     data-require-sim="{{ 'true' if require_simulation_id else 'false' }}"
-                    title="Click to change operation mode, Daikin control, or simulate-id enforcement">
+                    title="Daikin control + simulate-id enforcement. Passive = heat pump runs on its own curve (normal). Active = the LP schedules tank + LWT.">
                 <span class="mode-dot"></span>
-                <span class="mode-label">{{ operation_mode|upper }}</span>
-                {% if daikin_control_mode == 'passive' %}
-                    <span class="mode-sub">· daikin passive</span>
-                {% endif %}
+                <span class="mode-label">Daikin:</span>
+                <span class="mode-value">{{ daikin_control_mode }}</span>
             </button>
             <nav class="tabs" aria-label="Pages">
                 <a href="/" class="tab {% if active_page == 'cockpit' %}is-active{% endif %}">Cockpit</a>

--- a/src/api/templates/cockpit.html
+++ b/src/api/templates/cockpit.html
@@ -52,8 +52,41 @@
             <span class="fresh-chip-age" data-age>—</span>
             <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
         </button>
+        <button class="fresh-chip fresh-chip-settings" type="button" id="btnSettingsDrawer"
+                title="Open settings drawer — comfort targets, strategy, schedule cadence">
+            <span class="fresh-chip-name">⚙ Settings</span>
+        </button>
     </div>
 </section>
+
+<!-- Settings drawer — opens from the ⚙ chip. Same form as the /settings page
+     (container IDs match so settings.js populates both automatically). -->
+<div class="drawer-backdrop" id="settingsDrawerBackdrop" hidden>
+    <aside class="drawer" role="dialog" aria-modal="true" aria-labelledby="settingsDrawerTitle">
+        <header class="drawer-header">
+            <h2 id="settingsDrawerTitle">Settings</h2>
+            <a href="/settings" class="btn btn-sm btn-secondary" title="Open full settings page">Full page →</a>
+            <button class="drawer-close" id="btnSettingsDrawerClose" type="button" aria-label="Close">&times;</button>
+        </header>
+        <div class="drawer-body">
+            <p class="text-dim" style="font-size:0.78rem;margin:0 0 0.85rem 0;">
+                Quick tuning for comfort, strategy, and schedule. Every change simulates first.
+            </p>
+            <section class="drawer-card">
+                <h3 class="drawer-card-title">Comfort targets</h3>
+                <div id="settingsComfort"></div>
+            </section>
+            <section class="drawer-card">
+                <h3 class="drawer-card-title">Optimization strategy</h3>
+                <div id="settingsStrategy"></div>
+            </section>
+            <section class="drawer-card">
+                <h3 class="drawer-card-title">Schedule cadence</h3>
+                <div id="settingsSchedule"></div>
+            </section>
+        </div>
+    </aside>
+</div>
 
 <section class="card">
     <h2 class="card-title">House load breakdown</h2>
@@ -118,7 +151,11 @@
 
 <section class="override-section">
     <button class="override-toggle" id="overrideToggle" aria-expanded="false">
-        Controls · everything below requires preview &amp; confirm
+        <span class="override-toggle-left">
+            <span class="override-toggle-icon" aria-hidden="true">▸</span>
+            <span class="override-toggle-title">Controls</span>
+        </span>
+        <span class="override-toggle-right text-dim">Fox mode · Plan · Daikin — preview &amp; confirm</span>
     </button>
     <div class="override-body" id="overrideBody" hidden>
         <div class="override-tabs" role="tablist">
@@ -176,4 +213,5 @@
 
 {% block scripts %}
 <script src="/static/js/cockpit.js?v={{ static_v('js/cockpit.js') }}"></script>
+<script src="/static/js/settings.js?v={{ static_v('js/settings.js') }}"></script>
 {% endblock %}

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -70,11 +70,14 @@ def test_modal_partial_included(client):
 
 
 def test_mode_badge_rendered_on_every_v10_page(client):
-    """v10.2: every page renders the topbar mode badge with data-mode attr."""
+    """v10.2: every page renders the topbar mode badge. OPERATION_MODE was
+    retired (#130); the badge now reflects DAIKIN_CONTROL_MODE via
+    data-daikin plus a require-sim lock hint via data-require-sim."""
     for url in ("/", "/insights", "/workbench", "/settings"):
         body = client.get(url).text
         assert 'class="mode-badge"' in body, f"{url}: mode badge missing"
-        assert 'data-mode=' in body, f"{url}: data-mode attribute missing"
+        assert 'data-daikin=' in body, f"{url}: data-daikin attribute missing"
+        assert 'data-require-sim=' in body, f"{url}: data-require-sim attribute missing"
         assert 'id="modeBadge"' in body, f"{url}: badge id missing (click handler won't bind)"
 
 


### PR DESCRIPTION
## Summary
Six UX fixes from your feedback list, consolidated into one PR. Plus a docs-only capture of Fox work-mode and min-SoC landmines so we stop tripping over the same Onecta quirks.

## What changed

### Controls, not spinboxes
1. **LP_PLAN_PUSH_HOUR + LP_PLAN_PUSH_MINUTE → single `<input type=\"time\">`** — both keys apply via `/api/v1/settings/batch` in one simulate → confirm.
2. **LP_MPC_HOURS → 24-cell toggle grid** — click the hours the LP should re-solve at. Replaces the \"6,9,12,15\" CSV text input. Badge shows the count.

### Topbar mode badge
3. **Passive is no longer styled as a warning.** Passive = the firmware autonomous *default*; it shouldn't read as \"something's wrong\". Now a neutral chip with a blue dot for passive / warning-orange dot only for active (since active = LP actually writing to Daikin, a more attention-worthy state). Also drops the retired OPERATION_MODE reference; test updated.

### Cockpit ergonomics
4. **Settings drawer on the Cockpit** — the ⚙ chip in the hero ribbon slides in a right-side drawer containing Comfort / Strategy / Schedule. Same controls as the /settings page (shared settings.js, container IDs match). You can flip a DHW target or re-solve cadence and immediately see the effect on the live view. `/settings` stays around for deep-link use (drawer has a \"Full page →\" link).
5. **Controls header polish** — the collapsed Controls section header was plain text. Now a proper row with an expand arrow (rotates 90° on open) + subtitle explaining what's inside.

### Docs
6. **`docs/FOXESS/WORK_MODES_AND_SOC.md`** — captures the two main Fox API landmines the audit surfaced:
   - `workMode` strings use **spaces** for the global setting but **camelCase** for scheduler V3 groups.
   - `minSoc` vs `minSocOnGrid` — two different keys with different behaviours, and the shutdown 40257 we still see after every restart (`set_min_soc(10)` rejected by this device). Three hypotheses captured with a verification plan, TODO(fox-minsoc-40257) filed.

## Deferred
The merged tariff+plan timeline strip rewrite is deferred to a follow-up PR — it's a bigger visual change and I wanted to ship the drawer + topbar polish first so you see progress.

## Test plan
- [x] `pytest tests/ -x -q --ignore=tests/integration` — 419 passed, 1 skipped
- [x] Updated `test_mode_badge_rendered_on_every_v10_page` to assert the new `data-daikin` / `data-require-sim` contract (post-OPERATION_MODE retirement)
- [ ] After deploy: open Cockpit, click ⚙ → drawer slides in with the same controls as /settings; DHW target picker applies via batch
- [ ] After deploy: Settings page still renders; Plan push shows as one time picker; Re-solve hours is a 24-cell grid
- [ ] After deploy: topbar reads \"Daikin: passive\" with a blue dot (not orange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)