### PR TITLE
chore(ci): bump GH Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,21 +19,21 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -42,7 +42,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64


### PR DESCRIPTION
## Summary
- Silences the "Node.js 20 actions are deprecated" warning visible in PR #163 / #164 build logs.
- Gets us ahead of GitHub's 2026-06-02 cutover that forces Node 24 as the runner default.
- All five major bumps are explicit Node 24 runtime upgrades per upstream release notes; no API breaks for our usage (no deprecated inputs/envs touched).

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| docker/login-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v5 | v7 |

## Test plan
- [ ] CI build job runs to completion (the workflow itself self-validates the bump).
- [ ] Confirm the deprecation warning no longer appears in the run log.
- [ ] Confirm the resulting image is tagged `main` + `sha-<commit>` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)