### PR TITLE
feat(cockpit): trigger visibility — action_log duration + recent-triggers strip

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -964,6 +964,26 @@ async def cockpit_at(when: str):
     }
 
 
+@app.get("/api/v1/recent-triggers")
+async def recent_triggers(limit: int = 20, include_heartbeat: bool = False):
+    """Recent manual/scheduler action_log rows for the cockpit's
+    'Recent triggers' strip.
+
+    Filters out ``heartbeat`` and ``notification`` triggers by default so
+    the user sees meaningful events (manual MCP writes, plan proposes,
+    scheduler crons). Rows written via :func:`db.log_action_timed` carry
+    ``started_at`` / ``completed_at`` / ``duration_ms`` / ``actor``; legacy
+    fast-path rows have nulls in those fields (still rendered, just
+    without the duration chip).
+    """
+    exclude = ["notification"] if include_heartbeat else ["heartbeat", "notification"]
+    try:
+        rows = db.get_recent_triggers(limit=int(limit), exclude_triggers=exclude)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"recent-triggers: {e}")
+    return {"rows": rows, "count": len(rows)}
+
+
 @app.get("/api/v1/optimization/inputs")
 async def optimization_inputs(horizon_hours: int | None = None):
     """Everything the next LP solve will see, merged from caches + SQLite.

--- a/src/api/static/css/cockpit.css
+++ b/src/api/static/css/cockpit.css
@@ -278,6 +278,57 @@ a { color: inherit; text-decoration: none; }
     opacity: 0.7;
 }
 
+/* Recent-triggers strip — lives at the bottom of the NOW hero. Fed by
+ * /api/v1/recent-triggers, auto-refreshes after any wrapAction() flow
+ * so user-fired writes appear within a second. Horizontal scroll when
+ * > screen-width of chips. */
+.recent-triggers {
+    display: flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    margin-top: 0.55rem;
+    padding-top: 0.45rem;
+    border-top: 1px dashed var(--border);
+    font-size: 0.7rem;
+}
+.recent-triggers-head {
+    font-size: 0.64rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+    flex-shrink: 0;
+}
+.recent-triggers-list {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+    min-width: 0;
+    flex: 1;
+}
+.trigger-chip {
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: baseline;
+    padding: 0.2rem 0.5rem;
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.trigger-chip.is-failure {
+    border-color: rgba(220, 38, 38, 0.5);
+    background: rgba(220, 38, 38, 0.08);
+}
+.trigger-chip .trigger-action {
+    font-weight: 600;
+    color: var(--text);
+}
+.trigger-chip .trigger-meta {
+    color: var(--text-dim);
+    font-size: 0.64rem;
+}
+
 /* -----------------------------------------------------------------------
  * Phase 3: Forecast tab
  * ----------------------------------------------------------------------- */

--- a/src/api/static/js/cockpit.js
+++ b/src/api/static/js/cockpit.js
@@ -458,6 +458,59 @@
 
   // --- Boot ---------------------------------------------------------------
 
+  // --- Recent triggers strip ---------------------------------------------
+  // Populated by /api/v1/recent-triggers on page load + after any write
+  // (the latter happens via the MutationObserver on body.is-busy — when
+  // wrapAction removes the busy class, a fresh trigger has just fired).
+  function fmtDurationMs(ms) {
+    if (ms == null) return '';
+    if (ms < 1000) return `${ms}ms`;
+    const s = ms / 1000;
+    if (s < 10) return `${s.toFixed(1)}s`;
+    if (s < 60) return `${Math.round(s)}s`;
+    return `${Math.floor(s / 60)}m${Math.round(s % 60)}s`;
+  }
+
+  function fmtSinceShort(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (isNaN(d)) return '—';
+    const sec = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (sec < 60) return `${sec}s`;
+    if (sec < 3600) return `${Math.floor(sec / 60)}m`;
+    if (sec < 86400) return `${Math.floor(sec / 3600)}h`;
+    return `${Math.floor(sec / 86400)}d`;
+  }
+
+  async function loadRecentTriggers() {
+    const mount = $('#recentTriggersList');
+    if (!mount) return;
+    let data;
+    try {
+      data = await jsonFetch('/api/v1/recent-triggers?limit=6');
+    } catch (_e) {
+      mount.textContent = '—';
+      return;
+    }
+    const rows = (data && data.rows) || [];
+    if (!rows.length) { mount.textContent = 'no recent activity'; return; }
+    mount.innerHTML = '';
+    rows.forEach(r => {
+      const chip = document.createElement('span');
+      chip.className = 'trigger-chip' + (r.result === 'failure' ? ' is-failure' : '');
+      const when = r.started_at || r.timestamp;
+      const dur = fmtDurationMs(r.duration_ms);
+      const actorChip = r.actor ? ` · ${r.actor}` : '';
+      chip.innerHTML = `
+        <span class="trigger-action">${r.action}</span>
+        <span class="trigger-meta">${fmtSinceShort(when)} ago${dur ? ` · ${dur}` : ''}${actorChip}</span>
+      `;
+      if (r.error_msg) chip.title = `FAILED: ${r.error_msg}`;
+      else if (r.params) chip.title = `${r.action} · ${r.params}`;
+      mount.appendChild(chip);
+    });
+  }
+
   // --- Settings drawer ---------------------------------------------------
   // The drawer reuses settings.js — the container IDs on the cockpit page
   // (#settingsComfort / #settingsStrategy / #settingsSchedule) match the
@@ -477,15 +530,35 @@
     });
   }
 
+  // Hook the generic wrapAction busy-state: when body.is-busy flips off we
+  // know a user-fired write just finished, so pull the recent-triggers
+  // strip to show it landed. MutationObserver keeps the wiring loose — no
+  // coupling to individual button handlers.
+  function bindRecentTriggersAutoRefresh() {
+    const body = document.body;
+    let wasBusy = body.classList.contains('is-busy');
+    const obs = new MutationObserver(() => {
+      const busy = body.classList.contains('is-busy');
+      if (wasBusy && !busy) {
+        // Small delay so the INSERT has been committed before we re-fetch.
+        setTimeout(loadRecentTriggers, 400);
+      }
+      wasBusy = busy;
+    });
+    obs.observe(body, { attributes: true, attributeFilter: ['class'] });
+  }
+
   document.addEventListener('DOMContentLoaded', async () => {
     bindOverride();
     bindFreshnessChips();
     bindSettingsDrawer();
     bindSlotDetail();
+    bindRecentTriggersAutoRefresh();
     // Load the hero first so thresholds are available when strips render.
     await loadNow();
     loadTariff();
     loadPlan();
     loadBreakdown();
+    loadRecentTriggers();
   });
 })();

--- a/src/api/templates/cockpit.html
+++ b/src/api/templates/cockpit.html
@@ -57,6 +57,14 @@
             <span class="fresh-chip-name">⚙ Settings</span>
         </button>
     </div>
+    <!-- Recent manual/scheduler triggers with duration. Fed by
+         /api/v1/recent-triggers, reloaded after any wrapAction() apply so
+         a user-fired change (propose, Fox mode, tank temp) appears in the
+         strip within seconds. -->
+    <div class="recent-triggers" id="recentTriggers">
+        <span class="recent-triggers-head">Recent</span>
+        <span class="recent-triggers-list" id="recentTriggersList">—</span>
+    </div>
 </section>
 
 <!-- Settings drawer — opens from the ⚙ chip. Same form as the /settings page

--- a/src/db.py
+++ b/src/db.py
@@ -4,6 +4,7 @@ Uses stdlib sqlite3 for compatibility with APScheduler and sync device clients.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import sqlite3
@@ -508,6 +509,24 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_config_audit_key_ts ON config_audit(key, changed_at_utc DESC)"
     )
+
+    # V12: action_log duration tracking. Existing ``timestamp`` is still the
+    # "when this row was written" column; new ``started_at`` + ``completed_at``
+    # + ``duration_ms`` are populated only by the log_action_timed() path so
+    # the cockpit can show "propose_optimization_plan ran 1.23s ago, took
+    # 312ms". ``actor`` captures who fired the action (mcp / api / heartbeat
+    # / optimizer). Nullable so legacy rows + the fast-path log_action stay
+    # compatible.
+    cur = conn.execute("PRAGMA table_info(action_log)")
+    al_cols = {str(r[1]) for r in cur.fetchall()}
+    for col, typ in (
+        ("started_at", "TEXT"),
+        ("completed_at", "TEXT"),
+        ("duration_ms", "INTEGER"),
+        ("actor", "TEXT"),
+    ):
+        if col not in al_cols:
+            conn.execute(f"ALTER TABLE action_log ADD COLUMN {col} {typ}")
 
 
 def init_db() -> None:
@@ -1036,15 +1055,29 @@ def log_action(
     error_msg: str | None = None,
     slot_kind: str | None = None,
     agile_price_at_time: float | None = None,
+    started_at: str | None = None,
+    completed_at: str | None = None,
+    duration_ms: int | None = None,
+    actor: str | None = None,
 ) -> None:
+    """Append one row to action_log.
+
+    The canonical single-timestamp call shape is unchanged; the four
+    extended args (started_at, completed_at, duration_ms, actor) are
+    populated only by :func:`log_action_timed` when duration tracking
+    matters. Left nullable so legacy callers + the fast-path notification
+    emitter stay wire-compatible.
+    """
     ts = datetime.now(UTC).isoformat()
     with _lock:
         conn = get_connection()
         try:
             conn.execute(
                 """INSERT INTO action_log
