### PR TITLE
feat(mpc): forecast revision trigger — react to Open-Meteo updates (#144)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -445,6 +445,12 @@ class Config:
     # Plan-delta observability: how many hours of overlap between previous and new plan to
     # measure when logging the post-trigger delta. 6 h captures the immediate horizon.
     MPC_PLAN_DELTA_LOOKAHEAD_HOURS: int = int(os.getenv("MPC_PLAN_DELTA_LOOKAHEAD_HOURS", "6"))
+    # Forecast revision trigger (Open-Meteo updates ~hourly): how often to re-fetch and
+    # compare; how far ahead to compare; what delta is "material enough" to re-plan.
+    # MPC_FORECAST_REFRESH_INTERVAL_MINUTES is runtime-tunable (cron_reload=True) — see @property below.
+    MPC_FORECAST_DRIFT_LOOKAHEAD_HOURS: int = int(os.getenv("MPC_FORECAST_DRIFT_LOOKAHEAD_HOURS", "6"))
+    MPC_FORECAST_DRIFT_SOLAR_KWH_THRESHOLD: float = float(os.getenv("MPC_FORECAST_DRIFT_SOLAR_KWH_THRESHOLD", "2.0"))
+    MPC_FORECAST_DRIFT_TEMP_C_THRESHOLD: float = float(os.getenv("MPC_FORECAST_DRIFT_TEMP_C_THRESHOLD", "2.0"))
 
     @property
     def DAIKIN_COP_CURVE(self) -> list[tuple[float, float]]:
@@ -527,6 +533,14 @@ class Config:
     @LP_SOC_FINAL_KWH.setter
     def LP_SOC_FINAL_KWH(self, value: float) -> None:
         self._rt_set("LP_SOC_FINAL_KWH", float(value))
+
+    @property
+    def MPC_FORECAST_REFRESH_INTERVAL_MINUTES(self) -> int:
+        return int(self._rt_get("MPC_FORECAST_REFRESH_INTERVAL_MINUTES"))
+
+    @MPC_FORECAST_REFRESH_INTERVAL_MINUTES.setter
+    def MPC_FORECAST_REFRESH_INTERVAL_MINUTES(self, value: int) -> None:
+        self._rt_set("MPC_FORECAST_REFRESH_INTERVAL_MINUTES", int(value))
 
     @property
     def LP_PLAN_PUSH_HOUR(self) -> int:

--- a/src/db.py
+++ b/src/db.py
@@ -2651,6 +2651,40 @@ def get_meteo_forecast_at(fetch_at_utc: str) -> list[dict[str, Any]]:
             conn.close()
 
 
+def get_meteo_forecast_history_latest_before(when_utc: str) -> list[dict[str, Any]]:
+    """Return all rows of the most recent forecast fetch strictly before ``when_utc``.
+
+    Used by the Waze MPC forecast-revision trigger (Epic #73 — story #144) to
+    compare a freshly-pulled forecast against the previous version. Returns
+    ``[]`` when no prior fetch exists.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT forecast_fetch_at_utc
+                   FROM meteo_forecast_history
+                   WHERE forecast_fetch_at_utc < ?
+                   ORDER BY forecast_fetch_at_utc DESC
+                   LIMIT 1""",
+                (when_utc,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return []
+            prev_fetch_at = row[0]
+            cur = conn.execute(
+                """SELECT slot_time, temp_c, solar_w_m2
+                   FROM meteo_forecast_history
+                   WHERE forecast_fetch_at_utc = ?
+                   ORDER BY slot_time""",
+                (prev_fetch_at,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
 def log_config_change(
     key: str,
     value: str | None,

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -170,6 +170,20 @@ SCHEMA: dict[str, SettingSpec] = {
         cron_reload=True,
         description="Local hours at which the MPC re-solves the LP (e.g. [6,12,21]).",
     ),
+    "MPC_FORECAST_REFRESH_INTERVAL_MINUTES": SettingSpec(
+        key="MPC_FORECAST_REFRESH_INTERVAL_MINUTES",
+        type_name="int",
+        env_default=_int_env("MPC_FORECAST_REFRESH_INTERVAL_MINUTES", "60"),
+        min_value=10,
+        max_value=720,
+        cron_reload=True,
+        description=(
+            "Interval (minutes) for the Open-Meteo refresh + revision-trigger detector. "
+            "Each tick re-fetches the forecast and fires an MPC re-plan if the next 6h of "
+            "solar/temp diverged materially from the previous fetch. Lower = quicker reaction "
+            "to weather changes; higher = less Open-Meteo traffic."
+        ),
+    ),
     # Terminal SoC floor — anti-myopia. Each LP run must end its 24h horizon with
     # SoC ≥ this value (kWh). Without it, individual runs may plan to drain the
     # battery near the boundary before the next MPC corrects. Default = 25 % of

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -504,6 +504,72 @@ def schedule_dynamic_mpc_replan(replan_at_utc: datetime) -> dict[str, Any]:
     return out
 
 
+def bulletproof_forecast_refresh_job() -> None:
+    """Hourly Open-Meteo forecast refresh + revision-trigger detector (Epic #73 — story #144).
+
+    Pulls the latest forecast, persists in ``meteo_forecast_history`` (audit trail) and
+    ``meteo_forecast`` (latest-per-slot for the LP). Compares the next
+    ``MPC_FORECAST_DRIFT_LOOKAHEAD_HOURS`` against the previous fetch; if either solar
+    or temp delta exceeds threshold, fires ``bulletproof_mpc_job(force_write_devices=True,
+    trigger_reason='forecast_revision')`` to re-plan immediately.
+
+    Skipped (no-op) when the scheduler is paused or the kill switch is off. Always
+    persists the new fetch — even when the kill switch is off, the audit trail
+    (and the LP's source of forecast data) stays current.
+    """
+    if get_scheduler_paused():
+        return
+    try:
+        from .. import db as _db
+        from ..weather import _forecast_delta, fetch_forecast
+
+        lookahead_h = int(config.MPC_FORECAST_DRIFT_LOOKAHEAD_HOURS)
+        # Pull a forecast at least as long as the lookahead window we'll compare on,
+        # but cap reasonable: Open-Meteo gives 48h easily.
+        new_fcst = fetch_forecast(hours=max(lookahead_h, 24))
+        if not new_fcst:
+            logger.debug("forecast refresh: empty fetch, skipping")
+            return
+        now_utc = datetime.now(UTC)
+        new_rows = [
+            {
+                "slot_time": f.time_utc.isoformat(),
+                "temp_c": f.temperature_c,
+                "solar_w_m2": f.shortwave_radiation_wm2,
+            }
+            for f in new_fcst
+        ]
+        prev_rows = _db.get_meteo_forecast_history_latest_before(now_utc.isoformat())
+        # Persist new (always — keeps the LP's source of truth fresh + audit trail).
+        _db.save_meteo_forecast_history(now_utc.isoformat(), new_rows)
+        _db.save_meteo_forecast(new_rows, now_utc.date().isoformat())
+
+        if not config.MPC_EVENT_DRIVEN_ENABLED:
+            logger.debug("forecast refresh persisted; trigger disabled by kill switch")
+            return
+        if not prev_rows:
+            logger.debug("forecast refresh: no previous fetch in history, no comparison")
+            return
+        delta_pv_kwh, delta_temp_c = _forecast_delta(
+            prev_rows, new_rows, lookahead_hours=lookahead_h, horizon_start_utc=now_utc,
+        )
+        pv_thr = float(config.MPC_FORECAST_DRIFT_SOLAR_KWH_THRESHOLD)
+        t_thr = float(config.MPC_FORECAST_DRIFT_TEMP_C_THRESHOLD)
+        if delta_pv_kwh >= pv_thr or delta_temp_c >= t_thr:
+            logger.info(
+                "MPC forecast trigger: ΔPV=%.2f kWh (>=%.1f) ΔT=%.2f°C (>=%.1f) over next %dh",
+                delta_pv_kwh, pv_thr, delta_temp_c, t_thr, lookahead_h,
+            )
+            bulletproof_mpc_job(force_write_devices=True, trigger_reason="forecast_revision")
+        else:
+            logger.debug(
+                "forecast refresh delta below thresholds: ΔPV=%.2f kWh ΔT=%.2f°C",
+                delta_pv_kwh, delta_temp_c,
+            )
+    except Exception as e:
+        logger.warning("Forecast refresh job failed: %s", e)
+
+
 def _hhmm_to_minutes(s: str) -> int:
     parts = (s or "00:00").strip().split(":")
     h = int(parts[0]) if parts else 0
@@ -1024,6 +1090,19 @@ def start_background_scheduler() -> None:
                     config.LP_MPC_HOURS_LIST,
                     tz,
                 )
+            # Forecast revision trigger (Waze MPC story #144): hourly Open-Meteo refresh
+            # + delta detector. Persists every fetch (audit trail + LP source); fires MPC
+            # only when next-6h delta exceeds threshold. Skipped if kill switch off.
+            from apscheduler.triggers.interval import IntervalTrigger
+            _background_scheduler.add_job(
+                bulletproof_forecast_refresh_job,
+                IntervalTrigger(minutes=int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES)),
+                id="bulletproof_forecast_refresh",
+            )
+            logger.info(
+                "Forecast refresh cron scheduled every %d min",
+                int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES),
+            )
             # Nightly plan push: dispatch Fox + Daikin just after the Daikin daily quota
             # rollover (midnight UTC). Anchored to UTC regardless of BULLETPROOF_TIMEZONE
             # so the push always lands on a fresh quota day.
@@ -1110,7 +1189,11 @@ def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, A
     removed: list[str] = []
     for job in list(_background_scheduler.get_jobs()):
         jid = job.id
-        if jid == "bulletproof_plan_push" or jid.startswith("bulletproof_mpc_"):
+        if (
+            jid == "bulletproof_plan_push"
+            or jid.startswith("bulletproof_mpc_")
+            or jid == "bulletproof_forecast_refresh"
+        ):
             try:
                 _background_scheduler.remove_job(jid)
                 removed.append(jid)
@@ -1139,15 +1222,26 @@ def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, A
     )
     added.append(push_jid)
 
+    # Forecast refresh interval is hot-reloadable via runtime_settings.
+    from apscheduler.triggers.interval import IntervalTrigger
+    forecast_jid = "bulletproof_forecast_refresh"
+    _background_scheduler.add_job(
+        bulletproof_forecast_refresh_job,
+        IntervalTrigger(minutes=int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES)),
+        id=forecast_jid,
+    )
+    added.append(forecast_jid)
+
     logger.info(
         "Cron jobs re-registered (reason=%s): removed=%s added=%s "
-        "plan_push=%02d:%02d UTC mpc_hours=%s",
+        "plan_push=%02d:%02d UTC mpc_hours=%s forecast_refresh=%dmin",
         reason,
         removed,
         added,
         config.LP_PLAN_PUSH_HOUR,
         config.LP_PLAN_PUSH_MINUTE,
         config.LP_MPC_HOURS_LIST,
+        int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES),
     )
     return {
         "status": "ok",
@@ -1156,4 +1250,5 @@ def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, A
         "added": added,
         "plan_push_utc": f"{config.LP_PLAN_PUSH_HOUR:02d}:{config.LP_PLAN_PUSH_MINUTE:02d}",
         "mpc_hours": config.LP_MPC_HOURS_LIST,
+        "forecast_refresh_minutes": int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES),
     }

