### PR TITLE
hotfix(v10.0.1): night-brief PnL completeness + warning-table TTL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "home-energy-manager"
-version = "10.0.0"
+version = "10.0.1"
 description = "Home energy orchestration (Fox ESS, Daikin, Octopus)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/config.py
+++ b/src/config.py
@@ -850,6 +850,11 @@ class Config:
     )
     LP_SNAPSHOT_RETENTION_DAYS: int = int(os.getenv("LP_SNAPSHOT_RETENTION_DAYS", "90"))
     CONFIG_AUDIT_RETENTION_DAYS: int = int(os.getenv("CONFIG_AUDIT_RETENTION_DAYS", "365"))
+    # Per-day-keyed warning ack rows accumulate forever otherwise (issue #200);
+    # the keys are useless once the date passes, so 30 d is plenty.
+    ACKNOWLEDGED_WARNINGS_RETENTION_DAYS: int = int(
+        os.getenv("ACKNOWLEDGED_WARNINGS_RETENTION_DAYS", "30")
+    )
 
     def foxess_client_kwargs(self) -> dict:
         """Return the right kwargs for FoxESSClient based on what's configured."""

--- a/src/db.py
+++ b/src/db.py
@@ -3470,6 +3470,9 @@ def prune_history_tables() -> dict[str, int]:
         # to point at anyway — the snapshot is the source of truth).
         ("dispatch_decisions", "created_at", _config.LP_SNAPSHOT_RETENTION_DAYS, False),
         ("scenario_solve_log", "solved_at", _config.LP_SNAPSHOT_RETENTION_DAYS, False),
+        # Per-day-keyed warning acks (e.g. fox_scheduler_disabled_<date>) are
+        # useless once the date rolls over; without this they grow unbounded.
+        ("acknowledged_warnings", "acknowledged_at", _config.ACKNOWLEDGED_WARNINGS_RETENTION_DAYS, False),
     ]
     results: dict[str, int] = {}
     for table, col, days, epoch in policies:
@@ -3638,7 +3641,7 @@ def update_execution_log_metered(
     slot_start_utc: str,
     consumption_kwh: float,
 ) -> bool:
-    """Rewrite an ``execution_log`` row with metered (Octopus) consumption.
+    """Rewrite (or synthesise) an ``execution_log`` row with metered consumption.
 
     The heartbeat writes rows with ``source="estimated"`` based on a single
     ``Fox.load_power`` sample × 0.5 h — fast enough for the live cockpit but
