### PR TITLE
fix(dispatch): heuristic fallback overlapping Fox V3 groups + upload-side guard

### DIFF
--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -538,9 +538,52 @@ def build_fox_groups_from_lp(
     )
 
 
+def _detect_overlapping_groups(
+    groups: list[SchedulerGroup],
+) -> list[tuple[int, int]]:
+    """Return index pairs whose minute-of-day ranges intersect.
+
+    Fox V3 stores each group as HH:MM start/end with no date — the inverter
+    repeats them daily. Two groups whose intervals overlap produce undefined
+    behaviour (firmware appears to honour the last-registered window per
+    minute bucket). Catching this at the upload boundary stops bad payloads
+    from any source — LP, heuristic fallback, or future regressions — from
+    reaching hardware.
+
+    Endpoints are treated as ``[start, end)`` (end exclusive) to match the
+    merge code's adjacency convention: a group ``00:00-00:30`` followed by
+    ``00:30-01:59`` is a clean back-to-back schedule, NOT an overlap.
+    """
+    spans: list[tuple[int, int]] = []
+    for g in groups:
+        start = g.start_hour * 60 + g.start_minute
+        end = g.end_hour * 60 + g.end_minute
+        spans.append((start, end))
+    overlaps: list[tuple[int, int]] = []
+    for i in range(len(spans)):
+        for j in range(i + 1, len(spans)):
+            a_start, a_end = spans[i]
+            b_start, b_end = spans[j]
+            if a_start < b_end and b_start < a_end:
+                overlaps.append((i, j))
+    return overlaps
+
+
 def upload_fox_if_operational(fox: FoxESSClient | None, groups: list[SchedulerGroup]) -> bool:
     fox_ok = False
     if fox and fox.api_key and not config.OPENCLAW_READ_ONLY:
+        overlaps = _detect_overlapping_groups(groups)
+        if overlaps:
+            for i, j in overlaps:
+                gi, gj = groups[i], groups[j]
+                logger.error(
+                    "Refusing Fox V3 upload: overlapping groups detected "
+                    "[%d] %s %02d:%02d-%02d:%02d  vs  [%d] %s %02d:%02d-%02d:%02d "
+                    "(daily-cyclic clock would render duplicates — see #208)",
+                    i, gi.work_mode, gi.start_hour, gi.start_minute, gi.end_hour, gi.end_minute,
+                    j, gj.work_mode, gj.start_hour, gj.start_minute, gj.end_hour, gj.end_minute,
+                )
+            return False
         try:
             fox.set_scheduler_v3(groups, is_default=False)
             fox.warn_if_scheduler_v3_mismatch(groups)

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo
 
 from .. import db
 from ..config import config
-from ..foxess.client import FoxESSClient, FoxESSError
+from ..foxess.client import FoxESSClient
 from ..foxess.models import SchedulerGroup
 from ..foxess.service import get_cached_realtime
 from ..physics import build_shower_target_iso, calculate_dhw_setpoint, find_dhw_heat_end_utc
@@ -876,6 +876,8 @@ def _write_daikin_schedule(plan_date: str, slots: list[HalfHourSlot], forecast: 
 
 def _run_optimizer_heuristic(fox: FoxESSClient | None, daikin: Any | None = None) -> dict[str, Any]:
     """Legacy price-quantile classifier + Fox/Daikin writers."""
+    from .lp_dispatch import upload_fox_if_operational
+
     tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
     if not tariff:
         return {"ok": False, "error": "OCTOPUS_TARIFF_CODE not set"}
@@ -957,19 +959,17 @@ def _run_optimizer_heuristic(fox: FoxESSClient | None, daikin: Any | None = None
         }
     )
 
+    # Fox V3 dispatch is daily-cyclic — mirror the LP path's 24 h cap so D+1
+    # slots that share an hour-of-day with D+0 don't reach the inverter as
+    # overlapping groups (issue #208 / db8a59c). Without this the heuristic
+    # uploads all 96 slots from the 48 h plan window and Fox renders duplicates.
+    fox_slots = slots
+    if fox_slots:
+        cutoff = fox_slots[0].start_utc + timedelta(hours=24)
+        fox_slots = [s for s in fox_slots if s.start_utc < cutoff]
     fox_ok = False