--- a/src/weather.py
+++ b/src/weather.py
@@ -13,7 +13,8 @@ import json
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
 
 from .config import config, cop_at_temperature
 from .physics import apply_cop_lift_multiplier, get_lwt_base_c
@@ -322,6 +323,72 @@ def fetch_forecast(
             continue
 
     return result
+
+
+def _forecast_delta(
+    prev_rows: list[dict[str, Any]],
+    new_rows: list[dict[str, Any]],
+    *,
+    lookahead_hours: int,
+    horizon_start_utc: datetime | None = None,
+) -> tuple[float, float]:
+    """Compare two forecast snapshots over the next ``lookahead_hours``.
+
+    Returns ``(delta_pv_kwh_total, delta_temp_c_avg)`` summed/averaged across
+    slots present in **both** snapshots within the lookahead window. Used by
+    the Waze MPC forecast-revision trigger (Epic #73 — story #144) to decide
+    whether a re-plan is justified.
+
+    Each ``slot_time`` row covers 1 hour (Open-Meteo hourly), so PV (W/m²)
+    converts to kWh via ``estimate_pv_kw(rad) * 1.0 h``. Temp is averaged
+    across overlap.
+    """
+    if not prev_rows or not new_rows:
+        return (0.0, 0.0)
+    horizon_start = horizon_start_utc or datetime.now(UTC)
+    horizon_end = horizon_start + timedelta(hours=lookahead_hours)
+
+    def _index(rows: list[dict[str, Any]]) -> dict[datetime, dict[str, Any]]:
+        out: dict[datetime, dict[str, Any]] = {}
+        for r in rows:
+            st_raw = r.get("slot_time")
+            if not st_raw:
+                continue
+            try:
+                st = datetime.fromisoformat(str(st_raw).replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                continue
+            if st.tzinfo is None:
+                st = st.replace(tzinfo=UTC)
+            if horizon_start <= st < horizon_end:
+                out[st] = r
+        return out
+
+    prev_idx = _index(prev_rows)
+    new_idx = _index(new_rows)
+    common = sorted(prev_idx.keys() & new_idx.keys())
+    if not common:
+        return (0.0, 0.0)
+
+    delta_pv_kwh_total = 0.0
+    temp_deltas: list[float] = []
+    for slot in common:
+        p = prev_idx[slot]
+        n = new_idx[slot]
+        try:
+            prev_pv = estimate_pv_kw(float(p.get("solar_w_m2") or 0.0))
+            new_pv = estimate_pv_kw(float(n.get("solar_w_m2") or 0.0))
+            delta_pv_kwh_total += abs(new_pv - prev_pv)  # 1h slot → kW * 1h = kWh
+        except (ValueError, TypeError):
+            pass
+        try:
+            prev_t = float(p.get("temp_c") or 0.0)
+            new_t = float(n.get("temp_c") or 0.0)
+            temp_deltas.append(abs(new_t - prev_t))
+        except (ValueError, TypeError):
+            pass
+    delta_temp_c_avg = sum(temp_deltas) / len(temp_deltas) if temp_deltas else 0.0
+    return (delta_pv_kwh_total, delta_temp_c_avg)
 
 
 def get_forecast_for_slot(

--- a/tests/test_mpc_event_triggers.py
+++ b/tests/test_mpc_event_triggers.py
@@ -256,6 +256,159 @@ def test_octopus_fetch_calls_bulletproof_mpc_job_with_force_write(monkeypatch):
     assert captured_kwargs == {"force_write_devices": True, "trigger_reason": "octopus_fetch"}
 
 
+# -------------------- Forecast revision trigger --------------------
+
+
+def _make_forecast_rows(base_utc: datetime, *, count: int, solar_w_m2: float, temp_c: float) -> list[dict]:
+    return [
+        {
+            "slot_time": (base_utc + timedelta(hours=i)).isoformat(),
+            "temp_c": temp_c,
+            "solar_w_m2": solar_w_m2,
+        }
+        for i in range(count)
+    ]
+
+
+def test_forecast_delta_empty_inputs_returns_zero():
+    from src.weather import _forecast_delta
+
+    assert _forecast_delta([], [], lookahead_hours=6) == (0.0, 0.0)
+    assert _forecast_delta([], [{"slot_time": datetime.now(UTC).isoformat(), "solar_w_m2": 100, "temp_c": 10}], lookahead_hours=6) == (0.0, 0.0)
+
+
+def test_forecast_delta_solar_difference_summed_over_lookahead():
+    from src.weather import _forecast_delta, estimate_pv_kw
+
+    base = datetime.now(UTC) + timedelta(minutes=15)
+    prev = _make_forecast_rows(base, count=4, solar_w_m2=200.0, temp_c=12.0)
+    new = _make_forecast_rows(base, count=4, solar_w_m2=400.0, temp_c=12.0)
+    delta_pv, delta_temp = _forecast_delta(prev, new, lookahead_hours=6, horizon_start_utc=base)
+    # Each hour, |estimate_pv_kw(400) - estimate_pv_kw(200)| × 1h, summed over 4 slots
+    expected = abs(estimate_pv_kw(400.0) - estimate_pv_kw(200.0)) * 4
+    assert delta_pv == pytest.approx(expected, abs=0.01)
+    assert delta_temp == 0.0
+
+
+def test_forecast_delta_temp_difference_averaged():
+    from src.weather import _forecast_delta
+
+    base = datetime.now(UTC) + timedelta(minutes=15)
+    prev = _make_forecast_rows(base, count=4, solar_w_m2=0.0, temp_c=10.0)
+    new = _make_forecast_rows(base, count=4, solar_w_m2=0.0, temp_c=14.0)
+    delta_pv, delta_temp = _forecast_delta(prev, new, lookahead_hours=6, horizon_start_utc=base)
+    assert delta_pv == 0.0
+    assert delta_temp == pytest.approx(4.0, abs=0.01)
+
+
+def test_forecast_delta_ignores_slots_outside_lookahead():
+    from src.weather import _forecast_delta
+
+    base = datetime.now(UTC) + timedelta(minutes=15)
+    # 8 hourly slots, lookahead=4 — only first 4 must be counted.
+    prev = _make_forecast_rows(base, count=8, solar_w_m2=100.0, temp_c=10.0)
+    new = _make_forecast_rows(base, count=8, solar_w_m2=300.0, temp_c=15.0)
+    delta_pv_4, delta_temp_4 = _forecast_delta(prev, new, lookahead_hours=4, horizon_start_utc=base)
+    delta_pv_8, delta_temp_8 = _forecast_delta(prev, new, lookahead_hours=8, horizon_start_utc=base)
+    assert delta_pv_4 < delta_pv_8
+    # Per-slot temp delta is 5°C constant; average is 5°C regardless of N.
+    assert delta_temp_4 == pytest.approx(5.0, abs=0.01)
+    assert delta_temp_8 == pytest.approx(5.0, abs=0.01)
+
+
+def test_forecast_refresh_job_persists_even_when_disabled(monkeypatch):
+    """Kill switch off: still saves to history (audit trail) but never triggers MPC."""
+    from src.scheduler import runner
+
+    monkeypatch.setattr(runner.config, "MPC_EVENT_DRIVEN_ENABLED", False)
+    base = datetime.now(UTC)
+    fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.0, shortwave_radiation_wm2=100.0) for i in range(6)]
+
+    saved_history: list[tuple[str, list]] = []
+    saved_latest: list[tuple[list, str]] = []
+
+    def _save_hist(fetch_at, rows):
+        saved_history.append((fetch_at, rows))
+
+    def _save_latest(rows, day):
+        saved_latest.append((rows, day))
+
+    triggered = MagicMock(side_effect=AssertionError("MPC must not be triggered when kill switch is off"))
+
+    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+         patch("src.db.get_meteo_forecast_history_latest_before", return_value=[{"slot_time": (base + timedelta(hours=0)).isoformat(), "solar_w_m2": 50.0, "temp_c": 10.0}]), \
+         patch("src.db.save_meteo_forecast_history", side_effect=_save_hist), \
+         patch("src.db.save_meteo_forecast", side_effect=_save_latest), \
+         patch.object(runner, "bulletproof_mpc_job", triggered):
+        runner.bulletproof_forecast_refresh_job()
+
+    assert len(saved_history) == 1
+    assert len(saved_latest) == 1
+    triggered.assert_not_called()
+
+
+def test_forecast_refresh_job_no_trigger_without_previous_fetch(monkeypatch):
+    """First-ever invocation has no prev — must persist but never trigger."""
+    from src.scheduler import runner
+
+    base = datetime.now(UTC)
+    fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.0, shortwave_radiation_wm2=100.0) for i in range(6)]
+    triggered = MagicMock(side_effect=AssertionError("first-ever call must not trigger"))
+
+    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+         patch("src.db.get_meteo_forecast_history_latest_before", return_value=[]), \
+         patch("src.db.save_meteo_forecast_history"), \
+         patch("src.db.save_meteo_forecast"), \
+         patch.object(runner, "bulletproof_mpc_job", triggered):
+        runner.bulletproof_forecast_refresh_job()
+
+    triggered.assert_not_called()
+
+
+def test_forecast_refresh_job_triggers_when_solar_delta_exceeds_threshold(monkeypatch):
+    from src.scheduler import runner
+
+    monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_SOLAR_KWH_THRESHOLD", 0.5)
+    monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_LOOKAHEAD_HOURS", 6)
+    base = datetime.now(UTC)
+    # New forecast: much sunnier than the previous fetch — should cross the 0.5 kWh threshold easily.
+    fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.0, shortwave_radiation_wm2=600.0) for i in range(6)]
+    prev_rows = [{"slot_time": (base + timedelta(hours=i)).isoformat(), "solar_w_m2": 50.0, "temp_c": 10.0} for i in range(6)]
+
+    captured: dict = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+
+    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+         patch("src.db.get_meteo_forecast_history_latest_before", return_value=prev_rows), \
+         patch("src.db.save_meteo_forecast_history"), \
+         patch("src.db.save_meteo_forecast"), \
+         patch.object(runner, "bulletproof_mpc_job", _capture):
+        runner.bulletproof_forecast_refresh_job()
+
+    assert captured == {"force_write_devices": True, "trigger_reason": "forecast_revision"}
+
+
+def test_forecast_refresh_job_no_trigger_when_within_thresholds(monkeypatch):
+    from src.scheduler import runner
+
+    monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_SOLAR_KWH_THRESHOLD", 100.0)  # huge threshold
+    monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_TEMP_C_THRESHOLD", 100.0)
+    base = datetime.now(UTC)
+    fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.5, shortwave_radiation_wm2=110.0) for i in range(6)]
+    prev_rows = [{"slot_time": (base + timedelta(hours=i)).isoformat(), "solar_w_m2": 100.0, "temp_c": 10.0} for i in range(6)]
+
+    triggered = MagicMock(side_effect=AssertionError("must not trigger when delta is within thresholds"))
+    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+         patch("src.db.get_meteo_forecast_history_latest_before", return_value=prev_rows), \
+         patch("src.db.save_meteo_forecast_history"), \
+         patch("src.db.save_meteo_forecast"), \
+         patch.object(runner, "bulletproof_mpc_job", triggered):
+        runner.bulletproof_forecast_refresh_job()
+    triggered.assert_not_called()
+
+
 # -------------------- Plan-delta observability --------------------
 
 

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -180,12 +180,13 @@ def test_cron_reload_reregisters_jobs_when_active(monkeypatch):
         "bulletproof_mpc_12",
         "bulletproof_mpc_21",
     ])
