### PR TITLE
fix(api): dashboard reads Outgoing prices from agile_export_rates

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1068,9 +1068,11 @@ async def optimization_inputs(horizon_hours: int | None = None):
 
     Cache-only contract — mirror of the ``/cockpit/now`` discipline. Weather
     rows come from ``meteo_forecast`` (latest-per-slot, written by the last
-    LP solve). Prices from ``agile_rates``. Initial state via
-    ``read_lp_initial_state(allow_daikin_refresh=False)`` so no Daikin quota
-    is burned on a page load.
+    LP solve). Import prices from ``agile_rates``; export prices from
+    ``agile_export_rates`` (Octopus Outgoing Agile, mirroring what the LP
+    itself reads in :func:`scheduler.optimizer._build_export_price_line`).
+    Initial state via ``read_lp_initial_state(allow_daikin_refresh=False)``
+    so no Daikin quota is burned on a page load.
     """
     from datetime import UTC as _UTC
     from datetime import datetime as _dt
@@ -1089,7 +1091,16 @@ async def optimization_inputs(horizon_hours: int | None = None):
     tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
     export_tariff = (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip()
     import_rows = db.get_rates_for_period(tariff, day_start, window_end) if tariff else []
-    export_rows = db.get_rates_for_period(export_tariff, day_start, window_end) if export_tariff else []
+    # Outgoing rates live in agile_export_rates, NOT agile_rates — the export
+    # tariff code is never written to agile_rates, so get_rates_for_period
+    # would return [] regardless of whether Octopus has the data. Use the
+    # export-specific helper so the dashboard sees the same per-slot prices
+    # the LP objective uses.
+    export_rows = (
+        db.get_agile_export_rates_in_range(day_start.isoformat(), window_end.isoformat())
+        if export_tariff
+        else []
+    )
 
     # --- Meteo forecast (latest-per-slot, in the plan window) ---------------
     conn = db.get_connection()

--- a/tests/api/test_optimization_inputs.py
+++ b/tests/api/test_optimization_inputs.py
@@ -6,12 +6,14 @@ contract (response must be fast and never crash when sources are cold).
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
 
 from src import db
 from src.api.main import app
+from src.config import config
 
 
 @pytest.fixture(autouse=True)
@@ -80,3 +82,38 @@ def test_forecast_page_renders(client):
     assert r.status_code == 200
     assert b"LP inputs" in r.content
     assert b"forecast.js" in r.content
+
+
+def test_export_prices_populated_from_agile_export_rates(client, monkeypatch):
+    """Regression: dashboard must read Outgoing prices from agile_export_rates,
+    not from agile_rates (which only stores import). Bug shipped with PR #154 —
+    LP itself read the right table; this view endpoint did not."""
+    monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE",
+                        "E-1R-AGILE-OUTGOING-19-05-13-H")
+
+    # Seed two export-price rows aligned with the next two half-hour slots
+    # the endpoint will build (it computes day_start = now.replace(minute=0)).
+    now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    rows = [
+        {
+            "valid_from": now.isoformat().replace("+00:00", "Z"),
+            "valid_to": (now + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+            "value_inc_vat": 19.55,
+        },
+        {
+            "valid_from": (now + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+            "valid_to": (now + timedelta(minutes=60)).isoformat().replace("+00:00", "Z"),
+            "value_inc_vat": 19.63,
+        },
+    ]
+    db.save_agile_export_rates(rows, "E-1R-AGILE-OUTGOING-19-05-13-H")
+
+    r = client.get("/api/v1/optimization/inputs")
+    assert r.status_code == 200
+    slots = r.json()["slots"]
+    by_t = {s["t_utc"]: s for s in slots}
+
+    k1 = now.isoformat().replace("+00:00", "Z")
+    k2 = (now + timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
+    assert by_t[k1]["price_export_p"] == pytest.approx(19.55)
+    assert by_t[k2]["price_export_p"] == pytest.approx(19.63)


### PR DESCRIPTION
## Summary
- `/api/v1/optimization/inputs` returned `price_export_p: null` for every slot because it called `db.get_rates_for_period(export_tariff, ...)` — which only queries `agile_rates` (import). Outgoing rates live in `agile_export_rates`.
- The LP itself was unaffected (production path uses `optimizer._build_export_price_line`, which already reads the right table) — but the Forecast tab was blind to export pricing. With Octopus Outgoing peaks ~19.6p mid-afternoon today, this hid useful signal from the dashboard.
- Switches the view endpoint to `db.get_agile_export_rates_in_range`, mirroring the LP's read pattern.

## Verified on prod (HEM container, 2026-04-26)
Direct call to the LP helper returned 24 per-slot Outgoing prices, e.g.:
```
17:00  19.55 p/kWh    ← Outgoing peak
17:30  19.63 p/kWh
21:30  10.33 p/kWh
```
But `/api/v1/optimization/inputs` returned `price_export_p: null` for all 48 slots. Same data, different read path.

## Test plan
- [x] New regression test in `tests/api/test_optimization_inputs.py` seeds two `agile_export_rates` rows aligned with the next two half-hour slots, hits the endpoint, and asserts `price_export_p` carries the seeded values.
- [x] `pytest tests/api/ tests/test_lp_export_per_slot.py -q` → 130 passed.
- [ ] After merge: re-pull container on Hetzner (`systemctl restart hem`) and confirm `curl /api/v1/optimization/inputs | jq '.slots[16:20]'` shows non-null `price_export_p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)