### PR TITLE
feat(calendar): distinct blue tier for negative prices

### DIFF
--- a/src/google_calendar/tiers.py
+++ b/src/google_calendar/tiers.py
@@ -30,10 +30,20 @@ class Tier(NamedTuple):
 
 
 # Ordered cheapest → most expensive. Cost-order is implied by list position.
+# Negative is a distinct headline tier — being PAID to consume is rare enough
+# (typically a windy night or solar-glut afternoon with a negative Outgoing
+# rate) that it deserves its own colour and copy. We use Blueberry (9) for
+# unambiguous "blue blue" so the family can spot it across green near-zeros.
+TIER_NEGATIVE = Tier(
+    "negative", "🔵", "PAID to use", "9",
+    "NEGATIVE PRICE — you're being PAID to consume! Run laundry, dishwasher, "
+    "oven, charge the EV. Don't curtail PV either; the export rate is below "
+    "the import rate, so consuming is the cheapest disposal.",
+)
 TIER_VERY_CHEAP = Tier(
     "very_cheap", "🟢", "Very cheap", "10",
-    "Best window of the day — run heavy appliances now (laundry, dishwasher, "
-    "oven, EV charging if applicable).",
+    "Best (positive) window of the day — run heavy appliances now (laundry, "
+    "dishwasher, oven, EV charging if applicable).",
 )
 TIER_GREEN_LIGHT = Tier(
     "green_light", "🟩", "Green light", "2",
@@ -58,7 +68,7 @@ TIER_SEVERE_PEAK = Tier(
 )
 
 ALL_TIERS: list[Tier] = [
-    TIER_VERY_CHEAP, TIER_GREEN_LIGHT, TIER_MODERATE,
+    TIER_NEGATIVE, TIER_VERY_CHEAP, TIER_GREEN_LIGHT, TIER_MODERATE,
     TIER_ABOVE_AVG, TIER_EXPENSIVE, TIER_SEVERE_PEAK,
 ]
 _BY_KEY: dict[str, Tier] = {t.key: t for t in ALL_TIERS}
@@ -107,7 +117,14 @@ def classify_one(price: float, *, median: float, p10: float) -> Tier:
     headline signals. ``EXPENSIVE`` ranks above ``ABOVE_AVG`` so a price
     above the absolute floor goes orange/red even if it's only modestly
     above the median (e.g., a flat-cheap day where 25p is huge).
+
+    ``NEGATIVE`` short-circuits all other branches: any price strictly below
+    zero means we're being paid to consume — a fundamentally different
+    signal than "cheapest of today", so it deserves its own headline tier
+    even on a day where −5p happens to also be the bottom decile.
     """
+    if price < 0:
+        return TIER_NEGATIVE
     if price <= p10 and price < VERY_CHEAP_ABS_CEILING_P:
         return TIER_VERY_CHEAP
     if price >= SEVERE_PEAK_MEDIAN_RATIO * median and price > SEVERE_PEAK_ABS_FLOOR_P:
@@ -163,12 +180,19 @@ def _smooth_aba_noise(tiers: list[Tier]) -> list[Tier]:
     Catches sub-pence oscillation across a tier boundary (e.g., 24.4p →
     25.1p → 24.4p flipping Above-average / Expensive / Above-average).
     Multi-slot noise is handled by ``_fold_short_windows`` after merging.
+
+    The ``NEGATIVE`` tier is exempt from smoothing in either direction —
+    being paid to consume is a real qualitative signal that should never
+    be silently absorbed into a "very cheap" neighbour, even for a single
+    30-min slot.
     """
     if len(tiers) < 3:
         return tiers
     out = list(tiers)
     for i in range(1, len(out) - 1):
         prev_t, this_t, next_t = out[i - 1], out[i], out[i + 1]
+        if this_t.key == TIER_NEGATIVE.key or prev_t.key == TIER_NEGATIVE.key or next_t.key == TIER_NEGATIVE.key:
+            continue
         if prev_t.key == next_t.key and this_t.key != prev_t.key:
             if abs(_tier_index(this_t) - _tier_index(prev_t)) == 1:
                 out[i] = prev_t
@@ -192,6 +216,11 @@ def _fold_short_windows(windows: list[Window]) -> list[Window]:
     while True:
         target_idx = None
         for i, w in enumerate(windows):
+            # NEGATIVE windows are never folded — even a single 30-min
+            # "you're being paid" event is worth keeping on the calendar
+            # so the family doesn't miss it.
+            if w.tier.key == TIER_NEGATIVE.key:
+                continue
             if duration_min(w) < MIN_WINDOW_MINUTES:
                 target_idx = i
                 break
@@ -274,11 +303,19 @@ def classify_day(slots: list[Slot]) -> list[Window]:
 def format_event(window: Window) -> tuple[str, str]:
     """Return ``(summary, description)`` strings for a Google Calendar event.
 
-    Summary uses different bracket text on the extremes (``down to 9.8p`` /
-    ``up to 34.5p``) to keep the title visually distinctive at a glance.
+    Summary uses different bracket text on the extremes:
+      * ``NEGATIVE``  → ``down to -5.3p`` (negative price emphasised; calls out
+        that the family is being paid).
+      * ``VERY_CHEAP`` → ``down to 9.8p``
+      * ``SEVERE_PEAK`` → ``up to 34.5p``
+    Mid-tiers use a min–max range.
     """
     t = window.tier
-    if t.key == TIER_VERY_CHEAP.key:
+    if t.key == TIER_NEGATIVE.key:
+        # Negative window — emphasise the sign so the family sees a -5.3p
+        # number rather than mistaking it for a very-low positive price.
+        summary = f"{t.emoji} {t.title} (down to {window.price_min:.1f}p — paid!)"
+    elif t.key == TIER_VERY_CHEAP.key:
         summary = f"{t.emoji} {t.title} (down to {window.price_min:.1f}p)"
     elif t.key == TIER_SEVERE_PEAK.key:
         summary = f"{t.emoji} {t.title} (up to {window.price_max:.1f}p)"

--- a/tests/test_google_calendar_tiers.py
+++ b/tests/test_google_calendar_tiers.py
@@ -12,10 +12,12 @@ from src.google_calendar.tiers import (
     TIER_EXPENSIVE,
     TIER_GREEN_LIGHT,
     TIER_MODERATE,
+    TIER_NEGATIVE,
     TIER_SEVERE_PEAK,
     TIER_VERY_CHEAP,
     VERY_CHEAP_ABS_CEILING_P,
     Slot,
+    Window,
     _quantile,
     classify_day,
     classify_one,
@@ -235,3 +237,81 @@ def test_smoothing_preserves_meaningful_long_windows():
     keys = [w.tier.key for w in windows]
     assert "above_avg" in keys
     assert len(windows) == 3
+
+
+# ── Negative price tier (Blue, "PAID to use") ──────────────────────────────
+
+
+def test_negative_short_circuits_very_cheap():
+    """A −5.3p slot is NEGATIVE, not VERY_CHEAP, even though the ratio + abs
+    floor of very_cheap would also fire on negatives."""
+    # median 10, p10 -5: a -5.3 price would otherwise hit very_cheap.
+    assert classify_one(-5.3, median=10.0, p10=-5.0).key == TIER_NEGATIVE.key
+
+
+def test_zero_is_not_negative():
+    """The threshold is strictly < 0; exactly 0p is not 'paid'."""
+    assert classify_one(0.0, median=10.0, p10=0.0).key != TIER_NEGATIVE.key
+
+
+def test_negative_color_is_blueberry():
+    """Blueberry (9) is the chosen blue. Don't drift to peacock (7) or
+    lavender (1) — the family knows blue means 'they're paying us'."""
+    assert TIER_NEGATIVE.color_id == "9"
+    assert TIER_NEGATIVE.emoji == "🔵"
+
+
+def test_negative_format_event_emphasises_paid_signal():
+    """The summary must call out the negative sign explicitly so a glance
+    at the calendar reads 'PAID' rather than 'cheap'."""
+    t0 = datetime(2026, 4, 29, 12, 0, tzinfo=UTC)
+    w = Window(
+        start_utc=t0,
+        end_utc=t0 + timedelta(minutes=120),
+        tier=TIER_NEGATIVE,
+        prices=[-1.7, -3.2, -5.3, -2.8],
+    )
+    summary, description = format_event(w)
+    assert "PAID" in summary
+    assert "-5.3p" in summary  # min price visible with sign
+    assert "🔵" in summary
+    assert "PAID" in description.upper()
+
+
+def test_classify_day_keeps_lone_negative_slot():
+    """A single 30-min negative slot surrounded by very_cheap must NOT be
+    smoothed or folded away — being paid is a real signal."""
+    # 14p baseline (no slot is very_cheap because >12p ceiling); single -1p
+    # slot in the middle. Expected: 14, 14, NEGATIVE, 14, 14 → 3 windows.
+    prices = [14.0, 14.0, -1.0, 14.0, 14.0]
+    slots = _make_slots(prices)
+    windows = classify_day(slots)
+    keys = [w.tier.key for w in windows]
+    assert TIER_NEGATIVE.key in keys, f"negative slot was absorbed: {keys}"
+    # And a 30-min window stays as one event (not folded into a neighbour
+    # despite duration < MIN_WINDOW_MINUTES).
+    neg = next(w for w in windows if w.tier.key == TIER_NEGATIVE.key)
+    assert (neg.end_utc - neg.start_utc) == timedelta(minutes=30)
+
+
+def test_classify_day_merges_consecutive_negatives_into_one_window():
+    """Consecutive negative slots collapse into a single merged window
+    (the ordinary windowing path; the no-fold rule doesn't break this)."""
+    # All same tier (NEGATIVE) → one merged window.
+    prices = [-2.0, -3.5, -5.0, -1.8]
+    windows = classify_day(_make_slots(prices))
+    assert len(windows) == 1
+    assert windows[0].tier.key == TIER_NEGATIVE.key
+    assert windows[0].price_min == -5.0
+    assert windows[0].price_max == -1.8
+
+
+def test_negative_window_survives_with_short_neighbours():
+    """A 30-min negative window between a 90-min positive block on each
+    side stays alive even though the negative duration < MIN_WINDOW_MINUTES.
+    """
+    prices = [14.0, 14.0, 14.0, -2.0, 14.0, 14.0, 14.0]  # 30 min negative
+    windows = classify_day(_make_slots(prices))
+    keys = [w.tier.key for w in windows]
+    assert keys.count(TIER_NEGATIVE.key) == 1
+    assert len(windows) == 3  # left positive | negative | right positive


### PR DESCRIPTION
## Summary

- Negative-price slots were rendering as 🟢 Very cheap (e.g. \"🟢 Very cheap (down to -5.3p)\") because `classify_one` checked `price <= p10 AND price < 12p` first — trivially fired on negatives. The family calendar lost the "you're being **paid**" signal.
- Adds a distinct `TIER_NEGATIVE` (Blueberry / Google Calendar colorId 9, 🔵 emoji, "PAID to use" title) that short-circuits any other tier when `price < 0`.
- Summary now reads e.g. **"🔵 PAID to use (down to -5.3p — paid!)"** with copy explicitly calling out that import is cheaper than export-then-consume so the family knows to run laundry / dishwasher / EV charge.
- Smoothing + folding exemptions: a 30-min isolated negative window survives both `_smooth_aba_noise` and `_fold_short_windows`. Single negative slots are too valuable a signal to silently absorb into a "very cheap" neighbour.

## Test plan

- [x] `pytest tests/test_google_calendar_tiers.py` — 25 passed (18 existing + 7 new).
- [x] New tests cover: short-circuit on negative, strict `< 0` threshold (zero is not paid), Blueberry color invariant, format_event copy mentions "PAID", smoothing skips negative neighbours, single 30-min negative survives folding, consecutive negatives merge into one window.
- [ ] After merge + image rebuild + `systemctl restart hem`, the publisher's `_events_match_windows` will detect the colorId/summary mismatch on existing negative events (currently green) and wipe-and-recreate them with the new blue tier. Verify on the family calendar.

## Issues

Closes the user-reported issue: "negative prices are not highlighted in the calendar as expected. We expect negative window (when we're paid to use energy) to have a Blue color in the family calendar with a clear message."

🤖 Generated with [Claude Code](https://claude.com/claude-code)