-    # New MPC jobs match the freshly-written setting; push job re-added too.
+    # New MPC jobs match the freshly-written setting; push + forecast-refresh re-added too.
     assert set(fake.added) == {
         "bulletproof_mpc_04",
         "bulletproof_mpc_10",
         "bulletproof_mpc_15",
         "bulletproof_plan_push",
+        "bulletproof_forecast_refresh",
     }
     # Unrelated job is untouched.
     assert any(j.id == "bulletproof_octopus_fetch" for j in fake.get_jobs())


### PR DESCRIPTION
## Summary

Closes the **Waze MPC** stack (Epic #73). Hourly Open-Meteo refresh + delta detector that fires `bulletproof_mpc_job(force_write_devices=True, trigger_reason="forecast_revision")` when the next 6 h of solar/temp diverge materially from the previous fetch.

Closes #144.

## Why

Today the forecast is only refreshed on-demand inside `run_optimizer` — mid-day Open-Meteo revisions (the API publishes ~hourly) are invisible until the next cron MPC fires (3+ h away). This closes the third gap in event-driven re-planning, alongside the SoC-drift trigger (PR #151) and the standardised Octopus rebadge.

## Changes

| File | What |
|---|---|
| `src/scheduler/runner.py` | New `bulletproof_forecast_refresh_job()` + `IntervalTrigger` registration in `start_background_scheduler` and mirror in `reregister_cron_jobs` for hot-reload. |
| `src/db.py` | New `get_meteo_forecast_history_latest_before(when_utc)` returning rows of the most recent fetch strictly before `when_utc`. |
| `src/weather.py` | New private `_forecast_delta(prev, new, *, lookahead_hours, horizon_start_utc)` returning `(ΔPV kWh total, ΔT °C avg)` over slots in common within the lookahead window. |
| `src/runtime_settings.py` + `src/config.py` | `MPC_FORECAST_REFRESH_INTERVAL_MINUTES` promoted to runtime-tunable (`cron_reload=True`, range 10–720, default 60). Knob changes via `/api/v1/settings` re-register the cron without a restart. The 3 thresholds stay env-only (rarely tuned). |
| `tests/test_mpc_event_triggers.py` | 8 new cases covering `_forecast_delta` + the refresh job (kill switch, no-prev, threshold-exceeded, threshold-within). |
| `tests/test_runtime_settings.py` | Existing cron-reload test updated to expect the new `bulletproof_forecast_refresh` job. |

## Behaviour

- **Always** persists each new fetch in `meteo_forecast_history` + `meteo_forecast`, regardless of kill switch (audit trail + LP source-of-truth must stay fresh).
- **Trigger** is gated by `MPC_EVENT_DRIVEN_ENABLED` kill switch.
- First-ever invocation has no `prev` — persists, no trigger.
- Subsequent invocations compare; if `ΔPV ≥ 2 kWh` OR `ΔT ≥ 2 °C` over next 6 h → fires MPC.
- Cooldown gate from PR #151 still applies (5 min between any two MPC runs).

## Test plan

- [x] `pytest tests/test_mpc_event_triggers.py -v` — 26/26 green.
- [x] `pytest --ignore=tests/test_lp_optimizer.py` — 467/467 green.
- [ ] Post-deploy: confirm via `journalctl -u home-energy-manager` after ~60 min that `Forecast refresh cron scheduled every 60 min` appears at startup, and the first `forecast refresh delta below thresholds: ΔPV=… ΔT=…` (debug-level) shows the job firing. Real triggers expected sporadically (Open-Meteo revisions are usually small).

## Rollback

Set `MPC_EVENT_DRIVEN_ENABLED=false` via .env (drift + forecast triggers no-op; cron MPC continues; refresh still persists for audit). Hard rollback: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)