### PR TITLE
fix(lp): terminal SoC floor runtime-tunable, defaults to 25% capacity (#147)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -393,9 +393,10 @@ class Config:
     LP_SHOWER_MORNING_LOCAL: str = (os.getenv("LP_SHOWER_MORNING_LOCAL") or "").strip()
     LP_SHOWER_EVENING_LOCAL: str = (os.getenv("LP_SHOWER_EVENING_LOCAL") or "20:00").strip()
 
-    # Terminal SoC constraint: if > 0 the LP enforces SoC ≥ this value at the end of the horizon.
-    # 0 = soft terminal cost only (legacy behaviour). Typical: 20–30% of BATTERY_CAPACITY_KWH.
-    LP_SOC_FINAL_KWH: float = float(os.getenv("LP_SOC_FINAL_KWH", "0"))
+    # Terminal SoC constraint: now runtime-tunable via /api/v1/settings — see @property below.
+    # Default = 25% of BATTERY_CAPACITY_KWH so each LP run honours an anti-myopia floor at
+    # the end of its 24h rolling horizon. Without this, individual LP runs may plan to drain
+    # the battery near the boundary, executing those decisions before the next MPC corrects.
 
     # Model Predictive Control: re-run the LP intra-day with refreshed SoC / tank / forecasts.
     # LP_MPC_HOURS is runtime-tunable via /api/v1/settings (#52); cron jobs are
@@ -501,6 +502,14 @@ class Config:
     @DAIKIN_CONTROL_MODE.setter
     def DAIKIN_CONTROL_MODE(self, value: str) -> None:
         self._rt_set("DAIKIN_CONTROL_MODE", str(value).strip().lower())
+
+    @property
+    def LP_SOC_FINAL_KWH(self) -> float:
+        return float(self._rt_get("LP_SOC_FINAL_KWH"))
+
+    @LP_SOC_FINAL_KWH.setter
+    def LP_SOC_FINAL_KWH(self, value: float) -> None:
+        self._rt_set("LP_SOC_FINAL_KWH", float(value))
 
     @property
     def LP_PLAN_PUSH_HOUR(self) -> int:

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -73,6 +73,15 @@ def _int_list_env(name: str, default: str) -> Callable[[], list[int]]:
     return _load
 
 
+def _lp_soc_final_kwh_default() -> float:
+    """LP terminal SoC floor: explicit env override wins; otherwise 25 % of BATTERY_CAPACITY_KWH."""
+    env = os.getenv("LP_SOC_FINAL_KWH")
+    if env is not None and env.strip() != "":
+        return float(env)
+    cap = float(os.getenv("BATTERY_CAPACITY_KWH", "10"))
+    return round(cap * 0.25, 2)
+
+
 SCHEMA: dict[str, SettingSpec] = {
     # DHW comfort knobs — user-tunable per season / presence.
     "DHW_TEMP_COMFORT_C": SettingSpec(
@@ -160,6 +169,23 @@ SCHEMA: dict[str, SettingSpec] = {
         env_default=_int_list_env("LP_MPC_HOURS", "6,12,21"),
         cron_reload=True,
         description="Local hours at which the MPC re-solves the LP (e.g. [6,12,21]).",
+    ),
+    # Terminal SoC floor — anti-myopia. Each LP run must end its 24h horizon with
+    # SoC ≥ this value (kWh). Without it, individual runs may plan to drain the
+    # battery near the boundary before the next MPC corrects. Default = 25 % of
+    # BATTERY_CAPACITY_KWH so it scales with the installed battery.
+    "LP_SOC_FINAL_KWH": SettingSpec(
+        key="LP_SOC_FINAL_KWH",
+        type_name="float",
+        env_default=_lp_soc_final_kwh_default,
+        min_value=0.0,
+        max_value=50.0,  # generous upper bound (any battery 200 kWh stays safe)
+        description=(
+            "Hard SoC floor (kWh) the LP must hit at the end of its 24h horizon. "
+            "Anti-myopia constraint that prevents end-of-window battery drains. "
+            "0 = disabled (legacy soft-cost-only behaviour). Default = 25 % of "
+            "BATTERY_CAPACITY_KWH."
+        ),
     ),
 }
 

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -191,6 +191,38 @@ def test_cron_reload_reregisters_jobs_when_active(monkeypatch):
     assert any(j.id == "bulletproof_octopus_fetch" for j in fake.get_jobs())
 
 
+def test_lp_soc_final_kwh_default_scales_with_battery_capacity(monkeypatch):
+    """Default = 25 % of BATTERY_CAPACITY_KWH when no explicit override is set."""
+    import src.runtime_settings as rts
+    from src.config import config
+
+    # Clear any in-memory override and any DB row so we exercise the env_default path.
+    monkeypatch.setattr(config, "_overrides", {}, raising=False)
+    rts.delete_setting("LP_SOC_FINAL_KWH")
+    monkeypatch.delenv("LP_SOC_FINAL_KWH", raising=False)
+    monkeypatch.setenv("BATTERY_CAPACITY_KWH", "12")
+    rts._cache.pop("LP_SOC_FINAL_KWH", None)
+
+    assert rts.get_setting("LP_SOC_FINAL_KWH") == 3.0  # 25 % of 12 = 3.0
+
+    # Explicit env override beats the percentage default.
+    monkeypatch.setenv("LP_SOC_FINAL_KWH", "1.5")
+    rts._cache.pop("LP_SOC_FINAL_KWH", None)
+    assert rts.get_setting("LP_SOC_FINAL_KWH") == 1.5
+
+
+def test_lp_soc_final_kwh_runtime_tunable_round_trip(monkeypatch):
+    """PUT via runtime_settings persists; config.LP_SOC_FINAL_KWH reads it back."""
+    import src.runtime_settings as rts
+    from src.config import config
+
+    monkeypatch.setattr(config, "_overrides", {}, raising=False)
+    rts.set_setting("LP_SOC_FINAL_KWH", 4.2)
+    assert config.LP_SOC_FINAL_KWH == 4.2
+    # cleanup so other tests don't see the override
+    rts.delete_setting("LP_SOC_FINAL_KWH")
+
+
 def test_cron_reload_is_noop_when_scheduler_inactive(monkeypatch):
     from src.scheduler import runner
     monkeypatch.setattr(runner, "_background_scheduler", None)


### PR DESCRIPTION
## Summary

Closes #147 (first ship of the Waze MPC stability hardening — Epic #73).

The LP's terminal SoC constraint (`LP_SOC_FINAL_KWH`) defaulted to `0` — pure soft cost, no hard floor — meaning each LP run could plan to drain the battery near its 24 h horizon boundary. The dispatch writes those decisions to the inverter **before** the next MPC corrects, so the inverter may execute a discharge the next plan would have prevented. With the upcoming event-driven re-planning (drift / forecast triggers — Epic #73) we'll have more re-plans throughout the day, each with its own horizon end — multiplies the exposure.

Fix: promote the knob to runtime-tunable, default to 25 % of `BATTERY_CAPACITY_KWH`.

## Changes

| File | What |
|---|---|
| `src/runtime_settings.py` | New `LP_SOC_FINAL_KWH` SettingSpec. `_lp_soc_final_kwh_default()` helper: explicit env wins, else 25 % of `BATTERY_CAPACITY_KWH` (= 2.5 kWh on the standard 10 kWh battery). |
| `src/config.py` | New `@property` + setter mirroring the existing pattern (DAIKIN_CONTROL_MODE, OPTIMIZATION_PRESET, etc). Static `LP_SOC_FINAL_KWH = 0` removed. |
| `tests/test_runtime_settings.py` | Two new tests — percentage default scales with `BATTERY_CAPACITY_KWH`; PUT-then-read round trip. |

`getattr(config, "LP_SOC_FINAL_KWH", 0.0)` consumer in `src/scheduler/lp_optimizer.py:277` keeps working unchanged.

## Test plan

- [x] `pytest tests/test_runtime_settings.py -v` — 18/18 green (16 existing + 2 new).
- [x] `pytest --ignore=tests/test_lp_optimizer.py` — 440/440 green.
- [ ] Post-deploy: confirm via `curl /api/v1/settings` that `LP_SOC_FINAL_KWH` is listed with default `2.5` (Hetzner has 10 kWh battery).
- [ ] Post-deploy: confirm via `sqlite3` query on `lp_solution_snapshot` that the next LP run's terminal SoC is ≥ 2.5 kWh.

## Rollback

Set `LP_SOC_FINAL_KWH=0` via `PUT /api/v1/settings/LP_SOC_FINAL_KWH` (no restart needed) to revert to legacy soft-cost-only behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)