### PR TITLE
feat(brief): structured net-cost, BG comparison, forecasted-export, mode line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,16 @@ LP_MPC_HOURS=                                    # EMPTY by default (V12) — ev
 # --- V13 — nightly post-hoc consumption backfill ---
 CONSUMPTION_BACKFILL_HOUR=4                      # local TZ (default 04:00) — Octopus consumption
 CONSUMPTION_BACKFILL_MINUTE=0                    # endpoint lags ~24h, 04:00 the next day is safe
+
+# --- Brief expansion (#207 follow-up) — net cost + tariff comparisons ---
+# Realised cost in compute_daily_pnl + brief markdown is NET and INCLUDES the
+# daily standing charge (apples-to-apples vs shadows). Set MANUAL_STANDING_CHARGE
+# above for the Agile standing fee. Set the FIXED_TARIFF_* trio to surface a
+# "vs <label>" comparison line in the brief + MCP (e.g. previous fixed tariff).
+# Leave any of the FIXED_TARIFF_* values at 0 / empty to suppress the line.
+FIXED_TARIFF_LABEL=British Gas Fixed v58         # display label (free text)
+FIXED_TARIFF_RATE_PENCE=20.70                    # flat unit rate
+FIXED_TARIFF_STANDING_PENCE_PER_DAY=41.14        # daily standing charge
 ```
 
 `EXPORT_DISCHARGE_MIN_SOC_PERCENT` was **removed** (was the live-SoC global gate that
@@ -234,6 +244,34 @@ tomorrow's profitable peak-export disappeared during a re-plan after today's
 discharge had drawn the battery below 95 %).
 
 See `docs/DISPATCH_DECISIONS.md` for the design rationale and decision rule.
+
+### Daily PnL semantics — read this before quoting any £ figure
+
+The MCP tools `get_energy_metrics`, `get_daily_brief`, `get_night_brief`, and
+`get_tariff_comparison` (plus the markdown brief itself) all use the same
+convention. **Don't paraphrase numbers from the markdown — pull the
+structured fields:**
+
+- `realised_cost_gbp` is **NET** and **INCLUDES** the daily standing charge.
+  Formula: `Σ(slot_kwh × agile_p) + standing_pence_per_day − Σ(export_kwh × export_p)`.
+- All shadow costs (`svt_shadow_gbp`, `fixed_shadow_gbp`,
+  `fixed_tariff_shadow_gbp`) **also include** the standing charge — so
+  `delta_vs_*_gbp` is real money saved, not energy-cost-only saved. Positive
+  = Agile beat the shadow.
+- `realised_import_gbp` is the energy-import side only (no standing, no
+  export). Useful for breaking down "where did the cost come from".
+- `export_revenue_gbp` and `export_kwh` are **measured** (from
+  `pv_realtime_history` half-hour rollup × per-slot `agile_export_rates`).
+- When `export_kwh == 0` but the LP committed `peak_export` slots, the brief
+  surfaces a **forecasted** estimate flagged with 🔮 — that's the LP's
+  `scen_pessimistic_exp_kwh × per-slot Outgoing Agile rate`. It is an
+  estimate, not measurement; do not double-count.
+
+`Mode:` line in the brief tells OpenClaw whether HEM is actively driving
+Daikin (`active`) or just observing (`passive`). When passive, OpenClaw
+should never suggest tactical Daikin actions ("preheat the tank now!") —
+the heat pump runs on its own weather curve and HEM does not change
+setpoints. Read `_mode_status_line()` in `src/analytics/daily_brief.py`.
 
 ---
 

--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -16,6 +16,7 @@ restricted to genuine errors + the 🔵 PAID-to-use crossing.
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
+from typing import Any
 from zoneinfo import ZoneInfo
 
 from .. import db
@@ -64,16 +65,16 @@ def build_morning_payload() -> str:
         f"**Today ({today})**",
         strategy,
         "",
+        _mode_status_line(),
+        "",
     ]
     if tier_summary:
         lines.extend(["**Tariff windows today:**", tier_summary, ""])
     if pe_summary:
         lines.extend(["**Peak-export plan:**", pe_summary, ""])
 
-    lines.extend([
-        f"**Yesterday ({yesterday}):** realised £{pnl['realised_cost_gbp']:.2f}, "
-        f"vs SVT shadow £{pnl['delta_vs_svt_gbp']:+.2f}.",
-    ])
+    lines.append(f"**Yesterday ({yesterday}) — financial summary**")
+    lines.extend(_format_pnl_block(pnl, day=yesterday, tz=tz))
     return "\n".join(lines)
 
 
@@ -106,11 +107,12 @@ def build_night_payload() -> str:
     lines: list[str] = [
         "## 🌙 Night brief",
         f"**Today ({today})** — actuals",
-        f"- Realised cost: £{pnl['realised_cost_gbp']:.2f}",
-        f"- vs SVT shadow: £{pnl['delta_vs_svt_gbp']:+.2f}",
-        f"- vs fixed shadow: £{pnl['delta_vs_fixed_gbp']:+.2f}",
-        f"- VWAP: {vwap}p/kWh" if vwap else "- VWAP: n/a",
+        "",
+        _mode_status_line(),
+        "",
     ]
+    lines.extend(_format_pnl_block(pnl, day=today, tz=tz))
+    lines.append(f"- VWAP: {vwap}p/kWh" if vwap else "- VWAP: n/a")
     if slip is not None:
         lines.append(f"- Slippage vs target: {slip}p")
     if arb is not None:
@@ -119,6 +121,142 @@ def build_night_payload() -> str:
     if pe_today:
         lines.extend(["", "**Peak-export verdicts today:**", pe_today])
     return "\n".join(lines)
+
+
+def _mode_status_line() -> str:
+    """One-line mode status so OpenClaw stops inventing Daikin advice.
+
+    The user runs Daikin in passive mode (telemetry-only — Onecta firmware drives
+    the heat pump on its own weather curve, HEM doesn't touch setpoints). Without
+    this line, the LLM that paraphrases the brief tends to fill in tactical
+    Daikin advice ("preheat tank during cheap window!") that has no basis.
+    """
+    daikin_mode = (config.DAIKIN_CONTROL_MODE or "passive").strip().lower()
+    if daikin_mode == "active":
+        daikin_label = "active (HEM dispatches setpoints/LWT offset per LP plan)"
+    else:
+        daikin_label = (
+            "passive (telemetry-only; Onecta firmware drives autonomously on weather curve — "
+            "HEM does NOT alter setpoints)"
+        )
+    fox_label = (
+        "LP-dispatched (Scheduler V3 groups uploaded after each solve)"
+        if not config.OPENCLAW_READ_ONLY
+        else "READ_ONLY (no hardware writes)"
+    )
+    return f"**Mode:** Daikin={daikin_label}; Fox={fox_label}"
+
+
+def _format_pnl_block(pnl: dict[str, Any], *, day: date, tz: ZoneInfo) -> list[str]:
+    """Structured 4-pillar financial breakdown for both briefs.
+
+    Output lines:
+      - Net cost line breaking out import / standing / export
+      - Energy used + exported (kWh totals)
+      - One delta line per configured shadow tariff (SVT, Fixed, optional FIXED_TARIFF)
+      - Optional 🔮 forecasted-export line when telemetry export is 0 but the
+        LP planned committed peak_export slots for the day
+
+    Standing charges are baked into all shadows (apples-to-apples), so the
+    delta is genuine "money saved" not "energy-cost-only saved".
+    """
+    out: list[str] = []
+    net = pnl["realised_cost_gbp"]
+    imp = pnl["realised_import_gbp"]
+    std = pnl.get("standing_charge_gbp", 0.0)
+    exp_gbp = pnl["export_revenue_gbp"]
+    exp_kwh = pnl["export_kwh"]
+    used_kwh = pnl["kwh"]
+
+    out.append(
+        f"- Net cost: £{net:+.2f}  (import £{imp:.2f} + standing £{std:.2f} − export £{exp_gbp:.2f})"
+    )
+    out.append(f"- Energy used: {used_kwh:.1f} kWh  |  exported: {exp_kwh:.1f} kWh")
+
+    # Forecasted-export fallback: telemetry sometimes drops grid_export_kw
+    # samples, leaving export_kwh=0 even on days where the LP committed
+    # peak_export and the inverter genuinely discharged. Estimate from
+    # `dispatch_decisions × agile_export_rates` and flag with 🔮.
+    if exp_kwh == 0:
+        f_kwh, f_pence, f_slots = _forecasted_export_for_day(day, tz)
+        if f_slots > 0:
+            out.append(
+                f"- 🔮 Forecasted export (telemetry missing): "
+                f"~{f_kwh:.2f} kWh ≈ £{f_pence / 100.0:+.2f} "
+                f"(from {f_slots} committed peak_export slot{'s' if f_slots != 1 else ''})"
+            )
+
+    if "delta_vs_fixed_tariff_gbp" in pnl:
+        label = pnl.get("fixed_tariff_label") or "fixed tariff"
+        shadow = pnl["fixed_tariff_shadow_gbp"]
+        delta = pnl["delta_vs_fixed_tariff_gbp"]
+        out.append(
+            f"- vs {label} (would have cost £{shadow:.2f}): "
+            f"£{delta:+.2f} {'saved' if delta >= 0 else 'extra'}"
+        )
+    out.append(
+        f"- vs SVT (would have cost £{pnl['svt_shadow_gbp']:.2f}): "
+        f"£{pnl['delta_vs_svt_gbp']:+.2f} {'saved' if pnl['delta_vs_svt_gbp'] >= 0 else 'extra'}"
+    )
+    # "fixed shadow" is the legacy MANUAL_TARIFF_IMPORT_PENCE comparison —
+    # it falls back to SVT when not configured, so suppress the line in
+    # that case to avoid showing the same number twice.
+    if pnl["fixed_shadow_gbp"] != pnl["svt_shadow_gbp"]:
+        out.append(
+            f"- vs fixed shadow (£{pnl['fixed_shadow_gbp']:.2f}): "
+            f"£{pnl['delta_vs_fixed_gbp']:+.2f} {'saved' if pnl['delta_vs_fixed_gbp'] >= 0 else 'extra'}"
+        )
+    return out
+
+
+def _forecasted_export_for_day(day: date, tz: ZoneInfo) -> tuple[float, float, int]:
+    """Estimate exported kWh + pence from committed peak_export decisions.
+
+    Used as fallback when telemetry export is 0 on a day the LP committed
+    peak_export slots — most likely a missing-sample window in
+    ``pv_realtime_history``. Sums ``scen_pessimistic_exp_kwh`` (the safety-
+    floor amount the LP guaranteed) for every committed peak_export slot
+    whose local date matches ``day``, multiplied by per-slot
+    ``agile_export_rates`` (flat ``EXPORT_RATE_PENCE`` fallback).
+
+    Returns ``(kwh, pence, slot_count)`` or ``(0, 0, 0)``.
+    """
+    from datetime import UTC as _UTC
+
+    start_utc = datetime.combine(day, datetime.min.time()).replace(tzinfo=tz).astimezone(_UTC)
+    end_utc = start_utc + timedelta(days=1)
+    try:
+        commits = db.get_committed_peak_export_in_range(
+            start_utc.isoformat(), end_utc.isoformat()
+        )
+    except Exception:
+        return 0.0, 0.0, 0
+    if not commits:
+        return 0.0, 0.0, 0
+
+    flat = float(config.EXPORT_RATE_PENCE)
+    rate_by_start: dict[str, float] = {}
+    if (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip():
+        try:
+            for r in db.get_agile_export_rates_in_range(
+                start_utc.isoformat(), end_utc.isoformat()
+            ):
+                key = str(r["valid_from"]).replace("+00:00", "Z")
+                rate_by_start[key] = float(r["value_inc_vat"])
+        except Exception:
+            pass
+
+    total_kwh = 0.0
+    total_p = 0.0
+    for r in commits:
+        kwh = float(r.get("scen_pessimistic_exp_kwh") or 0.0)
+        if kwh <= 0:
+            continue
+        slot_iso = str(r["slot_time_utc"]).replace("+00:00", "Z")
+        rate = rate_by_start.get(slot_iso, flat)
+        total_kwh += kwh
+        total_p += kwh * rate
+    return total_kwh, total_p, len(commits)
 
 
 # --------------------------------------------------------------------------

--- a/src/analytics/pnl.py
+++ b/src/analytics/pnl.py
@@ -68,13 +68,21 @@ def _realised_export_pence(day: date) -> tuple[float, float]:
 
 
 def compute_daily_pnl(day: date) -> dict[str, Any]:
+    """Daily PnL with apples-to-apples standing-charge accounting.
+
+    All shadow costs (SVT, Fixed, configured legacy fixed tariff) include the
+    standing charge so the deltas reflect what the household would actually
+    pay on each tariff. Realised cost on Agile likewise embeds the Agile
+    standing charge (``MANUAL_STANDING_CHARGE_PENCE_PER_DAY``) so the user-facing
+    "you saved £X vs SVT" figure isn't off by ~62p/day.
+    """
     a, b = _day_bounds(day)
     rows = db.get_execution_logs(from_ts=a, to_ts=b, limit=5000)
     svt = svt_rate_pence()
     fixed = fixed_shadow_rate_pence()
     realised_import = 0.0
-    svt_cost = 0.0
-    fixed_cost = 0.0
+    svt_energy_cost = 0.0
+    fixed_energy_cost = 0.0
     kwh_sum = 0.0
     import_kwh = 0.0
     cheap_kwh = 0.0
@@ -86,8 +94,8 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
             continue
         kwh_sum += kwh
         realised_import += kwh * float(p)
-        svt_cost += kwh * svt
-        fixed_cost += kwh * fixed
+        svt_energy_cost += kwh * svt
+        fixed_energy_cost += kwh * fixed
         sk = (r.get("slot_kind") or "").lower()
         if sk == "peak":
             peak_kwh += kwh
@@ -97,17 +105,26 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
             import_kwh += kwh
 
     export_revenue, export_kwh = _realised_export_pence(day)
-    realised = realised_import - export_revenue
+    standing_p = float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0)
+
+    # Net daily cost = (energy import + standing) − export earnings.
+    # Standing is a fixed daily fee on Agile too, so it MUST be in here for
+    # comparisons to be meaningful.
+    realised = realised_import + standing_p - export_revenue
+    svt_cost = svt_energy_cost + standing_p
+    fixed_cost = fixed_energy_cost + standing_p
 
     alpha_svt = (svt_cost - realised) / 100.0
     alpha_fixed = (fixed_cost - realised) / 100.0
-    return {
+
+    out: dict[str, Any] = {
         "date": day.isoformat(),
         "kwh": round(kwh_sum, 3),
         "realised_cost_gbp": round(realised / 100.0, 4),
         "realised_import_gbp": round(realised_import / 100.0, 4),
         "export_revenue_gbp": round(export_revenue / 100.0, 4),
         "export_kwh": round(export_kwh, 3),
+        "standing_charge_gbp": round(standing_p / 100.0, 4),
         "svt_shadow_gbp": round(svt_cost / 100.0, 4),
         "fixed_shadow_gbp": round(fixed_cost / 100.0, 4),
         "delta_vs_svt_gbp": round(alpha_svt, 4),
@@ -115,6 +132,18 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
         "cheap_slot_kwh": round(cheap_kwh, 3),
         "peak_kwh": round(peak_kwh, 3),
     }
+
+    # Optional: legacy fixed tariff comparison (e.g. previous British Gas plan).
+    # Skipped entirely when not configured so the brief stays clean.
+    bg_rate = float(config.FIXED_TARIFF_RATE_PENCE or 0)
+    bg_standing = float(config.FIXED_TARIFF_STANDING_PENCE_PER_DAY or 0)
+    if bg_rate > 0 and bg_standing > 0:
+        bg_cost = (kwh_sum * bg_rate) + bg_standing
+        out["fixed_tariff_label"] = config.FIXED_TARIFF_LABEL or "fixed tariff"
+        out["fixed_tariff_shadow_gbp"] = round(bg_cost / 100.0, 4)
+        out["delta_vs_fixed_tariff_gbp"] = round((bg_cost - realised) / 100.0, 4)
+
+    return out
 
 
 def compute_vwap(day: date) -> float | None:

--- a/src/config.py
+++ b/src/config.py
@@ -216,6 +216,16 @@ class Config:
         os.getenv("MANUAL_STANDING_CHARGE_PENCE_PER_DAY", "0")
     )
 
+    # PnL comparison shadow: previous fixed tariff (e.g. British Gas PeakSave Fixed v58).
+    # Set both to surface a "vs <FIXED_TARIFF_LABEL>" line in the daily brief; leave
+    # either at 0 to suppress the line. Used by ``compute_daily_pnl`` to compute the
+    # alternative-cost shadow at apples-to-apples (kWh × rate + standing charge).
+    FIXED_TARIFF_LABEL: str = os.getenv("FIXED_TARIFF_LABEL", "")
+    FIXED_TARIFF_RATE_PENCE: float = float(os.getenv("FIXED_TARIFF_RATE_PENCE", "0"))
+    FIXED_TARIFF_STANDING_PENCE_PER_DAY: float = float(
+        os.getenv("FIXED_TARIFF_STANDING_PENCE_PER_DAY", "0")
+    )
+
     # Gas comparison (solar + heat pump vs gas): gas price p/kWh, boiler efficiency (e.g. 0.9)
     GAS_PRICE_PENCE_PER_KWH: float = float(os.getenv("GAS_PRICE_PENCE_PER_KWH", "0"))
     GAS_BOILER_EFFICIENCY: float = float(os.getenv("GAS_BOILER_EFFICIENCY", "0.9"))

--- a/src/db.py
+++ b/src/db.py
@@ -3764,6 +3764,41 @@ def get_dispatch_decisions(run_id: int) -> list[dict[str, Any]]:
             conn.close()
 
 
+def get_committed_peak_export_in_range(
+    period_from_iso: str,
+    period_to_iso: str,
+) -> list[dict[str, Any]]:
+    """Latest committed peak_export decision per slot in the UTC range.
+
+    Slots can be re-decided across multiple LP runs (each plan re-solve writes a
+    new row). For "what did we actually commit?" the most recent ``run_id`` per
+    slot is the source of truth.
+
+    Used by the daily-brief forecasted-export fallback: when telemetry export
+    is 0 on a day the LP committed peak_export, surface the planned amount so
+    the household sees an estimate flagged as forecasted instead of nothing.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT slot_time_utc, lp_kind, committed,
+                          scen_pessimistic_exp_kwh, scen_nominal_exp_kwh, run_id
+                   FROM dispatch_decisions
+                   WHERE slot_time_utc >= ? AND slot_time_utc < ?
+                     AND lp_kind = 'peak_export' AND committed = 1
+                     AND run_id = (
+                         SELECT MAX(run_id) FROM dispatch_decisions d2
+                         WHERE d2.slot_time_utc = dispatch_decisions.slot_time_utc
+                     )
+                   ORDER BY slot_time_utc ASC""",
+                (period_from_iso, period_to_iso),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
 def update_execution_log_metered(
     slot_start_utc: str,
     consumption_kwh: float,

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1657,8 +1657,14 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="get_energy_metrics",
         description=(
-            "Bulletproof: daily/weekly PnL vs SVT/fixed shadow, VWAP, arbitrage efficiency, "
-            "peak ratio, SLA snapshot, battery SoC."
+            "Today's net daily PnL with full transparency for OpenClaw. "
+            "ALL costs include the daily standing charge so deltas are real money saved "
+            "(not energy-cost-only). Returns: realised_cost (= import + standing − export "
+            "earnings), the import/standing/export components, SVT shadow, fixed shadow, "
+            "and — when FIXED_TARIFF_* env vars are set — a comparison vs the user's "
+            "previous fixed tariff (e.g. British Gas Fixed v58). Plus VWAP, slippage, "
+            "arbitrage efficiency, SLA snapshot, battery SoC. "
+            "Use this instead of parsing the daily-brief markdown."
         ),
     )
     def get_energy_metrics() -> dict[str, Any]:
@@ -1680,13 +1686,33 @@ def build_mcp() -> FastMCP:
             soc = get_cached_realtime().soc
         except Exception:
             pass
+
+        daily_block: dict[str, Any] = {
+            "date": daily.get("date"),
+            "realised_cost_pounds": daily.get("realised_cost_gbp"),
+            "realised_import_pounds": daily.get("realised_import_gbp"),
+            "standing_charge_pounds": daily.get("standing_charge_gbp"),
+            "export_revenue_pounds": daily.get("export_revenue_gbp"),
+            "export_kwh": daily.get("export_kwh"),
+            "energy_used_kwh": daily.get("kwh"),
+            "svt_shadow_pounds": daily.get("svt_shadow_gbp"),
+            "fixed_shadow_pounds": daily.get("fixed_shadow_gbp"),
+            "delta_vs_svt_pounds": daily.get("delta_vs_svt_gbp"),
+            "delta_vs_fixed_pounds": daily.get("delta_vs_fixed_gbp"),
+            "_note": "All costs include the daily standing charge for apples-to-apples deltas.",
+        }
+        # Optional legacy-tariff comparison (e.g. British Gas Fixed v58)
+        if "delta_vs_fixed_tariff_gbp" in daily:
+            daily_block["fixed_tariff_label"] = daily.get("fixed_tariff_label")
+            daily_block["fixed_tariff_shadow_pounds"] = daily.get("fixed_tariff_shadow_gbp")
+            daily_block["delta_vs_fixed_tariff_pounds"] = daily.get(
+                "delta_vs_fixed_tariff_gbp"
+            )
+
         return {
             "ok": True,
             "pnl": {
-                "daily": {
-                    "delta_vs_svt_pounds": daily.get("delta_vs_svt_gbp"),
-                    "delta_vs_fixed_pounds": daily.get("delta_vs_fixed_gbp"),
-                },
+                "daily": daily_block,
                 "weekly": {"delta_vs_svt_pounds": weekly.get("delta_vs_svt_gbp")},
                 "monthly": {"delta_vs_svt_pounds": monthly.get("delta_vs_svt_gbp")},
             },
@@ -1723,12 +1749,196 @@ def build_mcp() -> FastMCP:
 
     @mcp.tool(
         name="get_daily_brief",
-        description="Bulletproof: on-demand morning-style brief (yesterday PnL + today strategy).",
+        description=(
+            "On-demand morning brief — yesterday's net PnL + today's strategy + tier "
+            "windows + peak-export plan + control-mode status. Returns BOTH markdown "
+            "(for direct display) AND structured data (for OpenClaw to format prose "
+            "without parsing). The structured fields include net cost broken down "
+            "(import + standing − export), kWh used + exported, all configured shadow "
+            "comparisons (SVT, Fixed, optional FIXED_TARIFF_LABEL e.g. British Gas "
+            "Fixed v58), Daikin control mode (passive vs active), and a forecasted-"
+            "export estimate when telemetry was missing. Prefer the structured fields "
+            "over markdown parsing."
+        ),
     )
     def get_daily_brief() -> dict[str, Any]:
-        from .analytics.daily_brief import build_daily_brief_text
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
 
-        return {"ok": True, "markdown": build_daily_brief_text()}
+        from .analytics import pnl
+        from .analytics.daily_brief import (
+            _forecasted_export_for_day,
+            _mode_status_line,
+            build_morning_payload,
+        )
+
+        tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+        yesterday = datetime.now(tz).date() - timedelta(days=1)
+        ypnl = pnl.compute_daily_pnl(yesterday)
+
+        f_kwh, f_pence, f_slots = _forecasted_export_for_day(yesterday, tz)
+        forecasted = (
+            None
+            if ypnl.get("export_kwh") or f_slots == 0
+            else {
+                "export_kwh_estimated": round(f_kwh, 3),
+                "export_pence_estimated": round(f_pence, 2),
+                "committed_slot_count": f_slots,
+                "_note": (
+                    "Telemetry export was 0 for this day; estimate is the "
+                    "LP-committed peak_export amount × per-slot Outgoing Agile rates."
+                ),
+            }
+        )
+
+        return {
+            "ok": True,
+            "markdown": build_morning_payload(),
+            "data": {
+                "mode_status": _mode_status_line(),
+                "yesterday_pnl": ypnl,
+                "forecasted_export_yesterday": forecasted,
+                "_note": (
+                    "yesterday_pnl.realised_cost_gbp is NET and INCLUDES standing charge. "
+                    "All shadow costs include standing too — deltas are real money saved."
+                ),
+            },
+        }
+
+    @mcp.tool(
+        name="get_night_brief",
+        description=(
+            "On-demand night brief — today's actual net PnL + peak-export verdicts. "
+            "Returns BOTH markdown and structured data. Same semantics as "
+            "get_daily_brief: all costs include standing charge; deltas are real "
+            "money saved. Use this after ~22:00 local for end-of-day reporting."
+        ),
+    )
+    def get_night_brief() -> dict[str, Any]:
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        from .analytics import pnl
+        from .analytics.daily_brief import (
+            _forecasted_export_for_day,
+            _mode_status_line,
+            build_night_payload,
+        )
+
+        tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+        today = datetime.now(tz).date()
+        tpnl = pnl.compute_daily_pnl(today)
+
+        f_kwh, f_pence, f_slots = _forecasted_export_for_day(today, tz)
+        forecasted = (
+            None
+            if tpnl.get("export_kwh") or f_slots == 0
+            else {
+                "export_kwh_estimated": round(f_kwh, 3),
+                "export_pence_estimated": round(f_pence, 2),
+                "committed_slot_count": f_slots,
+                "_note": (
+                    "Telemetry export is 0 so far today; estimate from LP-committed "
+                    "peak_export × per-slot Outgoing Agile rates."
+                ),
+            }
+        )
+
+        return {
+            "ok": True,
+            "markdown": build_night_payload(),
+            "data": {
+                "mode_status": _mode_status_line(),
+                "today_pnl": tpnl,
+                "forecasted_export_today": forecasted,
+                "_note": (
+                    "today_pnl.realised_cost_gbp is NET (import + standing − export). "
+                    "All shadow costs include standing. Deltas reflect real money saved."
+                ),
+            },
+        }
+
+    @mcp.tool(
+        name="get_tariff_comparison",
+        description=(
+            "Apples-to-apples cost comparison for a given local date across every "
+            "configured tariff: realised cost on Octopus Agile + your current shadows "
+            "(SVT, Fixed, optional legacy fixed tariff via FIXED_TARIFF_*). All shadow "
+            "costs INCLUDE the standing charge so deltas are real money saved. Pass "
+            "date='YYYY-MM-DD' (defaults to yesterday). Each entry returns: shadow_cost_pounds, "
+            "delta_vs_realised_pounds (positive = saved on Agile vs that tariff), "
+            "rate_pence_per_kwh, standing_pence_per_day, source ('configured' / 'svt' "
+            "/ 'agile_realised'). Designed for OpenClaw to render the comparison "
+            "without inventing numbers."
+        ),
+    )
+    def get_tariff_comparison(date: str = "") -> dict[str, Any]:
+        from datetime import datetime, timedelta
+        from datetime import date as _date_t
+        from zoneinfo import ZoneInfo
+
+        from .analytics import pnl
+
+        tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+        if date.strip():
+            try:
+                day = _date_t.fromisoformat(date.strip())
+            except ValueError:
+                return {"ok": False, "error": f"invalid date: {date!r} (expected YYYY-MM-DD)"}
+        else:
+            day = datetime.now(tz).date() - timedelta(days=1)
+
+        p = pnl.compute_daily_pnl(day)
+        realised = float(p.get("realised_cost_gbp") or 0)
+        kwh = float(p.get("kwh") or 0)
+        standing_p_per_day = float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0)
+
+        comparisons: list[dict[str, Any]] = [
+            {
+                "label": "Octopus Agile (realised)",
+                "source": "agile_realised",
+                "shadow_cost_pounds": realised,
+                "delta_vs_realised_pounds": 0.0,
+                "rate_pence_per_kwh": None,
+                "standing_pence_per_day": standing_p_per_day,
+                "_note": "Per-slot Agile import rates + standing − export earnings.",
+            },
+            {
+                "label": "Octopus SVT (would-have)",
+                "source": "svt",
+                "shadow_cost_pounds": float(p.get("svt_shadow_gbp") or 0),
+                "delta_vs_realised_pounds": float(p.get("delta_vs_svt_gbp") or 0),
+                "rate_pence_per_kwh": float(config.SVT_RATE_PENCE),
+                "standing_pence_per_day": standing_p_per_day,
+            },
+        ]
+        if "delta_vs_fixed_tariff_gbp" in p:
+            comparisons.append(
+                {
+                    "label": p.get("fixed_tariff_label") or "Configured fixed tariff",
+                    "source": "configured",
+                    "shadow_cost_pounds": float(p.get("fixed_tariff_shadow_gbp") or 0),
+                    "delta_vs_realised_pounds": float(p.get("delta_vs_fixed_tariff_gbp") or 0),
+                    "rate_pence_per_kwh": float(config.FIXED_TARIFF_RATE_PENCE),
+                    "standing_pence_per_day": float(
+                        config.FIXED_TARIFF_STANDING_PENCE_PER_DAY
+                    ),
+                }
+            )
+
+        return {
+            "ok": True,
+            "date": day.isoformat(),
+            "energy_used_kwh": kwh,
+            "energy_exported_kwh": float(p.get("export_kwh") or 0),
+            "import_pounds": float(p.get("realised_import_gbp") or 0),
+            "export_revenue_pounds": float(p.get("export_revenue_gbp") or 0),
+            "comparisons": comparisons,
+            "_note": (
+                "Positive delta_vs_realised_pounds = Agile saved money vs that shadow. "
+                "All shadow costs include the daily standing charge."
+            ),
+        }
 
     @mcp.tool(
         name="get_battery_forecast",

--- a/tests/test_brief_expanded.py
+++ b/tests/test_brief_expanded.py
@@ -1,0 +1,296 @@
+"""Brief markdown carries net cost, comparisons, mode header, forecasted export.
+
+Issue follow-up to #207: OpenClaw was filling the prose with hallucinated
+Daikin advice and ambiguous "beat SVT by 40p" lines because the underlying
+HEM markdown was too sparse. These tests lock the structured fields the
+brief must surface so future paraphrasers have nothing to invent.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.analytics import daily_brief, pnl
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _brief_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", "AGILE-TEST")
+    monkeypatch.setattr(app_config, "OCTOPUS_EXPORT_TARIFF_CODE", "AGILE-OUT-TEST")
+    monkeypatch.setattr(app_config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 62.22)
+    monkeypatch.setattr(app_config, "EXPORT_RATE_PENCE", 15.0)
+
+
+def _seed_execution(ts: datetime, kwh: float, p: float) -> None:
+    db.log_execution(
+        {
+            "timestamp": ts.isoformat().replace("+00:00", "Z"),
+            "consumption_kwh": kwh,
+            "agile_price_pence": p,
+            "slot_kind": "standard",
+        }
+    )
+
+
+def _seed_export_sample(ts: datetime, kw: float) -> None:
+    db.save_pv_realtime_sample(
+        captured_at=ts.isoformat().replace("+00:00", "Z"),
+        solar_power_kw=0.0, soc_pct=50.0, load_power_kw=0.0,
+        grid_import_kw=0.0, grid_export_kw=kw,
+        battery_charge_kw=0.0, battery_discharge_kw=0.0,
+        source="test",
+    )
+
+
+def _seed_export_rate(ts: datetime, p: float) -> None:
+    db.save_agile_export_rates(
+        [{
+            "valid_from": ts.isoformat().replace("+00:00", "Z"),
+            "valid_to": (ts + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+            "value_inc_vat": p,
+        }],
+        "AGILE-OUT-TEST",
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_daily_pnl — standing charge + British Gas shadow
+# ---------------------------------------------------------------------------
+
+def test_pnl_includes_standing_charge_in_realised_and_shadows() -> None:
+    """Both realised cost and shadow costs MUST include the daily standing
+    charge so the delta is apples-to-apples (real money saved, not
+    energy-cost-only saved)."""
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _seed_execution(slot, kwh=1.0, p=20.0)  # 20p import
+    # No export
+
+    p = pnl.compute_daily_pnl(day)
+
+    # Realised = import 20p + standing 62.22p = 82.22p = £0.8222
+    assert p["standing_charge_gbp"] == pytest.approx(0.6222, abs=1e-3)
+    assert p["realised_cost_gbp"] == pytest.approx(0.8222, abs=1e-3)
+    # SVT shadow includes standing too
+    assert p["svt_shadow_gbp"] > p["standing_charge_gbp"], (
+        "SVT shadow must include standing"
+    )
+
+
+def test_pnl_emits_british_gas_shadow_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With FIXED_TARIFF_* set, the PnL dict gains the BG shadow + delta."""
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_LABEL", "British Gas Fixed v58")
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_RATE_PENCE", 20.70)
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_STANDING_PENCE_PER_DAY", 41.14)
+
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _seed_execution(slot, kwh=10.0, p=15.0)  # Agile cheaper than BG
+
+    p = pnl.compute_daily_pnl(day)
+
+    assert p["fixed_tariff_label"] == "British Gas Fixed v58"
+    # 10 kWh × 20.70p + 41.14p standing = 207.00 + 41.14 = 248.14p = £2.4814
+    assert p["fixed_tariff_shadow_gbp"] == pytest.approx(2.4814, abs=1e-3)
+    # Realised = 10 × 15p + 62.22p standing = 212.22p = £2.1222
+    # Delta vs BG = 2.4814 - 2.1222 = +£0.3592 saved (Agile beats BG)
+    assert p["delta_vs_fixed_tariff_gbp"] == pytest.approx(0.3592, abs=1e-3)
+
+
+def test_pnl_omits_british_gas_fields_when_not_configured() -> None:
+    """When no legacy fixed tariff is configured, the BG fields must NOT
+    appear in the dict (so the brief auto-suppresses the line)."""
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _seed_execution(slot, kwh=1.0, p=20.0)
+
+    p = pnl.compute_daily_pnl(day)
+
+    assert "fixed_tariff_shadow_gbp" not in p
+    assert "delta_vs_fixed_tariff_gbp" not in p
+
+
+# ---------------------------------------------------------------------------
+# Brief rendering — net cost, mode line, BG comparison
+# ---------------------------------------------------------------------------
+
+def _seed_typical_yesterday() -> date:
+    """Realistic prior day: 10 kWh imported around mean Agile, 5 kWh exported."""
+    yesterday = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _seed_execution(slot, kwh=10.0, p=22.0)
+    _seed_export_rate(slot, 18.0)
+    _seed_export_sample(slot, 10.0)
+    _seed_export_sample(slot + timedelta(minutes=30), 10.0)  # 5 kWh exported
+    return yesterday
+
+
+def test_morning_brief_breaks_out_net_cost_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_typical_yesterday()
+    # Pin "today" so the morning brief looks back at 2026-05-01.
+    monkeypatch.setattr(
+        daily_brief, "datetime_now_local_date", lambda tz: date(2026, 5, 2)
+    )
+
+    md = daily_brief.build_morning_payload()
+
+    assert "Net cost:" in md, f"missing structured Net cost line:\n{md}"
+    assert "import £" in md, f"missing import breakdown:\n{md}"
+    assert "standing £" in md, f"missing standing breakdown:\n{md}"
+    assert "− export £" in md, f"missing export deduction:\n{md}"
+    assert "Energy used:" in md and "exported:" in md, (
+        f"missing kWh breakdown line:\n{md}"
+    )
+
+
+def test_morning_brief_includes_mode_status_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mode line tells OpenClaw not to invent Daikin advice."""
+    _seed_typical_yesterday()
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "passive")
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr(
+        daily_brief, "datetime_now_local_date", lambda tz: date(2026, 5, 2)
+    )
+
+    md = daily_brief.build_morning_payload()
+
+    assert "**Mode:**" in md
+    assert "Daikin=passive" in md
+    assert "HEM does NOT alter setpoints" in md
+    assert "Fox=LP-dispatched" in md
+
+
+def test_morning_brief_renders_british_gas_comparison_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_LABEL", "British Gas Fixed v58")
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_RATE_PENCE", 23.054)
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_STANDING_PENCE_PER_DAY", 39.181)
+    _seed_typical_yesterday()
+    monkeypatch.setattr(
+        daily_brief, "datetime_now_local_date", lambda tz: date(2026, 5, 2)
+    )
+
+    md = daily_brief.build_morning_payload()
+
+    assert "British Gas Fixed v58" in md
+    # The shadow figure must appear with a £-amount
+    assert "would have cost £" in md
+
+
+def test_morning_brief_omits_british_gas_line_when_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_typical_yesterday()
+    monkeypatch.setattr(
+        daily_brief, "datetime_now_local_date", lambda tz: date(2026, 5, 2)
+    )
+
+    md = daily_brief.build_morning_payload()
+
+    assert "British Gas" not in md
+    assert "Fixed v58" not in md
+
+
+# ---------------------------------------------------------------------------
+# Forecasted-export fallback
+# ---------------------------------------------------------------------------
+
+def test_forecasted_export_line_appears_when_telemetry_export_is_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When grid_export_kw telemetry is missing for a day, the brief must
+    fall back to LP-committed peak_export estimates and flag with 🔮."""
+    yesterday = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 17, 0, tzinfo=UTC)  # peak window
+    _seed_execution(slot, kwh=2.0, p=35.0)
+    # NO pv_realtime_history samples → telemetry export = 0
+    # Seed a committed peak_export decision for that slot
+    db.upsert_dispatch_decision(
+        run_id=999,
+        slot_time_utc=slot.isoformat().replace("+00:00", "Z"),
+        lp_kind="peak_export",
+        dispatched_kind="peak_export",
+        committed=1,
+        reason="robust",
+        scen_optimistic_exp_kwh=2.0,
+        scen_nominal_exp_kwh=1.84,
+        scen_pessimistic_exp_kwh=1.60,
+    )
+    _seed_export_rate(slot, 30.0)
+    monkeypatch.setattr(
+        daily_brief, "datetime_now_local_date", lambda tz: date(2026, 5, 2)
+    )
+
+    md = daily_brief.build_morning_payload()
+
+    assert "🔮 Forecasted export (telemetry missing)" in md, (
+        f"forecasted line missing:\n{md}"
+    )
+    # Pessimistic 1.60 kWh × 30p = 48p ≈ £0.48
+    assert "1.60 kWh" in md
+    assert "1 committed peak_export slot" in md
+
+
+def test_forecasted_export_line_suppressed_when_telemetry_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If grid_export_kw IS recorded, no forecasted-fallback line."""
+    _seed_typical_yesterday()  # has telemetry
+    db.upsert_dispatch_decision(
+        run_id=999,
+        slot_time_utc=datetime(2026, 5, 1, 17, 0, tzinfo=UTC).isoformat().replace("+00:00", "Z"),
+        lp_kind="peak_export",
+        dispatched_kind="peak_export",
+        committed=1,
+        reason="robust",
+        scen_optimistic_exp_kwh=2.0,
+        scen_nominal_exp_kwh=1.84,
+        scen_pessimistic_exp_kwh=1.60,
+    )
+    monkeypatch.setattr(
+        daily_brief, "datetime_now_local_date", lambda tz: date(2026, 5, 2)
+    )
+
+    md = daily_brief.build_morning_payload()
+
+    assert "🔮" not in md, (
+        f"forecasted line should NOT appear when telemetry present:\n{md}"
+    )
+
+
+def test_committed_peak_export_in_range_picks_latest_run() -> None:
+    """When the same slot is decided across multiple runs, the helper must
+    return only the latest run's row."""
+    slot = datetime(2026, 5, 1, 17, 0, tzinfo=UTC).isoformat().replace("+00:00", "Z")
+    db.upsert_dispatch_decision(
+        run_id=100, slot_time_utc=slot, lp_kind="peak_export",
+        dispatched_kind="peak_export", committed=1, reason="robust",
+        scen_optimistic_exp_kwh=1.0, scen_nominal_exp_kwh=0.8, scen_pessimistic_exp_kwh=0.5,
+    )
+    db.upsert_dispatch_decision(
+        run_id=200, slot_time_utc=slot, lp_kind="peak_export",
+        dispatched_kind="peak_export", committed=1, reason="robust",
+        scen_optimistic_exp_kwh=2.0, scen_nominal_exp_kwh=1.84, scen_pessimistic_exp_kwh=1.60,
+    )
+    rows = db.get_committed_peak_export_in_range(
+        "2026-05-01T00:00:00+00:00", "2026-05-02T00:00:00+00:00",
+    )
+    assert len(rows) == 1
+    assert rows[0]["run_id"] == 200
+    assert rows[0]["scen_pessimistic_exp_kwh"] == 1.60

--- a/tests/test_daily_brief_split.py
+++ b/tests/test_daily_brief_split.py
@@ -34,7 +34,9 @@ def test_night_payload_renders_with_zero_data():
     body = build_night_payload()
     assert "Night brief" in body
     assert "actuals" in body
-    assert "Realised cost" in body
+    # The brief now uses the structured "Net cost" line (was "Realised cost") —
+    # see the daily-brief expansion for #207's follow-up. Either is acceptable.
+    assert "Net cost:" in body
 
 
 def test_morning_and_night_are_independent_calls():

--- a/tests/test_mcp_brief_data.py
+++ b/tests/test_mcp_brief_data.py
@@ -1,0 +1,169 @@
+"""MCP surfaces the new structured PnL fields so OpenClaw doesn't parse markdown.
+
+Follow-up to #207: the brief used to be markdown-only, leaving OpenClaw to
+guess at numbers from prose. These tests lock that the MCP tools
+(``get_energy_metrics``, ``get_daily_brief``, ``get_night_brief``,
+``get_tariff_comparison``) expose the structured fields the user asked for —
+net cost, import/standing/export breakdown, BG comparison when configured,
+mode status, forecasted-export estimate.
+"""
+from __future__ import annotations
+
+import unittest
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+pytest.importorskip("mcp", reason="Install the `mcp` package to run MCP server tests.")
+
+from src import db
+from src.config import config as app_config
+from src.mcp_server import build_mcp
+
+
+class TestMCPBriefData(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        db.init_db()
+        # Set FIXED_TARIFF_* so the BG comparison line is exercised.
+        self._orig = {
+            k: getattr(app_config, k, None)
+            for k in (
+                "FIXED_TARIFF_LABEL",
+                "FIXED_TARIFF_RATE_PENCE",
+                "FIXED_TARIFF_STANDING_PENCE_PER_DAY",
+                "MANUAL_STANDING_CHARGE_PENCE_PER_DAY",
+                "OCTOPUS_EXPORT_TARIFF_CODE",
+                "BULLETPROOF_TIMEZONE",
+                "DAIKIN_CONTROL_MODE",
+            )
+        }
+        app_config.FIXED_TARIFF_LABEL = "British Gas Fixed v58"
+        app_config.FIXED_TARIFF_RATE_PENCE = 20.70
+        app_config.FIXED_TARIFF_STANDING_PENCE_PER_DAY = 41.14
+        app_config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY = 62.22
+        app_config.OCTOPUS_EXPORT_TARIFF_CODE = "AGILE-OUT-TEST-MCP"
+        app_config.BULLETPROOF_TIMEZONE = "Europe/London"
+        app_config.DAIKIN_CONTROL_MODE = "passive"
+
+    def tearDown(self) -> None:
+        for k, v in self._orig.items():
+            if v is None:
+                continue
+            setattr(app_config, k, v)
+
+    def _seed_yesterday(self) -> date:
+        from zoneinfo import ZoneInfo
+        tz = ZoneInfo("Europe/London")
+        yesterday = (datetime.now(tz).date() - timedelta(days=1))
+        slot = datetime.combine(yesterday, datetime.min.time()).replace(
+            hour=12, tzinfo=UTC,
+        )
+        db.log_execution({
+            "timestamp": slot.isoformat().replace("+00:00", "Z"),
+            "consumption_kwh": 5.0,
+            "agile_price_pence": 15.0,
+            "slot_kind": "standard",
+        })
+        db.save_agile_export_rates([{
+            "valid_from": slot.isoformat().replace("+00:00", "Z"),
+            "valid_to": (slot + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+            "value_inc_vat": 25.0,
+        }], "AGILE-OUT-TEST-MCP")
+        return yesterday
+
+    async def test_get_energy_metrics_exposes_structured_pnl_fields(self) -> None:
+        self._seed_yesterday()
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool("get_energy_metrics", {})
+
+        self.assertTrue(out["ok"])
+        d = out["pnl"]["daily"]
+        # Structured cost components must be present
+        for key in (
+            "realised_cost_pounds",
+            "realised_import_pounds",
+            "standing_charge_pounds",
+            "export_revenue_pounds",
+            "export_kwh",
+            "energy_used_kwh",
+            "svt_shadow_pounds",
+            "fixed_shadow_pounds",
+            "delta_vs_svt_pounds",
+            "delta_vs_fixed_pounds",
+        ):
+            self.assertIn(key, d, f"missing key {key!r} in get_energy_metrics output")
+        # The BG comparison must surface when FIXED_TARIFF_* env vars are set
+        self.assertEqual(d["fixed_tariff_label"], "British Gas Fixed v58")
+        self.assertIn("fixed_tariff_shadow_pounds", d)
+        self.assertIn("delta_vs_fixed_tariff_pounds", d)
+        # Note must clarify standing-charge inclusion
+        self.assertIn("standing", d["_note"].lower())
+
+    async def test_get_daily_brief_returns_both_markdown_and_data(self) -> None:
+        self._seed_yesterday()
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool("get_daily_brief", {})
+
+        self.assertTrue(out["ok"])
+        self.assertIn("markdown", out)
+        self.assertIn("data", out)
+        d = out["data"]
+        self.assertIn("mode_status", d)
+        self.assertIn("Daikin=passive", d["mode_status"])
+        self.assertIn("yesterday_pnl", d)
+        # Standing charge present in structured pnl
+        self.assertIn("standing_charge_gbp", d["yesterday_pnl"])
+        # Note clarifies semantics
+        self.assertIn("NET", d["_note"])
+
+    async def test_get_night_brief_returns_both_markdown_and_data(self) -> None:
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool("get_night_brief", {})
+
+        self.assertTrue(out["ok"])
+        self.assertIn("markdown", out)
+        self.assertIn("data", out)
+        self.assertIn("today_pnl", out["data"])
+        self.assertIn("Daikin=passive", out["data"]["mode_status"])
+
+    async def test_get_tariff_comparison_includes_bg_when_configured(self) -> None:
+        yesterday = self._seed_yesterday()
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_tariff_comparison", {"date": yesterday.isoformat()}
+        )
+
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["date"], yesterday.isoformat())
+        labels = [c["label"] for c in out["comparisons"]]
+        self.assertIn("Octopus Agile (realised)", labels)
+        self.assertIn("Octopus SVT (would-have)", labels)
+        self.assertIn("British Gas Fixed v58", labels)
+        # BG entry has the configured rate
+        bg = next(c for c in out["comparisons"] if c["label"] == "British Gas Fixed v58")
+        self.assertEqual(bg["rate_pence_per_kwh"], 20.70)
+        self.assertEqual(bg["standing_pence_per_day"], 41.14)
+
+    async def test_get_tariff_comparison_omits_bg_when_not_configured(self) -> None:
+        app_config.FIXED_TARIFF_LABEL = ""
+        app_config.FIXED_TARIFF_RATE_PENCE = 0.0
+        app_config.FIXED_TARIFF_STANDING_PENCE_PER_DAY = 0.0
+        yesterday = self._seed_yesterday()
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_tariff_comparison", {"date": yesterday.isoformat()}
+        )
+
+        self.assertTrue(out["ok"])
+        labels = [c["label"] for c in out["comparisons"]]
+        # Only Agile + SVT, no third comparison
+        self.assertEqual(len(labels), 2)
+        self.assertNotIn("British Gas Fixed v58", labels)
+
+    async def test_get_tariff_comparison_rejects_bad_date(self) -> None:
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_tariff_comparison", {"date": "not-a-date"}
+        )
+        self.assertFalse(out["ok"])
+        self.assertIn("invalid date", out["error"])


### PR DESCRIPTION
## Summary

Follow-up to #207. The brief carried only `realised £4.28, vs SVT £+0.40` — too sparse for OpenClaw to render faithfully, so it was inventing "Today's shape", Daikin tactical advice (despite passive mode), and unclear whether the +40p was net or import-only.

This PR makes the HEM markdown structured + complete, **plus exposes every field via MCP** so OpenClaw never has to parse prose.

## Live preview (with realistic May 1 numbers)

```
## ☀️ Morning brief
**Today (2026-05-02)**
2026-05-02: PuLP MILP objective ~398p; cheap=20 std=22 peak=6 peak_export=2

