### PR TITLE
feat(replay): LP backtest harness for solver regression analysis

### DIFF
--- a/scripts/replay_period.py
+++ b/scripts/replay_period.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""One-shot replay across a date range against a DB snapshot.
+
+Usage:
+    DB_PATH=/tmp/hem-prod.db python scripts/replay_period.py \\
+        2026-04-22 2026-04-23 2026-04-24 2026-04-25 2026-04-26 2026-04-27
+
+Runs ``replay_lp_day(date, cadence='original', mode='honest')`` for each date
+and prints a per-date table plus aggregate totals for "prior" (first half) vs
+"recent" (second half) periods. ``mode='honest'`` keeps each day's snapshotted
+config so we test today's solver code against that day's settings — answering
+"do today's changes outperform what actually ran on day D?".
+
+Negative ``delta_cost_at_actual_p`` means today's code would have saved more.
+Positive means today's code would have cost more (regression candidate).
+
+Read-only — no Fox / Daikin / network touches. Does not write to the DB.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Sequence
+
+
+def _fmt_p(pence: float) -> str:
+    return f"{pence/100:>+8.2f} £"
+
+
+def _fmt_p_nosign(pence: float) -> str:
+    return f"{pence/100:>8.2f} £"
+
+
+def main(argv: Sequence[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+
+    dates = list(argv[1:])
+
+    # Late imports — config reads DB_PATH at import time.
+    from src.scheduler.lp_replay import replay_day
+
+    rows: list[dict] = []
+    for d in dates:
+        result = replay_day(d, cadence="original", mode="honest")
+        rows.append({
+            "date": d,
+            "ok": result.ok,
+            "error": result.error,
+            "n_recalcs": len(result.recalc_run_ids),
+            "orig_cost_p": result.total_original_cost_p,
+            "replayed_cost_p": result.total_replayed_cost_p,
+            "delta_cost_p": result.total_delta_cost_p,
+            "svt_p": result.total_svt_shadow_p,
+            "orig_savings_p": result.total_original_savings_vs_svt_p,
+            "replayed_savings_p": result.total_replayed_savings_vs_svt_p,
+            "n_active_slots": len(result.active_slots),
+        })
+
+    print()
+    print("Per-day replay (today's solver code, honest mode):")
+    print(
+        f"  {'Date':<12} {'recalcs':>8} {'slots':>6} "
+        f"{'orig £':>10} {'replay £':>10} {'Δ £':>10} "
+        f"{'orig vs SVT':>12} {'replay vs SVT':>14} {'status':<10}"
+    )
+    print("  " + "-" * 110)
+    for r in rows:
+        if not r["ok"]:
+            print(f"  {r['date']:<12} {'-':>8} {'-':>6} {'-':>10} {'-':>10} {'-':>10} "
+                  f"{'-':>12} {'-':>14} {'fail':<10}  ({r['error']})")
+            continue
+        print(
+            f"  {r['date']:<12} {r['n_recalcs']:>8} {r['n_active_slots']:>6} "
+            f"{_fmt_p_nosign(r['orig_cost_p']):>10} "
+            f"{_fmt_p_nosign(r['replayed_cost_p']):>10} "
+            f"{_fmt_p(r['delta_cost_p']):>10} "
+            f"{_fmt_p(r['orig_savings_p']):>12} "
+            f"{_fmt_p(r['replayed_savings_p']):>14}  ok"
+        )
+
+    ok = [r for r in rows if r["ok"]]
+    if len(ok) >= 2:
+        half = len(ok) // 2
+        prior = ok[:half]
+        recent = ok[half:]
+        prior_delta = sum(r["delta_cost_p"] for r in prior)
+        recent_delta = sum(r["delta_cost_p"] for r in recent)
+
+        prior_orig_savings = sum(r["orig_savings_p"] for r in prior)
+        prior_replay_savings = sum(r["replayed_savings_p"] for r in prior)
+        recent_orig_savings = sum(r["orig_savings_p"] for r in recent)
+        recent_replay_savings = sum(r["replayed_savings_p"] for r in recent)
+
+        print()
+        print(f"Aggregate — prior period ({prior[0]['date']}–{prior[-1]['date']}):")
+        print(f"  orig savings vs SVT:    {_fmt_p(prior_orig_savings)}")
+        print(f"  replay savings vs SVT:  {_fmt_p(prior_replay_savings)}")
+        print(f"  Δ cost vs original:     {_fmt_p(prior_delta)}  "
+              "(negative = today's code saves more)")
+
+        print()
+        print(f"Aggregate — recent period ({recent[0]['date']}–{recent[-1]['date']}):")
+        print(f"  orig savings vs SVT:    {_fmt_p(recent_orig_savings)}")
+        print(f"  replay savings vs SVT:  {_fmt_p(recent_replay_savings)}")
+        print(f"  Δ cost vs original:     {_fmt_p(recent_delta)}  "
+              "(negative = today's code saves more)")
+
+        print()
+        print("Verdict on 'did our recent changes outperform the previous setup?':")
+        # If today's code beats original on BOTH periods (negative deltas), it's
+        # a generic improvement. If it only beats on one, the answer is mixed.
+        n_better = sum(1 for r in ok if r["delta_cost_p"] < 0)
+        n_worse = sum(1 for r in ok if r["delta_cost_p"] > 0)
+        print(f"  days today's code saves more:  {n_better}/{len(ok)}")
+        print(f"  days today's code costs more:  {n_worse}/{len(ok)}")
+        net = sum(r["delta_cost_p"] for r in ok)
+        if net < 0:
+            print(f"  net £ across all days:         {_fmt_p(net)}  → today's code wins")
+        elif net > 0:
+            print(f"  net £ across all days:         {_fmt_p(net)}  → today's code loses")
+        else:
+            print(f"  net £ across all days:         {_fmt_p(net)}  → tie")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -43,6 +43,12 @@ from ..scheduler.runner import (
     stop_background_scheduler,
 )
 from ..mcp_server import build_mcp
+from ..scheduler.lp_replay import (
+    replay_day as lp_replay_day,
+    replay_run as lp_replay_run,
+    resolve_run_id_for_date as lp_resolve_run_id_for_date,
+    sweep_cadences as lp_sweep_cadences,
+)
 from . import safeguards
 from .middleware import BearerAuthMiddleware
 from .models import (
@@ -2758,6 +2764,109 @@ async def optimization_reject(req: RejectPlanRequest, x_simulation_id: str | Non
         status="not_applicable",
         message="Bulletproof does not use plan consent. Adjust presets and re-run POST /api/v1/optimization/propose.",
     )
+
+
+# ---------------------------------------------------------------------------
+# LP replay / backtest harness
+# ---------------------------------------------------------------------------
+
+from pydantic import BaseModel, Field as _PField  # local import — keeps top-of-file lean
+
+
+class LpReplayRequest(BaseModel):
+    run_id: int | None = _PField(None, description="Specific optimizer_log id to replay")
+    date: str | None = _PField(None, description="YYYY-MM-DD; first run of the local day is used")
+    mode: str = _PField("honest", description="'honest' (snapshotted config) or 'forward' (current config)")
+
+
+class LpReplayDayRequest(BaseModel):
+    date: str = _PField(..., description="YYYY-MM-DD local date")
+    cadence: str = _PField("original", description="'original'|'first'|'first:N'|'stride:K'|'subset:0,2,5'")
+    mode: str = _PField("honest", description="'honest' or 'forward'")
+
+
+class LpSweepRequest(BaseModel):
+    date: str = _PField(..., description="YYYY-MM-DD local date")
+    cadences: list[str] | None = _PField(None, description="Defaults to ['original','first','first:2','stride:2']")
+    mode: str = _PField("honest", description="'honest' or 'forward'")
+
+
+def _replay_dict(r) -> dict:
+    """Strip the internal _replayed_plan handle from a result dataclass before serialising."""
+    import dataclasses
+    d = dataclasses.asdict(r)
+    if "runs" in d:
+        for run in d.get("runs", []):
+            run.pop("_replayed_plan", None)
+    if "rows" in d:
+        for row in d.get("rows", []):
+            for run in row.get("runs", []):
+                run.pop("_replayed_plan", None)
+    d.pop("_replayed_plan", None)
+    return d
+
+
+def _validate_replay_mode(mode: str) -> None:
+    if mode not in ("honest", "forward"):
+        raise HTTPException(status_code=400, detail=f"mode must be 'honest' or 'forward', got {mode!r}")
+
+
+@app.post("/api/v1/lp/replay")
+async def lp_replay_endpoint(req: LpReplayRequest):
+    """Replay a single past LP run on its frozen snapshot inputs.
+
+    Provide either ``run_id`` (specific solve) or ``date`` (first run of that
+    local day). See :func:`src.scheduler.lp_replay.replay_run` for the
+    honest/forward mode semantics. Read-only — no DB / Fox / Daikin writes.
+    """
+    _validate_replay_mode(req.mode)
+    if req.run_id is None and not req.date:
+        raise HTTPException(status_code=400, detail="must provide run_id or date")
+    if req.run_id is not None and req.date:
+        raise HTTPException(status_code=400, detail="provide either run_id or date, not both")
+
+    run_id = req.run_id
+    if run_id is None:
+        try:
+            from datetime import date as _d
+            _d.fromisoformat(req.date)  # type: ignore[arg-type]
+        except ValueError:
+            raise HTTPException(status_code=400, detail=f"date must be YYYY-MM-DD, got {req.date!r}")
+        resolved = await asyncio.to_thread(lp_resolve_run_id_for_date, req.date)  # type: ignore[arg-type]
+        if resolved is None:
+            raise HTTPException(status_code=404, detail=f"no optimizer_log row for date={req.date}")
+        run_id = resolved
+
+    result = await asyncio.to_thread(lp_replay_run, run_id, mode=req.mode)
+    return _replay_dict(result)
+
+
+@app.post("/api/v1/lp/replay-day")
+async def lp_replay_day_endpoint(req: LpReplayDayRequest):
+    """Chain-replay all (or a subset of) the day's optimizer runs."""
+    _validate_replay_mode(req.mode)
+    try:
+        from datetime import date as _d
+        _d.fromisoformat(req.date)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"date must be YYYY-MM-DD, got {req.date!r}")
+
+    result = await asyncio.to_thread(lp_replay_day, req.date, cadence=req.cadence, mode=req.mode)
+    return _replay_dict(result)
+
+
+@app.post("/api/v1/lp/sweep-cadences")
+async def lp_sweep_cadences_endpoint(req: LpSweepRequest):
+    """Sweep multiple cadences across one local date and rank by savings vs SVT."""
+    _validate_replay_mode(req.mode)
+    try:
+        from datetime import date as _d
+        _d.fromisoformat(req.date)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"date must be YYYY-MM-DD, got {req.date!r}")
+    cadences = req.cadences if req.cadences else ["original", "first", "first:2", "stride:2"]
+    result = await asyncio.to_thread(lp_sweep_cadences, req.date, cadences=cadences, mode=req.mode)
+    return _replay_dict(result)
 
 
 @app.get("/api/v1/optimization/pending")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -36,6 +36,15 @@ from .daikin.client import DaikinClient, DaikinError
 from .daikin.models import DaikinDevice
 from .foxess.client import WORK_MODE_VALID, FoxESSClient, FoxESSError
 from .foxess.service import get_cached_realtime, get_refresh_stats
+from .scheduler.lp_replay import (
+    LpCadenceSweepResult,
+    LpDayReplayResult,
+    LpReplayResult,
+    replay_day,
+    replay_run,
+    resolve_run_id_for_date,
+    sweep_cadences,
+)
 from .scheduler.lp_simulation import run_lp_simulation
 
 # Single-worker executor for non-blocking optimizer calls from the MCP transport.
@@ -201,6 +210,55 @@ def _simulate_plan_empty_response(ok: bool, error: str | None, received: dict) -
         "applied_overrides": {},
         "ignored_overrides": {},
     }
