### PR TITLE
feat(pv): backfill telemetry + Solar Sponge maxSoc=100 + calibration analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 .home-energy-manager.pid
 daemon.log
 energy_state.db
+data/fox-ess-daily-extracts/
 agent_apply_v2.log
 backups/
 .claude/

--- a/scripts/analyse_pv_calibration.py
+++ b/scripts/analyse_pv_calibration.py
@@ -1,0 +1,226 @@
+"""Compare ``pv_realtime_history`` (5-min Fox samples) against Open-Meteo Archive
+modelled PV → identify systematic bias by hour-of-day and month.
+
+Usage
+-----
+    python -m scripts.analyse_pv_calibration [--start 2026-03-04] [--end 2026-04-25]
+
+Output is a structured text report (no DB writes). Decisions about adjusting
+``compute_pv_calibration_factor`` (window length, sun-angle correction) are
+human, made AFTER reading this report.
+
+Methodology
+-----------
+For each calendar day in ``[start, end]``:
+  1. Sum 5-min PV samples × (5/60) → measured kWh per UTC hour-of-day.
+  2. Fetch Open-Meteo Archive ``shortwave_radiation_instant`` per UTC hour.
+  3. Convert via project model: ``estimate_pv_kw(rad)`` × 1 h = kWh.
+  4. Per-hour ratio ``actual / modelled`` (skip if either ≤ 0.05 to avoid
+     division noise at dawn/dusk).
+
+Aggregations:
+- Bias per hour-of-day (median + p25/p75).
+- Bias per ISO month (median + n samples).
+- Daily totals comparison + total-period summary.
+
+The script never modifies code — only reads + prints recommendations.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, date, datetime, timedelta
+
+from src import db
+from src.config import config
+from src.weather import estimate_pv_kw
+
+
+def _fetch_hourly_radiation(start: date, end: date, lat: str, lon: str) -> dict[datetime, float]:
+    """Hit Open-Meteo Archive for hourly ``shortwave_radiation_instant`` (W/m²)."""
+    url = (
+        "https://archive-api.open-meteo.com/v1/archive?"
+        f"latitude={lat}&longitude={lon}"
+        f"&start_date={start.isoformat()}&end_date={end.isoformat()}"
+        "&hourly=shortwave_radiation_instant"
+        "&timezone=UTC"
+    )
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            data = json.loads(resp.read().decode())
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"open-meteo fetch failed: {e}", file=sys.stderr)
+        return {}
+    times = data.get("hourly", {}).get("time", [])
+    rads = data.get("hourly", {}).get("shortwave_radiation_instant", [])
+    out: dict[datetime, float] = {}
+    for t, r in zip(times, rads):
+        if r is None:
+            continue
+        try:
+            dt = datetime.fromisoformat(t.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+            out[dt.replace(minute=0, second=0, microsecond=0)] = float(r)
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def _measured_pv_kwh_per_hour(start: date, end: date) -> dict[datetime, float]:
+    """Aggregate ``pv_realtime_history`` 5-min samples into kWh per UTC hour."""
+    from src.db import _lock, get_connection
+    out: dict[datetime, float] = {}
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT captured_at, solar_power_kw
+                   FROM pv_realtime_history
+                   WHERE substr(captured_at, 1, 10) BETWEEN ? AND ?
+                     AND solar_power_kw IS NOT NULL""",
+                (start.isoformat(), end.isoformat()),
+            )
+            for row in cur.fetchall():
+                ts_raw = row[0]
+                kw = float(row[1] or 0.0)
+                try:
+                    ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+                except ValueError:
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=UTC)
+                hour_key = ts.replace(minute=0, second=0, microsecond=0)
+                # 5-min sample × (5/60)h = kWh contribution
+                out[hour_key] = out.get(hour_key, 0.0) + kw * (5.0 / 60.0)
+        finally:
+            conn.close()
+    return out
+
+
+def _format_pct(values: list[float]) -> str:
+    if not values:
+        return "n/a"
+    s = sorted(values)
+    return f"median={statistics.median(values):.2f}  p25={s[len(s)//4]:.2f}  p75={s[3*len(s)//4]:.2f}  n={len(s)}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--start", default="2026-03-04", help="ISO date inclusive")
+    p.add_argument("--end", default=None, help="ISO date inclusive (default: today)")
+    args = p.parse_args(argv)
+
+    start = date.fromisoformat(args.start)
+    end = date.fromisoformat(args.end) if args.end else date.today()
+
+    print(f"=== PV calibration analysis ===")
+    print(f"Period: {start} → {end}  ({(end - start).days + 1} days)")
+    print(f"Location: lat={config.WEATHER_LAT} lon={config.WEATHER_LON}")
+    print()
+
+    # Fetch both sources
+    measured = _measured_pv_kwh_per_hour(start, end)
+    radiation = _fetch_hourly_radiation(start, end, config.WEATHER_LAT, config.WEATHER_LON)
+    if not measured:
+        print("error: pv_realtime_history is empty for the requested window.", file=sys.stderr)
+        return 2
+    if not radiation:
+        print("error: Open-Meteo returned empty.", file=sys.stderr)
+        return 2
+
+    # Per-hour matched comparison
+    common = sorted(h for h in measured if h in radiation)
+    print(f"Matched hours: {len(common)}  (measured={len(measured)}, modelled={len(radiation)})")
+    print()
+
+    ratios: list[float] = []
+    by_hour: dict[int, list[float]] = {h: [] for h in range(24)}
+    by_month: dict[str, list[float]] = {}
+    daily_actual: dict[str, float] = {}
+    daily_model: dict[str, float] = {}
+
+    for h in common:
+        actual_kwh = measured[h]
+        rad = radiation[h]
+        modelled_kwh = estimate_pv_kw(rad) * 1.0  # 1-hour slot
+        # Skip dawn/dusk noise
+        if actual_kwh < 0.05 and modelled_kwh < 0.05:
+            continue
+        if modelled_kwh < 0.05:
+            continue
+        ratio = actual_kwh / modelled_kwh
+        # Drop egregious outliers (model artefact / sensor stuck)
+        if ratio > 5.0:
+            continue
+        ratios.append(ratio)
+        by_hour[h.hour].append(ratio)
+        ym = f"{h.year:04d}-{h.month:02d}"
+        by_month.setdefault(ym, []).append(ratio)
+        d = h.strftime("%Y-%m-%d")
+        daily_actual[d] = daily_actual.get(d, 0.0) + actual_kwh
+        daily_model[d] = daily_model.get(d, 0.0) + modelled_kwh
+
+    print("--- Overall ratio (actual / modelled) ---")
+    print(f"  {_format_pct(ratios)}")
+    print(f"  mean={statistics.mean(ratios):.3f}")
+    print()
+
+    print("--- Per hour-of-day (UTC) ---")
+    print(f"  {'hour':4} {'median':>7} {'p25':>6} {'p75':>6} {'n':>5}")
+    for h in range(24):
+        rs = by_hour[h]
+        if not rs:
+            continue
+        s = sorted(rs)
+        print(f"  {h:2d}   {statistics.median(rs):7.2f} {s[len(s)//4]:6.2f} {s[3*len(s)//4]:6.2f} {len(rs):5d}")
+    print()
+
+    print("--- Per month ---")
+    for ym in sorted(by_month):
+        rs = by_month[ym]
+        s = sorted(rs)
+        print(f"  {ym}: median={statistics.median(rs):.2f}  p25={s[len(s)//4]:.2f}  p75={s[3*len(s)//4]:.2f}  n={len(rs)}")
+    print()
+
+    print("--- Daily totals (top 20 by date desc) ---")
+    print(f"  {'date':10} {'actual':>8} {'modelled':>9} {'ratio':>6}")
+    days_sorted = sorted(daily_actual.keys(), reverse=True)[:20]
+    for d in days_sorted:
+        a = daily_actual[d]
+        m = daily_model[d]
+        if m > 0:
+            print(f"  {d}  {a:8.2f} {m:9.2f}  {a / m:6.2f}")
+    print()
+
+    daily_ratios = [daily_actual[d] / daily_model[d] for d in daily_actual if daily_model.get(d, 0) > 0]
+    if daily_ratios:
+        print("--- Daily ratio distribution ---")
+        s = sorted(daily_ratios)
+        print(f"  median={statistics.median(daily_ratios):.3f}  mean={statistics.mean(daily_ratios):.3f}  p25={s[len(s)//4]:.3f}  p75={s[3*len(s)//4]:.3f}  n={len(s)}")
+        print()
+
+    # Recommendation
+    print("=== Recommendation ===")
+    overall_median = statistics.median(ratios)
+    print(f"Overall median hourly ratio = {overall_median:.3f}")
+    print(f"Recent system-reported `compute_pv_calibration_factor`: read via API or check at runtime.")
+    if overall_median < 0.85:
+        suggested = round(0.85 * overall_median, 3)  # bias towards conservative correction
+        print(f"  → Model is OVERESTIMATING. Consider:")
+        print(f"     a) Reduce `_PV_SYSTEM_EFFICIENCY` in src/weather.py from 0.85 to {0.85 * overall_median:.3f}.")
+        print(f"     b) OR shorten window in `compute_pv_calibration_factor` (250 → 30 days) so seasonal bias responds faster.")
+    elif overall_median > 1.15:
+        print(f"  → Model is UNDERESTIMATING. Increase `_PV_SYSTEM_EFFICIENCY` or system capacity.")
+    else:
+        print(f"  → Model within ±15 % of reality. Probably fine; revisit after more data.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import_fox_csv_extracts.py
+++ b/scripts/import_fox_csv_extracts.py
@@ -1,0 +1,218 @@
+"""One-shot importer for Fox webapp CSV exports → pv_realtime_history + fox_energy_daily.
+
+Usage
+-----
+    python -m scripts.import_fox_csv_extracts [--dir data/fox-ess-daily-extracts]
+
+The CSV format (UTF-8 BOM) is what the Fox webapp downloads:
+    time, Grid Export(kW), Battery Charge(kW), Total Load(kW), Solar(kW),
+    Battery Discharge(kW), Grid Import(kW), SoC(%)
+
+Each row is a 5-min instantaneous sample. Negative ``Total Load`` means the
+house was net-importing at that instant (the sign convention in the export is
+``load_kw = pv + battery_discharge - grid_import - battery_charge - export``).
+We always store the absolute value.
+
+The importer is **idempotent**: re-running it never duplicates rows
+(``INSERT OR IGNORE`` on the ``captured_at`` PRIMARY KEY).
+
+For ``fox_energy_daily``, we sum 5-min kW samples → kWh (× 5/60 = ÷12) per
+column and ``INSERT OR REPLACE`` per date.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from src import db
+
+
+_FOX_TIME_FORMAT = "%d/%m/%Y %H:%M:%S"
+
+
+def _parse_iso(timestr: str) -> str | None:
+    """Parse ``dd/MM/yyyy HH:MM:SS {GMT|BST}`` → ISO UTC string.
+
+    Fox webapp exports use the wall-clock zone of the inverter — GMT in winter,
+    BST (UTC+1) in summer. We normalise everything to UTC.
+    """
+    s = (timestr or "").strip()
+    if not s:
+        return None
+    # Strip trailing zone label, default GMT (UTC+0).
+    offset_minutes = 0
+    if s.endswith(" BST"):
+        offset_minutes = 60
+        s = s[:-4]
+    elif s.endswith(" GMT"):
+        s = s[:-4]
+    try:
+        local = datetime.strptime(s, _FOX_TIME_FORMAT)
+    except (ValueError, AttributeError):
+        return None
+    return (local - timedelta(minutes=offset_minutes)).replace(tzinfo=UTC).isoformat()
+
+
+def _abs_or_none(value: str) -> float | None:
+    try:
+        v = float(value.strip())
+        return abs(v)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _import_one_csv(path: Path) -> tuple[int, int, dict[str, dict[str, float]]]:
+    """Import one CSV. Returns (rows_inserted, rows_skipped, daily_aggregates)."""
+    inserted = 0
+    skipped = 0
+    daily: dict[str, dict[str, float]] = {}
+
+    with path.open(encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ts = _parse_iso(row.get("time", ""))
+            if not ts:
+                skipped += 1
+                continue
+            solar = _abs_or_none(row.get("Solar(kW)", ""))
+            soc_raw = row.get("SoC(%)", "").strip()
+            try:
+                soc = float(soc_raw) if soc_raw else None
+            except ValueError:
+                soc = None
+            load = _abs_or_none(row.get("Total Load(kW)", ""))
+            grid_imp = _abs_or_none(row.get("Grid Import(kW)", ""))
+            grid_exp = _abs_or_none(row.get("Grid Export(kW)", ""))
+            bat_chg = _abs_or_none(row.get("Battery Charge(kW)", ""))
+            bat_dis = _abs_or_none(row.get("Battery Discharge(kW)", ""))
+
+            ok = db.save_pv_realtime_sample(
+                ts,
+                solar_power_kw=solar,
+                soc_pct=soc,
+                load_power_kw=load,
+                grid_import_kw=grid_imp,
+                grid_export_kw=grid_exp,
+                battery_charge_kw=bat_chg,
+                battery_discharge_kw=bat_dis,
+                source="csv_backfill",
+            )
+            if ok:
+                inserted += 1
+            else:
+                skipped += 1
+
+            day = ts[:10]
+            agg = daily.setdefault(day, {
+                "solar": 0.0, "load": 0.0, "import": 0.0,
+                "export": 0.0, "charge": 0.0, "discharge": 0.0,
+            })
+            # 5-min sample at instantaneous kW → kWh contribution = kW × (5/60) = kW / 12
+            f12 = 1.0 / 12.0
+            if solar is not None: agg["solar"] += solar * f12
+            if load is not None: agg["load"] += load * f12
+            if grid_imp is not None: agg["import"] += grid_imp * f12
+            if grid_exp is not None: agg["export"] += grid_exp * f12
+            if bat_chg is not None: agg["charge"] += bat_chg * f12
+            if bat_dis is not None: agg["discharge"] += bat_dis * f12
+
+    return inserted, skipped, daily
+
+
+def _upsert_daily_agg(daily: dict[str, dict[str, float]]) -> tuple[int, int]:
+    """Insert CSV-derived daily totals into fox_energy_daily WHEN MISSING.
+
+    Returns ``(inserted, skipped_existing)``. Uses ``INSERT OR IGNORE`` because
+    the Fox API ``report`` endpoint is the authoritative source for daily
+    totals (uses the inverter's internal cumulative meter, not 5-min sample
+    integration). The CSV-derived sum is a useful backfill for historical days
+    the API never covered, but should never overwrite an existing day.
+    """
+    from src.db import _lock, get_connection
+    now = datetime.now(UTC).isoformat()
+    inserted = 0
+    skipped = 0
+    with _lock:
+        conn = get_connection()
+        try:
+            for date_str, agg in daily.items():
+                cur = conn.execute(
+                    """INSERT OR IGNORE INTO fox_energy_daily
+                       (date, solar_kwh, load_kwh, import_kwh, export_kwh,
+                        charge_kwh, discharge_kwh, fetched_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        date_str,
+                        round(agg["solar"], 3),
+                        round(agg["load"], 3),
+                        round(agg["import"], 3),
+                        round(agg["export"], 3),
+                        round(agg["charge"], 3),
+                        round(agg["discharge"], 3),
+                        now,
+                    ),
+                )
+                if cur.rowcount > 0:
+                    inserted += 1
+                else:
+                    skipped += 1
+            conn.commit()
+        finally:
+            conn.close()
+    return inserted, skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--dir",
+        type=Path,
+        default=Path("data/fox-ess-daily-extracts"),
+        help="Directory containing PLANT*.csv exports",
+    )
+    args = p.parse_args(argv)
+
+    if not args.dir.exists():
+        print(f"error: directory not found: {args.dir}", file=sys.stderr)
+        return 2
+
+    db.init_db()  # ensure schema exists
+
+    files = sorted(args.dir.glob("*.csv"))
+    if not files:
+        print(f"warn: no CSV files in {args.dir}", file=sys.stderr)
+        return 1
+
+    total_inserted = 0
+    total_skipped = 0
+    all_daily: dict[str, dict[str, float]] = {}
+
+    for path in files:
+        ins, skp, daily = _import_one_csv(path)
+        total_inserted += ins
+        total_skipped += skp
+        # merge daily aggregates (a CSV file may span 1 day or more)
+        for d, agg in daily.items():
+            existing = all_daily.setdefault(d, {k: 0.0 for k in agg})
+            for k, v in agg.items():
+                existing[k] += v
+        print(f"  {path.name}: inserted={ins:4d}, skipped={skp:4d}, days={list(daily)}")
+
+    days_inserted, days_kept = _upsert_daily_agg(all_daily)
+
+    print()
+    print(f"=== Backfill complete ===")
+    print(f"  files processed:           {len(files)}")
+    print(f"  rows inserted:             {total_inserted}")
+    print(f"  rows skipped (dup/bad):    {total_skipped}")
+    print(f"  fox_energy_daily inserted: {days_inserted} (filled missing days)")
+    print(f"  fox_energy_daily kept:     {days_kept} (Fox API value preserved)")
+    print(f"  date range:                {min(all_daily)} → {max(all_daily)}" if all_daily else "  date range:             (empty)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_presence_periods.py
+++ b/scripts/seed_presence_periods.py
@@ -1,0 +1,61 @@
+"""Seed initial presence_periods rows from human-supplied chat metadata.
+
+Idempotent: safe to re-run. If a presence row with the same start/end/kind
+already exists, INSERT OR IGNORE silently skips it.
+
+Initial seed
+------------
+- 2026-03-27 → 2026-04-10 inclusive: ``travel`` (chat 2026-04-25).
+
+Add new rows here as the household reports them; they are read by future
+load-pattern analytics, never by the LP.
+"""
+from __future__ import annotations
+
+import sys
+
+from src import db
+
+
+# (start_utc, end_utc, kind, note)
+SEED: list[tuple[str, str, str, str]] = [
+    (
+        "2026-03-27T00:00:00+00:00",
+        "2026-04-10T23:59:59+00:00",
+        "travel",
+        "Reported in chat 2026-04-25 — household away during this window.",
+    ),
+]
+
+
+def main() -> int:
+    db.init_db()
+    inserted = 0
+    skipped = 0
+    # Idempotency: check existing exact-match rows before inserting.
+    from src.db import _lock, get_connection
+
+    for start, end, kind, note in SEED:
+        with _lock:
+            conn = get_connection()
+            try:
+                cur = conn.execute(
+                    """SELECT id FROM presence_periods
+                       WHERE start_utc = ? AND end_utc = ? AND kind = ?""",
+                    (start, end, kind),
+                )
+                if cur.fetchone():
+                    skipped += 1
+                    continue
+            finally:
+                conn.close()
+        pid = db.add_presence_period(start, end, kind, note)
+        print(f"  inserted #{pid}: {start} → {end}  ({kind})")
+        inserted += 1
+    print()
+    print(f"=== Presence seed complete: inserted={inserted}, skipped (already present)={skipped} ===")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/config.py
+++ b/src/config.py
@@ -543,6 +543,14 @@ class Config:
         self._rt_set("MPC_FORECAST_REFRESH_INTERVAL_MINUTES", int(value))
 
     @property
+    def PV_TELEMETRY_INTERVAL_MINUTES(self) -> int:
+        return int(self._rt_get("PV_TELEMETRY_INTERVAL_MINUTES"))
+
+    @PV_TELEMETRY_INTERVAL_MINUTES.setter
+    def PV_TELEMETRY_INTERVAL_MINUTES(self, value: int) -> None:
+        self._rt_set("PV_TELEMETRY_INTERVAL_MINUTES", int(value))
+
+    @property
     def LP_PLAN_PUSH_HOUR(self) -> int:
         return int(self._rt_get("LP_PLAN_PUSH_HOUR"))
 

--- a/src/db.py
+++ b/src/db.py
@@ -539,6 +539,46 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     if "last_notified_at" not in pc_cols_v13:
         conn.execute("ALTER TABLE plan_consent ADD COLUMN last_notified_at REAL")
 
+    # V14: pv_realtime_history — append-only per-sample telemetry for PV
+    # calibration analysis. Backfilled from Fox CSV exports (5-min) and topped
+    # up forward by bulletproof_pv_telemetry_job (30-min default). Columns
+    # mirror the Fox webapp exports + heartbeat realtime so both sources can
+    # populate the same table; ``source`` distinguishes them.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS pv_realtime_history (
+            captured_at            TEXT PRIMARY KEY,
+            solar_power_kw         REAL,
+            soc_pct                REAL,
+            load_power_kw          REAL,
+            grid_import_kw         REAL,
+            grid_export_kw         REAL,
+            battery_charge_kw      REAL,
+            battery_discharge_kw   REAL,
+            source                 TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_pv_rt_hist_time ON pv_realtime_history(captured_at)"
+    )
+
+    # V14: presence_periods — manually-flagged periods of household presence
+    # (home / travel / guests) so future load-pattern analyses + LP calibration
+    # can de-bias the rolling load profile by occupancy. Read by analytics
+    # only at this stage — LP does not consume yet.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS presence_periods (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            start_utc   TEXT NOT NULL,
+            end_utc     TEXT NOT NULL,
+            kind        TEXT NOT NULL,    -- 'home' | 'travel' | 'guests'
+            note        TEXT,
+            created_at  TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_presence_periods_range ON presence_periods(start_utc, end_utc)"
+    )
+
 
 def init_db() -> None:
     """Create tables if missing and apply lightweight migrations."""