**Mode:** Daikin=passive (telemetry-only; Onecta firmware drives autonomously
on weather curve — HEM does NOT alter setpoints); Fox=LP-dispatched

**Yesterday (2026-05-01) — financial summary**
- Net cost: £+3.33  (import £4.05 + standing £0.62 − export £1.34)
- Energy used: 18.4 kWh  |  exported: 7.4 kWh
- vs British Gas Fixed v58 (would have cost £4.22): £+0.89 saved
- vs SVT (would have cost £5.13): £+1.80 saved
```

## What changed

- **PnL** (`src/analytics/pnl.py`): standing charge baked into realised + every shadow → apples-to-apples deltas. Optional 4th comparison via `FIXED_TARIFF_*` env vars (auto-suppressed when not set).
- **Brief** (`src/analytics/daily_brief.py`): shared `_format_pnl_block` for morning + night; `_mode_status_line` so OpenClaw stops inventing Daikin advice; 🔮 forecasted-export fallback when telemetry export is 0 but the LP committed `peak_export`.
- **MCP** (`src/mcp_server.py`) — addresses "this needs to be in MCP of course":
  - `get_energy_metrics` daily PnL block expanded from 2 → 11 structured fields, description flags standing-included.
  - `get_daily_brief` keeps markdown, ADDS structured `data` (yesterday_pnl, mode_status, forecasted_export).
  - **NEW** `get_night_brief` — same pattern for end-of-day.
  - **NEW** `get_tariff_comparison(date)` — dedicated calculator view returning every tariff with shadow cost + delta. Designed for OpenClaw to render the comparison without reverse-engineering.
  - Every tool has a `_note` clarifying cost semantics.
- **DB** (`src/db.py`): `get_committed_peak_export_in_range` for the forecasted-export fallback.
- **Config** (`src/config.py`): `FIXED_TARIFF_LABEL`, `FIXED_TARIFF_RATE_PENCE`, `FIXED_TARIFF_STANDING_PENCE_PER_DAY`.
- **Docs** (`CLAUDE.md`): new `.env` block (BG defaults) + new "Daily PnL semantics" section so future agents know what's NET, what's measured vs forecasted, and what `Mode:` means.

## Deploy notes (after merge)

Add to `/srv/hem/.env` to surface the British Gas line:
```
FIXED_TARIFF_LABEL=British Gas Fixed v58
FIXED_TARIFF_RATE_PENCE=20.70
FIXED_TARIFF_STANDING_PENCE_PER_DAY=41.14
```
(Source: user's contract — covers 30 Apr 2025 → 29 Aug 2026.)

## Dependency

**Depends on #211** (export-aware `compute_daily_pnl`). Merge #211 first; this rebases on top.

## Test plan
- [x] `pytest tests/test_brief_expanded.py tests/test_pnl_export_revenue.py tests/test_daily_brief_split.py tests/test_mcp_brief_data.py` — 28/28 pass
- [x] Local preview rendered (above) matches expected structure
- [x] Full suite green: 683 passed, 1 skipped
- [ ] Post-deploy: morning brief includes `**Mode:**` + `Net cost:` lines
- [ ] Post-deploy: with `FIXED_TARIFF_*` env vars set, `vs British Gas Fixed v58` line appears
- [ ] Post-deploy: `mcp.get_tariff_comparison(date='2026-05-01')` returns 3 comparisons (Agile, SVT, BG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)