### PR TITLE
chore(test): bootstrap LP regression baseline at acf0979

### DIFF
--- a/tests/fixtures/lp_regression_baseline.json
+++ b/tests/fixtures/lp_regression_baseline.json
@@ -1,1 +1,33 @@
-{}
+{
+  "days_back": 14,
+  "frozen_at_iso": "2026-04-29T08:05:02.222899+00:00",
+  "frozen_at_sha": "acf0979431f9f0c3b82304e41078387a1bb07f70",
+  "per_date": {
+    "2026-04-25": {
+      "recalc_count": 22,
+      "total_original_cost_p": 215.748700801675,
+      "total_replayed_cost_p": 127.18994501102003
+    },
+    "2026-04-26": {
+      "recalc_count": 21,
+      "total_original_cost_p": 414.448505686299,
+      "total_replayed_cost_p": 173.56733565423608
+    },
+    "2026-04-27": {
+      "recalc_count": 28,
+      "total_original_cost_p": -3.244397772360004,
+      "total_replayed_cost_p": 27.221857368390005
+    },
+    "2026-04-28": {
+      "recalc_count": 21,
+      "total_original_cost_p": 218.02443517591996,
+      "total_replayed_cost_p": 182.153517036365
+    },
+    "2026-04-29": {
+      "recalc_count": 3,
+      "total_original_cost_p": 60.96463003420202,
+      "total_replayed_cost_p": 56.380169138765396
+    }
+  },
+  "total_replayed_cost_p": 566.5128242087765
+}


### PR DESCRIPTION
## Summary

First population of ``tests/fixtures/lp_regression_baseline.json`` — the file shipped empty (``{}``) in PR #191. Generated by replaying the last 14 days of optimizer_log runs against the prod DB snapshot (5 days produced ok results; 1 chained-failed on a recurring solver Infeasible — see ``project_lp_infeasibles`` memory entry, separate concern).

## Bootstrapped totals

| date | recalcs | orig £ | replay £ | Δ £ |
|---|---|---|---|---|
| 2026-04-25 | 22 | +2.16 | +1.27 | -0.89 |
| 2026-04-26 | 21 | +4.14 | +1.74 | -2.41 |
| 2026-04-27 | 28 | -0.03 | +0.27 | +0.30 |
| 2026-04-28 | 21 | +2.18 | +1.82 | -0.36 |
| 2026-04-29 |  3 | +0.61 | +0.56 | -0.05 |
| **TOTAL** | | **+£9.06** | **+£5.67** | **-£3.41** |

The combined V12+V13 work (scenario LP, tier-boundary triggers, removed live-SoC gate, removed fixed-hour cron) saved **£3.41** over these 5 days vs the originally-dispatched plans. Biggest single-day gain (-£2.41 on 2026-04-26) is consistent with the dispatch-incident day the user intervened on.

## Caveat

Original costs are computed from ``execution_log.consumption_kwh`` rows still tagged ``source="estimated"`` (PR #190's consumption backfill first runs tomorrow 04:00 local). Future baseline refreshes — once ~14 days of metered data accumulates — will be more accurate. The current baseline is fine for its purpose: an anchor that says "don't get worse than this."

## Verification

```
DB_PATH=/path/to/prod-snapshot.db .venv/bin/python scripts/check_lp_regression.py
```

  → NEW total replayed cost: **+£5.67**
  → Baseline total: **+£5.67** (threshold +£0.50)
  → Δ vs baseline: +£0.00
  → **VERDICT: PASS** — LP is no worse than baseline.

From now on, every PR touching ``src/scheduler/`` runs this gate and pastes the verdict. If a future change pushes the total above £6.17, CI fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)