### PR TITLE
fix(dispatch): widen restore-action window so heartbeat can't silently miss it

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -789,6 +789,21 @@ class Config:
     PLAN_AUTO_APPROVE: bool = os.getenv("PLAN_AUTO_APPROVE", "true").lower() in ("true", "1", "yes")
     PLAN_APPROVAL_TIMEOUT_SECONDS: int = int(os.getenv("PLAN_APPROVAL_TIMEOUT_SECONDS", "300"))
 
+    # ── Daikin action_schedule windows ───────────────────────────────────────
+    # Width of the "restore" window written by lp_dispatch after each LP-driven
+    # window (shutdown / max_heat / pre_heat / normal). The state machine
+    # silently marks an action `completed` (no fire) when ``now > end_time`` and
+    # status is still pending — so a window narrower than the heartbeat tick is
+    # racy. Production heartbeat is 120 s; 5 min gives 2.5× safety margin so
+    # restores always fire even when ticks land slightly off-grid. 2026-04-30
+    # active-mode rollout hit this with the legacy 1-min window: action 607
+    # (off) succeeded, action 606 (restore) was silently skipped, device stayed
+    # off until manual rollback to passive.
+    LP_RESTORE_WINDOW_MINUTES: int = max(
+        2,
+        int(os.getenv("LP_RESTORE_WINDOW_MINUTES", "5")),
+    )
+
     # ── API Quota & Cache ────────────────────────────────────────────────────
     # Daikin Onecta: soft daily budget (real limit ≈200; we stop at 180 to preserve 10% headroom)
     DAIKIN_DAILY_BUDGET: int = int(os.getenv("DAIKIN_DAILY_BUDGET", "180"))

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -268,7 +268,13 @@ def daikin_dispatch_preview(
 
         st = start_utc.isoformat().replace("+00:00", "Z")
         en = end_utc.isoformat().replace("+00:00", "Z")
-        restore_end = (end_utc + timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
+        # Wider than the heartbeat tick so restores can't be silently skipped
+        # by the state machine when a tick lands just past the window. See
+        # ``LP_RESTORE_WINDOW_MINUTES`` docstring for the 2026-04-30 incident.
+        restore_window = max(2, int(getattr(config, "LP_RESTORE_WINDOW_MINUTES", 5)))
+        restore_end = (
+            end_utc + timedelta(minutes=restore_window)
+        ).isoformat().replace("+00:00", "Z")
         restore_params = {
             "lwt_offset": 0.0,
             "tank_powerful": False,

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -227,6 +227,19 @@ def _reconcile_daikin_actions(
             continue
 
         if now_utc >= end:
+            if status == "pending":
+                # Pending past end-time = silently skipped (heartbeat missed
+                # the window). Visibly warn so this class of bug surfaces next
+                # time instead of being silent. The 2026-04-30 active-mode
+                # rollout hit this with a 1-min restore window vs 2-min
+                # heartbeat — see lp_dispatch.LP_RESTORE_WINDOW_MINUTES.
+                logger.warning(
+                    "action_schedule[%s] %s window missed (start=%s end=%s now=%s, "
+                    "marking completed without firing) — likely too-narrow window "
+                    "or heartbeat lag",
+                    aid, atype, act.get("start_time"), act.get("end_time"),
+                    now_utc.isoformat(),
+                )
             if status in ("pending", "active"):
                 db.mark_action(aid, "completed")
             continue

--- a/tests/test_lp_restore_window.py
+++ b/tests/test_lp_restore_window.py
@@ -1,0 +1,121 @@
+"""Restore-action window must be wider than the heartbeat tick.
+
+2026-04-30 active-mode rollout hit a race: the legacy 1-min restore window
+(end_utc + 1 min) was narrower than the 2-min heartbeat interval. When a
+heartbeat tick landed just past the restore window, the state machine
+silently marked the action ``completed`` without firing — leaving the device
+in its prior shutdown state until manual recovery.
+
+LP_RESTORE_WINDOW_MINUTES (default 5, min 2) widens the window so a heartbeat
+tick falling anywhere inside has time to dispatch."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.config import config as app_config
+from src.scheduler.lp_dispatch import daikin_dispatch_preview
+from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+from src.weather import HourlyForecast, WeatherLpSeries
+
+
+@pytest.fixture(autouse=True)
+def _fast_solver(monkeypatch):
+    monkeypatch.setattr(app_config, "LP_HIGHS_TIME_LIMIT_SECONDS", 15)
+    monkeypatch.setattr(app_config, "LP_CBC_TIME_LIMIT_SECONDS", 15)
+    monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
+    monkeypatch.setattr(app_config, "LP_HP_MIN_ON_SLOTS", 1)
+    monkeypatch.setattr(app_config, "LP_SOC_TERMINAL_VALUE_PENCE_PER_KWH", 0.0)
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active")
+
+
+def _build_plan_with_peak():
+    """Build an LP plan that will produce at least one shutdown + restore pair
+    (peak slot in the middle of the horizon).
+    """
+    base = datetime(2026, 7, 1, 14, 0, tzinfo=UTC)
+    n = 10
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    w = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[10.0] * n,
+        shortwave_radiation_wm2=[400.0] * n,
+        cloud_cover_pct=[40.0] * n,
+        pv_kwh_per_slot=[0.5] * n,
+        cop_space=[3.2] * n,
+        cop_dhw=[2.7] * n,
+    )
+    # Peak in the middle (slots 4-5)
+    prices = [10.0] * 4 + [40.0, 40.0] + [10.0] * 4
+    base_load = [0.4] * n
+    st = LpInitialState(soc_kwh=8.0, tank_temp_c=48.0, indoor_temp_c=21.0)
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=st,
+        tz=ZoneInfo("Europe/London"),
+    )
+    return plan, slots
+
+
+def _empty_forecast(slots):
+    return [
+        HourlyForecast(
+            time_utc=s,
+            temperature_c=10.0,
+            shortwave_radiation_wm2=400.0,
+            cloud_cover_pct=40.0,
+            estimated_pv_kw=0.0,
+            heating_demand_factor=1.0,
+        )
+        for s in slots
+    ]
+
+
+def test_restore_window_default_is_at_least_5_minutes(monkeypatch):
+    """Default restore window is wide enough to survive heartbeat jitter."""
+    monkeypatch.setattr(app_config, "LP_RESTORE_WINDOW_MINUTES", 5)
+    plan, slots = _build_plan_with_peak()
+    pairs = daikin_dispatch_preview(plan, _empty_forecast(slots))
+    if not pairs:
+        pytest.skip("LP plan produced no Daikin action pairs (warm/quiet day)")
+    for restore_row, action_row in pairs:
+        st = datetime.fromisoformat(restore_row["start_time"].replace("Z", "+00:00"))
+        en = datetime.fromisoformat(restore_row["end_time"].replace("Z", "+00:00"))
+        width = en - st
+        assert width >= timedelta(minutes=5), (
+            f"restore window {width} too narrow (start={st} end={en}) — "
+            f"would race with the 2-min heartbeat tick"
+        )
+
+
+def test_restore_window_respects_config_override(monkeypatch):
+    """LP_RESTORE_WINDOW_MINUTES env override widens the window."""
+    monkeypatch.setattr(app_config, "LP_RESTORE_WINDOW_MINUTES", 10)
+    plan, slots = _build_plan_with_peak()
+    pairs = daikin_dispatch_preview(plan, _empty_forecast(slots))
+    if not pairs:
+        pytest.skip("LP plan produced no Daikin action pairs")
+    for restore_row, _action_row in pairs:
+        st = datetime.fromisoformat(restore_row["start_time"].replace("Z", "+00:00"))
+        en = datetime.fromisoformat(restore_row["end_time"].replace("Z", "+00:00"))
+        assert (en - st) >= timedelta(minutes=10)
+
+
+def test_restore_window_floor_is_2_minutes(monkeypatch):
+    """Even with absurd config, window can't be narrower than the heartbeat tick."""
+    monkeypatch.setattr(app_config, "LP_RESTORE_WINDOW_MINUTES", 0)  # try to break it
+    plan, slots = _build_plan_with_peak()
+    pairs = daikin_dispatch_preview(plan, _empty_forecast(slots))
+    if not pairs:
+        pytest.skip("LP plan produced no Daikin action pairs")
+    for restore_row, _action_row in pairs:
+        st = datetime.fromisoformat(restore_row["start_time"].replace("Z", "+00:00"))
+        en = datetime.fromisoformat(restore_row["end_time"].replace("Z", "+00:00"))
+        assert (en - st) >= timedelta(minutes=2), (
+            "config_override below floor should clamp to 2 min"
+        )


### PR DESCRIPTION
## Summary

Post-mortem fix from today's active-mode rollout incident.

**Symptom:** Daikin climate + tank turned off at 14:01 UTC (LP-driven shutdown action 607 fired correctly), then **failed to recover** because the paired restore action 606 had a 1-minute window (15:00–15:01 UTC) that the 2-minute heartbeat tick missed. State machine at \`state_machine.py:229-232\` silently marks past-end pending actions as completed without firing — so the user only noticed when their hot water stopped.

**Root cause:** \`lp_dispatch.py:271\` legacy line — \`restore_end = end_utc + timedelta(minutes=1)\`. Narrower than \`HEARTBEAT_INTERVAL_SECONDS / 60\`, racy.

**Fix scope:**

1. **New config \`LP_RESTORE_WINDOW_MINUTES\`** (default 5, hard floor 2). Widens the restore window to ≥2.5× the heartbeat tick — restores can't slip the dispatcher anymore.

2. **State-machine WARNING when an action is silently dropped.** Past-end pending actions still get marked completed (correct behaviour for stale rows from old planner runs), but now the log shows \`action_schedule[id] window missed\` so this class of bug surfaces next time instead of being invisible.

3. **Tests:** three new cases in \`tests/test_lp_restore_window.py\` — default ≥ 5 min, config override widens further, floor of 2 min even with \`LP_RESTORE_WINDOW_MINUTES=0\` (defends against future config bugs).

## Sequencing

This is the post-incident fix from today's active-mode rollout:

- ✅ PR #202 — residual-load profile fix (earlier today)
- ✅ PR #203 — PV-curtail penalty + active-mode soak budget + circuit breaker
- 🔻 Active mode flipped to active at 14:12 UTC, hit this race at 15:01 UTC, **rolled back to passive** at ~15:05 UTC. Prod is now back on \`DAIKIN_CONTROL_MODE=passive\` running PR #203 code (curtail penalty still active — that part of PR #203 keeps benefitting).
- 🟢 **PR (this)** — restore-window fix.
- ⏭ Re-flip active mode after merge + deploy + visual verification of the widened window in \`action_schedule\` rows.

## Test plan

- [x] 3 new cases in \`tests/test_lp_restore_window.py\` all green
- [x] Full suite — **620 passed, 1 skipped** (was 617 before this PR; same 9 unrelated pre-existing HTML/template failures and stale \`test_mcp_singleton.py\` import).
- [ ] **Reviewer:** spot-check the \`restore_end\` calculation in \`lp_dispatch.py\`. Confirm \`max(2, ...)\` floor handles the \`LP_RESTORE_WINDOW_MINUTES=0\` case correctly.
- [ ] **Post-merge prod check:** after the next LP run, verify \`SELECT start_time, end_time FROM action_schedule WHERE action_type='restore' ORDER BY id DESC LIMIT 5\` shows windows ≥ 5 min wide.
- [ ] **Then:** re-flip \`DAIKIN_CONTROL_MODE=active\` in /srv/hem/.env and watch one full peak_export cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)