### PR TITLE
fix(pnl): clamp YTD/monthly to AGILE_TARIFF_START_DATE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,23 @@ should never suggest tactical Daikin actions ("preheat the tank now!") —
 the heat pump runs on its own weather curve and HEM does not change
 setpoints. Read `_mode_status_line()` in `src/analytics/daily_brief.py`.
 
+### Tariff start clamp (PR #214)
+
+```
+AGILE_TARIFF_START_DATE=2026-04-01    # household joined Octopus Agile on this date
+```
+
+Period aggregations (`compute_period_pnl` and everything that delegates to it
+— weekly/monthly/MTD/YTD) clamp their `start_day` upward to this value.
+Pre-Agile days were on a different tariff and would otherwise pollute the
+realised cost + shadow comparisons. When clamped:
+- Response carries `clamped: true`, `clamp_reason`, `requested_start`.
+- `label` gains a `(since YYYY-MM-DD)` suffix so OpenClaw renders an honest
+  qualifier on the YTD/monthly figure.
+- `n_days` reflects the *actual on-Agile* window, not the requested range.
+
+Leave empty to disable. Invalid ISO date logs a warning and disables clamp.
+
 ### Aggregation periods (PR #213)
 
 Five PnL scopes are exposed by the same shape:

--- a/src/analytics/pnl.py
+++ b/src/analytics/pnl.py
@@ -206,6 +206,20 @@ def compute_peak_ratio(day: date) -> float | None:
     return round(100.0 * peak / tot, 2) if tot > 0 else None
 
 
+def _agile_start_date() -> date | None:
+    """Parse ``config.AGILE_TARIFF_START_DATE``; ``None`` when unset/invalid."""
+    raw = (config.AGILE_TARIFF_START_DATE or "").strip()
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        logger.warning(
+            "AGILE_TARIFF_START_DATE=%r is not a valid ISO date — ignoring clamp", raw,
+        )
+        return None
+
+
 def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> dict[str, Any]:
     """Aggregate daily PnL across a date range (both bounds inclusive).
 
@@ -214,6 +228,12 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
     because each day's compute_daily_pnl already includes the daily standing fee
     (so summing N days gives N × standing automatically).
 
+    The start date is clamped upward to ``config.AGILE_TARIFF_START_DATE`` when
+    set — pre-switch days were on a different tariff and would pollute the
+    realised cost + shadow deltas. When clamping happens, the response carries
+    ``clamped=True`` + ``clamp_reason`` + ``requested_start`` so OpenClaw can
+    render an honest "since 2026-04-01" qualifier.
+
     Returns a dict with the same keys as ``compute_daily_pnl`` plus
     ``period_start``, ``period_end``, ``n_days``, ``label``. The optional legacy
     fixed tariff (``fixed_tariff_*``) is included only if at least one day
@@ -221,6 +241,45 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
     """
     if end_day < start_day:
         start_day, end_day = end_day, start_day
