### PR TITLE
fix(pnl): subtract export revenue from daily brief / metrics / cost-breakdown

### DIFF
--- a/src/analytics/pnl.py
+++ b/src/analytics/pnl.py
@@ -1,11 +1,15 @@
 """Volume-weighted cost and shadow PnL from execution_log."""
 from __future__ import annotations
 
+import logging
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from .. import db
+from ..config import config
 from .shadow_pricing import fixed_shadow_rate_pence, svt_rate_pence
+
+logger = logging.getLogger(__name__)
 
 
 def _day_bounds(d: date) -> tuple[str, str]:
@@ -14,12 +18,61 @@ def _day_bounds(d: date) -> tuple[str, str]:
     return start.isoformat(), end.isoformat()
 
 
+def _realised_export_pence(day: date) -> tuple[float, float]:
+    """Sum per-slot ``export_kwh × export_rate_pence`` for the day.
+
+    Returns ``(export_revenue_pence, export_kwh_total)``. Per-slot export kWh
+    comes from :func:`db.half_hourly_grid_export_kwh_for_day` (trapezoidal
+    integration of ``pv_realtime_history.grid_export_kw``). Per-slot export
+    rates come from ``agile_export_rates`` when ``OCTOPUS_EXPORT_TARIFF_CODE``
+    is configured; otherwise (or for unmatched slots) the flat
+    ``EXPORT_RATE_PENCE`` constant is used.
+
+    Closes #207: ``compute_daily_pnl`` previously sank only import × import-
+    tariff and silently dropped export earnings. On the user's tariff (Outgoing
+    Agile), peak export hours land at 30-60p/kWh — losing them flipped the
+    delta-vs-SVT sign on solar-heavy days (e.g. 2026-05-01 reported as
+    -£0.30 deficit when the actual delta was +£0.40 surplus).
+    """
+    bucket_kwh = db.half_hourly_grid_export_kwh_for_day(day)
+    if not bucket_kwh:
+        return 0.0, 0.0
+    a, b = _day_bounds(day)
+    rate_rows = (
+        db.get_agile_export_rates_in_range(a, b)
+        if (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip()
+        else []
+    )
+    rate_by_start: dict[str, float] = {}
+    for r in rate_rows:
+        try:
+            iso = r["valid_from"].replace("+00:00", "Z")
+            rate_by_start[iso] = float(r["value_inc_vat"])
+        except (KeyError, TypeError, ValueError):
+            continue
+    flat = float(config.EXPORT_RATE_PENCE)
+    revenue = 0.0
+    total_kwh = 0.0
+    matched = 0
+    for slot_iso, kwh in bucket_kwh.items():
+        rate = rate_by_start.get(slot_iso, flat)
+        if slot_iso in rate_by_start:
+            matched += 1
+        revenue += kwh * rate
+        total_kwh += kwh
+    logger.info(
+        "Realised export %s: %.3f kWh -> %.2fp (%d/%d slots matched per-slot rates, rest @ flat %.2fp)",
+        day.isoformat(), total_kwh, revenue, matched, len(bucket_kwh), flat,
+    )
+    return revenue, total_kwh
+
+
 def compute_daily_pnl(day: date) -> dict[str, Any]:
     a, b = _day_bounds(day)
     rows = db.get_execution_logs(from_ts=a, to_ts=b, limit=5000)
     svt = svt_rate_pence()
     fixed = fixed_shadow_rate_pence()
-    realised = 0.0
+    realised_import = 0.0
     svt_cost = 0.0
     fixed_cost = 0.0
     kwh_sum = 0.0
@@ -32,7 +85,7 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
         if p is None:
             continue
         kwh_sum += kwh
-        realised += kwh * float(p)
+        realised_import += kwh * float(p)
         svt_cost += kwh * svt
         fixed_cost += kwh * fixed
         sk = (r.get("slot_kind") or "").lower()
@@ -43,12 +96,18 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
         if float(p) > 0 and kwh > 0:
             import_kwh += kwh
 
+    export_revenue, export_kwh = _realised_export_pence(day)
+    realised = realised_import - export_revenue
+
     alpha_svt = (svt_cost - realised) / 100.0
     alpha_fixed = (fixed_cost - realised) / 100.0
     return {
         "date": day.isoformat(),
         "kwh": round(kwh_sum, 3),
         "realised_cost_gbp": round(realised / 100.0, 4),
+        "realised_import_gbp": round(realised_import / 100.0, 4),
+        "export_revenue_gbp": round(export_revenue / 100.0, 4),
+        "export_kwh": round(export_kwh, 3),
         "svt_shadow_gbp": round(svt_cost / 100.0, 4),
         "fixed_shadow_gbp": round(fixed_cost / 100.0, 4),
         "delta_vs_svt_gbp": round(alpha_svt, 4),

--- a/src/db.py
+++ b/src/db.py
@@ -2452,6 +2452,82 @@ def compute_fox_energy_daily_from_realtime(
     return out
 
 
+def half_hourly_grid_export_kwh_for_day(
+    day: date,
+    *,
+    max_gap_seconds: int = 1800,
+) -> dict[str, float]:
+    """Per-slot grid-export kWh for ``day``, keyed by ISO half-hour slot start (UTC).
+
+    Trapezoidal-integrates ``pv_realtime_history.grid_export_kw`` and assigns each
+    sample-pair's energy to the bucket containing the EARLIER sample (matching
+    :func:`compute_fox_energy_daily_from_realtime`). Slots with no telemetry get no
+    key — caller decides whether to treat missing as zero or fall back to a daily
+    total.
+
+    Used by :mod:`src.analytics.pnl` to value realised exports against per-slot
+    Octopus Outgoing rates (issue #207).
+    """
+    from collections import defaultdict
+    from datetime import datetime as _dt
+
+    day_iso = day.isoformat()
+    # Pull samples for the day plus one before/after for boundary integration.
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT captured_at, grid_export_kw
+                   FROM pv_realtime_history
+                   WHERE substr(captured_at, 1, 10) BETWEEN ? AND ?
+                   ORDER BY captured_at""",
+                (
+                    (day - timedelta(days=1)).isoformat(),
+                    (day + timedelta(days=1)).isoformat(),
+                ),
+            )
+            rows_raw = cur.fetchall()
+        finally:
+            conn.close()
+
+    if len(rows_raw) < 2:
+        return {}
+
+    def _parse(ts_raw: str) -> _dt | None:
+        try:
+            ts = _dt.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+            return ts if ts.tzinfo else ts.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            return None
+
+    def _slot_key(ts: _dt) -> str:
+        # Floor to 30-min boundary (UTC).
+        floor_min = (ts.minute // 30) * 30
+        slot = ts.replace(minute=floor_min, second=0, microsecond=0)
+        return slot.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+    buckets: dict[str, float] = defaultdict(float)
+    prev_ts: _dt | None = None
+    prev_export: float = 0.0
+    for row in rows_raw:
+        ts = _parse(row[0])
+        if ts is None:
+            continue
+        cur_export = float(row[1]) if row[1] is not None else 0.0
+        if prev_ts is not None:
+            dt_s = min((ts - prev_ts).total_seconds(), max_gap_seconds)
+            if dt_s > 0:
+                hours = dt_s / 3600.0
+                avg_kw = (prev_export + cur_export) / 2.0
+                # Only count pairs whose earlier sample falls on `day`.
+                if prev_ts.date().isoformat() == day_iso:
+                    buckets[_slot_key(prev_ts)] += avg_kw * hours
+        prev_ts = ts
+        prev_export = cur_export
+
+    return dict(buckets)
+
+
 def upsert_fox_energy_daily(rows: list[dict[str, Any]]) -> int:
     """Upsert Fox daily energy rows (dicts with date, solar_kwh, load_kwh, …).
 

--- a/tests/test_pnl_export_revenue.py
+++ b/tests/test_pnl_export_revenue.py
@@ -1,0 +1,180 @@
+"""Daily PnL must subtract export earnings (issue #207).
+
+Before this fix, ``compute_daily_pnl`` summed ``import_kwh × import_tariff``
+only and silently dropped export earnings. On the user's tariff (Outgoing
+Agile, peak export 30-60p/kWh), missing the export term flipped the
+delta-vs-SVT sign on solar-heavy days — e.g. the night brief on 2026-05-01
+reported -£0.30 deficit when the energy_metrics endpoint (which uses
+``_compute_cost_octopus`` with export accounting) reported +£0.40 surplus.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from src import db
+from src.analytics import pnl
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+def _save_export_rate(slot: datetime, p: float, tariff: str) -> None:
+    db.save_agile_export_rates(
+        [
+            {
+                "valid_from": slot.isoformat().replace("+00:00", "Z"),
+                "valid_to": (slot + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+                "value_inc_vat": p,
+            }
+        ],
+        tariff,
+    )
+
+
+def _save_pv_sample(ts: datetime, export_kw: float) -> None:
+    db.save_pv_realtime_sample(
+        captured_at=ts.isoformat().replace("+00:00", "Z"),
+        solar_power_kw=0.0,
+        soc_pct=50.0,
+        load_power_kw=0.0,
+        grid_import_kw=0.0,
+        grid_export_kw=export_kw,
+        battery_charge_kw=0.0,
+        battery_discharge_kw=0.0,
+        source="test",
+    )
+
+
+def _save_execution(ts: datetime, kwh: float, agile_p: float) -> None:
+    db.log_execution(
+        {
+            "timestamp": ts.isoformat().replace("+00:00", "Z"),
+            "consumption_kwh": kwh,
+            "agile_price_pence": agile_p,
+            "slot_kind": "standard",
+        }
+    )
+
+
+def test_half_hourly_export_helper_sums_into_correct_slots() -> None:
+    """Two samples 30 min apart with constant 2 kW export → 1 kWh in the
+    bucket containing the earlier sample."""
+    day = date(2026, 5, 1)
+    t0 = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _save_pv_sample(t0, 2.0)
+    _save_pv_sample(t0 + timedelta(minutes=30), 2.0)
+
+    out = db.half_hourly_grid_export_kwh_for_day(day)
+    key = "2026-05-01T12:00:00Z"
+    assert key in out, f"expected slot {key} in {out}"
+    assert out[key] == pytest.approx(1.0, abs=1e-3)
+
+
+def test_half_hourly_export_helper_returns_empty_for_no_telemetry() -> None:
+    assert db.half_hourly_grid_export_kwh_for_day(date(2026, 5, 1)) == {}
+
+
+def test_half_hourly_export_helper_caps_long_gaps() -> None:
+    """A 4-hour gap between samples must NOT extrapolate constant power; it's
+    capped at ``max_gap_seconds`` (default 30 min)."""
+    day = date(2026, 5, 1)
+    t0 = datetime(2026, 5, 1, 10, 0, tzinfo=UTC)
+    _save_pv_sample(t0, 4.0)
+    _save_pv_sample(t0 + timedelta(hours=4), 4.0)  # 4 h gap
+
+    out = db.half_hourly_grid_export_kwh_for_day(day)
+    # With cap at 30 min: 0.5 h × 4 kW = 2 kWh in the 10:00 bucket.
+    # Without cap: 4 h × 4 kW = 16 kWh — would be wildly wrong.
+    assert out["2026-05-01T10:00:00Z"] == pytest.approx(2.0, abs=1e-3)
+
+
+def test_compute_daily_pnl_subtracts_export_revenue(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #207: with 1 kWh consumed at 20p AND 1 kWh exported at 30p,
+    realised cost is 20 - 30 = -10p (i.e. net earnings)."""
+    tariff = "E-1R-AGILE-OUTGOING-TEST-207"
+    monkeypatch.setattr(app_config, "OCTOPUS_EXPORT_TARIFF_CODE", tariff)
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _save_execution(slot, kwh=1.0, agile_p=20.0)
+    _save_export_rate(slot, 30.0, tariff)
+    _save_pv_sample(slot, 2.0)
+    _save_pv_sample(slot + timedelta(minutes=30), 2.0)  # 1 kWh exported
+
+    p = pnl.compute_daily_pnl(day)
+
+    assert p["realised_import_gbp"] == pytest.approx(0.20, abs=1e-3)
+    assert p["export_kwh"] == pytest.approx(1.0, abs=1e-3)
+    assert p["export_revenue_gbp"] == pytest.approx(0.30, abs=1e-3)
+    # Net: 20p import - 30p export = -10p net cost
+    assert p["realised_cost_gbp"] == pytest.approx(-0.10, abs=1e-3)
+
+
+def test_compute_daily_pnl_falls_back_to_flat_export_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No Outgoing tariff configured → flat ``EXPORT_RATE_PENCE`` is used."""
+    monkeypatch.setattr(app_config, "OCTOPUS_EXPORT_TARIFF_CODE", "")
+    monkeypatch.setattr(app_config, "EXPORT_RATE_PENCE", 15.0)
+    day = date(2026, 5, 1)
+    t0 = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _save_execution(t0, kwh=0.5, agile_p=10.0)
+    _save_pv_sample(t0, 4.0)
+    _save_pv_sample(t0 + timedelta(minutes=30), 4.0)  # 2 kWh exported
+
+    p = pnl.compute_daily_pnl(day)
+
+    assert p["export_kwh"] == pytest.approx(2.0, abs=1e-3)
+    # 2 kWh × 15p = 30p revenue
+    assert p["export_revenue_gbp"] == pytest.approx(0.30, abs=1e-3)
+    # Net: 5p import - 30p export = -25p net cost
+    assert p["realised_cost_gbp"] == pytest.approx(-0.25, abs=1e-3)
+
+
+def test_compute_daily_pnl_with_no_export_keeps_old_behaviour() -> None:
+    """A day with zero export telemetry must report the same realised cost
+    as the import sum (back-compat — no surprise behaviour change)."""
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 18, 0, tzinfo=UTC)
+    _save_execution(slot, kwh=2.0, agile_p=25.0)
+    # No PV samples → no export
+
+    p = pnl.compute_daily_pnl(day)
+
+    assert p["export_kwh"] == 0.0
+    assert p["export_revenue_gbp"] == 0.0
+    assert p["realised_import_gbp"] == pytest.approx(0.50, abs=1e-3)
+    assert p["realised_cost_gbp"] == pytest.approx(0.50, abs=1e-3)
+
+
+def test_delta_vs_svt_flips_sign_when_export_is_significant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The headline incident from #207: a heavy-export day where the daily
+    brief reports a deficit but the system actually saved money vs SVT."""
+    tariff = "E-1R-AGILE-OUTGOING-TEST-207"
+    monkeypatch.setattr(app_config, "OCTOPUS_EXPORT_TARIFF_CODE", tariff)
+    monkeypatch.setattr(app_config, "SVT_RATE_PENCE", 25.0)
+
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    # 10 kWh imported at 28p (above SVT) — looks like a deficit on import alone
+    _save_execution(slot, kwh=10.0, agile_p=28.0)
+    # 7.5 kWh exported at 30p — turns the day profitable
+    _save_export_rate(slot, 30.0, tariff)
+    _save_pv_sample(slot, 15.0)
+    _save_pv_sample(slot + timedelta(minutes=30), 15.0)  # 7.5 kWh exported
+
+    p = pnl.compute_daily_pnl(day)
+    # SVT cost: 10 kWh × 25p = 250p
+    # Realised: (10 × 28) - (7.5 × 30) = 280 - 225 = 55p
+    # Delta vs SVT: (250 - 55) / 100 = +£1.95 surplus
+    assert p["delta_vs_svt_gbp"] > 0, (
+        f"Expected positive delta vs SVT (export wins), got {p['delta_vs_svt_gbp']}"
+    )
+    assert p["delta_vs_svt_gbp"] == pytest.approx(1.95, abs=1e-3)


### PR DESCRIPTION
## Summary

Closes #207.

The night brief on 2026-05-01 reported -£0.30 deficit while the day actually netted +£0.40 surplus. The 7.48 kWh of grid export Octopus paid out at peak (~30p/kWh) was missing from the brief because `compute_daily_pnl` (`src/analytics/pnl.py:17`) summed `import_kwh × import_tariff` only — the `execution_log` table has no `export_kwh` column.

Three surfaces consume this function — daily brief, `/api/v1/metrics`, `/api/v1/cost-breakdown` — so all three reported the same import-only number. Meanwhile `_compute_cost_octopus` in `src/energy/monthly.py` (export-aware) sat unused by the brief.

## Changes

- **`src/db.py`** — new `half_hourly_grid_export_kwh_for_day(day)` helper. Trapezoidal-integrates `pv_realtime_history.grid_export_kw` into per-half-hour buckets keyed by ISO slot start, with the same 30-min `max_gap_seconds` cap that `compute_fox_energy_daily_from_realtime` uses (so a multi-hour outage doesn't extrapolate constant power).
- **`src/analytics/pnl.py`** — new `_realised_export_pence(day)` helper. Multiplies per-slot kWh against `agile_export_rates`, falling back to flat `EXPORT_RATE_PENCE` for unmatched slots and when no Outgoing tariff is configured.
- **`compute_daily_pnl`** subtracts `export_revenue_pence` from the import sum. Adds three fields to the returned dict: `realised_import_gbp`, `export_revenue_gbp`, `export_kwh`. Existing fields (`realised_cost_gbp`, `delta_vs_svt_gbp`, `delta_vs_fixed_gbp`) keep their semantics — they now reflect the net (import − export) cost.

## Why per-slot accuracy

Outgoing Agile rates vary 5x across a day (negative midnight → 30-60p peak). A flat-mean approximation would systematically undercount peak-export hours where most of the value lives.

## Test plan
- [x] `pytest tests/test_pnl_export_revenue.py -v` — 7/7 pass:
  - Half-hour helper: bucket assignment, empty telemetry, gap cap
  - PnL with per-slot Agile export rates
  - PnL with flat-rate fallback (no Outgoing tariff)
  - Back-compat: zero export → realised_cost unchanged
  - Headline incident: sign flip from deficit to surplus when 7.5 kWh export at 30p covers 10 kWh import at 28p
- [x] Full suite green: 667 passed, 1 skipped
- [ ] Post-deploy: re-check May 1 brief number — must report a surplus, not a deficit
- [ ] Post-deploy: confirm `journalctl -u hem` shows the new "Realised export ... matched X/Y slots" log line each time the brief or metrics endpoint is hit

## Notes
- `/api/v1/metrics` and `/api/v1/cost-breakdown` get the fix automatically via the shared `compute_daily_pnl` call site — no separate changes needed.
- `pnl_execution_log` table is not touched — its schema lives independently and isn't read by the daily brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)