### PR TITLE
feat(lp): per-slot Octopus Outgoing export prices in LP objective

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -539,6 +539,27 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     if "last_notified_at" not in pc_cols_v13:
         conn.execute("ALTER TABLE plan_consent ADD COLUMN last_notified_at REAL")
 
+    # V14: agile_export_rates — Octopus Outgoing Agile half-hourly tariff. Mirrors
+    # agile_rates schema 1:1 so the LP can treat export pricing as time-varying just
+    # like import. Without this, the LP previously used a flat EXPORT_RATE_PENCE
+    # constant and missed the ±20p/kWh swings in Outgoing Agile (peak hours pay much
+    # more than overnight, which inverts the optimal export-vs-store trade-off
+    # depending on the slot).
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS agile_export_rates (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            valid_from      TEXT NOT NULL,
+            valid_to        TEXT NOT NULL,
+            value_inc_vat   REAL NOT NULL,
+            tariff_code     TEXT NOT NULL,
+            fetched_at      TEXT NOT NULL,
+            UNIQUE(valid_from, tariff_code)
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_agile_export_rates_valid_from ON agile_export_rates(valid_from)"
+    )
+
     # V14: pv_realtime_history — append-only per-sample telemetry for PV
     # calibration analysis. Backfilled from Fox CSV exports (5-min) and topped
     # up forward by bulletproof_pv_telemetry_job (30-min default). Columns
@@ -665,6 +686,73 @@ def save_agile_rates(rates: list[dict[str, Any]], tariff_code: str) -> int:
             dt_last.astimezone(tz_local).strftime("%a %d %b %H:%M %Z"),
         )
     return n