-                   (timestamp, device, action, params, result, error_msg, trigger, slot_kind, agile_price_at_time)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   (timestamp, device, action, params, result, error_msg, trigger,
+                    slot_kind, agile_price_at_time,
+                    started_at, completed_at, duration_ms, actor)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     ts,
                     device,
@@ -1055,9 +1088,108 @@ def log_action(
                     trigger,
                     slot_kind,
                     agile_price_at_time,
+                    started_at,
+                    completed_at,
+                    duration_ms,
+                    actor,
                 ),
             )
             conn.commit()
+        finally:
+            conn.close()
+
+
+@contextlib.contextmanager
+def log_action_timed(
+    *,
+    device: str,
+    action: str,
+    params: dict[str, Any] | None,
+    trigger: str,
+    actor: str | None = None,
+    slot_kind: str | None = None,
+    agile_price_at_time: float | None = None,
+) -> Any:
+    """Context manager that times an action block and writes a single
+    action_log row on exit with started_at / completed_at / duration_ms.
+
+    Usage:
+
+        with db.log_action_timed(
+            device="foxess", action="set_work_mode",
+            params={"mode": "Self Use"}, trigger="mcp", actor="mcp",
+        ):
+            fox.set_work_mode("Self Use")
+
+    On a raised exception the row is still written with ``result="failure"``
+    and ``error_msg`` set, then the exception re-propagates — so callers get
+    duration tracking for the failure path too.
+    """
+    import time as _time
+    started_mono = _time.monotonic()
+    started_iso = datetime.now(UTC).isoformat()
+    try:
+        yield
+    except Exception as e:
+        completed_iso = datetime.now(UTC).isoformat()
+        elapsed_ms = int((_time.monotonic() - started_mono) * 1000)
+        log_action(
+            device=device,
+            action=action,
+            params=params,
+            result="failure",
+            trigger=trigger,
+            error_msg=str(e)[:500],
+            slot_kind=slot_kind,
+            agile_price_at_time=agile_price_at_time,
+            started_at=started_iso,
+            completed_at=completed_iso,
+            duration_ms=elapsed_ms,
+            actor=actor,
+        )
+        raise
+    completed_iso = datetime.now(UTC).isoformat()
+    elapsed_ms = int((_time.monotonic() - started_mono) * 1000)
+    log_action(
+        device=device,
+        action=action,
+        params=params,
+        result="success",
+        trigger=trigger,
+        slot_kind=slot_kind,
+        agile_price_at_time=agile_price_at_time,
+        started_at=started_iso,
+        completed_at=completed_iso,
+        duration_ms=elapsed_ms,
+        actor=actor,
+    )
+
+
+def get_recent_triggers(limit: int = 20, exclude_triggers: list[str] | None = None) -> list[dict[str, Any]]:
+    """Recent action_log rows for the cockpit 'Recent triggers' strip.
+
+    Default filter excludes heartbeat + notification noise so the user
+    sees meaningful events: manual writes, plan proposes, scheduler cron
+    fires. Returns newest-first; ``duration_ms`` is null for rows written
+    via the fast-path log_action (e.g. notification dispatch).
+    """
+    if exclude_triggers is None:
+        exclude_triggers = ["heartbeat", "notification"]
+    with _lock:
+        conn = get_connection()
+        try:
+            placeholders = ",".join("?" for _ in exclude_triggers) if exclude_triggers else ""
+            where = f"WHERE trigger NOT IN ({placeholders})" if placeholders else ""
+            cur = conn.execute(
+                f"""SELECT id, timestamp, device, action, params, result, error_msg, trigger,
+                           slot_kind, agile_price_at_time, started_at, completed_at, duration_ms, actor
+                    FROM action_log
+                    {where}
+                    ORDER BY timestamp DESC
+                    LIMIT ?""",
+                (*exclude_triggers, int(limit)),
+            )
+            return [dict(r) for r in cur.fetchall()]
         finally:
             conn.close()
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -510,6 +510,7 @@ def build_mcp() -> FastMCP:
         ),
     )
     def set_inverter_mode(mode: str) -> dict[str, Any]:
+        from . import db as _db
         if config.OPENCLAW_READ_ONLY:
             safeguards.audit_log(FOXESS_MODE_ACTION, {"mode": mode}, "mcp", False, _write_blocked_message())
             return {"ok": False, "error": _write_blocked_message()}
@@ -524,9 +525,16 @@ def build_mcp() -> FastMCP:
                 "ok": False,
                 "error": f"Rate limited. Try again in {wait_time:.1f} seconds.",
             }
+        # log_action_timed captures started_at + completed_at + duration_ms
+        # regardless of success or failure, so the cockpit's recent-triggers
+        # strip can show "set_inverter_mode ran 1.2s ago, took 340ms, OK".
         try:
-            client = _foxess_client()
-            client.set_work_mode(mode)
+            with _db.log_action_timed(
+                device="foxess", action="set_work_mode",
+                params={"mode": mode}, trigger="mcp", actor="mcp",
+            ):
+                client = _foxess_client()
+                client.set_work_mode(mode)
         except ValueError as e:
             return {"ok": False, "error": str(e)}
         except FoxESSError as e:
@@ -701,6 +709,7 @@ def build_mcp() -> FastMCP:
         description="Set DHW tank target temperature (30–65°C) where supported. Pass confirmed=True to override a pending plan.",
     )
     def set_daikin_tank_temperature(temperature: float, confirmed: bool = False) -> dict[str, Any]:
+        from . import db as _db
         params = {"temperature": temperature}
         blocked = _daikin_write_preamble(DAIKIN_TANK_TEMP_ACTION, params)
         if blocked is not None:
@@ -712,8 +721,12 @@ def build_mcp() -> FastMCP:
         if conflict_warn and not confirmed:
             return {"ok": False, "requires_confirmation": True, "warning": conflict_warn}
         try:
-            from .daikin import service as _daikin_svc
-            _daikin_svc.set_tank_temperature(temperature, actor="mcp")
+            with _db.log_action_timed(
+                device="daikin", action="set_tank_temperature",
+                params=params, trigger="mcp", actor="mcp",
+            ):
+                from .daikin import service as _daikin_svc
+                _daikin_svc.set_tank_temperature(temperature, actor="mcp")
         except FileNotFoundError as e:
             return {"ok": False, "error": f"Daikin not configured: {e}"}
         except ValueError as e:
@@ -902,9 +915,20 @@ def build_mcp() -> FastMCP:
         except Exception:
             pass
 
+        # Wrap the background solve in log_action_timed so the cockpit's
+        # recent-triggers strip can show "propose_optimization_plan ran N
+        # seconds ago, took X ms, OK/failure" — the solve is async-ish
+        # (thread pool) but the context manager still captures start/end
+        # because it lives inside the worker thread.
         def _run_bg() -> None:
+            from . import db as _db
             try:
-                run_optimizer(fox, None)
+                with _db.log_action_timed(
+                    device="system", action="propose_optimization_plan",
+                    params={"plan_date": plan_date, "plan_id": plan_id},
+                    trigger="mcp", actor="mcp",
+                ):
+                    run_optimizer(fox, None)
             except Exception as exc:
                 logger.warning("Background optimizer error: %s", exc)
 
@@ -941,6 +965,7 @@ def build_mcp() -> FastMCP:
     )
     def approve_optimization_plan(plan_id: str) -> dict[str, Any]:
         from . import db
+        from .notifier import notify_action_confirmation
         ok = db.approve_plan(plan_id)
         if not ok:
             row = db.get_plan_consent(plan_id.replace("lp-", ""))
@@ -956,6 +981,12 @@ def build_mcp() -> FastMCP:
                 "plan_id": plan_id,
                 "message": "Plan not found or not in pending_approval state.",
             }
+        # Mirrors confirm_plan: user approvals should fire a hook so the
+        # cockpit/OpenClaw side sees a confirmation, not just silent state.
+        try:
+            notify_action_confirmation(f"Plan {plan_id} approved — Daikin execution active.")
+        except Exception:
+            pass
         return {
             "ok": True,
             "plan_id": plan_id,
@@ -972,6 +1003,7 @@ def build_mcp() -> FastMCP:
     )
     def reject_optimization_plan(plan_id: str, reason: str | None = None) -> dict[str, Any]:
         from . import db
+        from .notifier import notify_action_confirmation
         ok = db.reject_plan(plan_id)
         if not ok:
             return {
@@ -979,6 +1011,12 @@ def build_mcp() -> FastMCP:
                 "plan_id": plan_id,
                 "message": "Plan not found or not in pending_approval state.",
             }