@@ -3653,11 +3656,18 @@ def update_execution_log_metered(
     microsecond precision wherever the heartbeat happened to fire within the
     slot, so we match on the **half-hour bucket** rather than exact equality.
 
-    Returns True on a successful update (a heartbeat row existed in that
-    half-hour window and was rewritten), False if no matching row was found
-    (the heartbeat may have missed that slot, or the slot is in the past
-    before the service started). Idempotent — re-running with the same kWh
-    produces no further change.
+    **Missing-heartbeat fallback (issue #199):** if no heartbeat row exists
+    in the bucket (service was down, restart spanned the slot, etc.), this
+    inserts a synthetic row tagged ``source="metered_synthetic"`` provided
+    we can resolve an ``agile_rates`` row covering the slot. SVT and fixed
+    shadow prices come from the same helpers the heartbeat uses. Without
+    the synthetic insert the night-brief PnL silently under-reports cost
+    by exactly the missing slots' contribution.
+
+    Returns True on either an UPDATE of an existing heartbeat row or an
+    INSERT of a synthetic one. Returns False only when the slot has neither
+    a heartbeat row nor a published ``agile_rates`` price (truly no data).
+    Idempotent on re-run.
     """
     # Normalise the input to a half-hour boundary, then build a [start, end)
     # window the heartbeat row's microsecond-precision timestamp falls within.
@@ -3667,13 +3677,14 @@ def update_execution_log_metered(
         return False
     slot_start_iso = slot_dt.replace(microsecond=0).isoformat()
     slot_end_iso = (slot_dt + timedelta(minutes=30)).replace(microsecond=0).isoformat()
+    kwh = float(consumption_kwh)
 
     with _lock:
         conn = get_connection()
         try:
             cur = conn.execute(
                 """SELECT id, agile_price_pence, svt_shadow_price_pence,
-                          fixed_shadow_price_pence
+                          fixed_shadow_price_pence, source
                    FROM execution_log
                    WHERE timestamp >= ? AND timestamp < ?
                    ORDER BY timestamp ASC
@@ -3681,30 +3692,87 @@ def update_execution_log_metered(
                 (slot_start_iso, slot_end_iso),
             )
             row = cur.fetchone()
-            if not row:
+            if row:
+                agile = float(row["agile_price_pence"] or 0.0)
+                svt = float(row["svt_shadow_price_pence"] or 0.0)
+                fixed = float(row["fixed_shadow_price_pence"] or 0.0)
+                # Preserve 'metered_synthetic' lineage across idempotent re-runs;
+                # heartbeat-overlay rows otherwise become 'metered'.
+                next_source = (
+                    "metered_synthetic"
+                    if row["source"] == "metered_synthetic"
+                    else "metered"
+                )
+                conn.execute(
+                    """UPDATE execution_log SET
+                           consumption_kwh = ?,
+                           cost_realised_pence = ?,
+                           cost_svt_shadow_pence = ?,
+                           cost_fixed_shadow_pence = ?,
+                           delta_vs_svt_pence = ?,
+                           delta_vs_fixed_pence = ?,
+                           source = ?
+                       WHERE id = ?""",
+                    (
+                        kwh,
+                        kwh * agile,
+                        kwh * svt,
+                        kwh * fixed,
+                        kwh * (svt - agile),
+                        kwh * (fixed - agile),
+                        next_source,
+                        int(row["id"]),
+                    ),
+                )
+                conn.commit()
+                return True
+
+            # No heartbeat row in this bucket — synthesise one so the night
+            # brief's PnL is complete. Look up the Agile rate first; if no
+            # tariff slot covers this timestamp we genuinely have no price
+            # data and bail.
+            from .config import config as _config
+            tariff = (_config.OCTOPUS_TARIFF_CODE or "").strip()
+            if not tariff:
                 return False
-            agile = float(row["agile_price_pence"] or 0.0)
-            svt = float(row["svt_shadow_price_pence"] or 0.0)
-            fixed = float(row["fixed_shadow_price_pence"] or 0.0)
-            kwh = float(consumption_kwh)
+            # agile_rates stores timestamps with the 'Z' suffix (see
+            # get_rates_for_period); normalise our slot start to match so the
+            # lexicographic compare works.
+            slot_start_z = slot_dt.replace(microsecond=0).isoformat().replace(
+                "+00:00", "Z"
+            )
+            rate_cur = conn.execute(
+                """SELECT value_inc_vat
+                   FROM agile_rates
+                   WHERE tariff_code = ?
+                     AND valid_from <= ?
+                     AND valid_to > ?
+                   ORDER BY valid_from DESC
+                   LIMIT 1""",
+                (tariff, slot_start_z, slot_start_z),
+            )
+            rate_row = rate_cur.fetchone()
+            if not rate_row:
+                return False
+            agile = float(rate_row["value_inc_vat"])
+            from .analytics.shadow_pricing import (
+                fixed_shadow_rate_pence,
+                svt_rate_pence,
+            )
+            svt = svt_rate_pence()
+            fixed = fixed_shadow_rate_pence()
             conn.execute(
-                """UPDATE execution_log SET
-                       consumption_kwh = ?,
-                       cost_realised_pence = ?,
-                       cost_svt_shadow_pence = ?,
-                       cost_fixed_shadow_pence = ?,
-                       delta_vs_svt_pence = ?,
-                       delta_vs_fixed_pence = ?,
-                       source = 'metered'
-                   WHERE id = ?""",
+                """INSERT INTO execution_log
+                   (timestamp, consumption_kwh, agile_price_pence,
+                    svt_shadow_price_pence, fixed_shadow_price_pence,
+                    cost_realised_pence, cost_svt_shadow_pence,
+                    cost_fixed_shadow_pence, delta_vs_svt_pence,
+                    delta_vs_fixed_pence, source)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'metered_synthetic')""",
                 (
-                    kwh,
-                    kwh * agile,
-                    kwh * svt,
-                    kwh * fixed,
-                    kwh * (svt - agile),
-                    kwh * (fixed - agile),
-                    int(row["id"]),
+                    slot_start_iso, kwh, agile, svt, fixed,
+                    kwh * agile, kwh * svt, kwh * fixed,
+                    kwh * (svt - agile), kwh * (fixed - agile),
                 ),
             )
             conn.commit()

--- a/tests/test_consumption_backfill.py
+++ b/tests/test_consumption_backfill.py
@@ -112,11 +112,97 @@ def test_update_does_not_cross_slot_boundary():
     assert row["source"] == "estimated"
 
 
-def test_update_returns_false_when_no_matching_row():
+def test_update_returns_false_when_no_matching_row_and_no_agile_rate():
+    """Issue #199 — without a published Agile slot we have no price data;
+    nothing to insert, return False."""
     from src import db
 
     ok = db.update_execution_log_metered("2026-04-29T13:30:00+00:00", 1.0)
     assert ok is False
+
+
+def _seed_agile_rate(slot_start_iso: str, *, value_p=20.0, tariff="AGILE-FLEX-22-11-25"):
+    """Insert an agile_rates row covering the half-hour starting at *slot_start_iso*."""
+    from datetime import datetime as _dt
+    from datetime import timedelta as _td
+    from src import db
+
+    start = _dt.fromisoformat(slot_start_iso.replace("Z", "+00:00"))
+    end = start + _td(minutes=30)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """INSERT INTO agile_rates
+               (valid_from, valid_to, value_inc_vat, tariff_code, fetched_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                start.isoformat().replace("+00:00", "Z"),
+                end.isoformat().replace("+00:00", "Z"),
+                value_p,
+                tariff,
+                _dt.now().isoformat(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_update_inserts_synthetic_row_when_no_heartbeat(monkeypatch):
+    """Issue #199 — a half-hour with no heartbeat row but a published Agile
+    rate should INSERT a synthetic row tagged ``source='metered_synthetic'``
+    so the night-brief PnL is complete."""
+    from src import config as _config
+    from src import db
+
+    tariff = "AGILE-FLEX-22-11-25"
+    monkeypatch.setattr(_config.config, "OCTOPUS_TARIFF_CODE", tariff, raising=False)
+    monkeypatch.setattr(_config.config, "SVT_RATE_PENCE", 24.0, raising=False)
+    monkeypatch.setattr(_config.config, "MANUAL_TARIFF_IMPORT_PENCE", 22.0, raising=False)
+
+    _seed_agile_rate("2026-04-29T03:00:00+00:00", value_p=15.0, tariff=tariff)
+
+    ok = db.update_execution_log_metered("2026-04-29T03:00:00+00:00", 0.6)
+    assert ok is True
+
+    row = _read_row("2026-04-29T03:00:00")
+    assert row is not None
+    assert row["source"] == "metered_synthetic"
+    assert row["consumption_kwh"] == 0.6
+    assert row["agile_price_pence"] == pytest.approx(15.0)
+    assert row["svt_shadow_price_pence"] == pytest.approx(24.0)
+    assert row["fixed_shadow_price_pence"] == pytest.approx(22.0)
+    assert row["cost_realised_pence"] == pytest.approx(0.6 * 15.0)
+    assert row["cost_svt_shadow_pence"] == pytest.approx(0.6 * 24.0)
+    assert row["cost_fixed_shadow_pence"] == pytest.approx(0.6 * 22.0)
+
+
+def test_update_synthetic_idempotent_preserves_lineage(monkeypatch):
+    """Re-running the backfill with the same kWh after a synthetic INSERT
+    should be a no-op AND keep ``source='metered_synthetic'`` (don't relabel
+    as 'metered')."""
+    from src import config as _config
+    from src import db
+
+    tariff = "AGILE-FLEX-22-11-25"
+    monkeypatch.setattr(_config.config, "OCTOPUS_TARIFF_CODE", tariff, raising=False)
+
+    _seed_agile_rate("2026-04-29T03:00:00+00:00", value_p=15.0, tariff=tariff)
+    db.update_execution_log_metered("2026-04-29T03:00:00+00:00", 0.6)
+    db.update_execution_log_metered("2026-04-29T03:00:00+00:00", 0.6)
+
+    conn = db.get_connection()
+    try:
+        cur = conn.execute(
+            "SELECT COUNT(*) AS n FROM execution_log WHERE timestamp LIKE '2026-04-29T03:00:00%'"
+        )
+        assert int(cur.fetchone()["n"]) == 1  # no duplicate insert
+    finally:
+        conn.close()
+
+    row = _read_row("2026-04-29T03:00:00")
+    assert row["source"] == "metered_synthetic"  # lineage preserved
+    assert row["consumption_kwh"] == 0.6
 
 
 def test_update_idempotent():

--- a/tests/test_db_retention.py
+++ b/tests/test_db_retention.py
@@ -133,9 +133,36 @@ def test_prune_history_tables_returns_per_table_counts():
         # pruned, so they're swept on the same horizon.
         "dispatch_decisions",
         "scenario_solve_log",
+        # Per-day-keyed warning acks (issue #200) — without TTL the table
+        # grows linearly across days of stuck warnings.
+        "acknowledged_warnings",
     }
     assert results["daikin_telemetry"] >= 1
     assert results["config_audit"] >= 1
+
+
+def test_prune_history_tables_sweeps_acknowledged_warnings():
+    """Issue #200 — per-day-keyed acks accumulate; the prune sweep must
+    drop rows older than ACKNOWLEDGED_WARNINGS_RETENTION_DAYS (default 30 d)."""
+    conn = db.get_connection()
+    try:
+        old_ts = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+        recent_ts = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        conn.execute(
+            "INSERT INTO acknowledged_warnings (warning_key, acknowledged_at) VALUES (?, ?)",
+            ("fox_scheduler_disabled_2026-03-15", old_ts),
+        )
+        conn.execute(
+            "INSERT INTO acknowledged_warnings (warning_key, acknowledged_at) VALUES (?, ?)",
+            ("fox_scheduler_disabled_2026-04-24", recent_ts),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    results = db.prune_history_tables()
+    assert results["acknowledged_warnings"] == 1
+    assert _count("acknowledged_warnings") == 1
 
 
 def test_prune_history_tables_tolerates_one_bad_policy(monkeypatch):


### PR DESCRIPTION
## Summary

Two bugs from the V10 audit. Standalone hotfix on top of v10.0.0.

- **#199** — night-brief PnL under-reports cost when the heartbeat missed half-hour slots (e.g. service restart spanning the slot). `update_execution_log_metered` now INSERTs a synthetic row tagged `source='metered_synthetic'` when no heartbeat exists but an Agile rate does, so the night-brief sum is complete.
- **#200** — `acknowledged_warnings` table grew unbounded (per-day keys never cleaned up). Added to the nightly retention sweep with a 30-day default (`ACKNOWLEDGED_WARNINGS_RETENTION_DAYS`).

## Testing

- New tests in `tests/test_consumption_backfill.py`:
  - synthetic INSERT path with seeded Agile rate
  - false return when no heartbeat AND no Agile rate
  - idempotency preserves `metered_synthetic` source label
- New test in `tests/test_db_retention.py` for the warning-table TTL.
- Full suite: **637 passed, 1 skipped** (`tests/test_mcp_singleton.py` collection error is pre-existing from PR #163's stdio→HTTP migration; not introduced by this PR).

## Dispatch / LP changes

None. This PR doesn't touch `src/scheduler/`, so the LP regression gate and scenario-filter gate aren't required.

## Issues

Closes #199
Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)