### PR TITLE
fix(mcp): surface clamped metadata + use clamped dates in tariff_comparison

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1707,6 +1707,12 @@ def build_mcp() -> FastMCP:
                 "delta_vs_svt_pounds": p.get("delta_vs_svt_gbp"),
                 "delta_vs_fixed_pounds": p.get("delta_vs_fixed_gbp"),
             }
+            # Surface clamp metadata so OpenClaw can render an honest qualifier
+            # ("YTD since 2026-04-01 — household joined Agile then").
+            if p.get("clamped"):
+                block["clamped"] = True
+                block["clamp_reason"] = p.get("clamp_reason")
+                block["requested_start"] = p.get("requested_start")
             if "delta_vs_fixed_tariff_gbp" in p:
                 block["fixed_tariff_label"] = p.get("fixed_tariff_label")
                 block["fixed_tariff_shadow_pounds"] = p.get("fixed_tariff_shadow_gbp")
@@ -2015,11 +2021,19 @@ def build_mcp() -> FastMCP:
                 }
             )
 
+        # Use the values FROM the period_pnl response — they reflect the actual
+        # window used after AGILE_TARIFF_START_DATE clamping (#214). Echoing
+        # `start`/`end`/`n_days` from local variables ignores the clamp and
+        # produces internally inconsistent output (Jan 1 → May 2 with n_days=32).
+        period_start_used = p.get("period_start", start.isoformat())
+        period_end_used = p.get("period_end", end.isoformat())
+        label_resolved = p.get("label", label_used)
+
         result = {
             "ok": True,
-            "label": label_used,
-            "period_start": start.isoformat(),
-            "period_end": end.isoformat(),
+            "label": label_resolved,
+            "period_start": period_start_used,
+            "period_end": period_end_used,
             "n_days": n_days,
             "energy_used_kwh": kwh,
             "energy_exported_kwh": float(p.get("export_kwh") or 0),
@@ -2031,9 +2045,13 @@ def build_mcp() -> FastMCP:
                 "All shadow costs include the standing charge × n_days."
             ),
         }
+        if p.get("clamped"):
+            result["clamped"] = True
+            result["clamp_reason"] = p.get("clamp_reason")
+            result["requested_start"] = p.get("requested_start")
         if is_single_day:
             # Back-compat: callers from before the period extension expect ``date``.
-            result["date"] = start.isoformat()
+            result["date"] = period_start_used
         return result
 
     @mcp.tool(

--- a/tests/test_mcp_brief_data.py
+++ b/tests/test_mcp_brief_data.py
@@ -228,6 +228,55 @@ class TestMCPBriefData(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(out["ok"])
         self.assertIn("unknown period", out["error"])
 
+    async def test_get_energy_metrics_surfaces_clamped_metadata(self) -> None:
+        """When AGILE_TARIFF_START_DATE clamps a period, the MCP response must
+        carry ``clamped`` / ``clamp_reason`` / ``requested_start`` so OpenClaw
+        can render an honest "since YYYY-MM-DD" qualifier."""
+        from datetime import UTC, date as _date_t, datetime as _dt
+        # Switch a clamp date that's after Jan 1 (forces YTD to clamp)
+        app_config.AGILE_TARIFF_START_DATE = "2026-04-01"
+        # Seed at least one Apr+ day so YTD has data
+        from zoneinfo import ZoneInfo
+        tz = ZoneInfo("Europe/London")
+        today = _dt.now(tz).date()
+        slot = _dt.combine(_date_t(today.year, 4, 5), _dt.min.time()).replace(hour=12, tzinfo=UTC)
+        db.log_execution({
+            "timestamp": slot.isoformat().replace("+00:00", "Z"),
+            "consumption_kwh": 1.0, "agile_price_pence": 20.0, "slot_kind": "standard",
+        })
+        try:
+            mcp = build_mcp()
+            _b, out = await mcp.call_tool("get_energy_metrics", {})
+            ytd = out["pnl"]["year_to_date"]
+            assert ytd.get("clamped") is True, f"YTD should be clamped: {ytd}"
+            assert "AGILE_TARIFF_START_DATE" in ytd["clamp_reason"]
+            assert ytd["requested_start"] == f"{today.year}-01-01"
+            assert ytd["period_start"] == "2026-04-01"
+            assert "(since 2026-04-01)" in ytd["label"]
+        finally:
+            app_config.AGILE_TARIFF_START_DATE = ""
+
+    async def test_get_tariff_comparison_uses_clamped_dates_not_requested(self) -> None:
+        """Pre-#215 bug: get_tariff_comparison echoed pre-clamp start in
+        ``period_start`` while ``n_days`` reflected post-clamp count, producing
+        internally inconsistent output (Jan 1 → today but n_days=32). Lock fix."""
+        app_config.AGILE_TARIFF_START_DATE = "2026-04-01"
+        try:
+            mcp = build_mcp()
+            _b, out = await mcp.call_tool(
+                "get_tariff_comparison", {"period": "ytd"}
+            )
+            assert out["ok"]
+            assert out["period_start"] == "2026-04-01", (
+                f"period_start should be the clamped (post-Apr-1) value, got {out['period_start']!r}"
+            )
+            assert out.get("clamped") is True
+            assert "(since 2026-04-01)" in out["label"]
+            # n_days from same clamped window
+            assert out["n_days"] >= 1
+        finally:
+            app_config.AGILE_TARIFF_START_DATE = ""
+
     async def test_get_energy_metrics_includes_mtd_and_ytd_blocks(self) -> None:
         self._seed_yesterday()
         mcp = build_mcp()


### PR DESCRIPTION
## Summary

Post-#214 deploy smoke-test caught two MCP-layer wiring bugs. The underlying `compute_period_pnl` from #214 is correct — these bugs were purely in how `mcp_server.py` shaped its response.

## Bugs

### 1. `clamped` / `clamp_reason` / `requested_start` dropped by `get_energy_metrics`
The clamped `period_start` (e.g. `2026-04-01`) made it into the response, but the explanatory metadata that says *why* didn't. OpenClaw can't render an honest "since 2026-04-01 — household joined Agile then" qualifier without it.

### 2. `get_tariff_comparison` internal inconsistency
Pre-fix output:
```
period_start: 2026-01-01    ← from local Python var, NOT clamped
period_end:   2026-05-02
n_days:       32             ← from p["n_days"], IS clamped
```
Those dates span 122 days, not 32 — the response is self-contradictory.

## Fix

- `_period_block` propagates the 3 clamp metadata fields when present.
- `get_tariff_comparison` reads `period_start`/`period_end`/`label` from the `compute_period_pnl` return value instead of the local `start`/`end` variables.

No semantic change to `compute_period_pnl`. Pure MCP-wiring fix. **No prod env changes needed for this deploy.**

## Test plan
- [x] `pytest tests/test_mcp_brief_data.py tests/test_pnl_periods.py` — 27/27 pass
- [x] Full suite: 713 passed, 1 skipped (was 711)
- [ ] Post-deploy: `mcp.get_energy_metrics().pnl.year_to_date.clamped == True`
- [ ] Post-deploy: `mcp.get_tariff_comparison({"period":"ytd"}).period_start == "2026-04-01"` (not Jan 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)