### PR TITLE
feat(scheduler): drop trivial SelfUse groups from Fox V3 payload

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -420,6 +420,14 @@ class Config:
     REPLAN_SAFETY_MARGIN_MINUTES: int = int(os.getenv("REPLAN_SAFETY_MARGIN_MINUTES", "15"))
     DYNAMIC_REPLAN_MIN_LEAD_MINUTES: int = int(os.getenv("DYNAMIC_REPLAN_MIN_LEAD_MINUTES", "120"))
 
+    # Drop trivial SelfUse groups (work_mode=SelfUse AND min_soc_on_grid=MIN_SOC_RESERVE_PERCENT)
+    # before uploading to the Fox scheduler. The inverter's "Remaining Time Work Mode" is
+    # Self-use (confirmed in Fox app screen), so any time window with no scheduler group
+    # naturally falls back to that — sending an explicit SelfUse group with the global floor
+    # is wasted budget against the 8-group hardware cap. Setting this False reverts to the
+    # original behaviour (every LP window becomes a Fox group, including SelfUse gaps).
+    FOX_SKIP_TRIVIAL_SELFUSE_GROUPS: bool = os.getenv("FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", "true").lower() in ("1", "true", "yes")
+
     @property
     def DAIKIN_COP_CURVE(self) -> list[tuple[float, float]]:
         return parse_cop_curve_csv(self.DAIKIN_COP_CURVE_STR)

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -422,6 +422,25 @@ def _merge_fox_groups(
     # is minimised before any compression decisions.
     merged = _coarse_merge_fox(merged)
 
+    # Camada 0: drop trivial SelfUse windows (work_mode=SelfUse AND
+    # min_soc_on_grid == MIN_SOC_RESERVE_PERCENT). The Fox V3 firmware falls
+    # back to the inverter's "Remaining Time Work Mode" (Self-use) outside
+    # any scheduler group, with the global minSocOnGrid floor — so an explicit
+    # group with the same parameters is wasted budget against the 8-group cap.
+    # Solar-charge holds (SelfUse minSoc=100) and any other elevated floor are
+    # preserved because they DO deviate from the global default.
+    if config.FOX_SKIP_TRIVIAL_SELFUSE_GROUPS:
+        reserve = int(config.MIN_SOC_RESERVE_PERCENT)
+        filtered = [
+            w for w in merged
+            if not (w[2][0] == "SelfUse" and w[2][3] == reserve)
+        ]
+        # Defensive: a fully-trivial plan (no FC/FD/Backup/elevated SelfUse) would
+        # produce an empty payload, which the Fox firmware may reject. Keep the
+        # first window so the upload stays well-formed; the loss is bounded at
+        # one wasted slot in that very rare degenerate case.
+        merged = filtered if filtered else merged[:1]
+
     replan_at: datetime | None = None
     if truncate_horizon and (
         len(merged) + _count_midnight_crossings(merged, tz) > max_groups

--- a/tests/test_fox_groups_overflow.py
+++ b/tests/test_fox_groups_overflow.py
@@ -1,9 +1,11 @@
-"""Fox V3 8-group cap: eager SelfUse merge, dynamic-replan truncation, and
-back-bias compression fallback with peak_export protection.
+"""Fox V3 8-group cap: eager SelfUse merge, trivial-SelfUse drop, dynamic-replan
+truncation, and back-bias compression fallback with peak_export protection.
 
-Regression guards for the 2026-04-24 incident where the legacy compressor
-squashed ``merged[0]/merged[1]`` (sacrificing the immediate future) when the LP
-plan exceeded the inverter's 8-group hardware cap.
+Regression guards for the 2026-04-24 incidents where the legacy compressor
+squashed ``merged[0]/merged[1]`` (sacrificing the immediate future) and the
+upload payload spent half its 8-slot budget on SelfUse-with-default-floor gaps
+that the firmware naturally falls back to anyway (Fox app: "Remaining Time
+Work Mode: Self-use").
 """
 from __future__ import annotations
 
@@ -82,11 +84,17 @@ def _alternating_overflow_slots(base: datetime, count: int) -> list[HalfHourSlot
     return out
 
 
-def test_truncate_horizon_returns_first_8_windows_and_replan_at() -> None:
+def test_truncate_horizon_returns_first_8_windows_and_replan_at(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """When truncate_horizon=True and >8 distinct windows result, dispatch keeps
     only the first 8 windows (preserving the immediate future) and reports the
     end-time of the 8th as replan_at_utc.
+
+    Filter disabled so the alternating SelfUse/FC pattern produces a real
+    overflow scenario (otherwise the SelfUse halves get dropped pre-truncation).
     """
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", False)
     base = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)  # noon UTC, no midnight cross
     base_noon = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
     slots = _alternating_overflow_slots(base_noon, 9)  # 9 distinct windows
@@ -100,8 +108,11 @@ def test_truncate_horizon_returns_first_8_windows_and_replan_at() -> None:
     assert replan_at == base_noon + timedelta(minutes=30 * 8)
 
 
-def test_truncate_horizon_no_truncation_returns_replan_none() -> None:
+def test_truncate_horizon_no_truncation_returns_replan_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """When the input fits in 8 windows, no truncation happens and replan_at is None."""
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", False)
     base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
     slots = _alternating_overflow_slots(base, 4)  # 4 windows, well under cap
     result = _merge_fox_groups(slots, max_groups=8, truncate_horizon=True)
@@ -113,11 +124,16 @@ def test_truncate_horizon_no_truncation_returns_replan_none() -> None:
 # --- Camada 3: compression fallback (back-bias + peak guard) -------------
 
 
-def test_compression_fallback_back_bias_preserves_morning_window() -> None:
+def test_compression_fallback_back_bias_preserves_morning_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """When truncate_horizon=False (legacy path) and >8 windows, the back-bias
     compressor must squash from the tail. The first ForceCharge window
     (the critical near-future) survives intact.
+
+    Filter off so the SelfUse halves remain and we exercise the real overflow.
     """
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", False)
     base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
     slots = _alternating_overflow_slots(base, 9)
     groups = _merge_fox_groups(slots, max_groups=8)
@@ -135,10 +151,15 @@ def test_compression_fallback_back_bias_preserves_morning_window() -> None:
     )
 
 
-def test_compression_fallback_peak_guard_protects_force_discharge() -> None:
+def test_compression_fallback_peak_guard_protects_force_discharge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A ForceDischarge (peak_export) window late in the day must NOT be the
     victim of the brutal squash even though tail-bias would normally pick it.
+
+    Filter off so the SelfUse halves remain and we exercise the cap pressure.
     """
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", False)
     base = datetime(2026, 6, 1, 6, 0, tzinfo=UTC)  # all-daylight summer, no midnight cross
     # Build 9 picotated windows: 7 alternating standard/cheap, then peak_export
     # near the tail, then a final standard to ensure peak_export is in the
@@ -165,6 +186,153 @@ def test_compression_fallback_peak_guard_protects_force_discharge() -> None:
     assert "ForceDischarge" in modes, (
         f"peak_export ForceDischarge group was squashed; got modes={modes}"
     )
+
+
+# --- Camada 0: trivial SelfUse drop ---------------------------------------
+
+
+def _trivial_selfuse_slot(start_utc: datetime, *, minutes: int = 30) -> HalfHourSlot:
+    """A 'standard' kind → SelfUse with minSoc=MIN_SOC_RESERVE_PERCENT (the global)."""
+    return _slot(start_utc, kind="standard", minutes=minutes)
+
+
+def _force_charge_slot(start_utc: datetime) -> HalfHourSlot:
+    return _slot(
+        start_utc,
+        kind="cheap",
+        lp_grid_import_w=2000,
+        target_soc_pct=80,
+    )
+
+
+def test_trivial_selfuse_groups_are_filtered_when_flag_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reproduce the 2026-04-24 incident shape: 4 trivial SelfUse gaps interleaved
+    with 4 ForceCharge windows. After the filter, only the 4 FCs remain — the
+    inverter's "Remaining Time Work Mode: Self-use" handles the gaps for free.
+    """
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", True)
+    base = datetime(2026, 6, 1, 8, 0, tzinfo=UTC)  # all daylight, no midnight cross
+    slots: list[HalfHourSlot] = []
+    for i in range(8):
+        if i % 2 == 0:
+            slots.append(_trivial_selfuse_slot(base + timedelta(minutes=30 * i)))
+        else:
+            slots.append(_force_charge_slot(base + timedelta(minutes=30 * i)))
+    groups = _merge_fox_groups(slots, max_groups=8)
+    modes = [g.work_mode for g in groups]
+    assert all(m == "ForceCharge" for m in modes), (
+        f"trivial SelfUse should be filtered out; got modes={modes}"
+    )
+    # 4 ForceCharge windows survive (one per even/odd boundary in the input).
+    assert len(groups) == 4
+
+
+def test_solar_charge_selfuse_with_elevated_min_soc_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A solar_charge slot maps to SelfUse minSoc=100 — not the global default —
+    so the filter must KEEP it. Otherwise the battery wouldn't be held at 100%
+    during PV-stockpile windows.
+    """
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", True)
+    base = datetime(2026, 6, 1, 8, 0, tzinfo=UTC)
+    slots = [
+        _trivial_selfuse_slot(base),
+        _slot(base + timedelta(minutes=30), kind="solar_charge"),
+        _trivial_selfuse_slot(base + timedelta(hours=1)),
+    ]
+    groups = _merge_fox_groups(slots, max_groups=8)
+    # Trivial SelfUse stripped on both sides; only the elevated-floor SelfUse remains.
+    assert len(groups) == 1
+    assert groups[0].work_mode == "SelfUse"
+    assert groups[0].min_soc_on_grid == int(
+        getattr(app_config, "FOX_SOLAR_CHARGE_MIN_SOC_PERCENT", 100)
+    )
+
+
+def test_filter_disabled_keeps_legacy_behaviour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the flag off, every LP window becomes a Fox group (subject to the
+    standard merge / cap logic). Provides instant rollback if the firmware
+    misbehaves with sparse schedules."""
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", False)
+    base = datetime(2026, 6, 1, 8, 0, tzinfo=UTC)
+    slots = [
+        _trivial_selfuse_slot(base),
+        _force_charge_slot(base + timedelta(minutes=30)),
+        _trivial_selfuse_slot(base + timedelta(hours=1)),
+    ]
+    groups = _merge_fox_groups(slots, max_groups=8)
+    modes = [g.work_mode for g in groups]
+    assert "SelfUse" in modes  # trivial gaps preserved when flag off
+    assert "ForceCharge" in modes
+
+
+def test_filter_keeps_at_least_one_group_when_plan_is_all_trivial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Degenerate edge: an LP plan of nothing but trivial SelfUse windows. The
+    filter would empty the payload and the firmware may reject an empty groups
+    array — defensive fallback keeps the first window."""
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", True)
+    base = datetime(2026, 6, 1, 8, 0, tzinfo=UTC)
+    slots = [_trivial_selfuse_slot(base + timedelta(minutes=30 * i)) for i in range(4)]
+    groups = _merge_fox_groups(slots, max_groups=8)
+    # Initial scan + eager merge collapse all 4 into 1 SelfUse window; filter
+    # would normally drop it, but the defensive fallback keeps it. Expected: 1.
+    assert len(groups) == 1
+    assert groups[0].work_mode == "SelfUse"
+
+
+def test_real_incident_eight_groups_collapse_to_three_with_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replay the 2026-04-24 23:25 UTC payload shape on disk:
+        SU 23:30-23:59 | SU 00:00-03:30 | FC 03:30-04:59 | SU 05:00-11:30
+        FC 11:30-11:59 | SU 12:00-12:30 | FC 12:30-12:59 | SU 13:00-13:30
+    Without the filter the LP truncated at 13:30 (PR #141 dynamic replan) —
+    losing the 13:30 and 15:30 ForceCharges the LP had planned. With the filter,
+    the SelfUse gaps disappear, only 3 useful groups remain, and the would-be-
+    truncated tail fits comfortably under the 8-group cap.
+    """
+    monkeypatch.setattr(app_config, "FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", True)
+    base = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)  # noon-ish, no midnight cross for clarity
+    # Build the conceptual shape: trivial gap | FC | trivial gap | FC | trivial gap | FC
+    slots: list[HalfHourSlot] = []
+    cursor = base
+    # Gap 1
+    for _ in range(2):
+        slots.append(_trivial_selfuse_slot(cursor)); cursor += timedelta(minutes=30)
+    # FC 1
+    for _ in range(3):
+        slots.append(_force_charge_slot(cursor)); cursor += timedelta(minutes=30)
+    # Gap 2
+    for _ in range(4):
+        slots.append(_trivial_selfuse_slot(cursor)); cursor += timedelta(minutes=30)
+    # FC 2
+    for _ in range(1):
+        slots.append(_force_charge_slot(cursor)); cursor += timedelta(minutes=30)
+    # Gap 3
+    for _ in range(1):
+        slots.append(_trivial_selfuse_slot(cursor)); cursor += timedelta(minutes=30)
+    # FC 3
+    for _ in range(1):
+        slots.append(_force_charge_slot(cursor)); cursor += timedelta(minutes=30)
+    # Tail trivial gap (would have been truncated)
+    for _ in range(2):
+        slots.append(_trivial_selfuse_slot(cursor)); cursor += timedelta(minutes=30)
+
+    result = _merge_fox_groups(slots, max_groups=8, truncate_horizon=True)
+    groups, replan_at = result
+    modes = [g.work_mode for g in groups]
+    assert modes == ["ForceCharge", "ForceCharge", "ForceCharge"], (
+        f"expected exactly 3 ForceCharge groups after filter, got {modes}"
+    )
+    # No truncation needed — the filter already kept us well under the cap.
+    assert replan_at is None
 
 
 def test_compression_fallback_degenerate_all_force_discharge_does_not_crash() -> None:


### PR DESCRIPTION
## Summary

The Fox V3 firmware falls back to the inverter's **"Remaining Time Work Mode" (Self-use)** whenever no scheduler group covers the current time — confirmed both in the Fox app screen and via the live battery behaviour during gaps tonight (battery covering load, zero grid, no charge). So any group with `work_mode=SelfUse` and `min_soc_on_grid=MIN_SOC_RESERVE_PERCENT` is wasted budget against the 8-group hardware cap.

**Real incident on 2026-04-24** (just hours after PR #141 merged): the LP plan emitted exactly 8 groups, **4 of which were trivial SelfUse gaps** interleaved with 4 useful ForceCharges:

```
1. 23:30-23:59 SelfUse  minSoc=15  ← waste
2. 00:00-03:30 SelfUse  minSoc=15  ← waste
3. 03:30-04:59 ForceCharge fdSoc=36 fdPwr=2100  ✓
4. 05:00-11:30 SelfUse  minSoc=15  ← waste
5. 11:30-11:59 ForceCharge fdSoc=36 fdPwr=3300  ✓
6. 12:00-12:30 SelfUse  minSoc=15  ← waste
7. 12:30-12:59 ForceCharge fdSoc=39 fdPwr=3050  ✓
8. 13:00-13:30 SelfUse  minSoc=15  ← waste
```

The dynamic-replan path from PR #141 was forced to truncate at 13:30, dropping the 13:30 and 15:30 ForceCharges the LP had planned. Half the budget was air comprimido.

## Fix

Filter trivial SelfUse windows from the merged set **after Layer 1 eager merge and before truncation/compression** — so the filter reduces the count first and the cap pressure may disappear entirely. With this PR, the same 8-window incident shape collapses to **3 useful groups** and no truncation is needed.

**Preserves**:
- ForceCharge / ForceDischarge / Backup (any non-SelfUse mode)
- SelfUse with elevated `min_soc_on_grid` (e.g. `solar_charge` holding 100%)

**Defensive**: if filtering would produce an empty payload (very rare all-trivial plan), keep one window so the firmware never sees an empty `groups` array.

**Rollback**: gated by `FOX_SKIP_TRIVIAL_SELFUSE_GROUPS` env (default `true`). Flip to `false` and restart for instant revert.

## Changes

| File | What |
|---|---|
| `src/scheduler/optimizer.py` | New "Camada 0" filter inside `_merge_fox_groups`, applied after eager merge and before truncation. |
| `src/config.py` | New `FOX_SKIP_TRIVIAL_SELFUSE_GROUPS` env knob (default true). |
| `tests/test_fox_groups_overflow.py` | 5 new scenarios (filter on, solar_charge preserved, flag-off legacy, all-trivial defensive fallback, real-incident replay → 3 groups). Existing truncation/compression tests now pin the flag off to keep exercising their input shapes. |

## Test plan

- [x] `pytest tests/test_fox_groups_overflow.py` — 11/11 green (5 new + 6 existing).
- [x] `pytest --ignore=tests/test_lp_optimizer.py` — 438/438 green.
- [ ] After deploy: watch the next LP run. Expected: groups payload contains only useful (FC/FD/Backup/elevated-SelfUse) windows. The truncation path from PR #141 should no longer trigger on most plans.
- [ ] Sanity: confirm via Fox app that gap-time behaviour remains "Self-use" (it always was — we just stopped restating it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)