@@ -2056,6 +2096,92 @@ def mean_fox_load_kwh_per_slot(limit: int = 60) -> float | None:
 # V4: Fox ESS realtime snapshot (SoC, solar_power_kw, load_power_kw)
 # Used by MPC intra-day re-optimisation to seed the LP initial state.
 # ---------------------------------------------------------------------------
+
+def save_pv_realtime_sample(
+    captured_at: str,
+    *,
+    solar_power_kw: float | None = None,
+    soc_pct: float | None = None,
+    load_power_kw: float | None = None,
+    grid_import_kw: float | None = None,
+    grid_export_kw: float | None = None,
+    battery_charge_kw: float | None = None,
+    battery_discharge_kw: float | None = None,
+    source: str = "heartbeat",
+) -> bool:
+    """Append a PV/load/SoC sample to ``pv_realtime_history``.
+
+    Idempotent: ``INSERT OR IGNORE`` on the ``captured_at`` PRIMARY KEY so re-runs
+    of the CSV backfill or duplicate heartbeat ticks don't double-count.
+    Returns True if a row was inserted, False if it was a duplicate.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """INSERT OR IGNORE INTO pv_realtime_history
+                   (captured_at, solar_power_kw, soc_pct, load_power_kw,
+                    grid_import_kw, grid_export_kw, battery_charge_kw,
+                    battery_discharge_kw, source)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    captured_at,
+                    solar_power_kw,
+                    soc_pct,
+                    load_power_kw,
+                    grid_import_kw,
+                    grid_export_kw,
+                    battery_charge_kw,
+                    battery_discharge_kw,
+                    source,
+                ),
+            )
+            conn.commit()
+            return cur.rowcount > 0
+        finally:
+            conn.close()
+
+
+def add_presence_period(
+    start_utc: str,
+    end_utc: str,
+    kind: str,
+    note: str | None = None,
+) -> int:
+    """Insert a manual presence flag (home / travel / guests). Returns the new id."""
+    if kind not in ("home", "travel", "guests"):
+        raise ValueError(f"invalid presence kind {kind!r}")
+    from datetime import UTC as _UTC, datetime as _dt
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """INSERT INTO presence_periods (start_utc, end_utc, kind, note, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (start_utc, end_utc, kind, note, _dt.now(_UTC).isoformat()),
+            )
+            conn.commit()
+            return int(cur.lastrowid or 0)
+        finally:
+            conn.close()
+
+
+def get_presence_at(when_utc: str) -> str:
+    """Return the presence kind covering ``when_utc`` (most recent if overlapping). 'home' if none matches."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT kind FROM presence_periods
+                   WHERE start_utc <= ? AND end_utc >= ?
+                   ORDER BY id DESC LIMIT 1""",
+                (when_utc, when_utc),
+            )
+            row = cur.fetchone()
+            return str(row[0]) if row else "home"
+        finally:
+            conn.close()
+
 
 def upsert_fox_realtime_snapshot(snap: dict[str, Any]) -> None:
     """Insert or replace the single realtime snapshot row (id=1).

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -184,6 +184,20 @@ SCHEMA: dict[str, SettingSpec] = {
             "to weather changes; higher = less Open-Meteo traffic."
         ),
     ),