+
+
+def save_agile_export_rates(rates: list[dict[str, Any]], tariff_code: str) -> int:
+    """Upsert Agile **export** (Outgoing) rate rows into ``agile_export_rates``.
+
+    Mirror of :func:`save_agile_rates`: each rate dict has ``value_inc_vat``,
+    ``valid_from``, ``valid_to`` (ISO). Timestamps normalised to UTC Z.
+    """
+    if not rates or not tariff_code:
+        return 0
+    now = datetime.now(UTC).isoformat()
+    n = 0
+    with _lock:
+        conn = get_connection()
+        try:
+            for r in rates:
+                vf = r.get("valid_from")
+                vt = r.get("valid_to")
+                v = r.get("value_inc_vat")
+                if vf is None or vt is None or v is None:
+                    continue
+                try:
+                    vf_norm = _normalize_utc_iso(str(vf))
+                    vt_norm = _normalize_utc_iso(str(vt))
+                except ValueError:
+                    logger.error("TZ-AUDIT: unparseable export timestamp skipped: vf=%s vt=%s", vf, vt)
+                    continue
+                conn.execute(
+                    """INSERT INTO agile_export_rates (valid_from, valid_to, value_inc_vat, tariff_code, fetched_at)
+                       VALUES (?, ?, ?, ?, ?)
+                       ON CONFLICT(valid_from, tariff_code) DO UPDATE SET
+                         valid_to=excluded.valid_to,
+                         value_inc_vat=excluded.value_inc_vat,
+                         fetched_at=excluded.fetched_at""",
+                    (vf_norm, vt_norm, float(v), tariff_code, now),
+                )
+                n += 1
+            conn.commit()
+        finally:
+            conn.close()
+    if n:
+        logger.info("Octopus export rates saved: %d rows for %s", n, tariff_code)
+    return n
+
+
+def get_agile_export_rates_in_range(
+    period_from_iso: str,
+    period_to_iso: str,
+) -> list[dict[str, Any]]:
+    """Return export rate rows whose ``valid_from`` falls in ``[period_from, period_to)``.
+
+    Returns ``[]`` when the table is empty (no Outgoing tariff configured / not yet
+    fetched). Caller is responsible for the fallback to a flat constant.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT valid_from, valid_to, value_inc_vat, tariff_code
+                   FROM agile_export_rates
+                   WHERE valid_from >= ? AND valid_from < ?
+                   ORDER BY valid_from""",
+                (period_from_iso, period_to_iso),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
 
 
 def get_agile_rates_daily_summary(

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -177,13 +177,23 @@ def solve_lp(
     initial: LpInitialState,
     tz: ZoneInfo,
     micro_climate_offset_c: float = 0.0,
+    export_price_pence: list[float] | None = None,
 ) -> LpPlan:
-    """Build and solve the MILP. Raises ``ValueError`` on dimension mismatch."""
+    """Build and solve the MILP. Raises ``ValueError`` on dimension mismatch.
+
+    ``export_price_pence`` (optional): half-hourly Octopus Outgoing Agile rates.
+    When provided, the objective uses the per-slot value so the LP correctly
+    weighs export revenue at the actual time-of-use rate. When ``None`` (no
+    export tariff configured / not yet fetched) we fall back to the flat
+    ``EXPORT_RATE_PENCE`` constant.
+    """
     n = len(slot_starts_utc)
     if n == 0:
         raise ValueError("LP: empty horizon")
     if len(price_pence) != n or len(base_load_kwh) != n:
         raise ValueError("LP: price/base_load length mismatch")
+    if export_price_pence is not None and len(export_price_pence) != n:
+        raise ValueError("LP: export_price_pence length mismatch")
     if len(weather.pv_kwh_per_slot) != n:
         raise ValueError("LP: weather horizon mismatch")
 
@@ -328,7 +338,12 @@ def solve_lp(
     # -----------------------------------------------------------------------
     cycle_pen = float(config.LP_CYCLE_PENALTY_PENCE_PER_KWH)
     comfort_pen = float(config.LP_COMFORT_SLACK_PENCE_PER_DEGC_SLOT)
-    export_rate = float(config.EXPORT_RATE_PENCE)
+    flat_export_rate = float(config.EXPORT_RATE_PENCE)
+    # Per-slot export prices (Octopus Outgoing Agile) when supplied; flat fallback otherwise.
+    export_rate_line: list[float] = (
+        list(export_price_pence) if export_price_pence is not None
+        else [flat_export_rate] * n
+    )
 
     for i in range(n):
         e_hp_i = e_dhw[i] + e_space[i]
@@ -549,7 +564,10 @@ def solve_lp(
     # -----------------------------------------------------------------------
     # Objective
     # -----------------------------------------------------------------------
-    obj_grid = pulp.lpSum(imp[i] * price_line[i] - exp[i] * export_rate for i in range(n))
+    obj_grid = pulp.lpSum(
+        imp[i] * price_line[i] - exp[i] * export_rate_line[i]
+        for i in range(n)
+    )
     obj_cycle = cycle_pen * pulp.lpSum(chg[i] + dis[i] for i in range(n))
     obj_comfort = comfort_pen * pulp.lpSum(s_lo[i] + s_hi[i] for i in range(n))
     # DHW overshoot above the comfort ceiling is not a comfort issue — it's just stored

--- a/src/scheduler/octopus_fetch.py
+++ b/src/scheduler/octopus_fetch.py
@@ -9,7 +9,7 @@ from .. import db
 from ..config import config
 from ..foxess.client import FoxESSClient, FoxESSError
 from ..notifier import notify_critical
-from .agile import fetch_agile_rates
+from .agile import fetch_agile_export_rates, fetch_agile_rates
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,21 @@ def fetch_and_store_rates(fox: FoxESSClient | None = None) -> dict[str, Any]:
         clear_failure_streak=True,
     )
 
-    summary: dict[str, Any] = {"ok": True, "rows": n}
+    # Fetch + persist Octopus Outgoing (export) rates when configured. Stored separately
+    # in agile_export_rates so the LP can use a per-slot export price (Outgoing Agile
+    # varies ±20p/kWh half-hourly, just like the import side). Failure here is non-fatal —
+    # the LP falls back to the flat EXPORT_RATE_PENCE constant when the table is empty.
+    export_n = 0
+    export_code = (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip()
+    if export_code:
+        try:
+            export_rates = fetch_agile_export_rates(export_tariff_code=export_code)
+            if export_rates:
+                export_n = db.save_agile_export_rates(export_rates, export_code)
+        except Exception as e:
+            logger.warning("Octopus export-rates fetch failed (non-fatal): %s", e)
+
+    summary: dict[str, Any] = {"ok": True, "rows": n, "export_rows": export_n}
     if config.USE_BULLETPROOF_ENGINE:
         try:
             # Route through bulletproof_mpc_job so the cooldown gate, plan-delta logging

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1075,6 +1075,50 @@ def _persist_lp_snapshots(
     db.save_lp_snapshots(run_id=int(run_id), inputs_row=inputs_row, solution_rows=solution_rows)
 
 
+def _build_export_price_line(slot_starts_utc: list[datetime]) -> list[float] | None:
+    """Map per-slot start timestamps to the matching ``agile_export_rates`` value.
+
+    Returns ``None`` when no Outgoing tariff is configured or the table has no
+    rows in the planning window — caller falls back to the flat constant.
+    Missing per-slot rows are filled with the flat constant so the returned
+    list always matches the slot count when non-None.
+    """
+    if not slot_starts_utc:
+        return None
+    if not (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip():
+        return None
+    period_from = slot_starts_utc[0].isoformat()
+    period_to = (slot_starts_utc[-1] + timedelta(minutes=30)).isoformat()
+    rows = db.get_agile_export_rates_in_range(period_from, period_to)
+    if not rows:
+        return None
+    by_start: dict[str, float] = {}
+    for r in rows:
+        try:
+            iso_norm = r["valid_from"].replace("+00:00", "Z")
+            by_start[iso_norm] = float(r["value_inc_vat"])
+        except (KeyError, TypeError, ValueError):
+            continue
+    flat = float(config.EXPORT_RATE_PENCE)
+    out: list[float] = []
+    n_matched = 0
+    for st in slot_starts_utc:
+        key = st.isoformat().replace("+00:00", "Z")
+        v = by_start.get(key)
+        if v is not None:
+            out.append(v)
+            n_matched += 1
+        else:
+            out.append(flat)
+    if n_matched == 0:
+        return None  # nothing matched — let caller use flat path entirely
+    logger.info(
+        "Export prices: matched %d/%d slots from agile_export_rates (rest use flat %.2fp)",
+        n_matched, len(slot_starts_utc), flat,
+    )
+    return out
+
+
 def _run_optimizer_lp(fox: FoxESSClient | None, daikin: Any | None = None) -> dict[str, Any]:
     """PuLP MILP horizon planner (V8). Falls back to heuristic if solve is not optimal."""
     from .lp_dispatch import (
@@ -1143,6 +1187,11 @@ def _run_optimizer_lp(fox: FoxESSClient | None, daikin: Any | None = None) -> di
     initial = read_lp_initial_state(daikin)
     micro_climate_offset = db.get_micro_climate_offset_c(config.DAIKIN_MICRO_CLIMATE_LOOKBACK)
 
+    # Per-slot Octopus Outgoing Agile (export) prices. When the table is empty (no
+    # tariff configured / not yet fetched), the LP falls back to the flat
+    # EXPORT_RATE_PENCE constant, preserving legacy behaviour.
+    export_prices = _build_export_price_line(starts)
+
     plan = solve_lp(
         slot_starts_utc=starts,
         price_pence=prices,
@@ -1151,6 +1200,7 @@ def _run_optimizer_lp(fox: FoxESSClient | None, daikin: Any | None = None) -> di
         initial=initial,
         tz=tz,
         micro_climate_offset_c=micro_climate_offset,
+        export_price_pence=export_prices,
     )
     if not plan.ok:
         logger.warning("PuLP status %s — falling back to heuristic classifier", plan.status)

--- a/tests/test_lp_export_per_slot.py
+++ b/tests/test_lp_export_per_slot.py
@@ -1,0 +1,153 @@
+"""LP per-slot export pricing — Octopus Outgoing Agile.
+
+Covers:
+- ``save_agile_export_rates`` + ``get_agile_export_rates_in_range`` round-trip.
+- ``_build_export_price_line`` returns None when tariff code is empty.
+- ``_build_export_price_line`` returns None when the table is empty.
+- ``_build_export_price_line`` matches per-slot rows + falls back to flat for gaps.
+- ``solve_lp`` uses per-slot export when supplied; falls back to flat constant otherwise.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db
+from src.config import config
+
+
+@pytest.fixture(autouse=True)
+def _clean_export_table(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.setattr(db, "_DB_PATH", str(db_path), raising=False)
+    db.init_db()
+    yield
+
+
+def test_save_get_export_rates_round_trip():
+    rows = [
+        {"valid_from": "2026-05-01T12:00:00Z", "valid_to": "2026-05-01T12:30:00Z", "value_inc_vat": 18.5},
+        {"valid_from": "2026-05-01T12:30:00Z", "valid_to": "2026-05-01T13:00:00Z", "value_inc_vat": 22.0},
+    ]
+    n = db.save_agile_export_rates(rows, "E-1R-AGILE-OUTGOING-19-05-13-H")
+    assert n == 2
+    got = db.get_agile_export_rates_in_range("2026-05-01T00:00:00Z", "2026-05-02T00:00:00Z")
+    assert len(got) == 2
+    assert got[0]["value_inc_vat"] == 18.5
+    assert got[1]["value_inc_vat"] == 22.0
+
+
+def test_save_export_rates_idempotent_upsert():
+    rows = [{"valid_from": "2026-05-01T12:00:00Z", "valid_to": "2026-05-01T12:30:00Z", "value_inc_vat": 18.5}]
+    db.save_agile_export_rates(rows, "X")
+    # Re-save with new value — UPSERT should overwrite.
+    rows[0]["value_inc_vat"] = 25.0
+    db.save_agile_export_rates(rows, "X")
+    got = db.get_agile_export_rates_in_range("2026-05-01T00:00:00Z", "2026-05-02T00:00:00Z")
+    assert len(got) == 1
+    assert got[0]["value_inc_vat"] == 25.0
+
+
+def test_build_export_price_line_returns_none_when_tariff_empty(monkeypatch):
+    from src.scheduler.optimizer import _build_export_price_line
+    monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE", "")
+    slots = [datetime(2026, 5, 1, 12, 0, tzinfo=UTC)]
+    assert _build_export_price_line(slots) is None
+
+
+def test_build_export_price_line_returns_none_when_table_empty(monkeypatch):
+    from src.scheduler.optimizer import _build_export_price_line
+    monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE", "E-1R-AGILE-OUTGOING-19-05-13-H")
+    slots = [datetime(2026, 5, 1, 12, 0, tzinfo=UTC)]
+    assert _build_export_price_line(slots) is None
+
+
+def test_build_export_price_line_matches_per_slot_rows(monkeypatch):
+    from src.scheduler.optimizer import _build_export_price_line
+    monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE", "X")
+    monkeypatch.setattr(config, "EXPORT_RATE_PENCE", 15.0)
+    db.save_agile_export_rates(
+        [
+            {"valid_from": "2026-05-01T12:00:00Z", "valid_to": "2026-05-01T12:30:00Z", "value_inc_vat": 8.0},
+            {"valid_from": "2026-05-01T13:00:00Z", "valid_to": "2026-05-01T13:30:00Z", "value_inc_vat": 25.0},
+        ],
+        "X",
+    )
+    slots = [
+        datetime(2026, 5, 1, 12, 0, tzinfo=UTC),  # match → 8.0
+        datetime(2026, 5, 1, 12, 30, tzinfo=UTC),  # gap → flat 15.0
+        datetime(2026, 5, 1, 13, 0, tzinfo=UTC),  # match → 25.0
+    ]
+    out = _build_export_price_line(slots)
+    assert out == [8.0, 15.0, 25.0]
+
+
+def test_solve_lp_uses_per_slot_export_when_provided():
+    """High export price in slot 1 should make the LP prefer exporting then vs storing for later."""
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+    from src.weather import WeatherLpSeries
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 4
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    # PV abundant in slot 1, none elsewhere; cheap import always so storing has no advantage.
+    pv = [0.0, 5.0, 0.0, 0.0]
+    prices = [5.0, 5.0, 5.0, 5.0]
+    base_load = [0.3] * n
+    # High-export tariff at slot 1 (50p), zero elsewhere → solver should prefer exporting in slot 1.
+    export_prices = [0.0, 50.0, 0.0, 0.0]
+    weather = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[15.0] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[50.0] * n,
+        pv_kwh_per_slot=pv,
+        cop_space=[3.5] * n,
+        cop_dhw=[3.0] * n,
+    )
+    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    pv = pv  # silence linter
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=weather,
+        initial=init,
+        tz=ZoneInfo("Europe/London"),
+        export_price_pence=export_prices,
+    )
+    assert plan.ok, plan.status
+    # The high-tariff slot 1 should have non-trivial export.
+    assert plan.export_kwh[1] > 0.5, f"expected export in slot 1; got {plan.export_kwh}"
+
+
+def test_solve_lp_export_length_mismatch_raises():
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+    from src.weather import WeatherLpSeries
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 4
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    weather = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[15.0] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[50.0] * n,
+        pv_kwh_per_slot=[0.0] * n,
+        cop_space=[3.5] * n,
+        cop_dhw=[3.0] * n,
+    )
+    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    with pytest.raises(ValueError, match="export_price_pence length"):
+        solve_lp(
+            slot_starts_utc=slots,
+            price_pence=[5.0] * n,
+            base_load_kwh=[0.3] * n,
+            weather=weather,
+            initial=init,
+            tz=ZoneInfo("Europe/London"),
+            export_price_pence=[10.0, 20.0],  # wrong length
+        )


### PR DESCRIPTION
## Summary

The LP objective used a flat `EXPORT_RATE_PENCE=15.0` constant for every slot, ignoring the half-hourly variation in Octopus Outgoing Agile (Outgoing swings ±20 p/kWh just like the import side). The fetch existed (`fetch_agile_export_rates` + `OCTOPUS_EXPORT_TARIFF_CODE` configured in prod) but rates were never persisted, and the LP never consumed them.

**Net effect of the bug**: solver couldn't tell apart "export now (peak Outgoing 25p) and buy later (peak import 30p)" from "store now and discharge in peak" — both looked equally good at the flat 15p assumption. With per-slot pricing the delta becomes visible and the optimal export-vs-store trade-off shifts correctly throughout the day.

## Changes

| File | What |
|---|---|
| `src/db.py` | New `agile_export_rates` table (mirror of `agile_rates`); `save_agile_export_rates()` UPSERT; `get_agile_export_rates_in_range()` query helper. |
| `src/scheduler/octopus_fetch.py` | `fetch_and_store_rates` now also fetches+persists Outgoing when `OCTOPUS_EXPORT_TARIFF_CODE` is set. Failure is non-fatal. |
| `src/scheduler/lp_optimizer.py` | `solve_lp(export_price_pence: list[float] \| None = None)`. Per-slot revenue in objective when supplied; flat fallback otherwise. |
| `src/scheduler/optimizer.py` | New `_build_export_price_line(starts)` helper queries the table; `run_optimizer` wires it into `solve_lp`. |
| `tests/test_lp_export_per_slot.py` (new) | 7 cases — round-trip, UPSERT idempotency, empty-tariff/empty-table/gap-fill paths, LP behaviour with per-slot prices, length validation. |

## Behaviour preserved

- Empty `OCTOPUS_EXPORT_TARIFF_CODE` → `_build_export_price_line` returns `None` → flat constant used (legacy).
- Tariff configured but no rows yet (e.g. before first fetch) → same fallback.
- Tariff with partial coverage → matched slots use Outgoing, gaps filled with flat constant.

## Test plan

- [x] `pytest tests/test_lp_export_per_slot.py -v` — 7/7 green.
- [x] `pytest --ignore=tests/test_lp_optimizer.py` — 483/483 green.
- [ ] Post-deploy: `bulletproof_octopus_fetch_job` runs (next 16:05 UTC, or trigger via service restart) and populates `agile_export_rates`. Verify with `sqlite3 .../energy_state.db "SELECT COUNT(*) FROM agile_export_rates"`.
- [ ] Next LP run logs `Export prices: matched N/M slots from agile_export_rates`.

## Rollback

Unset `OCTOPUS_EXPORT_TARIFF_CODE` (env) or delete the table; LP reverts to flat constant. No schema-incompatible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)