-    groups = _merge_fox_groups(slots, max_groups=8, peak_export_discharge=False)
-    if fox and fox.api_key and not config.OPENCLAW_READ_ONLY:
-        try:
-            fox.set_scheduler_v3(groups, is_default=False)
-            fox.warn_if_scheduler_v3_mismatch(groups)
-            fox.set_scheduler_flag(True)
-            fox_ok = True
-            db.save_fox_schedule_state([g.to_api_dict() for g in groups], enabled=True)
-        except FoxESSError as e:
-            logger.warning("Fox Scheduler V3 upload failed: %s", e)
-    elif fox and fox.api_key:
-        logger.info("Skipping Fox Scheduler V3 upload (read-only)")
+    groups = _merge_fox_groups(fox_slots, max_groups=8, peak_export_discharge=False)
+    fox_ok = upload_fox_if_operational(fox, groups)
 
     daikin_n = _write_daikin_schedule(plan_date, slots, forecast)
 

--- a/tests/test_fox_upload_overlap_guard.py
+++ b/tests/test_fox_upload_overlap_guard.py
@@ -1,0 +1,117 @@
+"""Defensive backstop: Fox V3 uploads with overlapping groups are refused.
+
+Fox V3 stores HH:MM only and cycles daily. Any two groups whose minute-of-day
+ranges intersect become indistinguishable on the inverter (firmware appears
+to honour the last-registered window per minute bucket). #208 documented a
+real prod incident on 2026-05-02 where the heuristic fallback emitted four
+ForceCharge groups with overlapping ranges. The upload-time guard here is
+the last line of defense — it stops bad payloads from any source (LP,
+heuristic, or future regression) from reaching hardware.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from src import db
+from src.foxess.models import SchedulerGroup
+from src.scheduler.lp_dispatch import (
+    _detect_overlapping_groups,
+    upload_fox_if_operational,
+)
+
+
+def _g(start_h: int, start_m: int, end_h: int, end_m: int, mode: str = "ForceCharge") -> SchedulerGroup:
+    return SchedulerGroup(
+        start_hour=start_h,
+        start_minute=start_m,
+        end_hour=end_h,
+        end_minute=end_m,
+        work_mode=mode,
+        min_soc_on_grid=15,
+        fd_soc=95,
+        fd_pwr=3000,
+    )
+
+
+def test_detect_overlapping_groups_flags_prod_incident_payload() -> None:
+    """The exact payload from upload id=264 on 2026-05-02 must be flagged."""
+    groups = [
+        _g(1, 0, 5, 59),    # parent
+        _g(10, 0, 15, 59),
+        _g(1, 0, 1, 59),    # overlaps parent at 01:00-01:59
+        _g(2, 30, 3, 59),   # overlaps parent at 02:30-03:59
+    ]
+    overlaps = _detect_overlapping_groups(groups)
+    assert (0, 2) in overlaps, f"expected (0,2) overlap, got {overlaps}"
+    assert (0, 3) in overlaps, f"expected (0,3) overlap, got {overlaps}"
+    # 01:00-01:59 vs 02:30-03:59 do NOT overlap each other
+    assert (2, 3) not in overlaps
+
+
+def test_detect_overlapping_groups_passes_clean_payload() -> None:
+    """A well-formed daily schedule (no overlaps) returns []."""
+    groups = [
+        _g(7, 30, 23, 59, "SelfUse"),
+        _g(0, 0, 0, 30, "SelfUse"),
+        _g(0, 30, 1, 59),
+        _g(2, 30, 4, 30),
+    ]
+    assert _detect_overlapping_groups(groups) == []
+
+
+def test_detect_overlapping_groups_handles_single_group() -> None:
+    assert _detect_overlapping_groups([_g(0, 0, 23, 59)]) == []
+
+
+def test_detect_overlapping_groups_handles_empty() -> None:
+    assert _detect_overlapping_groups([]) == []
+
+
+def test_adjacent_non_overlapping_groups_are_not_flagged() -> None:
+    """01:00-01:59 then 02:00-02:59 must NOT be considered overlapping
+    (end_minute is inclusive, so 01:59 and 02:00 are distinct minutes)."""
+    groups = [_g(1, 0, 1, 59), _g(2, 0, 2, 59)]
+    assert _detect_overlapping_groups(groups) == []
+
+
+def test_upload_refused_when_overlap_detected(monkeypatch: Any, caplog: Any) -> None:
+    """upload_fox_if_operational must short-circuit and never call set_scheduler_v3
+    when the groups list contains overlaps."""
+    from src.config import config as app_config
+
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", False)
+
+    fox = MagicMock()
+    fox.api_key = "test-key"
+
+    save_called: list[Any] = []
+    monkeypatch.setattr(db, "save_fox_schedule_state", lambda *a, **kw: save_called.append((a, kw)))
+
+    bad_groups = [_g(1, 0, 5, 59), _g(1, 0, 1, 59)]
+    with caplog.at_level("ERROR"):
+        ok = upload_fox_if_operational(fox, bad_groups)
+
+    assert ok is False
+    fox.set_scheduler_v3.assert_not_called()
+    fox.set_scheduler_flag.assert_not_called()
+    assert save_called == []
+    assert any("Refusing Fox V3 upload" in r.getMessage() for r in caplog.records)
+
+
+def test_upload_proceeds_for_clean_groups(monkeypatch: Any) -> None:
+    """Clean groups must reach set_scheduler_v3 + set_scheduler_flag(True)."""
+    from src.config import config as app_config
+
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", False)
+
+    fox = MagicMock()
+    fox.api_key = "test-key"
+    monkeypatch.setattr(db, "save_fox_schedule_state", lambda *a, **kw: None)
+
+    clean_groups = [_g(0, 30, 1, 59), _g(2, 30, 4, 30)]
+    ok = upload_fox_if_operational(fox, clean_groups)
+
+    assert ok is True
+    fox.set_scheduler_v3.assert_called_once()
+    fox.set_scheduler_flag.assert_called_once_with(True)

--- a/tests/test_heuristic_fallback.py
+++ b/tests/test_heuristic_fallback.py
@@ -76,3 +76,63 @@ def test_heuristic_fallback_returns_plan(monkeypatch: pytest.MonkeyPatch) -> Non
     assert isinstance(result.get("daikin_actions"), int), (
         f"missing daikin_actions count: {result}"
     )
+
+
+def test_heuristic_caps_fox_dispatch_at_24h(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #208: when both today's and tomorrow's Agile rates are present, the
+    heuristic must NOT emit Fox V3 groups for D+1 slots that share an
+    hour-of-day with D+0 slots (Fox V3 is daily-cyclic — overlap = duplicates
+    on the inverter). Mirrors the LP-side cap from db8a59c."""
+    now = datetime(2026, 4, 22, 14, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    # Seed BOTH days so the plan window is the full 48 h horizon.
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+    _seed_realistic_day(datetime(2026, 4, 23, 0, 0, tzinfo=UTC))
+
+    captured: dict[str, list] = {}
+
+    def _capture_merge(slots, **kwargs):
+        captured["slots"] = list(slots)
+        # call through to keep the rest of the code path sane
+        return _real_merge(slots, **kwargs)
+
+    _real_merge = optimizer._merge_fox_groups
+    monkeypatch.setattr(optimizer, "_merge_fox_groups", _capture_merge)
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result.get("ok") is True
+
+    slots = captured["slots"]
+    assert slots, "heuristic produced no slots to merge"
+    # 24 h = 48 half-hour slots; cap must hold.
+    span_hours = (slots[-1].end_utc - slots[0].start_utc).total_seconds() / 3600
+    assert span_hours <= 24.0, (
+        f"heuristic dispatch span exceeded 24 h: {span_hours:.2f} h "
+        f"({slots[0].start_utc.isoformat()} -> {slots[-1].end_utc.isoformat()}) — "
+        f"would emit overlapping Fox V3 groups (#208)"
+    )
+
+
+def test_heuristic_uses_shared_upload_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The heuristic must route through ``upload_fox_if_operational`` — that's
+    where the overlap-detection backstop lives (#208). If a future refactor
+    inlines the upload again, the backstop won't fire."""
+    now = datetime(2026, 4, 22, 14, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+
+    from src.scheduler import lp_dispatch
+
+    calls: list[Any] = []
+
+    def _capture_upload(fox, groups):  # type: ignore[no-untyped-def]
+        calls.append(groups)
+        return False
+
+    monkeypatch.setattr(lp_dispatch, "upload_fox_if_operational", _capture_upload)
+    monkeypatch.setattr(optimizer, "upload_fox_if_operational", _capture_upload, raising=False)
+
+    fox = type("FakeFox", (), {"api_key": "x"})()
+    result = optimizer.run_optimizer(fox=fox, daikin=None)
+    assert result.get("ok") is True
+    assert calls, "upload_fox_if_operational was never called by heuristic"


### PR DESCRIPTION
## Summary

Closes #208.

The optimizer's heuristic fallback path (taken when the LP solver returns not-ok — see CLAUDE.md "LP Infeasibles recurring in prod") was uploading Fox V3 schedules that contained **overlapping ForceCharge groups**, because it never received the 24h dispatch cap that the LP path got in db8a59c (#174).

## Smoking gun (prod, 2026-05-02 02:30 UTC)

`fox_schedule_state` upload id=264:
```
01:00-05:59  ForceCharge  fdSoc=95  fdPwr=3000   ← parent
10:00-15:59  ForceCharge  fdSoc=95  fdPwr=3000
01:00-01:59  ForceCharge  fdSoc=95  fdPwr=3000   ← OVERLAPS parent
02:30-03:59  ForceCharge  fdSoc=95  fdPwr=3000   ← OVERLAPS parent
```

The next clean upload (id=265 at 06:25 UTC) was the LP recovering — 4 well-formed groups, no overlaps. Run #288's `strategy_summary` is the heuristic-style "indicative vs SVT ~1.86 GBP/day at mean Agile", *not* the LP-style "PuLP MILP objective ~Xp", confirming the fallback path emitted upload 264.

## Changes

- **`src/scheduler/optimizer.py`** — apply the same 24h cap in `_run_optimizer_heuristic` as `build_fox_groups_from_lp` already does. Route the heuristic upload through `upload_fox_if_operational` (the shared LP helper) instead of inlining the upload.
- **`src/scheduler/lp_dispatch.py`** — add `_detect_overlapping_groups` defensive backstop in `upload_fox_if_operational`. If any two groups' minute-of-day ranges intersect, log ERROR and refuse the upload. Inverter keeps its previous (clean) groups; the next plan-push fixes things naturally. End is treated as exclusive to match the merge code's adjacency convention (`00:00-00:30` then `00:30-01:59` is back-to-back, not an overlap).

## Why both fixes (root-cause + backstop)

The 24h cap addresses the immediate root cause for the heuristic path. The upload-side overlap guard catches **any** future regression — LP, heuristic, or new code path — at the last line of defence before hardware. Cheap (~30 LOC), high signal (will fire loud ERROR if it ever bites).

## Test plan
- [x] `pytest tests/test_fox_upload_overlap_guard.py tests/test_heuristic_fallback.py tests/test_lp_dispatch_24h_cap.py -v` — 12/12 pass (7 new + 2 new + 3 existing for LP cap)
- [x] Full suite green: 669 passed, 1 skipped
- [ ] Post-deploy: confirm `journalctl -u hem` shows no `Refusing Fox V3 upload` lines under normal operation
- [ ] Post-deploy: when the LP next falls back to heuristic, confirm the resulting upload has no overlapping groups (DB query: `SELECT groups_json FROM fox_schedule_state ORDER BY id DESC LIMIT 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)