+    "PV_TELEMETRY_INTERVAL_MINUTES": SettingSpec(
+        key="PV_TELEMETRY_INTERVAL_MINUTES",
+        type_name="int",
+        env_default=_int_env("PV_TELEMETRY_INTERVAL_MINUTES", "30"),
+        min_value=5,
+        max_value=120,
+        cron_reload=True,
+        description=(
+            "Interval (minutes) for the PV-realtime telemetry job. Each tick reads the "
+            "Fox cached realtime (SoC%, solar/load/grid/battery kW) and persists in "
+            "pv_realtime_history for offline calibration analysis. Zero Fox quota cost "
+            "(reads heartbeat-cached values)."
+        ),
+    ),
     # Terminal SoC floor — anti-myopia. Each LP run must end its 24h horizon with
     # SoC ≥ this value (kWh). Without it, individual runs may plan to drain the
     # battery near the boundary before the next MPC corrects. Default = 25 % of

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -265,14 +265,15 @@ def _slot_fox_tuple(
     s: HalfHourSlot,
     *,
     peak_export_discharge: bool = False,
-) -> tuple[str, int | None, int | None, int]:
-    """work_mode, fd_soc, fd_pwr, min_soc_on_grid for Scheduler V3.
+) -> tuple[str, int | None, int | None, int, int | None]:
+    """``(work_mode, fd_soc, fd_pwr, min_soc_on_grid, max_soc)`` for Scheduler V3.
 
     For ForceCharge slots the ``fdPwr`` (W) is taken from ``s.lp_grid_import_w`` when set
     (LP path), or falls back to the configured ``FOX_FORCE_CHARGE_*_PWR`` constants.
     For solar_charge slots (LP import≈0, battery charges from PV) we use SelfUse with an
     elevated minSocOnGrid so the battery is held at the LP's target level without forcing