+
+
+def _replay_result_to_dict(r: LpReplayResult) -> dict[str, Any]:
+    """Serialise an LpReplayResult, stripping the internal _replayed_plan handle."""
+    import dataclasses
+    d = dataclasses.asdict(r)
+    d.pop("_replayed_plan", None)
+    return d
+
+
+def _day_result_to_dict(r: LpDayReplayResult) -> dict[str, Any]:
+    """Serialise LpDayReplayResult; nested run results have their plan handle stripped."""
+    import dataclasses
+    d = dataclasses.asdict(r)
+    # asdict recurses, so nested runs are already dicts. Strip the key from each.
+    for run in d.get("runs", []):
+        run.pop("_replayed_plan", None)
+    return d
+
+
+def _sweep_result_to_dict(r: LpCadenceSweepResult) -> dict[str, Any]:
+    import dataclasses
+    d = dataclasses.asdict(r)
+    for row in d.get("rows", []):
+        for run in row.get("runs", []):
+            run.pop("_replayed_plan", None)
+    return d
+
+
+_REPLAY_VALID_MODES = frozenset({"honest", "forward"})
+
+
+def _validate_replay_args(
+    *, run_id: int | None, date: str | None, mode: str,
+) -> str | None:
+    """Return error string when args are invalid, or None when ok."""
+    if mode not in _REPLAY_VALID_MODES:
+        return f"mode must be one of {sorted(_REPLAY_VALID_MODES)}, got {mode!r}"
+    if run_id is None and not date:
+        return "must provide run_id or date"
+    if run_id is not None and date:
+        return "provide either run_id or date, not both"
+    if date:
+        try:
+            from datetime import date as _d
+            _d.fromisoformat(date)
+        except ValueError:
+            return f"date must be YYYY-MM-DD, got {date!r}"
+    return None
 
 
 def _run_simulate_plan_body(overrides: dict[str, Any]) -> dict[str, Any]:
@@ -768,6 +826,105 @@ def build_mcp() -> FastMCP:
             return _simulate_plan_empty_response(
                 False, f"simulate_plan failed: {e}", overrides
             )