+
+    requested_start = start_day
+    clamped = False
+    clamp_reason: str | None = None
+    agile_start = _agile_start_date()
+    if agile_start and start_day < agile_start:
+        if end_day < agile_start:
+            # Entire requested period predates Agile — return an empty shape
+            # so the caller can render "n/a (since YYYY-MM-DD)".
+            return {
+                "label": label or f"{requested_start.isoformat()}..{end_day.isoformat()}",
+                "period_start": agile_start.isoformat(),
+                "period_end": end_day.isoformat(),
+                "requested_start": requested_start.isoformat(),
+                "clamped": True,
+                "clamp_reason": (
+                    f"Entire range predates AGILE_TARIFF_START_DATE={agile_start.isoformat()}"
+                ),
+                "n_days": 0,
+                "kwh": 0.0,
+                "realised_cost_gbp": 0.0,
+                "realised_import_gbp": 0.0,
+                "export_revenue_gbp": 0.0,
+                "export_kwh": 0.0,
+                "standing_charge_gbp": 0.0,
+                "svt_shadow_gbp": 0.0,
+                "fixed_shadow_gbp": 0.0,
+                "delta_vs_svt_gbp": 0.0,
+                "delta_vs_fixed_gbp": 0.0,
+                "cheap_slot_kwh": 0.0,
+                "peak_kwh": 0.0,
+            }
+        start_day = agile_start
+        clamped = True
+        clamp_reason = (
+            f"Clamped to AGILE_TARIFF_START_DATE={agile_start.isoformat()} "
+            f"(before that the household was on a different tariff)"
+        )
+
     n = (end_day - start_day).days + 1
 
     totals = {
@@ -253,12 +312,20 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
             bg_delta += float(p["delta_vs_fixed_tariff_gbp"])
             bg_label = bg_label or p.get("fixed_tariff_label")
 
+    base_label = label or f"{start_day.isoformat()}..{end_day.isoformat()}"
+    if clamped:
+        base_label = f"{base_label} (since {start_day.isoformat()})"
+
     out: dict[str, Any] = {
-        "label": label or f"{start_day.isoformat()}..{end_day.isoformat()}",
+        "label": base_label,
         "period_start": start_day.isoformat(),
         "period_end": end_day.isoformat(),
         "n_days": n,
     }
+    if clamped:
+        out["requested_start"] = requested_start.isoformat()
+        out["clamped"] = True
+        out["clamp_reason"] = clamp_reason
     out.update({k: round(v, 4 if not k.endswith("_kwh") else 3) for k, v in totals.items()})
     if bg_seen:
         out["fixed_tariff_label"] = bg_label or "fixed tariff"

--- a/src/config.py
+++ b/src/config.py
@@ -226,6 +226,13 @@ class Config:
         os.getenv("FIXED_TARIFF_STANDING_PENCE_PER_DAY", "0")
     )
 
+    # Effective start of the Octopus Agile tariff. Period aggregations
+    # (weekly/monthly/MTD/YTD) clamp their start date upward to this value
+    # so pre-switch days don't pollute the realised cost or shadow comparisons
+    # (the household was on a different tariff back then). ISO date string
+    # ``YYYY-MM-DD``; empty disables the clamp (= include all history).
+    AGILE_TARIFF_START_DATE: str = os.getenv("AGILE_TARIFF_START_DATE", "")
+
     # Gas comparison (solar + heat pump vs gas): gas price p/kWh, boiler efficiency (e.g. 0.9)
     GAS_PRICE_PENCE_PER_KWH: float = float(os.getenv("GAS_PRICE_PENCE_PER_KWH", "0"))
     GAS_BOILER_EFFICIENCY: float = float(os.getenv("GAS_BOILER_EFFICIENCY", "0.9"))

--- a/tests/test_pnl_periods.py
+++ b/tests/test_pnl_periods.py
@@ -149,3 +149,81 @@ def test_compute_monthly_pnl_keeps_old_keys_for_backcompat() -> None:
     assert "month" in p
     assert "delta_vs_svt_gbp" in p
     assert "delta_vs_fixed_gbp" in p