-    any grid import — PV handles the charging naturally.
+    any grid import — PV handles the charging naturally. We ALSO set ``maxSoc=100`` to
+    explicitly give the firmware the "Solar Sponge" cue: PV-only fill up to 100 % cap.
     """
     min_r = int(config.MIN_SOC_RESERVE_PERCENT)
     if s.kind == "solar_charge":
@@ -280,22 +281,25 @@ def _slot_fox_tuple(
         # SelfUse mode forbids active grid import regardless of minSocOnGrid — this only
         # blocks discharge, letting excess PV accumulate. MPC at 06:00/12:00 corrects
         # for cloud shortfalls by switching to ForceCharge if SoC lags the target.
+        # maxSoc=100 is the canonical Fox V3 "Solar Sponge" cue (per TonyM1958/FoxESS-Cloud
+        # wiki) — explicit cap so the firmware never tries to top via grid past 100 %.
         min_soc = int(getattr(config, "FOX_SOLAR_CHARGE_MIN_SOC_PERCENT", 100))
-        return ("SelfUse", None, None, min_soc)
+        return ("SelfUse", None, None, min_soc, 100)
     if s.kind == "negative":
         pwr = s.lp_grid_import_w if s.lp_grid_import_w is not None else config.FOX_FORCE_CHARGE_MAX_PWR
         fds = s.target_soc_pct if s.target_soc_pct is not None else 100
-        return ("ForceCharge", fds, pwr, min_r)
+        return ("ForceCharge", fds, pwr, min_r, None)
     if s.kind == "cheap":
         pwr = s.lp_grid_import_w if s.lp_grid_import_w is not None else config.FOX_FORCE_CHARGE_NORMAL_PWR
         fds = s.target_soc_pct if s.target_soc_pct is not None else 95
-        return ("ForceCharge", fds, pwr, min_r)
+        return ("ForceCharge", fds, pwr, min_r, None)
     if s.kind == "peak_export":
         return (
             "ForceDischarge",
             int(config.EXPORT_DISCHARGE_FLOOR_SOC_PERCENT),
             config.FOX_FORCE_CHARGE_MAX_PWR,
             min_r,
+            None,
         )
     if s.kind == "peak" and peak_export_discharge:
         return (
@@ -303,13 +307,14 @@ def _slot_fox_tuple(
             int(config.EXPORT_DISCHARGE_FLOOR_SOC_PERCENT),
             config.FOX_FORCE_CHARGE_MAX_PWR,
             min_r,
+            None,
         )
     if s.kind == "negative_hold":
         # Fox "Backup" work mode = native "hold battery": no discharge, no grid
         # charge. Directly enforces the LP's dis = 0 constraint during negative
         # slots when chg is also zero (battery saturated or PV alone suffices).
-        return ("Backup", None, None, min_r)
-    return ("SelfUse", None, None, min_r)
+        return ("Backup", None, None, min_r, None)
+    return ("SelfUse", None, None, min_r, None)
 
 
 def _optimization_preset_away_like() -> bool:
@@ -503,22 +508,28 @@ def _merge_fox_groups(
             victim = len(merged) - 2
         a, _, ka = merged[victim]
         _, d, kb = merged[victim + 1]
+        ka_max = ka[4] if len(ka) > 4 else None
+        kb_max = kb[4] if len(kb) > 4 else None
         if ka[0] == "ForceCharge" and kb[0] == "ForceCharge":
             nk = (
                 "ForceCharge",
                 max(ka[1] or 0, kb[1] or 0),
                 max(ka[2] or 0, kb[2] or 0),
                 max(ka[3], kb[3]),
+                _max_optional(ka_max, kb_max),
             )
         else:
-            nk = ("SelfUse", None, None, int(config.MIN_SOC_RESERVE_PERCENT))
+            nk = ("SelfUse", None, None, int(config.MIN_SOC_RESERVE_PERCENT), None)
         merged[victim] = (a, d, nk)
         del merged[victim + 1]
 
     merged = _split_at_local_midnight(merged, tz)
 
     groups: list[SchedulerGroup] = []
-    for start_utc, end_utc, (wm, fds, fdp, msg) in merged:
+    for start_utc, end_utc, key in merged:
+        # Tuple is now (wm, fds, fdp, msg, max_soc); accept legacy 4-tuples defensively.
+        wm, fds, fdp, msg = key[0], key[1], key[2], key[3]
+        max_soc = key[4] if len(key) > 4 else None
         ls = start_utc.astimezone(tz)
         le = end_utc.astimezone(tz)
         eh, em = le.hour, le.minute
@@ -535,6 +546,7 @@ def _merge_fox_groups(
                 min_soc_on_grid=msg,
                 fd_soc=fds,
                 fd_pwr=fdp,
+                max_soc=max_soc,
             )
         )
     if truncate_horizon:
@@ -545,7 +557,10 @@ def _merge_fox_groups(
 def _merge_adjacent_force_charge_rows(
     merged: list[tuple[datetime, datetime, tuple]],
 ) -> list[tuple[datetime, datetime, tuple]]:
-    """Join consecutive ForceCharge segments even when fdSoc/fdPwr differ (e.g. negative vs cheap slot)."""
+    """Join consecutive ForceCharge segments even when fdSoc/fdPwr differ (e.g. negative vs cheap slot).
+
+    Tuple convention: ``(work_mode, fd_soc, fd_pwr, min_soc_on_grid, max_soc)``.
+    """
     out: list[tuple[datetime, datetime, tuple]] = []
     for a, b, k in merged:
         if (
@@ -559,6 +574,7 @@ def _merge_adjacent_force_charge_rows(
                 max(k0[1] or 0, k[1] or 0),
                 max(k0[2] or 0, k[2] or 0),
                 max(k0[3], k[3]),
+                _max_optional(k0[4] if len(k0) > 4 else None, k[4] if len(k) > 4 else None),
             )
             out[-1] = (a0, b, nk)
         else:
@@ -566,17 +582,31 @@ def _merge_adjacent_force_charge_rows(
     return out
 
 
+def _max_optional(a: int | None, b: int | None) -> int | None:
+    """Return max of two optional ints; None if both None."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return max(a, b)
+
+
 def _coarse_merge_fox(
     merged: list[tuple[datetime, datetime, tuple]],
 ) -> list[tuple[datetime, datetime, tuple]]:
-    """Collapse SelfUse variants; preserve highest minSocOnGrid when merging solar_charge windows."""
+    """Collapse SelfUse variants; preserve highest minSocOnGrid + maxSoc when merging solar_charge windows."""
     out: list[tuple[datetime, datetime, tuple]] = []
     for a, b, k in merged:
-        nk = ("SelfUse", None, None, k[3]) if k[0] == "SelfUse" else k
+        # Normalise SelfUse-shape entries; preserve the original max_soc (5th element).
+        if k[0] == "SelfUse":
+            nk = ("SelfUse", None, None, k[3], k[4] if len(k) > 4 else None)
+        else:
+            nk = k
         if out and out[-1][2][0] == "SelfUse" and nk[0] == "SelfUse" and out[-1][1] == a:
-            prev_msg = out[-1][2][3]
-            merged_msg = max(prev_msg, nk[3])
-            out[-1] = (out[-1][0], b, ("SelfUse", None, None, merged_msg))
+            prev = out[-1][2]
+            merged_msg = max(prev[3], nk[3])
+            merged_max = _max_optional(prev[4] if len(prev) > 4 else None, nk[4])
+            out[-1] = (out[-1][0], b, ("SelfUse", None, None, merged_msg, merged_max))
         elif out and out[-1][2] == nk and out[-1][1] == a:
             out[-1] = (out[-1][0], b, nk)
         else:

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -570,6 +570,38 @@ def bulletproof_forecast_refresh_job() -> None:
         logger.warning("Forecast refresh job failed: %s", e)
 
 