+
+    @mcp.tool(
+        name="replay_lp_plan",
+        description=(
+            "Replay one past LP run on its frozen snapshot inputs. Use this to "
+            "answer 'did today's solver code regress vs the code that ran on day D?'. "
+            "Provide either run_id (specific solve) or date (YYYY-MM-DD; picks first run "
+            "of that local day). Mode 'honest' (default) applies the snapshotted config "
+            "so we test today's solver code against that day's config; mode 'forward' "
+            "uses today's config to ask 'would the current setup do better on D's market?'. "
+            "Returns objective deltas plus £-cost of the replayed plan priced at actual "
+            "Agile rates vs the original plan, so negative delta_cost_at_actual_p means "
+            "today's code would have saved more money on that day. Read-only — no DB / "
+            "Fox / Daikin writes, no quota burn."
+        ),
+    )
+    def replay_lp_plan(
+        run_id: int | None = None,
+        date: str | None = None,
+        mode: str = "honest",
+    ) -> dict[str, Any]:
+        err = _validate_replay_args(run_id=run_id, date=date, mode=mode)
+        if err:
+            return {"ok": False, "error": err}
+
+        if run_id is None:
+            assert date is not None
+            resolved = resolve_run_id_for_date(date, which="first")
+            if resolved is None:
+                return {"ok": False, "error": f"no optimizer_log row for date={date}"}
+            run_id = resolved
+
+        try:
+            future = _optimizer_executor.submit(replay_run, run_id, mode=mode)  # type: ignore[arg-type]
+            result = future.result(timeout=120)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "replay_lp_plan timed out after 120s"}
+        except Exception as e:
+            return {"ok": False, "error": f"replay_lp_plan failed: {e}"}
+        return _replay_result_to_dict(result)
+
+    @mcp.tool(
+        name="replay_lp_day",
+        description=(
+            "Chain-replay the day's optimizer runs (subset by cadence) on frozen inputs, "
+            "scoring the whole day's policy under today's solver. Cadence DSL: 'original' "
+            "(all runs that fired that day), 'first' (only first run), 'first:N', 'stride:K' "
+            "(every K-th), 'subset:0,2,5' (specific positions). Returns total £-cost of the "
+            "chained replay vs the originals priced at actual Agile rates, plus per-slot "
+            "active dispatch and a savings-vs-SVT figure for both. Custom-clock cadences "
+            "('hourly', 'fixed:HH:MM') are deferred to v2 — they synthesise inputs the LP "
+            "never saw, which would taint the comparison."
+        ),
+    )
+    def replay_lp_day(
+        date: str,
+        cadence: str = "original",
+        mode: str = "honest",
+    ) -> dict[str, Any]:
+        err = _validate_replay_args(run_id=None, date=date, mode=mode)
+        if err:
+            return {"ok": False, "error": err}
+        try:
+            future = _optimizer_executor.submit(replay_day, date, cadence=cadence, mode=mode)  # type: ignore[arg-type]
+            result = future.result(timeout=600)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "replay_lp_day timed out after 600s"}
+        except Exception as e:
+            return {"ok": False, "error": f"replay_lp_day failed: {e}"}
+        return _day_result_to_dict(result)
+
+    @mcp.tool(
+        name="sweep_lp_cadences",
+        description=(
+            "Run replay_lp_day across multiple cadences for one local date and rank by "
+            "savings vs SVT. Default cadences cover ('original', 'first', 'first:2', "
+            "'stride:2'). Use this to answer 'would fewer / more recalcs have done better?'. "
+            "Returns the full per-cadence breakdown and the winning label."
+        ),
+    )
+    def sweep_lp_cadences(
+        date: str,
+        cadences: list[str] | None = None,
+        mode: str = "honest",
+    ) -> dict[str, Any]:
+        err = _validate_replay_args(run_id=None, date=date, mode=mode)
+        if err:
+            return {"ok": False, "error": err}
+        cadence_list = cadences if cadences else ["original", "first", "first:2", "stride:2"]
+        try:
+            future = _optimizer_executor.submit(  # type: ignore[arg-type]
+                sweep_cadences, date, cadences=cadence_list, mode=mode,
+            )
+            result = future.result(timeout=1200)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "sweep_lp_cadences timed out after 1200s"}
+        except Exception as e:
+            return {"ok": False, "error": f"sweep_lp_cadences failed: {e}"}
+        return _sweep_result_to_dict(result)
 
     @mcp.tool(
         name="propose_optimization_plan",

--- a/src/scheduler/lp_replay.py
+++ b/src/scheduler/lp_replay.py
@@ -1,0 +1,941 @@
+"""LP backtest / replay harness.
+
+Re-runs :func:`solve_lp` for past optimizer runs using the inputs that were
+durably snapshotted at the time. Lets us answer:
+
+1. Did today's solver code regress vs the code that ran on day D? — replay
+   each of D's runs on its own snapshot, compare the new objective and the
+   £-cost of the replayed plan against the original.
+
+2. Did the recalc cadence we ran (n recalcs/day) beat fewer/more recalcs? —
+   chain replays through subsets of the day's runs, score each cadence's
+   total dispatch against the actual Agile rates for that day.
+
+3. Would today's *config* do better if we re-ran it on D's market? — same as
+   (1) but with current config (mode="forward") instead of the snapshotted
+   config (mode="honest").
+
+State propagation between chained replays trusts the LP's own forward
+integration (``lp_solution_snapshot.soc_kwh`` / ``tank_temp_c``) — the plan
+is assumed to be followed perfectly. Absolute £ totals therefore differ
+from prod realised totals; *deltas* between solvers/cadences on the same
+chain are clean.
+
+This module never touches Fox/Daikin and never fetches live weather. All
+inputs come from SQLite snapshots:
+
+* ``lp_inputs_snapshot``   — config, base load, initial SoC/tank/indoor.
+* ``lp_solution_snapshot`` — slot vector + price + original dispatch.
+* ``meteo_forecast_history`` — weather forecast as the LP saw it.
+* ``agile_rates`` / ``agile_export_rates`` — actual published prices.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, date as _date, datetime, timedelta
+from typing import Any, Iterable, Iterator, Literal
+from zoneinfo import ZoneInfo
+
+from .. import db
+from ..config import config
+from ..weather import (
+    HourlyForecast,
+    WeatherLpSeries,
+    compute_heating_demand_factor,
+    estimate_pv_kw,
+    forecast_to_lp_inputs,
+)
+from .lp_optimizer import LpInitialState, LpPlan, solve_lp
+
+logger = logging.getLogger(__name__)
+
+Mode = Literal["honest", "forward"]
+WeatherFidelity = Literal["approx", "missing"]
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LpReplayResult:
+    """Outcome of one single-run replay (Layer 1)."""
+
+    ok: bool
+    error: str | None = None
+
+    run_id: int = 0
+    plan_date: str = ""
+    run_at_utc: str = ""
+    mode: Mode = "honest"
+    weather_fidelity: WeatherFidelity = "approx"
+    skipped_config_keys: list[str] = field(default_factory=list)
+
+    original_objective_pence: float | None = None
+    original_objective_reconstructed: bool = True
+    replayed_objective_pence: float = 0.0
+    delta_objective_pence: float = 0.0  # replayed - original
+
+    original_cost_at_actual_p: float = 0.0
+    replayed_cost_at_actual_p: float = 0.0
+    delta_cost_at_actual_p: float = 0.0  # replayed - original; negative = today's code saves more
+    svt_shadow_p: float = 0.0
+    original_savings_vs_svt_p: float = 0.0
+    replayed_savings_vs_svt_p: float = 0.0
+
+    slot_diffs: list[dict[str, Any]] = field(default_factory=list)
+
+    # Internal — Layer 2 chains use this. Not exposed via JSON.
+    _replayed_plan: LpPlan | None = None
+
+
+@dataclass
+class LpDayReplayResult:
+    """Outcome of a multi-run chained replay across one day (Layer 2)."""
+
+    ok: bool
+    error: str | None = None
+
+    plan_date: str = ""
+    cadence_label: str = ""
+    mode: Mode = "honest"
+    recalc_run_ids: list[int] = field(default_factory=list)
+    recalc_timestamps_utc: list[str] = field(default_factory=list)
+    runs: list[LpReplayResult] = field(default_factory=list)
+
+    active_slots: list[dict[str, Any]] = field(default_factory=list)
+    total_original_cost_p: float = 0.0
+    total_replayed_cost_p: float = 0.0
+    total_delta_cost_p: float = 0.0
+    total_svt_shadow_p: float = 0.0
+    total_original_savings_vs_svt_p: float = 0.0
+    total_replayed_savings_vs_svt_p: float = 0.0
+
+    fidelity_notes: str = (
+        "plan-followed-perfectly idealisation: state propagated from each plan's "
+        "predicted SoC/tank into the next recalc, no execution-noise injection"
+    )
+
+
+@dataclass
+class LpCadenceSweepResult:
+    """Outcome of a multi-cadence sweep across one day (Layer 3)."""
+
+    ok: bool
+    error: str | None = None
+
+    plan_date: str = ""
+    mode: Mode = "honest"
+    rows: list[LpDayReplayResult] = field(default_factory=list)
+    best_cadence_label: str = ""
+    best_total_replayed_savings_vs_svt_p: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+def resolve_run_id_for_date(
+    local_date: str,
+    *,
+    which: Literal["first", "last"] = "first",
+    tz_name: str | None = None,
+) -> int | None:
+    """Pick a single run_id for a given local calendar day.
+
+    ``local_date`` is ``YYYY-MM-DD``. Returns the first (or last) optimizer_log
+    row whose ``run_at`` falls inside that local day.
+    """
+    try:
+        d = _date.fromisoformat(local_date)
+    except ValueError:
+        return None
+    tz = ZoneInfo(tz_name or config.BULLETPROOF_TIMEZONE)
+    local_start = datetime.combine(d, datetime.min.time(), tzinfo=tz)
+    local_end = local_start + timedelta(days=1)
+    utc_start = local_start.astimezone(UTC).isoformat()
+    utc_end = local_end.astimezone(UTC).isoformat()
+
+    order = "ASC" if which == "first" else "DESC"
+    with db._lock:
+        conn = db.get_connection()
+        try:
+            cur = conn.execute(
+                f"""SELECT id FROM optimizer_log
+                   WHERE run_at >= ? AND run_at < ?
+                   ORDER BY run_at {order} LIMIT 1""",
+                (utc_start, utc_end),
+            )
+            row = cur.fetchone()
+            return int(row[0]) if row else None
+        finally:
+            conn.close()
+
+
+def list_run_ids_for_date(
+    local_date: str,
+    *,
+    tz_name: str | None = None,
+) -> list[tuple[int, str]]:
+    """Replayable (run_id, run_at_utc) tuples for a local calendar day.
+
+    Restricted to runs that have a corresponding ``lp_inputs_snapshot`` row —
+    i.e. LP runs (not heuristic fallbacks) and runs after the V11 snapshot
+    migration. Ordered by run_at ASC.
+    """
+    try:
+        d = _date.fromisoformat(local_date)
+    except ValueError:
+        return []
+    tz = ZoneInfo(tz_name or config.BULLETPROOF_TIMEZONE)
+    local_start = datetime.combine(d, datetime.min.time(), tzinfo=tz)
+    local_end = local_start + timedelta(days=1)
+    utc_start = local_start.astimezone(UTC).isoformat()
+    utc_end = local_end.astimezone(UTC).isoformat()
+    with db._lock:
+        conn = db.get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT o.id, o.run_at FROM optimizer_log o
+                   INNER JOIN lp_inputs_snapshot s ON s.run_id = o.id
+                   WHERE o.run_at >= ? AND o.run_at < ?
+                   ORDER BY o.run_at ASC""",
+                (utc_start, utc_end),
+            )
+            return [(int(r[0]), str(r[1])) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def replay_run(
+    run_id: int,
+    *,
+    mode: Mode = "honest",
+    initial_override: LpInitialState | None = None,
+) -> LpReplayResult:
+    """Replay one past optimizer run on its frozen snapshot inputs.
+
+    See module docstring for honest vs forward mode semantics.
+    """
+    inputs = db.get_lp_inputs(run_id)
+    if not inputs:
+        return LpReplayResult(
+            ok=False, error=f"no lp_inputs_snapshot for run_id={run_id}", run_id=run_id, mode=mode,
+        )
+    slots = db.get_lp_solution_slots(run_id)
+    if not slots:
+        return LpReplayResult(
+            ok=False, error=f"no lp_solution_snapshot for run_id={run_id}", run_id=run_id, mode=mode,
+        )
+
+    run_at_utc = str(inputs.get("run_at_utc") or "")
+    plan_date = str(inputs.get("plan_date") or "")
+
+    # Slot vector + prices come from the snapshot — preserves DST 46/50 exactly.
+    slot_starts_utc: list[datetime] = []
+    price_pence: list[float] = []
+    for s in slots:
+        try:
+            t = _parse_iso(str(s["slot_time_utc"]))
+        except (KeyError, ValueError, TypeError) as e:
+            return LpReplayResult(
+                ok=False, error=f"bad slot_time_utc in snapshot: {e}",
+                run_id=run_id, mode=mode, run_at_utc=run_at_utc, plan_date=plan_date,
+            )
+        slot_starts_utc.append(t)
+        price_pence.append(float(s.get("price_p") or 0.0))
+
+    # base_load_json is what the LP saw at solve-time. Truth-as-the-LP-saw-it.
+    try:
+        base_load_kwh = [float(x) for x in json.loads(inputs.get("base_load_json") or "[]")]
+    except (TypeError, ValueError, json.JSONDecodeError) as e:
+        return LpReplayResult(
+            ok=False, error=f"bad base_load_json: {e}",
+            run_id=run_id, mode=mode, run_at_utc=run_at_utc, plan_date=plan_date,
+        )
+    if len(base_load_kwh) != len(slot_starts_utc):
+        return LpReplayResult(
+            ok=False,
+            error=f"base_load length {len(base_load_kwh)} != slot count {len(slot_starts_utc)}",
+            run_id=run_id, mode=mode, run_at_utc=run_at_utc, plan_date=plan_date,
+        )
+
+    # Initial state — caller may override (Layer 2 chaining).
+    if initial_override is not None:
+        initial = initial_override
+    else:
+        initial = LpInitialState(
+            soc_kwh=float(inputs.get("soc_initial_kwh") or 0.0),
+            tank_temp_c=float(inputs.get("tank_initial_c") or 45.0),
+            indoor_temp_c=float(inputs.get("indoor_initial_c") or 20.0),
+            soc_source=str(inputs.get("soc_source") or "snapshot"),
+            tank_source=str(inputs.get("tank_source") or "snapshot"),
+            indoor_source=str(inputs.get("indoor_source") or "snapshot"),
+        )
+
+    # Weather: prefer the forecast snapshot at-or-before run_at_utc (closest fetch).
+    weather, weather_fidelity = _reconstruct_weather(run_at_utc, slot_starts_utc)
+    if weather_fidelity == "missing":
+        return LpReplayResult(
+            ok=False, error="weather snapshot missing for this run",
+            run_id=run_id, mode=mode, run_at_utc=run_at_utc, plan_date=plan_date,
+            weather_fidelity="missing",
+        )
+
+    # Export prices for the same window — None if outgoing tariff not fetched/configured.
+    export_price_pence = _build_export_prices(slot_starts_utc)
+
+    # Micro-climate offset: snapshot value in honest mode, current config in forward.
+    if mode == "honest":
+        mco = float(inputs.get("micro_climate_offset_c") or 0.0)
+    else:
+        try:
+            mco = float(db.get_micro_climate_offset_c(getattr(config, "DAIKIN_MICRO_CLIMATE_LOOKBACK", 96)))
+        except Exception:
+            mco = 0.0
+
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+
+    # Apply config overrides (honest only) and solve.
+    overrides_payload: dict[str, Any] | None = None
+    if mode == "honest":
+        try:
+            overrides_payload = json.loads(inputs.get("config_snapshot_json") or "{}")
+        except (TypeError, ValueError, json.JSONDecodeError):
+            overrides_payload = {}
+
+    skipped_keys: list[str] = []
+    with _config_overrides(overrides_payload, skipped_keys):
+        try:
+            plan = solve_lp(
+                slot_starts_utc=slot_starts_utc,
+                price_pence=price_pence,
+                base_load_kwh=base_load_kwh,
+                weather=weather,
+                initial=initial,
+                tz=tz,
+                micro_climate_offset_c=mco,
+                export_price_pence=export_price_pence,
+            )
+        except Exception as e:  # solver failure — surface, don't crash
+            return LpReplayResult(
+                ok=False, error=f"solve_lp raised: {e}",
+                run_id=run_id, mode=mode, run_at_utc=run_at_utc, plan_date=plan_date,
+                weather_fidelity=weather_fidelity, skipped_config_keys=skipped_keys,
+            )
+
+    if not plan.ok:
+        return LpReplayResult(
+            ok=False, error=f"solver status: {plan.status}",
+            run_id=run_id, mode=mode, run_at_utc=run_at_utc, plan_date=plan_date,
+            weather_fidelity=weather_fidelity, skipped_config_keys=skipped_keys,
+            replayed_objective_pence=float(plan.objective_pence),
+        )
+
+    # Score against actual published rates (the £ counterfactual).
+    score = _score_against_actuals(slot_starts_utc, slots, plan)
+
+    # Reconstruct the original objective from snapshot dispatch + price (no penalties).
+    original_objective_recon = _reconstruct_original_objective_from_slots(slots, export_price_pence)
+
+    slot_diffs = _build_slot_diffs(slots, plan)
+
+    return LpReplayResult(
+        ok=True,
+        run_id=run_id,
+        plan_date=plan_date,
+        run_at_utc=run_at_utc,
+        mode=mode,
+        weather_fidelity=weather_fidelity,
+        skipped_config_keys=skipped_keys,
+        original_objective_pence=original_objective_recon,
+        original_objective_reconstructed=True,
+        replayed_objective_pence=float(plan.objective_pence),
+        delta_objective_pence=float(plan.objective_pence) - original_objective_recon,
+        original_cost_at_actual_p=score["original_cost_p"],
+        replayed_cost_at_actual_p=score["replayed_cost_p"],
+        delta_cost_at_actual_p=score["replayed_cost_p"] - score["original_cost_p"],
+        svt_shadow_p=score["svt_shadow_p"],
+        original_savings_vs_svt_p=score["svt_shadow_p"] - score["original_cost_p"],
+        replayed_savings_vs_svt_p=score["svt_shadow_p"] - score["replayed_cost_p"],
+        slot_diffs=slot_diffs,
+        _replayed_plan=plan,
+    )
+
+
+def replay_day(
+    local_date: str,
+    *,
+    cadence: str = "original",
+    mode: Mode = "honest",
+) -> LpDayReplayResult:
+    """Chain-replay all (or a subset of) the day's optimizer runs.
+
+    ``cadence`` (subset of original run_ids — see module docstring):
+      - ``"original"`` — every run_id that fired that local day.
+      - ``"first"`` — only the first run_id of the day.
+      - ``"first:N"`` — only the first N run_ids.
+      - ``"stride:K"`` — every K-th run_id (so ``stride:2`` is every other).
+      - ``"subset:0,2,5"`` — specific 0-indexed positions in the day's run list.
+
+    Custom-clock cadences (e.g. ``"hourly"``, ``"fixed:00:05,12:00"``) are a
+    deliberate v2 — they require synthesising inputs the LP never saw, which
+    would taint the comparison. Until that arrives, use subset cadences over
+    the real recalc sequence.
+    """
+    runs = list_run_ids_for_date(local_date)
+    if not runs:
+        return LpDayReplayResult(
+            ok=False, error=f"no optimizer_log rows for {local_date}",
+            plan_date=local_date, cadence_label=cadence, mode=mode,
+        )
+
+    try:
+        selected = _apply_cadence_filter(runs, cadence)
+    except ValueError as e:
+        return LpDayReplayResult(
+            ok=False, error=f"bad cadence: {e}",
+            plan_date=local_date, cadence_label=cadence, mode=mode,
+        )
+    if not selected:
+        return LpDayReplayResult(
+            ok=False, error=f"cadence {cadence!r} matched zero runs",
+            plan_date=local_date, cadence_label=cadence, mode=mode,
+        )
+
+    # Boundary timestamps: each run is "active" until the next selected run starts.
+    selected_run_ids = [rid for rid, _ in selected]
+    selected_timestamps = [ts for _, ts in selected]
+
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+    local_d = _date.fromisoformat(local_date)
+    day_end_utc = (
+        datetime.combine(local_d + timedelta(days=1), datetime.min.time(), tzinfo=tz).astimezone(UTC)
+    )
+
+    boundaries_utc: list[datetime] = []
+    for ts in selected_timestamps:
+        boundaries_utc.append(_parse_iso(ts))
+    boundaries_utc.append(day_end_utc)  # last run runs through end-of-day
+
+    results: list[LpReplayResult] = []
+    state_override: LpInitialState | None = None
+
+    for k, run_id in enumerate(selected_run_ids):
+        next_boundary = boundaries_utc[k + 1]
+
+        result = replay_run(run_id, mode=mode, initial_override=state_override)
+        results.append(result)
+        if not result.ok:
+            return LpDayReplayResult(
+                ok=False, error=f"chain broke at run_id={run_id}: {result.error}",
+                plan_date=local_date, cadence_label=cadence, mode=mode,
+                recalc_run_ids=selected_run_ids[: k + 1],
+                recalc_timestamps_utc=selected_timestamps[: k + 1],
+                runs=results,
+            )
+
+        # Seed next recalc from THIS replay's predicted state at the boundary.
+        plan = result._replayed_plan
+        if plan is not None and k + 1 < len(selected_run_ids):
+            state_override = _state_at(plan, next_boundary)
+
+    # Concatenate active slot windows: each run's plan slots in [t_k, t_{k+1}).
+    total_original_p = 0.0
+    total_replayed_p = 0.0
+    total_svt_p = 0.0
+    active: list[dict[str, Any]] = []
+    for k, result in enumerate(results):
+        plan = result._replayed_plan
+        if plan is None:
+            continue
+        t_lo = boundaries_utc[k]
+        t_hi = boundaries_utc[k + 1]
+        # Slots whose START falls in [t_lo, t_hi). Original t_lo equals the run's
+        # first slot, so this is the "until next recalc" window.
+        for i, st in enumerate(plan.slot_starts_utc):
+            if not (t_lo <= st < t_hi):
+                continue
+            agile_p = float(plan.price_pence[i]) if i < len(plan.price_pence) else 0.0
+            export_p = _export_for_slot(st)
+            replayed_imp = float(plan.import_kwh[i]) if i < len(plan.import_kwh) else 0.0
+            replayed_exp = float(plan.export_kwh[i]) if i < len(plan.export_kwh) else 0.0
+            replayed_cost = replayed_imp * agile_p - replayed_exp * export_p
+
+            # Original dispatch on the same slot — pull from the snapshot whose
+            # window covers this t (the run that fired at boundaries_utc[k]).
+            orig_row = _find_original_slot(result.run_id, st)
+            if orig_row is not None:
+                orig_imp = float(orig_row.get("import_kwh") or 0.0)
+                orig_exp = float(orig_row.get("export_kwh") or 0.0)
+                orig_cost = orig_imp * agile_p - orig_exp * export_p
+            else:
+                orig_imp = 0.0
+                orig_exp = 0.0
+                orig_cost = 0.0
+
+            svt_p = _svt_shadow_for_slot(st)
+            active.append({
+                "slot_time_utc": st.isoformat(),
+                "active_run_id": result.run_id,
+                "price_p": agile_p,
+                "export_price_p": export_p,
+                "original_import_kwh": orig_imp,
+                "original_export_kwh": orig_exp,
+                "original_cost_p": orig_cost,
+                "replayed_import_kwh": replayed_imp,
+                "replayed_export_kwh": replayed_exp,
+                "replayed_cost_p": replayed_cost,
+                "svt_shadow_p": svt_p,
+            })
+            total_original_p += orig_cost
+            total_replayed_p += replayed_cost
+            total_svt_p += svt_p
+
+    return LpDayReplayResult(
+        ok=True,
+        plan_date=local_date,
+        cadence_label=cadence,
+        mode=mode,
+        recalc_run_ids=selected_run_ids,
+        recalc_timestamps_utc=selected_timestamps,
+        runs=results,
+        active_slots=active,
+        total_original_cost_p=total_original_p,
+        total_replayed_cost_p=total_replayed_p,
+        total_delta_cost_p=total_replayed_p - total_original_p,
+        total_svt_shadow_p=total_svt_p,
+        total_original_savings_vs_svt_p=total_svt_p - total_original_p,
+        total_replayed_savings_vs_svt_p=total_svt_p - total_replayed_p,
+    )
+
+
+def sweep_cadences(
+    local_date: str,
+    *,
+    cadences: Iterable[str] = (
+        "original",
+        "first",
+        "first:2",
+        "stride:2",
+    ),
+    mode: Mode = "honest",
+) -> LpCadenceSweepResult:
+    """Run :func:`replay_day` across multiple cadences and rank by savings vs SVT."""
+    rows: list[LpDayReplayResult] = []
+    for c in cadences:
+        rows.append(replay_day(local_date, cadence=c, mode=mode))
+
+    ok_rows = [r for r in rows if r.ok]
+    if not ok_rows:
+        return LpCadenceSweepResult(
+            ok=False,
+            error="no cadence produced a valid replay (see rows for per-cadence errors)",
+            plan_date=local_date, mode=mode, rows=rows,
+        )
+
+    best = max(ok_rows, key=lambda r: r.total_replayed_savings_vs_svt_p)
+    return LpCadenceSweepResult(
+        ok=True,
+        plan_date=local_date,
+        mode=mode,
+        rows=rows,
+        best_cadence_label=best.cadence_label,
+        best_total_replayed_savings_vs_svt_p=best.total_replayed_savings_vs_svt_p,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _parse_iso(s: str) -> datetime:
+    """Parse a UTC ISO timestamp; tolerate trailing 'Z' and missing tz."""
+    s = s.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+@contextmanager
+def _config_overrides(
+    snapshot: dict[str, Any] | None,
+    skipped_out: list[str],
+) -> Iterator[None]:
+    """Save-set-restore each key on the live ``config`` object.
+
+    Mirrors the simulate_plan pattern in src/mcp_server.py:206-236. Keys not
+    present on the current Config (schema drift) are recorded in ``skipped_out``
+    so the result can surface them rather than silently no-op.
+    """
+    if not snapshot:
+        yield
+        return
+
+    saved: dict[str, Any] = {}
+    try:
+        for k, v in snapshot.items():
+            if hasattr(config, k):
+                saved[k] = getattr(config, k)
+                try:
+                    setattr(config, k, v)
+                except Exception:
+                    skipped_out.append(k)
+            else:
+                skipped_out.append(k)
+        yield
+    finally:
+        for k, v in saved.items():
+            try:
+                setattr(config, k, v)
+            except Exception:
+                pass
+
+
+def _reconstruct_weather(
+    run_at_utc: str,
+    slot_starts_utc: list[datetime],
+) -> tuple[WeatherLpSeries, WeatherFidelity]:
+    """Rebuild WeatherLpSeries from meteo_forecast_history.
+
+    Picks the most recent forecast fetch strictly before ``run_at_utc`` (the
+    forecast the LP saw when it solved). Returns ``("missing")`` fidelity when
+    no fetch exists — caller surfaces an error.
+
+    Cloud cover is lost in the snapshot (only ``temp_c`` + ``solar_w_m2`` are
+    stored). We pass ``cloud_cover_pct=0.0`` to ``HourlyForecast``, which means
+    ``forecast_to_lp_inputs`` skips its cloud-attenuation step. Replay PV is
+    therefore marginally higher than the original solve saw — known fidelity gap.
+    """
+    rows: list[dict[str, Any]] = []
+    if run_at_utc:
+        rows = db.get_meteo_forecast_history_latest_before(run_at_utc)
+    # Empty array → no prior fetch existed.
+    if not rows:
+        empty = WeatherLpSeries(
+            slot_starts_utc=list(slot_starts_utc),
+            temperature_outdoor_c=[10.0] * len(slot_starts_utc),
+            shortwave_radiation_wm2=[0.0] * len(slot_starts_utc),
+            cloud_cover_pct=[0.0] * len(slot_starts_utc),
+            pv_kwh_per_slot=[0.0] * len(slot_starts_utc),
+            cop_space=[3.0] * len(slot_starts_utc),
+            cop_dhw=[2.5] * len(slot_starts_utc),
+        )
+        return empty, "missing"
+
+    forecast: list[HourlyForecast] = []
+    for r in rows:
+        try:
+            t = _parse_iso(str(r["slot_time"]))
+        except (KeyError, ValueError, TypeError):
+            continue
+        temp_c = float(r.get("temp_c") or 10.0)
+        rad = float(r.get("solar_w_m2") or 0.0)
+        forecast.append(
+            HourlyForecast(
+                time_utc=t,
+                temperature_c=temp_c,
+                cloud_cover_pct=0.0,  # lost in snapshot — see docstring
+                shortwave_radiation_wm2=rad,
+                estimated_pv_kw=estimate_pv_kw(rad),
+                heating_demand_factor=compute_heating_demand_factor(temp_c),
+            )
+        )
+
+    weather = forecast_to_lp_inputs(forecast, slot_starts_utc, pv_scale=1.0)
+    return weather, "approx"
+
+
+def _build_export_prices(slot_starts_utc: list[datetime]) -> list[float] | None:
+    """Map per-slot starts to ``agile_export_rates`` value, or None when no outgoing tariff."""
+    if not slot_starts_utc:
+        return None
+    if not (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip():
+        return None
+    period_from = slot_starts_utc[0].isoformat()
+    period_to = (slot_starts_utc[-1] + timedelta(minutes=30)).isoformat()
+    rows = db.get_agile_export_rates_in_range(period_from, period_to)
+    if not rows:
+        return None
+    by_start: dict[str, float] = {}
+    for r in rows:
+        try:
+            iso_norm = str(r["valid_from"]).replace("+00:00", "Z")
+            by_start[iso_norm] = float(r["value_inc_vat"])
+        except (KeyError, TypeError, ValueError):
+            continue
+    flat = float(config.EXPORT_RATE_PENCE)
+    out: list[float] = []
+    matched = 0
+    for st in slot_starts_utc:
+        key = st.isoformat().replace("+00:00", "Z")
+        v = by_start.get(key)
+        if v is not None:
+            out.append(v)
+            matched += 1
+        else:
+            out.append(flat)
+    if matched == 0:
+        return None
+    return out
+
+
+def _export_for_slot(slot_utc: datetime) -> float:
+    """Best-effort actual export rate for one slot. Falls back to flat constant."""
+    iso = slot_utc.isoformat().replace("+00:00", "Z")
+    rows = db.get_agile_export_rates_in_range(slot_utc.isoformat(), (slot_utc + timedelta(minutes=30)).isoformat())
+    for r in rows:
+        if str(r.get("valid_from", "")).replace("+00:00", "Z") == iso:
+            try:
+                return float(r["value_inc_vat"])
+            except (KeyError, TypeError, ValueError):
+                pass
+    return float(config.EXPORT_RATE_PENCE)
+
+
+def _svt_shadow_for_slot(slot_utc: datetime) -> float:
+    """SVT shadow cost for one slot, summed from execution_log within the slot window."""
+    from_ts = slot_utc.isoformat()
+    to_ts = (slot_utc + timedelta(minutes=30)).isoformat()
+    rows = db.get_execution_logs(from_ts=from_ts, to_ts=to_ts, limit=4)
+    total = 0.0
+    for r in rows:
+        v = r.get("cost_svt_shadow_pence")
+        if v is not None:
+            try:
+                total += float(v)
+            except (TypeError, ValueError):
+                pass
+    return total
+
+
+def _find_original_slot(run_id: int, slot_utc: datetime) -> dict[str, Any] | None:
+    """Return the lp_solution_snapshot row for one slot of a known run."""
+    iso_targets = {
+        slot_utc.isoformat(),
+        slot_utc.isoformat().replace("+00:00", "Z"),
+    }
+    for s in db.get_lp_solution_slots(run_id):
+        if str(s.get("slot_time_utc", "")) in iso_targets:
+            return s
+    return None
+
+
+def _score_against_actuals(
+    slot_starts_utc: list[datetime],
+    original_slots: list[dict[str, Any]],
+    replayed_plan: LpPlan,
+) -> dict[str, float]:
+    """£-cost of original vs replayed plan, both priced at actual published rates.
+
+    The LP saw published Agile prices when it solved (Octopus publishes a day
+    ahead), so ``actual ≈ snapshot price_p``. Any £ delta therefore reflects
+    dispatch decision changes only — the regression signal we want.
+    """
+    # Pull actual rates for the entire slot window in one go.
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    rates_by_start: dict[str, float] = {}
+    if tariff and slot_starts_utc:
+        period_from = slot_starts_utc[0]
+        period_to = slot_starts_utc[-1] + timedelta(minutes=30)
+        for r in db.get_rates_for_period(tariff, period_from, period_to):
+            iso = str(r.get("valid_from", "")).replace("+00:00", "Z")
+            try:
+                rates_by_start[iso] = float(r["value_inc_vat"])
+            except (KeyError, TypeError, ValueError):
+                continue
+
+    def _agile(slot: datetime) -> float:
+        iso = slot.isoformat().replace("+00:00", "Z")
+        return rates_by_start.get(iso, 0.0)
+
+    export_actual = [_export_for_slot(s) for s in slot_starts_utc]
+
+    original_cost = 0.0
+    for s in original_slots:
+        try:
+            t = _parse_iso(str(s["slot_time_utc"]))
+        except (KeyError, ValueError, TypeError):
+            continue
+        agile = _agile(t)
+        # Find this slot's index for export price.
+        try:
+            idx = slot_starts_utc.index(t)
+            ep = export_actual[idx]
+        except ValueError:
+            ep = float(config.EXPORT_RATE_PENCE)
+        imp = float(s.get("import_kwh") or 0.0)
+        exp = float(s.get("export_kwh") or 0.0)
+        original_cost += imp * agile - exp * ep
+
+    replayed_cost = 0.0
+    for i, t in enumerate(replayed_plan.slot_starts_utc):
+        agile = _agile(t)
+        ep = export_actual[i] if i < len(export_actual) else float(config.EXPORT_RATE_PENCE)
+        imp = float(replayed_plan.import_kwh[i]) if i < len(replayed_plan.import_kwh) else 0.0
+        exp = float(replayed_plan.export_kwh[i]) if i < len(replayed_plan.export_kwh) else 0.0
+        replayed_cost += imp * agile - exp * ep
+
+    # SVT shadow for the slot window.
+    svt = 0.0
+    if slot_starts_utc:
+        from_ts = slot_starts_utc[0].isoformat()
+        to_ts = (slot_starts_utc[-1] + timedelta(minutes=30)).isoformat()
+        for row in db.get_execution_logs(from_ts=from_ts, to_ts=to_ts, limit=2000):
+            v = row.get("cost_svt_shadow_pence")
+            if v is None:
+                continue
+            try:
+                svt += float(v)
+            except (TypeError, ValueError):
+                continue
+
+    return {
+        "original_cost_p": original_cost,
+        "replayed_cost_p": replayed_cost,
+        "svt_shadow_p": svt,
+    }
+
+
+def _reconstruct_original_objective_from_slots(
+    original_slots: list[dict[str, Any]],
+    export_price_pence: list[float] | None,
+) -> float:
+    """Approximate the original LP's objective from snapshotted dispatch + price.
+
+    This equals the solver's grid component (Σ import·price − Σ export·export_price)
+    minus the soft penalties (cycle, comfort, tank overshoot). Good enough for
+    relative comparison; full fidelity needs a new column on lp_inputs_snapshot.
+    """
+    flat_export = float(config.EXPORT_RATE_PENCE)
+    total = 0.0
+    for i, s in enumerate(original_slots):
+        try:
+            agile = float(s.get("price_p") or 0.0)
+            imp = float(s.get("import_kwh") or 0.0)
+            exp = float(s.get("export_kwh") or 0.0)
+        except (TypeError, ValueError):
+            continue
+        ep = (
+            export_price_pence[i]
+            if export_price_pence is not None and i < len(export_price_pence)
+            else flat_export
+        )
+        total += imp * agile - exp * ep
+    return total
+
+
+def _build_slot_diffs(
+    original_slots: list[dict[str, Any]],
+    plan: LpPlan,
+) -> list[dict[str, Any]]:
+    """Per-slot diff table for downstream rendering / debugging."""
+    out: list[dict[str, Any]] = []
+    n = min(len(original_slots), len(plan.slot_starts_utc))
+    for i in range(n):
+        orig = original_slots[i]
+        st = plan.slot_starts_utc[i]
+        d = {
+            "slot_index": int(orig.get("slot_index", i)),
+            "slot_time_utc": st.isoformat(),
+            "price_p": float(plan.price_pence[i]) if i < len(plan.price_pence) else 0.0,
+            "orig_import_kwh": float(orig.get("import_kwh") or 0.0),
+            "new_import_kwh": float(plan.import_kwh[i]) if i < len(plan.import_kwh) else 0.0,
+            "orig_export_kwh": float(orig.get("export_kwh") or 0.0),
+            "new_export_kwh": float(plan.export_kwh[i]) if i < len(plan.export_kwh) else 0.0,
+            "orig_charge_kwh": float(orig.get("charge_kwh") or 0.0),
+            "new_charge_kwh": float(plan.battery_charge_kwh[i]) if i < len(plan.battery_charge_kwh) else 0.0,
+            "orig_discharge_kwh": float(orig.get("discharge_kwh") or 0.0),
+            "new_discharge_kwh": float(plan.battery_discharge_kwh[i]) if i < len(plan.battery_discharge_kwh) else 0.0,
+            "orig_dhw_kwh": float(orig.get("dhw_kwh") or 0.0),
+            "new_dhw_kwh": float(plan.dhw_electric_kwh[i]) if i < len(plan.dhw_electric_kwh) else 0.0,
+            "orig_space_kwh": float(orig.get("space_kwh") or 0.0),
+            "new_space_kwh": float(plan.space_electric_kwh[i]) if i < len(plan.space_electric_kwh) else 0.0,
+            "orig_soc_kwh": float(orig.get("soc_kwh") or 0.0),
+            "new_soc_kwh": float(plan.soc_kwh[i + 1]) if i + 1 < len(plan.soc_kwh) else 0.0,
+            "orig_tank_temp_c": float(orig.get("tank_temp_c") or 0.0),
+            "new_tank_temp_c": float(plan.tank_temp_c[i + 1]) if i + 1 < len(plan.tank_temp_c) else 0.0,
+        }
+        for k in ("import", "export", "charge", "discharge", "dhw", "space"):
+            d[f"d_{k}_kwh"] = d[f"new_{k}_kwh"] - d[f"orig_{k}_kwh"]
+        out.append(d)
+    return out
+
+
+def _state_at(plan: LpPlan, when_utc: datetime) -> LpInitialState:
+    """Pluck SoC / tank / indoor from the plan at the slot whose start ≤ when_utc < next.
+
+    Used to seed the next chained replay's initial state. The plan's per-slot
+    state arrays are length N+1 (state at start of slot i is index i; state at
+    end is index i+1). We want the state AT ``when_utc``, i.e. the start of the
+    slot beginning at ``when_utc``, or the final state if past the horizon.
+    """
+    starts = plan.slot_starts_utc
+    if not starts:
+        return LpInitialState(soc_kwh=0.0, tank_temp_c=45.0, indoor_temp_c=20.0)
+    if when_utc <= starts[0]:
+        idx = 0
+    elif when_utc >= starts[-1]:
+        idx = len(starts)  # → final state
+    else:
+        # Find first slot whose start >= when_utc.
+        idx = 0
+        for i, st in enumerate(starts):
+            if st >= when_utc:
+                idx = i
+                break
+    soc = plan.soc_kwh[idx] if idx < len(plan.soc_kwh) else (plan.soc_kwh[-1] if plan.soc_kwh else 0.0)
+    tank = plan.tank_temp_c[idx] if idx < len(plan.tank_temp_c) else (plan.tank_temp_c[-1] if plan.tank_temp_c else 45.0)
+    indoor = plan.indoor_temp_c[idx] if idx < len(plan.indoor_temp_c) else (plan.indoor_temp_c[-1] if plan.indoor_temp_c else 20.0)
+    return LpInitialState(
+        soc_kwh=float(soc),
+        tank_temp_c=float(tank),
+        indoor_temp_c=float(indoor),
+        soc_source="replay_chain",
+        tank_source="replay_chain",
+        indoor_source="replay_chain",
+    )
+
+
+def _apply_cadence_filter(
+    runs: list[tuple[int, str]],
+    cadence: str,
+) -> list[tuple[int, str]]:
+    """Filter the day's runs by cadence DSL.
+
+    See :func:`replay_day` for syntax.
+    """
+    cadence = (cadence or "original").strip().lower()
+    if cadence == "original":
+        return list(runs)
+    if cadence == "first":
+        return runs[:1]
+    if cadence.startswith("first:"):
+        try:
+            n = int(cadence.split(":", 1)[1])
+        except ValueError as e:
+            raise ValueError(f"first:N must be integer, got {cadence!r}") from e
+        if n <= 0:
+            raise ValueError(f"first:N must be positive, got {n}")
+        return runs[:n]
+    if cadence.startswith("stride:"):
+        try:
+            k = int(cadence.split(":", 1)[1])
+        except ValueError as e:
+            raise ValueError(f"stride:K must be integer, got {cadence!r}") from e
+        if k <= 0:
+            raise ValueError(f"stride:K must be positive, got {k}")
+        return [r for i, r in enumerate(runs) if i % k == 0]
+    if cadence.startswith("subset:"):
+        try:
+            indices = [int(x.strip()) for x in cadence.split(":", 1)[1].split(",") if x.strip()]
+        except ValueError as e:
+            raise ValueError(f"subset:idx,idx,... must be ints, got {cadence!r}") from e
+        return [runs[i] for i in indices if 0 <= i < len(runs)]
+    raise ValueError(f"unknown cadence {cadence!r}")

--- a/tests/test_lp_replay.py
+++ b/tests/test_lp_replay.py
@@ -1,0 +1,450 @@
+"""LP replay/backtest harness tests.
+
+Layer 1 (single-run replay), Layer 2 (chained day replay), Layer 3 (cadence
+sweep). Builds synthetic snapshots so we don't depend on prod history.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.scheduler.lp_optimizer import LpInitialState, LpPlan, solve_lp
+from src.scheduler.lp_replay import (
+    LpDayReplayResult,
+    _apply_cadence_filter,
+    list_run_ids_for_date,
+    replay_day,
+    replay_run,
+    resolve_run_id_for_date,
+    sweep_cadences,
+)
+from src.weather import (
+    HourlyForecast,
+    WeatherLpSeries,
+    compute_heating_demand_factor,
+    estimate_pv_kw,
+    forecast_to_lp_inputs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _db_ready():
+    db.init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _fast_solver(monkeypatch):
+    """Match test_lp_optimizer's fixture so solves are fast and deterministic."""
+    monkeypatch.setattr(app_config, "LP_HIGHS_TIME_LIMIT_SECONDS", 15)
+    monkeypatch.setattr(app_config, "LP_CBC_TIME_LIMIT_SECONDS", 15)
+    monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
+    monkeypatch.setattr(app_config, "LP_HP_MIN_ON_SLOTS", 1)
+    monkeypatch.setattr(app_config, "LP_SOC_TERMINAL_VALUE_PENCE_PER_KWH", 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a LpPlan, then persist it as if it were the original solve.
+# ---------------------------------------------------------------------------
+
+def _build_forecast(slots: list[datetime], temp_c: float = 10.0, rad_wm2: float = 400.0) -> list[HourlyForecast]:
+    """Hourly forecast covering the slot range — replay reads these back from DB."""
+    out: list[HourlyForecast] = []
+    seen_hours: set[datetime] = set()
+    for st in slots:
+        hour_anchor = st.replace(minute=0, second=0, microsecond=0)
+        if hour_anchor in seen_hours:
+            continue
+        seen_hours.add(hour_anchor)
+        out.append(HourlyForecast(
+            time_utc=hour_anchor,
+            temperature_c=temp_c,
+            cloud_cover_pct=0.0,  # matches what replay reconstructs from snapshot
+            shortwave_radiation_wm2=rad_wm2,
+            estimated_pv_kw=estimate_pv_kw(rad_wm2),
+            heating_demand_factor=compute_heating_demand_factor(temp_c),
+        ))
+    return out
+
+
+def _series(n: int, base: datetime) -> tuple[list[datetime], WeatherLpSeries, list[HourlyForecast]]:
+    """Build slots + WeatherLpSeries through the SAME path replay uses.
+
+    Replay rebuilds WeatherLpSeries by calling forecast_to_lp_inputs on rows
+    pulled from meteo_forecast_history. To make the round-trip test fair we
+    drive the original solve through the same function so PV/COP arrays match.
+    """
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    forecast = _build_forecast(slots)
+    w = forecast_to_lp_inputs(forecast, slots, pv_scale=1.0)
+    return slots, w, forecast
+
+
+def _solve_baseline(
+    n: int,
+    base: datetime,
+    *,
+    soc0: float = 4.0,
+    tank0: float = 44.0,
+    indoor0: float = 20.5,
+    prices: list[float] | None = None,
+    base_load: list[float] | None = None,
+) -> tuple[LpPlan, list[datetime], list[float], list[float], LpInitialState, list[HourlyForecast]]:
+    slots, w, forecast = _series(n, base)
+    if prices is None:
+        prices = [12.0] * n
+    if base_load is None:
+        base_load = [0.4] * n
+    initial = LpInitialState(soc_kwh=soc0, tank_temp_c=tank0, indoor_temp_c=indoor0)
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=initial,
+        tz=ZoneInfo("Europe/London"),
+    )
+    return plan, slots, prices, base_load, initial, forecast
+
+
+def _persist_plan_as_run(
+    plan: LpPlan,
+    slots: list[datetime],
+    prices: list[float],
+    base_load: list[float],
+    initial: LpInitialState,
+    forecast: list[HourlyForecast],
+    *,
+    run_at_utc: datetime,
+    plan_date: str,
+    config_snapshot: dict | None = None,
+) -> int:
+    """Insert optimizer_log + lp_inputs_snapshot + lp_solution_snapshot + meteo_forecast_history rows."""
+    run_id = db.log_optimizer_run({
+        "run_at": run_at_utc.isoformat(),
+        "rates_count": len(slots),
+        "cheap_slots": 0,
+        "peak_slots": 0,
+        "standard_slots": len(slots),
+        "negative_slots": 0,
+        "target_vwap": float(sum(prices) / len(prices)) if prices else 0.0,
+        "actual_agile_mean": float(sum(prices) / len(prices)) if prices else 0.0,
+        "battery_warning": False,
+        "strategy_summary": "test",
+        "fox_schedule_uploaded": False,
+        "daikin_actions_count": 0,
+    })
+
+    inputs_row = {
+        "run_at_utc": run_at_utc.isoformat(),
+        "plan_date": plan_date,
+        "horizon_hours": int(len(slots) * 0.5),
+        "soc_initial_kwh": initial.soc_kwh,
+        "tank_initial_c": initial.tank_temp_c,
+        "indoor_initial_c": initial.indoor_temp_c,
+        "soc_source": initial.soc_source,
+        "tank_source": initial.tank_source,
+        "indoor_source": initial.indoor_source,
+        "base_load_json": json.dumps(base_load),
+        "micro_climate_offset_c": 0.0,
+        "config_snapshot_json": json.dumps(config_snapshot or {}),
+        "price_quantize_p": 1.0,
+        "peak_threshold_p": float(plan.peak_threshold_pence),
+        "cheap_threshold_p": float(plan.cheap_threshold_pence),
+        "daikin_control_mode": "active",
+        "optimization_preset": "normal",
+        "energy_strategy_mode": "savings_first",
+    }
+
+    solution_rows: list[dict] = []
+    for i, st in enumerate(plan.slot_starts_utc):
+        solution_rows.append({
+            "slot_index": i,
+            "slot_time_utc": st.isoformat(),
+            "price_p": float(plan.price_pence[i]),
+            "import_kwh": float(plan.import_kwh[i]),
+            "export_kwh": float(plan.export_kwh[i]),
+            "charge_kwh": float(plan.battery_charge_kwh[i]),
+            "discharge_kwh": float(plan.battery_discharge_kwh[i]),
+            "pv_use_kwh": float(plan.pv_use_kwh[i]),
+            "pv_curtail_kwh": float(plan.pv_curtail_kwh[i]),
+            "dhw_kwh": float(plan.dhw_electric_kwh[i]),
+            "space_kwh": float(plan.space_electric_kwh[i]),
+            "soc_kwh": float(plan.soc_kwh[i + 1]) if i + 1 < len(plan.soc_kwh) else 0.0,
+            "tank_temp_c": float(plan.tank_temp_c[i + 1]) if i + 1 < len(plan.tank_temp_c) else 0.0,
+            "indoor_temp_c": float(plan.indoor_temp_c[i + 1]) if i + 1 < len(plan.indoor_temp_c) else 0.0,
+            "outdoor_temp_c": float(plan.temp_outdoor_c[i]) if i < len(plan.temp_outdoor_c) else 10.0,
+            "lwt_offset_c": float(plan.lwt_offset_c[i]) if i < len(plan.lwt_offset_c) else 0.0,
+        })
+
+    db.save_lp_snapshots(run_id, inputs_row, solution_rows)
+
+    # Weather snapshot — fetched a second BEFORE run_at_utc so
+    # get_meteo_forecast_history_latest_before(run_at_utc) finds it. Round-trip
+    # the test's hourly forecast list so replay reconstructs an identical series.
+    fetch_at = (run_at_utc - timedelta(seconds=1)).isoformat()
+    forecast_rows = [
+        {
+            "slot_time": f.time_utc.isoformat(),
+            "temp_c": float(f.temperature_c),
+            "solar_w_m2": float(f.shortwave_radiation_wm2),
+        }
+        for f in forecast
+    ]
+    db.save_meteo_forecast_history(fetch_at, forecast_rows)
+
+    return run_id
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 tests — replay_run
+# ---------------------------------------------------------------------------
+
+def test_replay_run_honest_round_trip_matches_original_within_tolerance():
+    """Honest mode on identical inputs should reproduce the original plan.
+
+    We assert per-slot dispatch parity (the strong signal) and cost-at-actual
+    parity (the £-PnL signal). We do NOT assert objective_pence parity because
+    the snapshot's reconstructed objective only includes the grid component
+    (Σ import·price − Σ export·export_price), while the LP's true objective
+    also includes cycle / comfort / tank-overshoot soft penalties — they are
+    not equal even at zero solver noise.
+    """
+    base = datetime(2026, 7, 1, 0, 0, tzinfo=UTC)
+    plan, slots, prices, base_load, initial, forecast = _solve_baseline(12, base)
+    run_id = _persist_plan_as_run(
+        plan, slots, prices, base_load, initial, forecast,
+        run_at_utc=base, plan_date="2026-07-01",
+    )
+
+    result = replay_run(run_id, mode="honest")
+    assert result.ok, result.error
+    assert result.run_id == run_id
+    assert result.plan_date == "2026-07-01"
+    # Per-slot dispatch should match — every d_*_kwh near zero.
+    for d in result.slot_diffs:
+        for key in ("d_import_kwh", "d_export_kwh", "d_charge_kwh", "d_discharge_kwh", "d_dhw_kwh", "d_space_kwh"):
+            assert abs(d[key]) < 0.01, f"slot {d['slot_index']} {key}={d[key]}"
+    # Cost priced at actual rates: original and replayed must match — same
+    # dispatch on the same prices. (The snapshot's price_p IS the actual price
+    # since Octopus publishes day-ahead and we replay against the same row.)
+    assert abs(result.delta_cost_at_actual_p) < 0.5
+
+
+def test_replay_run_missing_weather_returns_clean_error():
+    """A run with no meteo_forecast_history snapshot should fail-fast cleanly."""
+    base = datetime(2026, 7, 1, 0, 0, tzinfo=UTC)
+    plan, slots, prices, base_load, initial, _forecast = _solve_baseline(8, base)
+
+    # Persist run + snapshots but DON'T add meteo_forecast_history.
+    run_id = db.log_optimizer_run({
+        "run_at": base.isoformat(), "rates_count": 8,
+        "cheap_slots": 0, "peak_slots": 0, "standard_slots": 8, "negative_slots": 0,
+        "target_vwap": 12.0, "actual_agile_mean": 12.0, "battery_warning": False,
+        "strategy_summary": "no-weather", "fox_schedule_uploaded": False, "daikin_actions_count": 0,
+    })
+    inputs_row = {
+        "run_at_utc": base.isoformat(),
+        "plan_date": "2026-07-01",
+        "horizon_hours": 4,
+        "soc_initial_kwh": initial.soc_kwh,
+        "tank_initial_c": initial.tank_temp_c,
+        "indoor_initial_c": initial.indoor_temp_c,
+        "soc_source": "test", "tank_source": "test", "indoor_source": "test",
+        "base_load_json": json.dumps(base_load),
+        "micro_climate_offset_c": 0.0,
+        "config_snapshot_json": json.dumps({}),
+        "price_quantize_p": 1.0, "peak_threshold_p": 0.0, "cheap_threshold_p": 0.0,
+        "daikin_control_mode": "active", "optimization_preset": "normal",
+        "energy_strategy_mode": "savings_first",
+    }
+    solution_rows = []
+    for i, st in enumerate(slots):
+        solution_rows.append({
+            "slot_index": i, "slot_time_utc": st.isoformat(),
+            "price_p": prices[i], "import_kwh": 0.0, "export_kwh": 0.0,
+            "charge_kwh": 0.0, "discharge_kwh": 0.0, "pv_use_kwh": 0.0, "pv_curtail_kwh": 0.0,
+            "dhw_kwh": 0.0, "space_kwh": 0.0, "soc_kwh": 4.0, "tank_temp_c": 44.0,
+            "indoor_temp_c": 20.5, "outdoor_temp_c": 10.0, "lwt_offset_c": 0.0,
+        })
+    db.save_lp_snapshots(run_id, inputs_row, solution_rows)
+
+    result = replay_run(run_id, mode="honest")
+    assert not result.ok
+    assert result.error is not None
+    assert "weather snapshot missing" in result.error
+
+
+def test_replay_run_unknown_run_id_returns_error():
+    result = replay_run(999999, mode="honest")
+    assert not result.ok
+    assert "no lp_inputs_snapshot" in (result.error or "")
+
+
+def test_replay_run_forward_mode_changes_under_config_drift(monkeypatch):
+    """Forward mode uses today's config; mutating config should change the result."""
+    base = datetime(2026, 7, 2, 0, 0, tzinfo=UTC)
+    plan, slots, prices, base_load, initial, forecast = _solve_baseline(8, base)
+    # Capture current battery capacity so we can stash it in the snapshot.
+    snap_capacity = float(app_config.BATTERY_CAPACITY_KWH)
+    run_id = _persist_plan_as_run(
+        plan, slots, prices, base_load, initial, forecast,
+        run_at_utc=base, plan_date="2026-07-02",
+        config_snapshot={"BATTERY_CAPACITY_KWH": snap_capacity},
+    )
+
+    # Honest replay should match.
+    honest = replay_run(run_id, mode="honest")
+    assert honest.ok
+
+    # Forward replay with reduced battery → different decisions / objective.
+    monkeypatch.setattr(app_config, "BATTERY_CAPACITY_KWH", snap_capacity * 0.5)
+    forward = replay_run(run_id, mode="forward")
+    assert forward.ok
+    # We don't assert a specific delta sign — just that it differs measurably.
+    assert abs(forward.replayed_objective_pence - honest.replayed_objective_pence) > 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 tests — replay_day chain
+# ---------------------------------------------------------------------------
+
+def test_resolve_run_id_for_date_picks_first_run_of_local_day():
+    base_utc = datetime(2026, 7, 3, 4, 0, tzinfo=UTC)  # 05:00 BST
+    plan, slots, prices, base_load, initial, forecast = _solve_baseline(8, base_utc)
+    rid_a = _persist_plan_as_run(
+        plan, slots, prices, base_load, initial, forecast,
+        run_at_utc=base_utc, plan_date="2026-07-03",
+    )
+    later = base_utc + timedelta(hours=6)
+    plan2, slots2, _, _, _, forecast2 = _solve_baseline(8, later)
+    rid_b = _persist_plan_as_run(
+        plan2, slots2, prices, base_load, initial, forecast2,
+        run_at_utc=later, plan_date="2026-07-03",
+    )
+
+    assert resolve_run_id_for_date("2026-07-03", which="first") == rid_a
+    assert resolve_run_id_for_date("2026-07-03", which="last") == rid_b
+    assert resolve_run_id_for_date("not-a-date") is None
+    assert resolve_run_id_for_date("2026-07-99") is None  # ISO parser rejects
+
+
+def test_replay_day_original_cadence_chains_runs_and_produces_active_slots():
+    """Two runs through the day, chained, scoring the chained dispatch.
+
+    Uses afternoon UTC + warmer initial state so the second run remains feasible
+    once the first run's plan-tail state is propagated into it. This is the
+    intended fidelity behaviour of multi-run replay — but for solver feasibility
+    we need inputs with enough slack that drift doesn't hit a binding constraint.
+    """
+    base_utc = datetime(2026, 7, 4, 11, 0, tzinfo=UTC)
+
+    # Run 1 at 12:00 BST (covers 4 slots = 2 hrs). Warm start, mid SoC.
+    plan1, s1, p1, bl1, init1, fc1 = _solve_baseline(
+        4, base_utc, soc0=6.0, tank0=48.0, indoor0=21.5,
+    )
+    _persist_plan_as_run(
+        plan1, s1, p1, bl1, init1, fc1,
+        run_at_utc=base_utc, plan_date="2026-07-04",
+    )
+
+    # Run 2 at 14:00 BST — covers next 4 slots
+    t2 = base_utc + timedelta(hours=2)
+    plan2, s2, p2, bl2, init2, fc2 = _solve_baseline(
+        4, t2, soc0=6.0, tank0=48.0, indoor0=21.5,
+    )
+    _persist_plan_as_run(
+        plan2, s2, p2, bl2, init2, fc2,
+        run_at_utc=t2, plan_date="2026-07-04",
+    )
+
+    result = replay_day("2026-07-04", cadence="original", mode="honest")
+    assert result.ok, result.error
+    assert len(result.recalc_run_ids) == 2
+    assert len(result.runs) == 2
+    for r in result.runs:
+        assert r.ok, r.error
+    # Active slots: run 1 covers [t0, t2), run 2 covers [t2, end-of-day). Run 1's
+    # plan has 4 slots all in [t0, t2). Run 2's plan has 4 slots — all active.
+    assert len(result.active_slots) == 8
+    assert isinstance(result.total_replayed_cost_p, float)
+    assert isinstance(result.total_original_cost_p, float)
+
+
+def test_replay_day_unknown_date_returns_clean_error():
+    result = replay_day("2099-12-31", cadence="original", mode="honest")
+    assert not result.ok
+    assert "no optimizer_log rows" in (result.error or "")
+
+
+def test_replay_day_bad_cadence_string_surfaced():
+    base_utc = datetime(2026, 7, 5, 0, 0, tzinfo=UTC)
+    plan, s, p, bl, init, fc = _solve_baseline(4, base_utc)
+    _persist_plan_as_run(plan, s, p, bl, init, fc, run_at_utc=base_utc, plan_date="2026-07-05")
+
+    result = replay_day("2026-07-05", cadence="hourly", mode="honest")
+    assert not result.ok
+    assert "bad cadence" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Cadence DSL parser
+# ---------------------------------------------------------------------------
+
+def test_apply_cadence_filter_dsl():
+    runs = [(1, "t1"), (2, "t2"), (3, "t3"), (4, "t4"), (5, "t5")]
+
+    assert _apply_cadence_filter(runs, "original") == runs
+    assert _apply_cadence_filter(runs, "first") == [(1, "t1")]
+    assert _apply_cadence_filter(runs, "first:3") == runs[:3]
+    assert _apply_cadence_filter(runs, "stride:2") == [(1, "t1"), (3, "t3"), (5, "t5")]
+    assert _apply_cadence_filter(runs, "subset:0,2,4") == [(1, "t1"), (3, "t3"), (5, "t5")]
+    # Empty subset is allowed (caller surfaces "matched zero runs").
+    assert _apply_cadence_filter(runs, "subset:") == []
+
+    with pytest.raises(ValueError):
+        _apply_cadence_filter(runs, "first:zero")
+    with pytest.raises(ValueError):
+        _apply_cadence_filter(runs, "first:-1")
+    with pytest.raises(ValueError):
+        _apply_cadence_filter(runs, "stride:0")
+    with pytest.raises(ValueError):
+        _apply_cadence_filter(runs, "garbage")
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 tests — sweep_cadences
+# ---------------------------------------------------------------------------
+
+def test_sweep_cadences_runs_all_cadences_and_picks_a_winner():
+    base_utc = datetime(2026, 7, 6, 11, 0, tzinfo=UTC)
+    # Three runs spaced 2h apart, with mildly different prices so cadence
+    # subsets diverge measurably. Afternoon + warm state for chain feasibility.
+    for i in range(3):
+        t = base_utc + timedelta(hours=2 * i)
+        prices = [12.0 + i] * 4  # different per run
+        plan, s, p, bl, init, fc = _solve_baseline(
+            4, t, soc0=6.0, tank0=48.0, indoor0=21.5, prices=prices,
+        )
+        _persist_plan_as_run(plan, s, p, bl, init, fc, run_at_utc=t, plan_date="2026-07-06")
+
+    result = sweep_cadences(
+        "2026-07-06",
+        cadences=["original", "first", "stride:2"],
+        mode="honest",
+    )
+    assert result.ok, result.error
+    assert len(result.rows) == 3
+    assert all(r.ok for r in result.rows)
+    assert result.best_cadence_label in ("original", "first", "stride:2")
+
+
+def test_sweep_cadences_no_runs_for_date_returns_error_per_row_then_top_level_failure():
+    result = sweep_cadences("2099-12-31", cadences=["original"], mode="honest")
+    assert not result.ok
+    assert result.rows and not result.rows[0].ok


### PR DESCRIPTION
## Summary

- Offline replay/backtest harness over `solve_lp` so we can answer "do today's LP changes outperform what actually ran on past day D?" on identical historical inputs — no rebuild / deploy needed.
- Three layers in `src/scheduler/lp_replay.py`: `replay_run` (single past run), `replay_day` (chained day-of-recalcs), `sweep_cadences` (cadence ranking).
- Surfaces: 3 MCP tools, 3 HTTP endpoints (`POST /api/v1/lp/{replay,replay-day,sweep-cadences}`), 1 CLI (`scripts/replay_period.py`).

## Why not gate live dispatch with this?

Each LP run sees a different problem (forecast refresh, PV calibration drift, rolling load profile, current SoC) — pre-apply comparison isn't apples-to-apples and can't tell you whether the *code* changed for the better. Regression detection belongs in **CI / pre-merge**, not on the live path. Layer 4 (golden-day fixture set + GitHub Actions) is the natural follow-up.

## Backtest result (already used to answer the user's "is it better?" question)

Prod 24-27 Apr (4-day window — V11 snapshot migration cuts off earlier replay). Single-run `first` cadence to isolate solver quality from chain-drift dynamics:

| Date | Original cost | Replayed cost | Δ £ |
|------|---------------|---------------|-----|
| 24 Apr | −£0.78 | −£0.41 | +£0.37 ⚠ |
| 25 Apr | +£1.22 | +£0.62 | −£0.60 ✓ |
| 26 Apr | +£1.90 | +£1.23 | −£0.68 ✓ |
| 27 Apr | +£0.46 | +£0.21 | −£0.24 ✓ |

**Net: today's solver wins 3/4 days, ~£1.15 better across the window.** Total savings vs SVT goes from £18.41 → £19.56.

## Known fidelity gaps (surfaced in result fields)

- `meteo_forecast_history` loses `cloud_pct` → replay PV marginally higher than original solve saw.
- Original objective reconstructed from snapshot dispatch (no penalty terms) — flagged via `original_objective_reconstructed=True`.
- Honest mode hard-codes `pv_scale=1.0` (calibration not snapshotted).

## Out of scope (deliberate)

- Layer 4 CI fixture set + GitHub Actions wiring.
- Battery/tank physics simulator under counterfactual dispatch (we use the LP's own predicted state evolution — "plan-followed-perfectly" idealisation).
- Custom-clock cadences (`hourly`, `fixed:HH:MM`) — would require synthesising inputs the LP never saw, tainting the comparison. Restricted to subsets of real run_ids.
- Local DB mirror (so analysis tools don't round-trip prod each time) — separate story.

## Test plan

- [x] Unit tests cover all three layers + cadence DSL parser + missing-snapshot + forward-mode config drift (11 cases, all green)
- [x] Live smoke against rsynced prod DB snapshot — generates the table above
- [ ] Layer 4 (CI integration) — follow-up
- [ ] Local-DB-mirror story — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)