+
+
+# ---------------------------------------------------------------------------
+# AGILE_TARIFF_START_DATE clamp
+# ---------------------------------------------------------------------------
+
+def test_period_clamps_start_to_agile_start_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """YTD asked from Jan 1 but Agile started Apr 1 → period_start = Apr 1,
+    n_days reflects the on-Agile window only, clamped=True with reason."""
+    monkeypatch.setattr(app_config, "AGILE_TARIFF_START_DATE", "2026-04-01")
+    _seed_day(date(2026, 4, 1), kwh=2.0, p_per_kwh=20.0)
+    _seed_day(date(2026, 5, 2), kwh=2.0, p_per_kwh=20.0)
+
+    p = pnl.compute_ytd_pnl(date(2026, 5, 2))
+
+    assert p["clamped"] is True
+    assert "AGILE_TARIFF_START_DATE" in p["clamp_reason"]
+    assert p["period_start"] == "2026-04-01"
+    assert p["period_end"] == "2026-05-02"
+    assert p["requested_start"] == "2026-01-01"
+    # 32 days from 2026-04-01 to 2026-05-02 inclusive
+    assert p["n_days"] == 32
+    # Pre-Apr days excluded — kWh sums only Apr 1 + May 2 = 4 kWh
+    assert p["kwh"] == pytest.approx(4.0, abs=1e-3)
+
+
+def test_period_unclamped_when_agile_start_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No AGILE_TARIFF_START_DATE → no clamp; period covers full requested range."""
+    monkeypatch.setattr(app_config, "AGILE_TARIFF_START_DATE", "")
+    _seed_day(date(2026, 1, 5), kwh=1.0, p_per_kwh=20.0)
+
+    p = pnl.compute_ytd_pnl(date(2026, 5, 2))
+
+    assert p.get("clamped") is None or p["clamped"] is False
+    assert p["period_start"] == "2026-01-01"
+    assert p["n_days"] == 122
+
+
+def test_period_invalid_agile_start_logged_and_ignored(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Garbage AGILE_TARIFF_START_DATE must not crash; warns and skips clamp."""
+    monkeypatch.setattr(app_config, "AGILE_TARIFF_START_DATE", "not-a-date")
+    _seed_day(date(2026, 1, 5), kwh=1.0, p_per_kwh=20.0)
+
+    with caplog.at_level("WARNING"):
+        p = pnl.compute_ytd_pnl(date(2026, 5, 2))
+
+    assert p.get("clamped") is None or p["clamped"] is False
+    assert any("AGILE_TARIFF_START_DATE" in r.getMessage() for r in caplog.records)
+
+
+def test_period_entirely_before_agile_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Asking for a March-only range when Agile started Apr 1 → empty shape
+    with n_days=0 and clamped=True (so callers can render 'n/a since…')."""
+    monkeypatch.setattr(app_config, "AGILE_TARIFF_START_DATE", "2026-04-01")
+
+    p = pnl.compute_period_pnl(date(2026, 3, 1), date(2026, 3, 31))
+
+    assert p["clamped"] is True
+    assert p["n_days"] == 0
+    assert p["kwh"] == 0.0
+    assert p["realised_cost_gbp"] == 0.0
+
+
+def test_label_includes_since_qualifier_when_clamped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The human-friendly label must say 'since YYYY-MM-DD' when clamped so
+    OpenClaw can render an honest qualifier on the YTD/monthly figure."""
+    monkeypatch.setattr(app_config, "AGILE_TARIFF_START_DATE", "2026-04-01")
+    _seed_day(date(2026, 4, 15), kwh=1.0, p_per_kwh=20.0)
+
+    p = pnl.compute_ytd_pnl(date(2026, 5, 2))
+
+    assert "(since 2026-04-01)" in p["label"]


### PR DESCRIPTION
## Summary

Fix follow-up to #213. User flagged that the new YTD report was meaningless: it included **122 days (Jan 1 → today)** but the household only joined Octopus Agile on **2026-04-01**. The pre-Apr days were on a different tariff (British Gas Fixed v58), so summing realised cost across them is bogus and the SVT/BG shadow comparisons are counterfactual nonsense for that window.

## What changed

- **`src/config.py`** — new `AGILE_TARIFF_START_DATE` env var (ISO date; empty disables the clamp).
- **`src/analytics/pnl.py`** — `compute_period_pnl` clamps `start_day` upward to that date when set. Response gains `clamped`, `clamp_reason`, `requested_start`; `label` gets a `(since YYYY-MM-DD)` suffix; `n_days` reflects the actual on-Agile window.

## Edge cases handled

- **Entirely pre-Agile range** (e.g. asking for March data) → empty shape with `n_days=0` so callers render "n/a since YYYY-MM-DD" rather than fake totals or crash.
- **Invalid env value** → logs a warning, disables clamp (doesn't crash on misconfig).

## Before/after on prod data

```
Before:  YTD n_days=122  realised=£129.62  delta_vs_svt=+£32.29   ← but most of those days weren't on Agile
After:   YTD n_days=32   period_start=2026-04-01  clamped=true    ← honest "since Agile started"
         label="year-to-date (since 2026-04-01)"
```

## Deploy step (after merge)

Append to `/srv/hem/.env`:
```
AGILE_TARIFF_START_DATE=2026-04-01
```

## Test plan
- [x] `pytest tests/test_pnl_periods.py -v` — 13/13 pass (5 new clamp cases)
- [x] Full suite green: 711 passed, 1 skipped (was 706 baseline)
- [ ] Post-deploy: `mcp.get_tariff_comparison({"period":"ytd"})` returns `n_days=32` and `clamped=true`
- [ ] Post-deploy: `pnl.year_to_date.label` includes "(since 2026-04-01)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)