+def bulletproof_pv_telemetry_job() -> None:
+    """Per-N-min sample of Fox realtime → ``pv_realtime_history`` for PV calibration.
+
+    Reads the heartbeat-cached realtime (zero Fox quota cost) and appends one row.
+    Runs in parallel to the heartbeat to avoid coupling cadences. Idempotent:
+    duplicate ``captured_at`` is silently dropped by the table's PRIMARY KEY.
+    """
+    if get_scheduler_paused():
+        return
+    try:
+        rt = get_cached_realtime()
+    except Exception as e:
+        logger.debug("pv telemetry: realtime unavailable: %s", e)
+        return
+    if rt.soc is None and rt.solar_power is None:
+        return  # nothing meaningful to persist
+    try:
+        db.save_pv_realtime_sample(
+            datetime.now(UTC).isoformat(),
+            solar_power_kw=float(rt.solar_power) if rt.solar_power is not None else None,
+            soc_pct=float(rt.soc) if rt.soc is not None else None,
+            load_power_kw=float(rt.load_power) if rt.load_power is not None else None,
+            grid_import_kw=float(rt.grid_power) if rt.grid_power is not None and rt.grid_power > 0 else None,
+            grid_export_kw=float(-rt.grid_power) if rt.grid_power is not None and rt.grid_power < 0 else None,
+            battery_charge_kw=float(rt.battery_power) if rt.battery_power is not None and rt.battery_power > 0 else None,
+            battery_discharge_kw=float(-rt.battery_power) if rt.battery_power is not None and rt.battery_power < 0 else None,
+            source="heartbeat",
+        )
+    except Exception as e:
+        logger.debug("pv telemetry: save failed (non-fatal): %s", e)
+
+
 def _hhmm_to_minutes(s: str) -> int:
     parts = (s or "00:00").strip().split(":")
     h = int(parts[0]) if parts else 0
@@ -1103,6 +1135,18 @@ def start_background_scheduler() -> None:
                 "Forecast refresh cron scheduled every %d min",
                 int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES),
             )
+            # PV realtime telemetry (Solar Sponge analysis): persist Fox cached realtime
+            # to pv_realtime_history. Zero Fox quota cost (heartbeat-cached). Used by
+            # offline PV calibration analysis.
+            _background_scheduler.add_job(
+                bulletproof_pv_telemetry_job,
+                IntervalTrigger(minutes=int(config.PV_TELEMETRY_INTERVAL_MINUTES)),
+                id="bulletproof_pv_telemetry",
+            )
+            logger.info(
+                "PV telemetry cron scheduled every %d min",
+                int(config.PV_TELEMETRY_INTERVAL_MINUTES),
+            )
             # Nightly plan push: dispatch Fox + Daikin just after the Daikin daily quota
             # rollover (midnight UTC). Anchored to UTC regardless of BULLETPROOF_TIMEZONE
             # so the push always lands on a fresh quota day.
@@ -1193,6 +1237,7 @@ def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, A
             jid == "bulletproof_plan_push"
             or jid.startswith("bulletproof_mpc_")
             or jid == "bulletproof_forecast_refresh"
+            or jid == "bulletproof_pv_telemetry"
         ):
             try:
                 _background_scheduler.remove_job(jid)
@@ -1232,9 +1277,17 @@ def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, A
     )
     added.append(forecast_jid)
 
+    pv_jid = "bulletproof_pv_telemetry"
+    _background_scheduler.add_job(
+        bulletproof_pv_telemetry_job,
+        IntervalTrigger(minutes=int(config.PV_TELEMETRY_INTERVAL_MINUTES)),
+        id=pv_jid,
+    )
+    added.append(pv_jid)
+
     logger.info(
         "Cron jobs re-registered (reason=%s): removed=%s added=%s "
-        "plan_push=%02d:%02d UTC mpc_hours=%s forecast_refresh=%dmin",
+        "plan_push=%02d:%02d UTC mpc_hours=%s forecast_refresh=%dmin pv_telemetry=%dmin",
         reason,
         removed,
         added,
@@ -1242,6 +1295,7 @@ def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, A
         config.LP_PLAN_PUSH_MINUTE,
         config.LP_MPC_HOURS_LIST,
         int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES),
+        int(config.PV_TELEMETRY_INTERVAL_MINUTES),
     )
     return {
         "status": "ok",
@@ -1251,4 +1305,5 @@ def reregister_cron_jobs(reason: str = "runtime_settings_change") -> dict[str, A
         "plan_push_utc": f"{config.LP_PLAN_PUSH_HOUR:02d}:{config.LP_PLAN_PUSH_MINUTE:02d}",
         "mpc_hours": config.LP_MPC_HOURS_LIST,
         "forecast_refresh_minutes": int(config.MPC_FORECAST_REFRESH_INTERVAL_MINUTES),
+        "pv_telemetry_minutes": int(config.PV_TELEMETRY_INTERVAL_MINUTES),
     }

--- a/tests/test_fox_lp_dispatch_soc.py
+++ b/tests/test_fox_lp_dispatch_soc.py
@@ -51,7 +51,7 @@ def test_slot_fox_tuple_force_charge_uses_target_and_reserve() -> None:
         lp_grid_import_w=1500,
         target_soc_pct=62,
     )