+        try:
+            notify_action_confirmation(
+                f"Plan {plan_id} rejected{f' — {reason}' if reason else ''}. Schedule cleared."
+            )
+        except Exception:
+            pass
         return {
             "ok": True,
             "plan_id": plan_id,
@@ -2214,6 +2252,25 @@ def build_mcp() -> FastMCP:
             finally:
                 conn.close()
             return {"ok": True, "rows": rows}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+    @mcp.tool(
+        name="get_recent_triggers",
+        description=(
+            "Recent manual/scheduler action_log rows (newest first) with "
+            "when-fired + duration-ms + actor + result. Same data the "
+            "cockpit's recent-triggers strip shows. Filters out heartbeat "
+            "+ notification noise by default; set include_heartbeat=true "
+            "to see everything."
+        ),
+    )
+    def get_recent_triggers(limit: int = 20, include_heartbeat: bool = False) -> dict[str, Any]:
+        from . import db
+        try:
+            exclude = ["notification"] if include_heartbeat else ["heartbeat", "notification"]
+            rows = db.get_recent_triggers(limit=int(limit), exclude_triggers=exclude)
+            return {"ok": True, "rows": rows, "count": len(rows)}
         except Exception as e:
             return {"ok": False, "error": str(e)}
 

--- a/tests/test_action_log_duration.py
+++ b/tests/test_action_log_duration.py
@@ -1,0 +1,146 @@
+"""PR B — action_log duration tracking + recent-triggers endpoint.
+
+The user asked for "manual triggers in the cockpit — when fired, how long
+it took". This file covers the plumbing:
+
+* log_action_timed() captures started_at + completed_at + duration_ms for
+  both success and failure paths.
+* get_recent_triggers() filters out heartbeat + notification noise by
+  default so the cockpit sees meaningful events.
+* /api/v1/recent-triggers wraps it for the browser.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.api.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+    # Start each test with an empty action_log so counts + filters are deterministic.
+    conn = db.get_connection()
+    try:
+        conn.execute("DELETE FROM action_log")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# log_action_timed
+# ---------------------------------------------------------------------------
+
+def test_log_action_timed_captures_success_duration():
+    with db.log_action_timed(
+        device="test", action="sample", params={"n": 1},
+        trigger="mcp", actor="test",
+    ):
+        time.sleep(0.03)
+
+    rows = db.get_recent_triggers(limit=5, exclude_triggers=[])
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["device"] == "test"
+    assert r["action"] == "sample"
+    assert r["result"] == "success"
+    assert r["actor"] == "test"
+    assert r["started_at"] is not None
+    assert r["completed_at"] is not None
+    assert r["duration_ms"] is not None
+    # 30ms ± 50ms slack for slow CI.
+    assert 20 <= r["duration_ms"] <= 200, f"duration_ms={r['duration_ms']} outside expected band"
+
+
+def test_log_action_timed_writes_row_on_failure_and_reraises():
+    with pytest.raises(ValueError, match="boom"):
+        with db.log_action_timed(
+            device="test", action="fails", params={}, trigger="mcp", actor="test",
+        ):
+            raise ValueError("boom")
+
+    rows = db.get_recent_triggers(limit=5, exclude_triggers=[])
+    assert len(rows) == 1
+    assert rows[0]["result"] == "failure"
+    assert "boom" in (rows[0]["error_msg"] or "")
+    assert rows[0]["duration_ms"] is not None
+
+
+def test_log_action_legacy_path_leaves_new_columns_null():
+    db.log_action(
+        device="system", action="heartbeat_tick", params={},
+        result="success", trigger="heartbeat",
+    )
+    rows = db.get_recent_triggers(limit=5, exclude_triggers=[])
+    # Heartbeat filtered out by default — pass exclude_triggers=[] above.
+    assert len(rows) == 1
+    assert rows[0]["started_at"] is None
+    assert rows[0]["completed_at"] is None
+    assert rows[0]["duration_ms"] is None
+    assert rows[0]["actor"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_recent_triggers filtering
+# ---------------------------------------------------------------------------
+
+def test_get_recent_triggers_hides_heartbeat_and_notification_by_default():
+    db.log_action(device="system", action="heartbeat_tick", params={}, result="success", trigger="heartbeat")
+    db.log_action(device="system", action="plan_proposed", params={}, result="success", trigger="notification")
+    db.log_action(device="foxess", action="set_work_mode", params={"mode": "Self Use"},
+                  result="success", trigger="mcp", actor="mcp")
+
+    rows = db.get_recent_triggers(limit=10)
+    # Only the foxess row survives the default filter.
+    assert len(rows) == 1
+    assert rows[0]["device"] == "foxess"
+
+
+def test_get_recent_triggers_custom_exclude():
+    db.log_action(device="foxess", action="set_work_mode", params={}, result="success", trigger="mcp")
+    db.log_action(device="system", action="mpc_tick", params={}, result="success", trigger="scheduler")
+
+    only_mcp = db.get_recent_triggers(limit=10, exclude_triggers=["heartbeat", "notification", "scheduler"])
+    assert len(only_mcp) == 1
+    assert only_mcp[0]["device"] == "foxess"
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/recent-triggers endpoint
+# ---------------------------------------------------------------------------
+
+def test_recent_triggers_endpoint_returns_ok_shape(client):
+    with db.log_action_timed(
+        device="daikin", action="set_tank_temperature",
+        params={"temperature": 48}, trigger="mcp", actor="mcp",
+    ):
+        pass
+
+    r = client.get("/api/v1/recent-triggers?limit=5")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 1
+    assert body["rows"][0]["action"] == "set_tank_temperature"
+    assert body["rows"][0]["actor"] == "mcp"
+    assert body["rows"][0]["duration_ms"] is not None
+
+
+def test_recent_triggers_endpoint_include_heartbeat_param(client):
+    db.log_action(device="system", action="heartbeat_tick", params={},
+                  result="success", trigger="heartbeat")
+    # Default: excluded.
+    default_body = client.get("/api/v1/recent-triggers").json()
+    assert all(r["trigger"] != "heartbeat" for r in default_body["rows"])
+    # Opt-in: included.
+    included = client.get("/api/v1/recent-triggers?include_heartbeat=true").json()
+    assert any(r["trigger"] == "heartbeat" for r in included["rows"])

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -52,6 +52,10 @@ class TestMCPServerFoxTools(unittest.IsolatedAsyncioTestCase):
         self.assertIn("OPENCLAW_READ_ONLY", out["error"])
 
     async def test_set_inverter_mode_success(self) -> None:
+        # Ensure action_log exists — PR B wrapped set_inverter_mode in
+        # log_action_timed() which writes a row on success/failure.
+        from src import db as _db
+        _db.init_db()
         mcp = build_mcp()
         mock_client = MagicMock()
         with patch("src.mcp_server.config") as cfg, patch(


### PR DESCRIPTION
## Summary
Closes the visibility gap around manual + scheduler triggers: when they fired, how long they took, who fired them, whether they succeeded. Lands as a schema migration, a reusable context manager, instrumented MCP writers, plan-approval hooks, a new endpoint + MCP tool, and a cockpit UI strip.

## Schema (V12 — additive, nullable)

```sql
ALTER TABLE action_log ADD started_at TEXT;
ALTER TABLE action_log ADD completed_at TEXT;
ALTER TABLE action_log ADD duration_ms INTEGER;
ALTER TABLE action_log ADD actor TEXT;
```

Existing rows + the fast-path `log_action()` path stay wire-compatible (new cols are NULL for non-timed writes).

## The helper

```python
with db.log_action_timed(
    device="foxess", action="set_work_mode",
    params={"mode": "Self Use"}, trigger="mcp", actor="mcp",
):
    client.set_work_mode("Self Use")
```

Writes **one** row on exit with `started_at` + `completed_at` + `duration_ms` + `result='success'|'failure'`. Failure path still writes + captures `error_msg` before re-raising — duration tracking covers errors too.

## Instrumented writers (pattern established, extend as needed)

| Tool | Actor | Captures |
|---|---|---|
| `set_inverter_mode` | `mcp` | timing + success/failure |
| `set_daikin_tank_temperature` | `mcp` | timing + success/failure |
| `propose_optimization_plan` (bg thread) | `mcp` | full solve duration |

Other hardware writers still use the fast-path `safeguards.audit_log()` — converting them is a one-line diff per tool.

## Plan-approval hooks closed

`approve_optimization_plan` + `reject_optimization_plan` aliases now fire `notify_action_confirmation` (mirrors the existing `confirm_plan` / `reject_plan` path). Previously only the initial `PLAN_PROPOSED` alert fired; users approving/rejecting got no hook.

## New surface

- `GET /api/v1/recent-triggers?limit=20&include_heartbeat=false` — last N filtered rows. Default excludes `heartbeat` + `notification` noise.
- MCP tool `get_recent_triggers` mirrors it so LLM clients see the same data.
- **Cockpit: "Recent" strip at the bottom of the NOW hero** showing last 6 triggers as pills: action + when-fired-relative + duration + actor, with red-tinted failure styling. A `MutationObserver` on `body.is-busy` auto-refreshes the strip after any `wrapAction()` flow so user-fired writes appear within a second.

## Test plan
- [x] `pytest tests/ -x -q --ignore=tests/integration` — 438 passed, 1 skipped (+7 new)
- [x] Duration captured within 20–200ms for a 30ms sleep (CI-safe band)
- [x] Failure path writes + reraises + persists error_msg
- [x] Legacy fast-path rows leave new cols NULL (no regression)
- [x] Default filter hides heartbeat + notification
- [x] `include_heartbeat=true` opt-in param exposes the noisy rows
- [ ] After deploy: fire "Re-plan" → cockpit strip shows "propose_optimization_plan · Xs ago · Yms · mcp" within ~1s
- [ ] After deploy: MCP tool `get_recent_triggers` returns the same rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)