-    wm, fds, pwr, msg = _slot_fox_tuple(s)
+    wm, fds, pwr, msg, max_soc = _slot_fox_tuple(s)
     assert wm == "ForceCharge"
     assert fds == 62
     assert pwr == 1500
@@ -67,7 +67,7 @@ def test_slot_fox_tuple_cheap_fallback_when_no_target() -> None:
         kind="cheap",
         target_soc_pct=None,
     )
-    wm, fds, pwr, msg = _slot_fox_tuple(s)
+    wm, fds, pwr, msg, max_soc = _slot_fox_tuple(s)
     assert fds == 95
     assert msg == _min_r()
 
@@ -106,7 +106,7 @@ def test_slot_fox_tuple_peak_export_uses_reserve_min_soc() -> None:
         price_pence=35.0,
         kind="peak_export",
     )
-    wm, fds, pwr, msg = _slot_fox_tuple(s)
+    wm, fds, pwr, msg, max_soc = _slot_fox_tuple(s)
     assert wm == "ForceDischarge"
     assert msg == _min_r()
 
@@ -119,9 +119,49 @@ def test_slot_fox_tuple_standard_selfuse_uses_reserve_min_soc() -> None:
         price_pence=12.0,
         kind="standard",
     )
-    wm, fds, pwr, msg = _slot_fox_tuple(s)
+    wm, fds, pwr, msg, max_soc = _slot_fox_tuple(s)
     assert wm == "SelfUse"
     assert msg == _min_r()
+
+
+def test_solar_charge_emits_solar_sponge_max_soc_100() -> None:
+    """A solar_charge slot must emit SelfUse + minSoc=100 + maxSoc=100 — the
+    canonical Fox V3 'Solar Sponge' shape so the firmware never tops via grid past 100 %."""
+    t0 = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    s = HalfHourSlot(
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=30),
+        price_pence=10.0,
+        kind="solar_charge",
+    )
+    wm, fds, pwr, msg, max_soc = _slot_fox_tuple(s)
+    assert wm == "SelfUse"
+    assert fds is None
+    assert pwr is None
+    assert msg == 100
+    assert max_soc == 100
+    # Confirm propagation through the merge pipeline + into the API payload.
+    groups = _merge_fox_groups([s])
+    assert len(groups) == 1
+    assert groups[0].max_soc == 100
+    assert groups[0].to_api_dict()["extraParam"]["maxSoc"] == 100
+
+
+def test_non_solar_charge_kinds_have_no_max_soc() -> None:
+    """ForceCharge / ForceDischarge / Backup / standard SelfUse must NOT emit maxSoc —
+    only solar_charge does. Defensive against accidentally capping other modes."""
+    t0 = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    for kind in ("cheap", "negative", "standard", "negative_hold", "peak_export"):
+        s = HalfHourSlot(
+            start_utc=t0,
+            end_utc=t0 + timedelta(minutes=30),
+            price_pence=5.0,
+            kind=kind,
+            lp_grid_import_w=1000 if kind in ("cheap", "negative") else None,
+            target_soc_pct=80 if kind in ("cheap", "negative") else None,
+        )
+        _, _, _, _, max_soc = _slot_fox_tuple(s)
+        assert max_soc is None, f"{kind} must NOT set max_soc, got {max_soc}"
 
 
 def test_negative_hold_kind_when_battery_full_and_price_negative() -> None:
@@ -155,7 +195,7 @@ def test_negative_hold_kind_when_battery_full_and_price_negative() -> None:
         assert s.kind == "negative_hold", (
             f"slot {i} (price={plan.price_pence[i]}p, chg=0, full SoC): kind={s.kind!r}"
         )
-    wm, fds, pwr, _ = _slot_fox_tuple(slots[0])
+    wm, fds, pwr, _, _ = _slot_fox_tuple(slots[0])
     assert wm == "Backup", f"negative_hold must map to Fox Backup mode, got {wm!r}"
     assert fds is None
     assert pwr is None

--- a/tests/test_pv_telemetry.py
+++ b/tests/test_pv_telemetry.py
@@ -1,0 +1,123 @@
+"""PV realtime telemetry: helper, idempotency, presence_periods, cron job behaviour."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch, tmp_path):
+    """Each test runs against a throwaway DB."""
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    # Force module-level path cache to refresh
+    from src import db
+    monkeypatch.setattr(db, "_DB_PATH", str(db_path), raising=False)
+    db.init_db()
+    yield
+
+
+def test_save_pv_realtime_sample_inserts_row():
+    from src import db
+    ok = db.save_pv_realtime_sample(
+        "2026-05-01T12:00:00+00:00",
+        solar_power_kw=2.5,
+        soc_pct=80.0,
+        load_power_kw=0.5,
+        grid_import_kw=0.0,
+        grid_export_kw=2.0,
+        battery_charge_kw=0.0,
+        battery_discharge_kw=0.0,
+        source="test",
+    )
+    assert ok is True
+
+
+def test_save_pv_realtime_sample_idempotent_on_duplicate_timestamp():
+    from src import db
+    ts = "2026-05-01T13:00:00+00:00"
+    first = db.save_pv_realtime_sample(ts, solar_power_kw=1.0, source="test")
+    second = db.save_pv_realtime_sample(ts, solar_power_kw=999.0, source="test")
+    assert first is True
+    assert second is False  # duplicate silently ignored
+
+
+def test_presence_period_lookup_returns_kind_when_in_range():
+    from src import db
+    db.add_presence_period(
+        "2026-04-01T00:00:00+00:00",
+        "2026-04-15T23:59:59+00:00",
+        "travel",
+        "test",
+    )
+    assert db.get_presence_at("2026-04-10T12:00:00+00:00") == "travel"
+    assert db.get_presence_at("2026-04-20T12:00:00+00:00") == "home"  # outside range
+    assert db.get_presence_at("2026-03-01T12:00:00+00:00") == "home"  # before range
+
+
+def test_presence_period_rejects_invalid_kind():
+    from src import db
+    with pytest.raises(ValueError):
+        db.add_presence_period("2026-04-01T00:00:00+00:00", "2026-04-15T23:59:59+00:00", "vacation", "")
+
+
+def test_pv_telemetry_job_persists_when_realtime_available(monkeypatch):
+    from src.scheduler import runner
+    from src import db
+
+    fake_rt = MagicMock(soc=75.0, solar_power=2.0, load_power=0.5, grid_power=-1.5, battery_power=1.0, work_mode="SelfUse")
+    monkeypatch.setattr(runner, "get_cached_realtime", lambda: fake_rt)
+    monkeypatch.setattr(runner, "_scheduler_paused", False)
+
+    runner.bulletproof_pv_telemetry_job()
+
+    # Confirm a row landed in the table
+    from src.db import _lock, get_connection
+    with _lock:
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT solar_power_kw, soc_pct, load_power_kw, grid_export_kw, source FROM pv_realtime_history"
+            ).fetchone()
+        finally:
+            conn.close()
+    assert row is not None
+    assert row[0] == 2.0
+    assert row[1] == 75.0
+    assert row[2] == 0.5
+    assert row[3] == 1.5  # negative grid_power → export side
+    assert row[4] == "heartbeat"
+
+
+def test_pv_telemetry_job_silent_when_realtime_empty(monkeypatch):
+    from src.scheduler import runner
+
+    fake_rt = MagicMock(soc=None, solar_power=None, load_power=None, grid_power=None, battery_power=None, work_mode="unknown")
+    monkeypatch.setattr(runner, "get_cached_realtime", lambda: fake_rt)
+    monkeypatch.setattr(runner, "_scheduler_paused", False)
+
+    # Should not raise; should not write
+    runner.bulletproof_pv_telemetry_job()
+
+    from src.db import _lock, get_connection
+    with _lock:
+        conn = get_connection()
+        try:
+            n = conn.execute("SELECT COUNT(*) FROM pv_realtime_history").fetchone()[0]
+        finally:
+            conn.close()
+    assert n == 0
+
+
+def test_pv_telemetry_job_skipped_when_scheduler_paused(monkeypatch):
+    from src.scheduler import runner
+
+    fake_rt = MagicMock(soc=75.0, solar_power=2.0, load_power=0.5, grid_power=0.0, battery_power=0.0, work_mode="SelfUse")
+    spy = MagicMock(side_effect=AssertionError("must not call get_cached_realtime when paused"))
+    monkeypatch.setattr(runner, "get_cached_realtime", spy)
+    monkeypatch.setattr(runner, "_scheduler_paused", True)
+
+    runner.bulletproof_pv_telemetry_job()
+    spy.assert_not_called()

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -180,13 +180,14 @@ def test_cron_reload_reregisters_jobs_when_active(monkeypatch):
         "bulletproof_mpc_12",
         "bulletproof_mpc_21",
     ])
-    # New MPC jobs match the freshly-written setting; push + forecast-refresh re-added too.
+    # New MPC jobs match the freshly-written setting; push + forecast-refresh + pv-telemetry re-added too.
     assert set(fake.added) == {
         "bulletproof_mpc_04",
         "bulletproof_mpc_10",
         "bulletproof_mpc_15",
         "bulletproof_plan_push",
         "bulletproof_forecast_refresh",
+        "bulletproof_pv_telemetry",
     }
     # Unrelated job is untouched.
     assert any(j.id == "bulletproof_octopus_fetch" for j in fake.get_jobs())


### PR DESCRIPTION
## Summary

Three connected deliverables to start the PV optimization track:

### A. PV realtime telemetry (backfill + forward)

- **New table** `pv_realtime_history` (PRIMARY KEY captured_at, append-only).
- **Backfill script** `scripts/import_fox_csv_extracts.py` — handles 53 days of Fox webapp CSV exports (5-min samples), GMT/BST aware, idempotent. Local run produced **~15 000 rows**.
- **Forward telemetry cron** `bulletproof_pv_telemetry_job` — every 30 min (runtime-tunable via `PV_TELEMETRY_INTERVAL_MINUTES`), reads heartbeat-cached realtime → zero Fox API quota cost. Same table as backfill.

### B. Solar Sponge — `maxSoc=100` on solar_charge groups

Per Fox V3 API research (TonyM1958/FoxESS-Cloud wiki), **`SelfUse + maxSoc=100` is the canonical PV-only "battery sponge" cue**. Our `solar_charge` slot kind already used `SelfUse + minSocOnGrid=100` but didn't set the explicit cap.

- `_slot_fox_tuple` returns 5-tuple including `max_soc`.
- `_merge_fox_groups` + helpers propagate via new `_max_optional`.
- Other kinds unchanged (defensive: `max_soc=None`).

### C. Calibration analysis + presence flag

- **Analysis script** `scripts/analyse_pv_calibration.py` — compares measured vs Open-Meteo Archive, outputs bias per hour-of-day / month / day. **No code changes** — informs future PR.
- **`presence_periods` table** + helpers for manually-flagged household occupancy (home/travel/guests).
- Seeds the **2026-03-27 → 2026-04-10 travel** window from chat. Read-only — LP doesn't consume yet.

## Initial calibration finding (from local backfill)

PV model **overestimates by ~40 %** on median (hourly ratio actual/modelled = 0.50). Bias far worse in late afternoon:

| Hour UTC | Median ratio |
|---|---|
| 11-12 | 0.72-0.76 |
| 14 | 0.54 |
| 16 | 0.27 |
| 17 | 0.14 |
| 18 | 0.08 |

Suggests shading / panel-tilt issue beyond what `_PV_SYSTEM_EFFICIENCY=0.85` accounts for. Recommendation: reduce the efficiency constant **or** shorten the window in `compute_pv_calibration_factor` (250 → 30 days). **Decision + PR to follow** — this commit ships only the data + analysis tooling.

## Test plan

- [x] `pytest --ignore=tests/test_lp_optimizer.py` — 476/476 green (5 existing _slot_fox_tuple tests updated for 5-tuple, 2 new Solar Sponge cases, 7 new PV telemetry cases).
- [x] Local backfill produced 53 days × ~283 5-min samples = ~15 000 rows.
- [x] Solar Sponge smoke: `solar_charge` slot → group `to_api_dict()` includes `extraParam: {minSocOnGrid: 100, maxSoc: 100}`.
- [ ] Post-deploy: confirm `bulletproof_pv_telemetry` cron registered. After 30 min: `SELECT COUNT(*) FROM pv_realtime_history WHERE source='heartbeat'` ≥ 1.
- [ ] Post-deploy: scp the CSV exports to Hetzner + run backfill on prod (preserves current Fox-API daily totals via OR IGNORE).
- [ ] Verify next Fox V3 upload includes `maxSoc:100` for any `solar_charge` groups in the plan.

## Rollback

- Disable telemetry: set `PV_TELEMETRY_INTERVAL_MINUTES=120` (max), or remove the cron via `reregister_cron_jobs`.
- Solar Sponge maxSoc=100 is defensive — won't regress; if firmware misbehaves, revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)