### PR TITLE
feat(smartthings): replace PAT with OAuth 2.0 (mirror Daikin)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,72 @@ Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously (Sunday 
 
 ---
 
+## SmartThings (Samsung) — OAuth + appliance scheduling
+
+Mirror-of-Daikin OAuth Authorization Code flow. Tokens at
+`data/.smartthings-tokens.json` (JSON with access_token + refresh_token +
+expires_in + obtained_at + scope). Access token expires every 24h; auto-
+refreshed by `src/smartthings/auth.py:get_valid_access_token` on every
+device API call. Refresh circuit breaker after 3 consecutive failures
+(15-min cooldown).
+
+### One-time bootstrap (after `.env` has CLIENT_ID + CLIENT_SECRET set)
+
+```bash
+# 1. From your laptop, tunnel :8080:
+ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
+
+# 2. On the host, launch the auth-only container:
+docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm smartthings-auth
+
+# 3. Open the URL the container prints in your local browser. Samsung
+#    redirects to http://localhost:8080/oauth/smartthings/callback
+#    (= the container, via your SSH tunnel). Tokens land in
+#    /srv/hem/data/.smartthings-tokens.json. Container exits.
+
+# 4. Restart hem so the service picks up the new tokens.
+systemctl restart hem
+```
+
+### Refresh access token (refresh_token still valid)
+
+Automatic — `get_valid_access_token` refreshes if within
+`SMARTTHINGS_ACCESS_REFRESH_LEEWAY_SECONDS` (default 300) of expiry. On a
+401 from the device API the client retries once with `force_refresh=True`.
+No manual action needed unless the refresh circuit trips.
+
+### Full re-auth (refresh circuit tripped or refresh_token revoked)
+
+Same one-shot container as bootstrap (above) — overwrites the token file.
+
+### Required `.env` keys
+
+```
+SMARTTHINGS_CLIENT_ID=<from `smartthings apps:create`>
+SMARTTHINGS_CLIENT_SECRET=<from `smartthings apps:create` — sensitive>
+SMARTTHINGS_REDIRECT_URI=http://localhost:8080/oauth/smartthings/callback
+SMARTTHINGS_TOKEN_FILE=/app/data/.smartthings-tokens.json   # absolute inside container
+APPLIANCE_DISPATCH_ENABLED=true
+```
+
+### Appliance dispatch
+
+LP solver hooks `appliance_dispatch.reconcile()` at the start of each
+solve. Reads each registered appliance's `remoteControlEnabled` via
+SmartThings; when true, picks the cheapest contiguous window before the
+deadline, includes the planned kWh in the LP residual-load profile, and
+registers a one-shot APScheduler `DateTrigger` cron at the chosen time.
+Cron fires `setMachineState run` after pre-fire safety re-check.
+Cancelling on the unit before fire time → next LP solve drops the cron
+and re-plans without the load. Physical Smart Control button on the
+appliance IS the consent gate — no MCP confirm.
+
+`device_type` accepts `washer | dryer | dishwasher` — same SmartThings
+`setMachineState run` command for all three. Register multiple devices
+via the discover/register MCP tools or REST endpoints.
+
+---
+
 ## Key `.env` settings to know
 
 ```

--- a/deploy/compose.smartthings-auth.yaml
+++ b/deploy/compose.smartthings-auth.yaml
@@ -1,0 +1,48 @@
+# One-shot SmartThings OAuth enrollment.
+#
+# Usage:
+#   1. From your laptop, tunnel :8080 to the Hetzner host:
+#        ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
+#   2. On the host, launch the auth-only container:
+#        docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm smartthings-auth
+#   3. The container prints an authorize URL — open it in your local browser.
+#      Samsung redirects to http://localhost:8080/oauth/smartthings/callback
+#      (= the container, via your SSH tunnel). Tokens land in
+#      /srv/hem/data/.smartthings-tokens.json.
+#   4. After the container exits, restart the main service so it picks up
+#      the new tokens:
+#        systemctl restart hem
+#
+# Mirrors the shape of compose.daikin-auth.yaml — same SSH-tunnel pattern,
+# same token-file convention.
+services:
+  smartthings-auth:
+    image: ghcr.io/albinati/home-energy-manager:${HEM_IMAGE_TAG:-main}
+    container_name: hem-smartthings-auth
+    pull_policy: always
+
+    # OAuth callback listens on :8080 inside the container; published only to
+    # loopback. Operator opens an SSH tunnel from a workstation and visits the
+    # printed URL in their local browser.
+    ports:
+      - "127.0.0.1:8080:8080"
+
+    volumes:
+      - /srv/hem/data:/app/data
+      - /srv/hem/.env:/app/.env:ro
+
+    environment:
+      DB_PATH: /app/data/energy_state.db
+      SMARTTHINGS_TOKEN_FILE: /app/data/.smartthings-tokens.json
+      SMARTTHINGS_REDIRECT_URI: http://localhost:8080/oauth/smartthings/callback
+      TZ: Europe/London
+      PYTHONPATH: /app
+
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+
+    # Override the default service entrypoint — this is a one-shot OAuth flow,
+    # not the long-running API server.
+    entrypoint: ["/usr/bin/tini", "--"]
+    command: ["python", "-m", "src.smartthings"]

--- a/src/api/routers/appliances.py
+++ b/src/api/routers/appliances.py
@@ -1,12 +1,20 @@
 """Smart appliance scheduling REST endpoints (Phase 1: SmartThings washer).
 
 Loopback-only — same as every other ``/api/v1/...`` route, no auth middleware.
-The PAT-write endpoint validates by round-tripping a SmartThings list_devices
-call before persisting; it never returns the PAT itself.
+
+OAuth bootstrap is **not** done via REST (writing tokens via web endpoint
+would defeat the user-consent property of the auth code flow). Use the
+one-shot enrollment container instead:
+
+    docker compose -f deploy/compose.smartthings-auth.yaml run --rm smartthings-auth
+
+The endpoints here surface read-only status and let the operator revoke
+local OAuth state from the API if needed.
 """
 from __future__ import annotations
 
 import logging
+import secrets
 import sqlite3
 from typing import Any
 
@@ -16,8 +24,9 @@ from pydantic import BaseModel, Field
 from ... import db
 from ...config import config
 from ...scheduler import appliance_dispatch
+from ...smartthings import auth as st_auth
 from ...smartthings import service as st_service
-from ...smartthings.client import SmartThingsClient, SmartThingsError
+from ...smartthings.client import SmartThingsError
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +55,10 @@ class UpdateApplianceRequest(BaseModel):
     enabled: bool | None = None
 
 
-class SetCredentialsRequest(BaseModel):
-    pat: str = Field(..., min_length=1, description="SmartThings Personal Access Token")
+# SetCredentialsRequest removed — OAuth tokens are written by the one-shot
+# enrollment container (deploy/compose.smartthings-auth.yaml). The /credentials
+# POST endpoint is gone for the same reason: the auth code flow needs a real
+# user-agent (browser) to present consent, not a JSON POST.
 
 
 # ---------------------------------------------------------------------------
@@ -212,42 +223,50 @@ async def cancel_job(job_id: int) -> dict[str, Any]:
 # /api/v1/integrations/smartthings — credentials + status
 # ---------------------------------------------------------------------------
 
-@router.post("/integrations/smartthings/credentials")
-async def set_smartthings_credentials(req: SetCredentialsRequest) -> dict[str, Any]:
-    """Validate the PAT via SmartThings ``list_devices`` round-trip then
-    persist it 0600 at ``config.SMARTTHINGS_TOKEN_FILE``.
+@router.get("/integrations/smartthings/oauth/start")
+async def smartthings_oauth_start() -> dict[str, Any]:
+    """Return the Samsung consent URL the operator opens in a browser.
 
-    Never echoes the PAT back. Returns the device count on success so the
-    caller knows it worked.
+    NOTE: this endpoint does NOT actually start the callback server — that
+    runs inside the one-shot ``smartthings-auth`` container. Use this when
+    you want to visit the URL manually after starting the container, or to
+    inspect what scopes will be requested. Generates a fresh ``state`` token
+    each call (no persistence — the container's own server validates it).
     """
-    pat = req.pat.strip()
-    if not pat:
-        raise HTTPException(400, "pat is empty")
-    try:
-        probe = SmartThingsClient(pat=pat, base_url=config.SMARTTHINGS_API_BASE)
-        devices = probe.list_devices()
-    except SmartThingsError as e:
-        raise HTTPException(401 if e.code == "pat_invalid" else 502,
-                            f"SmartThings rejected the PAT: {e}") from None
-    path = st_service.write_pat(pat)
+    if not config.SMARTTHINGS_CLIENT_ID:
+        raise HTTPException(412, "SMARTTHINGS_CLIENT_ID not configured")
+    state = secrets.token_urlsafe(16)
     return {
         "ok": True,
-        "token_file": str(path),
-        "device_count": len(devices),
+        "authorize_url": st_auth.authorize_url(state),
+        "state": state,
+        "scopes": config.SMARTTHINGS_OAUTH_SCOPES,
+        "redirect_uri": config.SMARTTHINGS_REDIRECT_URI,
+        "_note": (
+            "Run `docker compose -f deploy/compose.smartthings-auth.yaml run --rm "
+            "smartthings-auth` to start the local callback server, then open "
+            "this authorize_url in a browser through an SSH port-forward to :8080."
+        ),
     }
 
 
 @router.delete("/integrations/smartthings/credentials", status_code=204)
 async def delete_smartthings_credentials() -> None:
-    st_service.delete_pat()
+    """Revoke local OAuth state by deleting the token file.
+
+    Does NOT revoke the SmartThings-side authorization — to do that, the user
+    must visit Samsung's "Connected Services" UI in the SmartThings app.
+    """
+    st_service.delete_tokens()
 
 
 @router.get("/integrations/smartthings/status")
 async def smartthings_status() -> dict[str, Any]:
-    """Health check for the SmartThings integration. Never returns the PAT."""
-    present = st_service.pat_present()
+    """Health check for the SmartThings integration. Never returns secrets."""
+    present = st_service.tokens_present()
     out: dict[str, Any] = {
-        "pat_present": present,
+        "tokens_present": present,
+        "client_id_configured": bool(config.SMARTTHINGS_CLIENT_ID),
         "api_base": config.SMARTTHINGS_API_BASE,
         "dispatch_enabled": bool(config.APPLIANCE_DISPATCH_ENABLED),
         "read_only": bool(config.OPENCLAW_READ_ONLY),

--- a/src/config.py
+++ b/src/config.py
@@ -321,16 +321,39 @@ class Config:
     CONSUMPTION_BACKFILL_MINUTE: int = int(os.getenv("CONSUMPTION_BACKFILL_MINUTE", "0"))
     BULLETPROOF_TIMEZONE: str = (os.getenv("BULLETPROOF_TIMEZONE") or "Europe/London").strip()
 
-    # ── SmartThings smart-appliance scheduling (Phase 1: Samsung washer) ────
-    # PAT (Personal Access Token) lives at SMARTTHINGS_TOKEN_FILE — plaintext
-    # 0600, mirrors .daikin-tokens.json / .openclaw-token. Set via the
-    # POST /api/v1/integrations/smartthings/credentials endpoint.
+    # ── SmartThings smart-appliance scheduling — OAuth 2.0 (mirrors Daikin) ──
+    # Tokens live at SMARTTHINGS_TOKEN_FILE (JSON, 0600, mirrors .daikin-tokens.json
+    # shape: access_token + refresh_token + expires_in + obtained_at + scope).
+    # Bootstrap via the one-shot ``deploy/compose.smartthings-auth.yaml`` container.
+    SMARTTHINGS_CLIENT_ID: str = (os.getenv("SMARTTHINGS_CLIENT_ID") or "").strip()
+    SMARTTHINGS_CLIENT_SECRET: str = (os.getenv("SMARTTHINGS_CLIENT_SECRET") or "").strip()
+    SMARTTHINGS_REDIRECT_URI: str = (
+        os.getenv("SMARTTHINGS_REDIRECT_URI")
+        or "http://localhost:8080/oauth/smartthings/callback"
+    ).strip()
+    SMARTTHINGS_AUTHORIZE_URL: str = (
+        os.getenv("SMARTTHINGS_AUTHORIZE_URL") or "https://api.smartthings.com/oauth/authorize"
+    ).strip().rstrip("/")
+    SMARTTHINGS_TOKEN_URL: str = (
+        os.getenv("SMARTTHINGS_TOKEN_URL")
+        or "https://auth-global.api.smartthings.com/oauth/token"
+    ).strip().rstrip("/")
+    SMARTTHINGS_OAUTH_SCOPES: str = (
+        os.getenv("SMARTTHINGS_OAUTH_SCOPES") or "r:devices:* x:devices:*"
+    ).strip()
     SMARTTHINGS_TOKEN_FILE: Path = Path(
-        os.getenv("SMARTTHINGS_TOKEN_FILE", "data/.smartthings-token")
+        os.getenv("SMARTTHINGS_TOKEN_FILE", "data/.smartthings-tokens.json")
     )
     SMARTTHINGS_API_BASE: str = (
         os.getenv("SMARTTHINGS_API_BASE") or "https://api.smartthings.com/v1"
     ).strip().rstrip("/")
+    # Refresh leeway: get a new access token if it expires within this many seconds.
+    SMARTTHINGS_ACCESS_REFRESH_LEEWAY_SECONDS: int = int(
+        os.getenv("SMARTTHINGS_ACCESS_REFRESH_LEEWAY_SECONDS", "300")
+    )
+    SMARTTHINGS_TOKEN_REFRESH_MIN_INTERVAL_SECONDS: int = int(
+        os.getenv("SMARTTHINGS_TOKEN_REFRESH_MIN_INTERVAL_SECONDS", "60")
+    )
     APPLIANCE_DISPATCH_ENABLED: bool = os.getenv(
         "APPLIANCE_DISPATCH_ENABLED", "true"
     ).lower() in ("true", "1", "yes")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -3163,16 +3163,20 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="get_smartthings_status",
         description=(
-            "Health check for the SmartThings integration: is the PAT "
-            "configured? does a list_devices round-trip succeed? Never "
-            "returns the PAT itself."
+            "Health check for the SmartThings OAuth integration: are the "
+            "OAuth tokens present on disk? does a list_devices round-trip "
+            "succeed? Never returns the access_token / refresh_token. "
+            "When tokens_present=False, run the one-shot enrollment container "
+            "(``docker compose -f deploy/compose.smartthings-auth.yaml run --rm "
+            "smartthings-auth``)."
         ),
     )
     def get_smartthings_status_tool() -> dict[str, Any]:
-        present = _st_service.pat_present()
+        present = _st_service.tokens_present()
         out: dict[str, Any] = {
             "ok": True,
-            "pat_present": present,
+            "tokens_present": present,
+            "client_id_configured": bool(config.SMARTTHINGS_CLIENT_ID),
             "api_base": config.SMARTTHINGS_API_BASE,
             "dispatch_enabled": bool(config.APPLIANCE_DISPATCH_ENABLED),
             "read_only": bool(config.OPENCLAW_READ_ONLY),

--- a/src/smartthings/__init__.py
+++ b/src/smartthings/__init__.py
@@ -1,10 +1,12 @@
-"""SmartThings integration — Personal Access Token (PAT) auth, REST API.
+"""SmartThings integration — OAuth 2.0 auth, REST API.
 
 Phase 1 use case: detect when a Samsung washing machine is in remote-start
 mode and schedule its cycle to fire during the cheapest energy window.
 
-The client is a thin sync wrapper over ``urllib.request`` mirroring the
-``src.daikin.client`` shape. The service module exposes a lazy singleton.
+Auth model: OAuth Authorization Code flow (mirrors :mod:`src.daikin.auth`),
+bootstrap via the one-shot ``deploy/compose.smartthings-auth.yaml`` container.
+The client fetches a bearer token from :mod:`src.smartthings.auth` per
+request and refreshes on HTTP 401.
 """
 from .client import SmartThingsClient, SmartThingsError
 

--- a/src/smartthings/__main__.py
+++ b/src/smartthings/__main__.py
@@ -1,0 +1,25 @@
+"""Entry point for the one-shot OAuth enrollment container.
+
+Run via the compose file:
+
+    docker compose -f deploy/compose.smartthings-auth.yaml run --rm smartthings-auth
+
+Equivalent to ``python -m src.smartthings`` — invokes ``auth.run_setup()``
+which spawns the callback server, prints the Samsung consent URL, waits
+for the redirect, exchanges the code for tokens, and persists them to
+``config.SMARTTHINGS_TOKEN_FILE``.
+"""
+from __future__ import annotations
+
+import sys
+
+from .auth import run_setup
+
+
+def main() -> int:
+    result = run_setup()
+    return 0 if result and result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/smartthings/auth.py
+++ b/src/smartthings/auth.py
@@ -1,0 +1,443 @@
+"""SmartThings OAuth 2.0 — Authorization Code flow + token persistence.
+
+Mirrors the shape of :mod:`src.daikin.auth`. Differences from Daikin:
+
+  - Samsung uses **HTTP Basic Auth** for client credentials at the token
+    endpoint (Daikin sends client_id/client_secret as form fields).
+  - Token URL: ``https://auth-global.api.smartthings.com/oauth/token``
+  - Authorize URL: ``https://api.smartthings.com/oauth/authorize``
+  - Access token expires every 24 h; refresh_token has long-life (~30 days
+    of inactivity is the published baseline).
+
+Token file format (JSON, 0600):
+
+    {
+      "access_token":  "...",
+      "refresh_token": "...",
+      "expires_in":    86400,
+      "token_type":    "bearer",
+      "scope":         "r:devices:* x:devices:*",
+      "obtained_at":   1714657123        # epoch seconds, set by us
+    }
+
+Bootstrap path (one-shot):
+
+    docker compose -f deploy/compose.smartthings-auth.yaml run --rm smartthings-auth
+
+The container starts a callback HTTP server on :8080, prints the
+authorize URL, the operator opens it in their laptop browser (via
+``ssh -L 8080:localhost:8080``), Samsung redirects back with ``?code=…``,
+the server exchanges the code for tokens and writes the JSON file to
+``data/.smartthings-tokens.json`` on the volume.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import secrets
+import subprocess
+import threading
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Event
+
+from ..config import config
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Errors + circuit breaker (mirror Daikin)
+# ---------------------------------------------------------------------------
+
+class SmartThingsAuthError(RuntimeError):
+    """Raised when the OAuth flow can't complete (bad code, refresh failure,
+    misconfig, etc.). Distinct from :class:`SmartThingsError` which is for
+    REST errors against the device API."""
+
+
+class SmartThingsAuthCircuitOpen(RuntimeError):
+    """Refresh circuit breaker tripped — refuse further refresh attempts
+    until the cooldown elapses."""
+
+
+_AUTH_CIRCUIT_THRESHOLD = 3
+_AUTH_CIRCUIT_COOLDOWN_SECONDS = 900   # 15 min — prevents heartbeat hammering
+
+_circuit_lock = threading.Lock()
+_consecutive_auth_failures = 0
+_circuit_tripped_at = 0.0
+_token_io_lock = threading.RLock()
+_last_token_refresh_monotonic = 0.0
+
+
+def _auth_circuit_state() -> tuple[int, bool, float]:
+    """Return (failures_count, tripped_now, cooldown_remaining_s)."""
+    with _circuit_lock:
+        now = time.monotonic()
+        tripped = (
+            _consecutive_auth_failures >= _AUTH_CIRCUIT_THRESHOLD
+            and (now - _circuit_tripped_at) < _AUTH_CIRCUIT_COOLDOWN_SECONDS
+        )
+        remaining = max(
+            0.0,
+            _AUTH_CIRCUIT_COOLDOWN_SECONDS - (now - _circuit_tripped_at),
+        ) if tripped else 0.0
+        return _consecutive_auth_failures, tripped, remaining
+
+
+def _reset_auth_circuit() -> None:
+    global _consecutive_auth_failures, _circuit_tripped_at
+    with _circuit_lock:
+        _consecutive_auth_failures = 0
+        _circuit_tripped_at = 0.0
+
+
+def _record_auth_failure(reason: str) -> None:
+    global _consecutive_auth_failures, _circuit_tripped_at
+    with _circuit_lock:
+        _consecutive_auth_failures += 1
+        if _consecutive_auth_failures >= _AUTH_CIRCUIT_THRESHOLD:
+            _circuit_tripped_at = time.monotonic()
+            logger.error(
+                "SmartThings auth circuit tripped (%d consecutive failures, "
+                "last reason: %s) — refusing refresh for %ds",
+                _consecutive_auth_failures, reason, _AUTH_CIRCUIT_COOLDOWN_SECONDS,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Token persistence
+# ---------------------------------------------------------------------------
+
+def _resolve_token_path() -> Path:
+    p = Path(config.SMARTTHINGS_TOKEN_FILE)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    return p
+
+
+def save_tokens(tokens: dict) -> None:
+    """Write the tokens dict to disk with 0600 perms (atomic via tmp+rename)."""
+    p = _resolve_token_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
+    tmp.chmod(0o600)
+    tmp.replace(p)
+
+
+def load_tokens() -> dict:
+    """Read the tokens dict from disk; raise SmartThingsAuthError if absent."""
+    p = _resolve_token_path()
+    if not p.is_file():
+        raise SmartThingsAuthError(
+            f"token file {p} not present — run the smartthings-auth container "
+            "(docker compose -f deploy/compose.smartthings-auth.yaml run --rm smartthings-auth)"
+        )
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise SmartThingsAuthError(f"token file {p} unreadable: {e}") from e
+
+
+def has_tokens() -> bool:
+    return _resolve_token_path().is_file()
+
+
+# ---------------------------------------------------------------------------
+# Token endpoint (Basic Auth + form-encoded body)
+# ---------------------------------------------------------------------------
+
+def _basic_auth_header() -> str:
+    """Build the ``Authorization: Basic <base64(client_id:client_secret)>`` header.
+
+    Samsung requires Basic Auth at the token endpoint (Daikin uses form fields).
+    """
+    if not config.SMARTTHINGS_CLIENT_ID or not config.SMARTTHINGS_CLIENT_SECRET:
+        raise SmartThingsAuthError(
+            "SMARTTHINGS_CLIENT_ID / SMARTTHINGS_CLIENT_SECRET unset"
+        )
+    raw = f"{config.SMARTTHINGS_CLIENT_ID}:{config.SMARTTHINGS_CLIENT_SECRET}"
+    b64 = base64.b64encode(raw.encode("utf-8")).decode("ascii")
+    return f"Basic {b64}"
+
+
+def _post_token(form_fields: dict[str, str]) -> dict:
+    """POST form-encoded fields to the SmartThings token endpoint.
+
+    Uses curl because urllib's HTTPSConnection sometimes hits CloudFront WAFs
+    that the Daikin endpoint also fronts (kept for symmetry — no observed
+    issue on Samsung yet, but the same shape avoids a divergent bug surface).
+    """
+    body = urllib.parse.urlencode(form_fields)
+    result = subprocess.run(
+        [
+            "curl", "-s", "-X", "POST", config.SMARTTHINGS_TOKEN_URL,
+            "-H", "Content-Type: application/x-www-form-urlencoded",
+            "-H", "Accept: application/json",
+            "-H", f"Authorization: {_basic_auth_header()}",
+            "-d", body,
+        ],
+        capture_output=True, text=True, timeout=15,
+    )
+    if result.returncode != 0:
+        raise SmartThingsAuthError(f"curl failed: {result.stderr}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise SmartThingsAuthError(
+            f"token endpoint returned non-JSON: {result.stdout[:300]!r}"
+        ) from e
+    if "error" in payload:
+        raise SmartThingsAuthError(
+            f"{payload['error']}: {payload.get('error_description', '')}"
+        )
+    payload["obtained_at"] = int(time.time())
+    return payload
+
+
+def exchange_code(code: str) -> dict:
+    """Exchange an authorization code for tokens (initial flow)."""
+    return _post_token({
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": config.SMARTTHINGS_REDIRECT_URI,
+    })
+
+
+def refresh_tokens(tokens: dict) -> dict:
+    """Refresh the access token via refresh_token; gated by a circuit breaker.
+
+    On success: writes new tokens to disk, clears any prior circuit fault.
+    On failure: increments failure counter; trips the circuit after 3.
+    """
+    _, tripped, remaining = _auth_circuit_state()
+    if tripped:
+        raise SmartThingsAuthCircuitOpen(
+            f"SmartThings auth circuit open (cooldown {remaining:.0f}s remaining) — re-auth required"
+        )
+    rt = tokens.get("refresh_token")
+    if not rt:
+        raise SmartThingsAuthError("token file has no refresh_token — re-enrollment required")
+    try:
+        new_tokens = _post_token({
+            "grant_type": "refresh_token",
+            "refresh_token": rt,
+        })
+    except SmartThingsAuthError as e:
+        _record_auth_failure(str(e)[:80])
+        raise
+    # Samsung sometimes omits refresh_token on refresh; carry the previous one.
+    if "refresh_token" not in new_tokens:
+        new_tokens["refresh_token"] = rt
+    save_tokens(new_tokens)
+    _reset_auth_circuit()
+    return new_tokens
+
+
+def get_valid_access_token(*, force_refresh: bool = False) -> str:
+    """Return an access token, refreshing if within leeway of expiry.
+
+    Called by every SmartThings API request via the client; on a 401 the client
+    can retry once with ``force_refresh=True`` to handle clock skew or revoked
+    access tokens.
+    """
+    global _last_token_refresh_monotonic
+    with _token_io_lock:
+        tokens = load_tokens()
+        exp = max(60.0, float(tokens.get("expires_in", 86400)))
+        obtained_at = float(tokens.get("obtained_at", 0))
+        leeway_cfg = max(60, int(config.SMARTTHINGS_ACCESS_REFRESH_LEEWAY_SECONDS))
+        leeway = min(leeway_cfg, max(60, int(exp) - 30))
+        stale = time.time() > obtained_at + exp - leeway
+        hard_expired = time.time() > obtained_at + exp
+        if force_refresh or stale:
+            min_gap = max(0, int(config.SMARTTHINGS_TOKEN_REFRESH_MIN_INTERVAL_SECONDS))
+            now_m = time.monotonic()
+            if (
+                not force_refresh
+                and not hard_expired
+                and min_gap > 0
+                and (now_m - _last_token_refresh_monotonic) < min_gap
+            ):
+                return tokens["access_token"]
+            tokens = refresh_tokens(tokens)
+            _last_token_refresh_monotonic = time.monotonic()
+        return tokens["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# One-shot enrollment server (callback handler)
+# ---------------------------------------------------------------------------
+
+def authorize_url(state: str) -> str:
+    """Build the Samsung OAuth consent URL the operator opens in a browser."""
+    if not config.SMARTTHINGS_CLIENT_ID:
+        raise SmartThingsAuthError("SMARTTHINGS_CLIENT_ID unset")
+    qs = urllib.parse.urlencode({
+        "response_type": "code",
+        "client_id": config.SMARTTHINGS_CLIENT_ID,
+        "redirect_uri": config.SMARTTHINGS_REDIRECT_URI,
+        "scope": config.SMARTTHINGS_OAUTH_SCOPES,
+        "state": state,
+    })
+    return f"{config.SMARTTHINGS_AUTHORIZE_URL}?{qs}"
+
+
+_auth_result: dict = {}
+_done_event = Event()
+_expected_state: str = ""
+
+
+def _success_page(message: str = "Authentication successful") -> bytes:
+    return (
+        b"<!DOCTYPE html><html><head><title>SmartThings auth</title>"
+        b"<meta charset=\"utf-8\"><style>body{font-family:sans-serif;display:flex;"
+        b"justify-content:center;align-items:center;min-height:100vh;margin:0;"
+        b"background:#f0f9ff;}.card{background:white;padding:2rem;border-radius:12px;"
+        b"box-shadow:0 2px 12px rgba(0,0,0,0.08);text-align:center;}"
+        b".ok{color:#16a34a;font-size:3rem;}</style></head>"
+        b"<body><div class=\"card\"><div class=\"ok\">&#10003;</div>"
+        b"<h2>" + message.encode("utf-8") + b"</h2>"
+        b"<p>You can close this tab.</p></div></body></html>"
+    )
+
+
+def _error_page(reason: str) -> bytes:
+    return (
+        b"<!DOCTYPE html><html><head><title>SmartThings auth - error</title>"
+        b"<meta charset=\"utf-8\"></head><body style=\"font-family:sans-serif;"
+        b"max-width:560px;margin:40px auto;padding:0 20px;\">"
+        b"<h2 style=\"color:#b91c1c;\">Authentication failed</h2>"
+        b"<p>" + reason.encode("utf-8") + b"</p></body></html>"
+    )
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """Handle ``GET /oauth/smartthings/callback?code=…&state=…``.
+
+    Validates the state token, exchanges the code via :func:`exchange_code`,
+    persists the tokens, signals completion, and returns a success/error page.
+    """
+
+    def do_GET(self) -> None:  # noqa: N802 — required by BaseHTTPRequestHandler
+        global _auth_result
+        url = urllib.parse.urlparse(self.path)
+        if not url.path.endswith("/oauth/smartthings/callback"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        params = dict(urllib.parse.parse_qsl(url.query))
+        if params.get("error"):
+            reason = (
+                f"{params['error']}: "
+                f"{params.get('error_description', '')}"
+            )
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_error_page(reason))
+            _auth_result = {"error": reason}
+            _done_event.set()
+            return
+        if params.get("state") != _expected_state:
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_error_page("state mismatch — possible CSRF; restart the auth flow"))
+            _auth_result = {"error": "state_mismatch"}
+            _done_event.set()
+            return
+        code = params.get("code")
+        if not code:
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_error_page("no ?code= parameter in callback"))
+            _auth_result = {"error": "no_code"}
+            _done_event.set()
+            return
+        try:
+            tokens = exchange_code(code)
+            save_tokens(tokens)
+        except Exception as e:  # noqa: BLE001
+            self.send_response(500)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_error_page(f"token exchange failed: {e}"))
+            _auth_result = {"error": str(e)}
+            _done_event.set()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(_success_page())
+        _auth_result = {"ok": True, "scope": tokens.get("scope")}
+        _done_event.set()
+
+    def log_message(self, _fmt, *_args):  # noqa: N802 — interface override
+        # Suppress default stderr access log; routes our own info via logger
+        # if/when needed.
+        pass
+
+
+def run_auth_flow(*, port: int | None = None, timeout_s: int = 600) -> dict:
+    """Spawn the callback server, print the authorize URL, wait for the redirect.
+
+    Returns the result dict (``{"ok": True, ...}`` on success or
+    ``{"error": "..."}`` on failure). Times out after ``timeout_s``.
+    """
+    global _auth_result, _expected_state
+    _auth_result = {}
+    _done_event.clear()
+    _expected_state = secrets.token_urlsafe(16)
+
+    # Bind port. Default = 8080 to match the Daikin pattern + our redirect URI.
+    bind_port = port if port is not None else 8080
+    server = HTTPServer(("0.0.0.0", bind_port), _CallbackHandler)  # noqa: S104
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = authorize_url(_expected_state)
+        print("\n" + "=" * 70)
+        print("Open this URL in your browser (with SSH tunnel to localhost:%d):" % bind_port)
+        print("\n  " + url + "\n")
+        print("Waiting for the callback... (timeout %ds)" % timeout_s)
+        print("=" * 70 + "\n")
+        if not _done_event.wait(timeout=timeout_s):
+            return {"error": "timeout waiting for callback"}
+        return dict(_auth_result)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def run_setup() -> dict | None:
+    """Top-level entry for the ``smartthings-auth`` one-shot container."""
+    result = run_auth_flow()
+    if result.get("ok"):
+        path = _resolve_token_path()
+        print(f"\n[OK] Tokens written to {path}\n")
+        print(f"     Scopes granted: {result.get('scope')}\n")
+        return result
+    err = result.get("error", "unknown")
+    print(f"\n[FAIL] {err}\n")
+    return None
+
+
+# Convenience for prefetching at heartbeat (called by scheduler if wired)
+def prefetch_smartthings_access_token() -> None:
+    if not config.SMARTTHINGS_CLIENT_ID or not config.SMARTTHINGS_CLIENT_SECRET:
+        return
+    if not has_tokens():
+        return
+    try:
+        get_valid_access_token(force_refresh=False)
+    except (SmartThingsAuthError, SmartThingsAuthCircuitOpen):
+        # Quiet — on-the-wire errors will be handled by the caller's notify_risk.
+        pass

--- a/src/smartthings/client.py
+++ b/src/smartthings/client.py
@@ -1,4 +1,4 @@
-"""SmartThings public REST API client (Personal Access Token).
+"""SmartThings public REST API client (OAuth bearer token).
 
 API: https://developer.smartthings.com/docs/api/public
 
@@ -8,11 +8,16 @@ Phase 1 surface — only what the appliance scheduler needs:
 - read full status (cycle metadata, best-effort)
 - POST setMachineState run (the fire path)
 
+Bearer access token is sourced from :mod:`src.smartthings.auth` (OAuth flow
++ refresh-on-stale). On HTTP 401 the client refreshes once and retries —
+covers token revocation / clock skew / Samsung's silent rotation.
+
 Honours ``OPENCLAW_READ_ONLY``: when true, ``start_cycle`` returns
 ``{"skipped": "read_only"}`` without making an HTTP request.
 
 Errors are surfaced as :class:`SmartThingsError` with a short ``code`` so
-callers can match on ``"pat_invalid"`` (401), ``"not_found"`` (404), etc.
+callers can match on ``"auth_invalid"`` (401 even after refresh),
+``"not_found"`` (404), etc.
 """
 from __future__ import annotations
 
@@ -22,6 +27,7 @@ import urllib.error
 import urllib.request
 
 from ..config import config
+from . import auth as _auth
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +35,7 @@ logger = logging.getLogger(__name__)
 class SmartThingsError(Exception):
     """Raised on any SmartThings REST error.
 
-    ``code`` is a short machine-readable label (``pat_invalid``,
+    ``code`` is a short machine-readable label (``auth_invalid``,
     ``not_found``, ``http_error``, ``transport``); ``http_status`` is the
     HTTP status code when the error came from a server response.
     """
@@ -49,16 +55,24 @@ class SmartThingsError(Exception):
 class SmartThingsClient:
     """Thin sync wrapper around api.smartthings.com.
 
-    No retry on 4xx; one retry on 5xx. SmartThings is not Daikin-quota-
-    constrained — the appliance dispatcher reads remote_mode at most once
-    per LP solve (~50 reads/day total).
+    No retry on most 4xx; one retry on 5xx; one refresh+retry on 401.
+    SmartThings is not Daikin-quota-constrained — the appliance dispatcher
+    reads remote_mode at most once per LP solve (~50 reads/day total).
+
+    Pass ``access_token=None`` (default) to source from the OAuth file via
+    :func:`src.smartthings.auth.get_valid_access_token`. Pass an explicit
+    token only for tests.
     """
 
-    def __init__(self, pat: str, base_url: str | None = None) -> None:
-        if not pat:
-            raise SmartThingsError("pat_missing", "PAT is empty")
-        self._pat = pat.strip()
+    def __init__(self, access_token: str | None = None, base_url: str | None = None) -> None:
+        self._explicit_token = access_token.strip() if access_token else None
         self._base = (base_url or config.SMARTTHINGS_API_BASE).rstrip("/")
+
+    def _bearer(self, *, force_refresh: bool = False) -> str:
+        """Return a bearer token — explicit override or OAuth-managed."""
+        if self._explicit_token is not None:
+            return self._explicit_token
+        return _auth.get_valid_access_token(force_refresh=force_refresh)
 
     # ------------------------------------------------------------------
     # Public API
@@ -150,18 +164,28 @@ class SmartThingsClient:
     def _request(self, method: str, path: str, body: dict | None = None) -> dict:
         url = f"{self._base}{path}"
         payload = None
-        headers = {
-            "Authorization": f"Bearer {self._pat}",
-            "Accept": "application/json",
-        }
         if body is not None:
             payload = json.dumps(body).encode()
-            headers["Content-Type"] = "application/json"
 
-        req = urllib.request.Request(url, data=payload, headers=headers, method=method)
-
-        # No retry on 4xx; one retry on 5xx (transient).
-        for attempt in range(2):
+        # Up to 3 attempts: (1) initial, (2) 401-refresh, (3) 5xx-retry.
+        # ``forced_refresh`` ensures we only refresh once per call so a stale
+        # refresh_token can't push us into an infinite loop.
+        forced_refresh = False
+        last_5xx_retried = False
+        for attempt in range(3):
+            try:
+                token = self._bearer(force_refresh=(forced_refresh and attempt == 1))
+            except _auth.SmartThingsAuthError as e:
+                raise SmartThingsError("auth_missing", str(e)) from e
+            except _auth.SmartThingsAuthCircuitOpen as e:
+                raise SmartThingsError("auth_circuit_open", str(e)) from e
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            }
+            if payload is not None:
+                headers["Content-Type"] = "application/json"
+            req = urllib.request.Request(url, data=payload, headers=headers, method=method)
             try:
                 with urllib.request.urlopen(req, timeout=15) as resp:
                     raw = resp.read()
@@ -180,9 +204,16 @@ class SmartThingsClient:
                     err_body = e.read().decode("utf-8", errors="replace")[:500]
                 except Exception:
                     pass
+                if e.code == 401 and not forced_refresh and self._explicit_token is None:
+                    logger.info(
+                        "smartthings %s %s → 401, refreshing access token + retry",
+                        method, path,
+                    )
+                    forced_refresh = True
+                    continue
                 if e.code == 401:
                     raise SmartThingsError(
-                        "pat_invalid", err_body or "PAT rejected",
+                        "auth_invalid", err_body or "access token rejected",
                         http_status=401,
                     ) from None
                 if e.code == 404:
@@ -190,26 +221,29 @@ class SmartThingsClient:
                         "not_found", err_body or "device or capability not found",
                         http_status=404,
                     ) from None
-                if 500 <= e.code < 600 and attempt == 0:
+                if 500 <= e.code < 600 and not last_5xx_retried:
                     logger.warning(
                         "smartthings %s %s → HTTP %d, retrying once",
                         method, path, e.code,
                     )
+                    last_5xx_retried = True
                     continue
                 raise SmartThingsError(
                     "http_error", f"HTTP {e.code}: {err_body}".rstrip(),
                     http_status=e.code,
                 ) from None
             except urllib.error.URLError as e:
-                if attempt == 0:
+                if not last_5xx_retried:
                     logger.warning(
                         "smartthings %s %s → transport error %s, retrying once",
                         method, path, e,
                     )
+                    last_5xx_retried = True
                     continue
                 raise SmartThingsError("transport", str(e)) from None
             except OSError as e:
-                if attempt == 0:
+                if not last_5xx_retried:
+                    last_5xx_retried = True
                     continue
                 raise SmartThingsError("transport", str(e)) from None
         raise SmartThingsError("transport", "unreachable code path")

--- a/src/smartthings/service.py
+++ b/src/smartthings/service.py
@@ -1,18 +1,18 @@
-"""SmartThings service — lazy singleton, PAT loaded from
-:data:`config.SMARTTHINGS_TOKEN_FILE`.
+"""SmartThings service — singleton client backed by the OAuth token file.
 
-Mirrors :mod:`src.daikin.service` shape. The PAT lives at a 0600 file
-on disk (matching the convention for ``.daikin-tokens.json`` and
-``.openclaw-token``); the credentials endpoint writes it.
+Mirrors :mod:`src.daikin.service` shape. The token file at
+``config.SMARTTHINGS_TOKEN_FILE`` is written by the one-shot enrollment
+container (``deploy/compose.smartthings-auth.yaml``) and refreshed
+automatically by :mod:`src.smartthings.auth`.
 """
 from __future__ import annotations
 
 import logging
 import threading
-from pathlib import Path
 
 from ..config import config
-from .client import SmartThingsClient, SmartThingsError
+from . import auth as _auth
+from .client import SmartThingsClient
 
 logger = logging.getLogger(__name__)
 
@@ -20,82 +20,45 @@ _lock = threading.RLock()
 _client: SmartThingsClient | None = None
 
 
-def _resolve_token_path() -> Path:
-    p = Path(config.SMARTTHINGS_TOKEN_FILE)
-    if not p.is_absolute():
-        p = Path.cwd() / p
-    return p
-
-
-def _load_pat() -> str:
-    """Read the PAT from disk. Raises :class:`SmartThingsError` if absent."""
-    p = _resolve_token_path()
-    if not p.is_file():
-        raise SmartThingsError(
-            "pat_missing",
-            f"token file {p} not present — POST /api/v1/integrations/smartthings/credentials first",
-        )
-    pat = p.read_text(encoding="utf-8").strip()
-    if not pat:
-        raise SmartThingsError("pat_missing", f"token file {p} is empty")
-    return pat
-
-
 def get_client() -> SmartThingsClient:
     """Return the lazy-init singleton SmartThingsClient.
 
-    Raises :class:`SmartThingsError` (``code='pat_missing'``) when the PAT
-    file is absent — callers can handle this as "integration not configured"
-    without crashing the LP solve.
+    The client sources its bearer token from
+    :func:`src.smartthings.auth.get_valid_access_token` on every request
+    (auto-refresh on stale, 401-retry on revoked). No PAT.
+
+    Raises :class:`src.smartthings.auth.SmartThingsAuthError` from the first
+    request if the token file is absent — callers can catch this as
+    "integration not configured" without crashing the LP solve.
     """
     global _client
     with _lock:
         if _client is None:
-            pat = _load_pat()
-            _client = SmartThingsClient(pat=pat, base_url=config.SMARTTHINGS_API_BASE)
+            _client = SmartThingsClient(base_url=config.SMARTTHINGS_API_BASE)
         return _client
 
 
 def reset_client() -> None:
-    """Drop the cached client so the next ``get_client()`` re-reads the PAT.
-
-    Called after the credentials endpoint writes a new token, or after a 401
-    failure surfaces.
-    """
+    """Drop the cached client. Mostly for tests + the rare revocation path."""
     global _client
     with _lock:
         _client = None
 
 
-def write_pat(pat: str) -> Path:
-    """Persist a PAT to ``config.SMARTTHINGS_TOKEN_FILE`` with 0600 perms.
-
-    Returns the resolved path. Caller is responsible for round-trip validation
-    (e.g. ``list_devices``) BEFORE accepting the token from a user.
-    """
-    if not pat or not pat.strip():
-        raise SmartThingsError("pat_missing", "refusing to write empty PAT")
-    p = _resolve_token_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(pat.strip() + "\n", encoding="utf-8")
-    try:
-        p.chmod(0o600)
-    except OSError:
-        logger.debug("Could not chmod %s to 0600 (continuing)", p)
-    reset_client()
-    return p
+def tokens_present() -> bool:
+    """Cheap check used by the status endpoint — does NOT load the file body."""
+    return _auth.has_tokens()
 
 
-def delete_pat() -> bool:
-    """Remove the PAT file. Returns True if a file was removed."""
-    p = _resolve_token_path()
+def delete_tokens() -> bool:
+    """Remove the token file (revokes local OAuth state). Returns True if removed."""
+    from pathlib import Path
+
+    p = Path(config.SMARTTHINGS_TOKEN_FILE)
+    if not p.is_absolute():
+        p = __import__("pathlib").Path.cwd() / p
     if not p.exists():
         return False
     p.unlink()
     reset_client()
     return True
-
-
-def pat_present() -> bool:
-    """Cheap check used by the status endpoint — does NOT load the file."""
-    return _resolve_token_path().is_file()

--- a/tests/api/test_appliances.py
+++ b/tests/api/test_appliances.py
@@ -136,67 +136,55 @@ def test_cancel_nonexistent_job_404(client):
 # /api/v1/integrations/smartthings
 # ---------------------------------------------------------------------------
 
-def test_status_no_pat(client, monkeypatch, tmp_path):
+def test_status_no_tokens(client, monkeypatch, tmp_path):
     monkeypatch.setattr(
-        "src.config.config.SMARTTHINGS_TOKEN_FILE", tmp_path / ".st-token-missing"
+        "src.config.config.SMARTTHINGS_TOKEN_FILE", tmp_path / ".st-tokens-missing"
     )
     r = client.get("/api/v1/integrations/smartthings/status")
     assert r.status_code == 200
     body = r.json()
-    assert body["pat_present"] is False
+    assert body["tokens_present"] is False
     assert body["reachable"] is None
-    # Crucially: no PAT field at all.
-    assert "pat" not in body
+    # No secrets in the response (access_token, refresh_token, client_secret).
+    for forbidden in ("access_token", "refresh_token", "pat", "client_secret"):
+        assert forbidden not in body
 
 
-def test_set_credentials_validates_via_round_trip(client, monkeypatch, tmp_path):
-    token_path = tmp_path / ".st-token-set"
-    monkeypatch.setattr("src.config.config.SMARTTHINGS_TOKEN_FILE", token_path)
-
-    # Mock SmartThings list_devices to succeed.
-    def fake_list_devices(self):
-        return [{"deviceId": "x", "label": "Washer"}]
-
-    with patch("src.smartthings.client.SmartThingsClient.list_devices",
-               new=fake_list_devices):
-        r = client.post(
-            "/api/v1/integrations/smartthings/credentials",
-            json={"pat": "valid-pat-123"},
-        )
+def test_oauth_start_returns_authorize_url(client, monkeypatch):
+    monkeypatch.setattr("src.config.config.SMARTTHINGS_CLIENT_ID", "test-client-id")
+    monkeypatch.setattr(
+        "src.config.config.SMARTTHINGS_REDIRECT_URI",
+        "http://localhost:8080/oauth/smartthings/callback",
+    )
+    monkeypatch.setattr(
+        "src.config.config.SMARTTHINGS_OAUTH_SCOPES", "r:devices:* x:devices:*"
+    )
+    r = client.get("/api/v1/integrations/smartthings/oauth/start")
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["ok"] is True
-    assert body["device_count"] == 1
-    # Token persisted with correct contents and 0600 perms.
-    assert token_path.read_text().strip() == "valid-pat-123"
-    assert oct(token_path.stat().st_mode & 0o777) == "0o600"
-    # Crucially: the response never echoes the PAT.
-    assert "pat" not in body
+    assert "authorize_url" in body
+    assert "client_id=test-client-id" in body["authorize_url"]
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A8080" in body["authorize_url"]
+    assert "state=" in body["authorize_url"]
+    # state is also returned for clients that want to round-trip it.
+    assert body["state"]
+    # Critical: do not leak the client_secret.
+    assert "client_secret" not in body
+    assert "client_secret" not in body["authorize_url"]
 
 
-def test_set_credentials_rejects_invalid_pat(client, monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        "src.config.config.SMARTTHINGS_TOKEN_FILE", tmp_path / ".st-token-rej"
-    )
-
-    def fake_list_devices_401(self):
-        raise SmartThingsError("pat_invalid", "401", http_status=401)
-
-    with patch("src.smartthings.client.SmartThingsClient.list_devices",
-               new=fake_list_devices_401):
-        r = client.post(
-            "/api/v1/integrations/smartthings/credentials",
-            json={"pat": "bad-pat"},
-        )
-    assert r.status_code == 401
-    # Token file must NOT have been written.
-    assert not (tmp_path / ".st-token-rej").exists()
+def test_oauth_start_412_when_client_id_missing(client, monkeypatch):
+    monkeypatch.setattr("src.config.config.SMARTTHINGS_CLIENT_ID", "")
+    r = client.get("/api/v1/integrations/smartthings/oauth/start")
+    assert r.status_code == 412
+    assert "SMARTTHINGS_CLIENT_ID" in r.text
 
 
-def test_delete_credentials(client, monkeypatch, tmp_path):
-    token_path = tmp_path / ".st-token-del"
+def test_delete_credentials_removes_token_file(client, monkeypatch, tmp_path):
+    token_path = tmp_path / ".st-tokens-del.json"
     monkeypatch.setattr("src.config.config.SMARTTHINGS_TOKEN_FILE", token_path)
-    token_path.write_text("some-pat\n")
+    token_path.write_text('{"access_token": "x", "refresh_token": "y"}')
     assert token_path.exists()
     r = client.delete("/api/v1/integrations/smartthings/credentials")
     assert r.status_code == 204

--- a/tests/smartthings/test_auth.py
+++ b/tests/smartthings/test_auth.py
@@ -1,0 +1,205 @@
+"""SmartThings OAuth auth module tests.
+
+Covers:
+  - Basic Auth header construction (the differentiator from Daikin).
+  - Token persistence (load/save round-trip + 0600 perms).
+  - exchange_code happy path.
+  - refresh_tokens carries refresh_token forward when Samsung omits it.
+  - Circuit breaker trips after 3 consecutive failures.
+  - get_valid_access_token refresh-if-stale + min-gap throttle.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.config import config as app_config
+from src.smartthings import auth as st_auth
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(app_config, "SMARTTHINGS_CLIENT_ID", "test-client")
+    monkeypatch.setattr(app_config, "SMARTTHINGS_CLIENT_SECRET", "test-secret")
+    monkeypatch.setattr(
+        app_config, "SMARTTHINGS_REDIRECT_URI",
+        "http://localhost:8080/oauth/smartthings/callback",
+    )
+    monkeypatch.setattr(app_config, "SMARTTHINGS_TOKEN_FILE", tmp_path / "tokens.json")
+    monkeypatch.setattr(app_config, "SMARTTHINGS_OAUTH_SCOPES", "r:devices:* x:devices:*")
+    monkeypatch.setattr(app_config, "SMARTTHINGS_ACCESS_REFRESH_LEEWAY_SECONDS", 60)
+    monkeypatch.setattr(app_config, "SMARTTHINGS_TOKEN_REFRESH_MIN_INTERVAL_SECONDS", 0)
+    # Reset circuit breaker between tests
+    st_auth._reset_auth_circuit()
+    st_auth._last_token_refresh_monotonic = 0.0
+
+
+def test_basic_auth_header_encodes_client_credentials() -> None:
+    h = st_auth._basic_auth_header()
+    assert h.startswith("Basic ")
+    decoded = base64.b64decode(h[6:]).decode()
+    assert decoded == "test-client:test-secret"
+
+
+def test_basic_auth_header_raises_when_creds_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "SMARTTHINGS_CLIENT_ID", "")
+    with pytest.raises(st_auth.SmartThingsAuthError):
+        st_auth._basic_auth_header()
+
+
+def test_save_load_tokens_roundtrip() -> None:
+    tokens = {
+        "access_token": "abc",
+        "refresh_token": "def",
+        "expires_in": 86400,
+        "token_type": "bearer",
+        "scope": "r:devices:* x:devices:*",
+        "obtained_at": 1714657123,
+    }
+    st_auth.save_tokens(tokens)
+    loaded = st_auth.load_tokens()
+    assert loaded == tokens
+
+    # 0600 perms
+    p = st_auth._resolve_token_path()
+    assert oct(p.stat().st_mode & 0o777) == "0o600"
+
+
+def test_load_tokens_raises_when_file_missing() -> None:
+    with pytest.raises(st_auth.SmartThingsAuthError) as ex:
+        st_auth.load_tokens()
+    assert "not present" in str(ex.value)
+
+
+def test_has_tokens_reflects_file_presence() -> None:
+    assert st_auth.has_tokens() is False
+    st_auth.save_tokens({"access_token": "x", "refresh_token": "y"})
+    assert st_auth.has_tokens() is True
+
+
+def test_authorize_url_includes_required_params() -> None:
+    url = st_auth.authorize_url("test-state-token")
+    assert "client_id=test-client" in url
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauth%2Fsmartthings%2Fcallback" in url
+    assert "scope=r%3Adevices%3A%2A+x%3Adevices%3A%2A" in url
+    assert "state=test-state-token" in url
+    assert "response_type=code" in url
+
+
+def test_exchange_code_calls_token_endpoint_with_basic_auth() -> None:
+    payload = {
+        "access_token": "AT-NEW",
+        "refresh_token": "RT-NEW",
+        "expires_in": 86400,
+        "scope": "r:devices:* x:devices:*",
+        "token_type": "bearer",
+    }
+    fake_proc = MagicMock(returncode=0, stdout=json.dumps(payload), stderr="")
+    with patch("subprocess.run", return_value=fake_proc) as run:
+        out = st_auth.exchange_code("test-code")
+    assert out["access_token"] == "AT-NEW"
+    assert out["refresh_token"] == "RT-NEW"
+    assert "obtained_at" in out  # we set this
+
+    # Confirm Basic Auth header was sent
+    call_args = run.call_args[0][0]  # the curl argv list
+    assert any(
+        "Authorization: Basic" in a for a in call_args
+    ), f"Basic Auth header missing in curl args: {call_args}"
+    # Confirm grant_type=authorization_code was form-encoded into -d body
+    body_arg_idx = call_args.index("-d") + 1
+    assert "grant_type=authorization_code" in call_args[body_arg_idx]
+    assert "code=test-code" in call_args[body_arg_idx]
+
+
+def test_refresh_tokens_carries_refresh_token_when_omitted() -> None:
+    """Samsung may omit refresh_token on refresh — our code must preserve the old one."""
+    old = {
+        "access_token": "AT-OLD",
+        "refresh_token": "RT-OLD",
+        "expires_in": 86400,
+        "obtained_at": int(time.time()) - 90000,
+    }
+    new_payload = {
+        "access_token": "AT-FRESH",
+        "expires_in": 86400,
+        "scope": "r:devices:* x:devices:*",
+        # NOTE: no refresh_token in response
+    }
+    fake_proc = MagicMock(returncode=0, stdout=json.dumps(new_payload), stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        out = st_auth.refresh_tokens(old)
+    assert out["access_token"] == "AT-FRESH"
+    assert out["refresh_token"] == "RT-OLD"  # carried over
+
+
+def test_refresh_circuit_trips_after_three_failures() -> None:
+    old = {"access_token": "x", "refresh_token": "RT", "expires_in": 86400, "obtained_at": 0}
+    fake_proc = MagicMock(returncode=0, stdout='{"error":"invalid_grant"}', stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        for _ in range(3):
+            with pytest.raises(st_auth.SmartThingsAuthError):
+                st_auth.refresh_tokens(old)
+        # 4th call → circuit open
+        with pytest.raises(st_auth.SmartThingsAuthCircuitOpen):
+            st_auth.refresh_tokens(old)
+
+
+def test_get_valid_access_token_refreshes_when_stale() -> None:
+    """Token expired beyond leeway → refresh_tokens called."""
+    stale_tokens = {
+        "access_token": "AT-STALE",
+        "refresh_token": "RT",
+        "expires_in": 100,           # very short
+        "obtained_at": int(time.time()) - 200,  # already expired
+    }
+    st_auth.save_tokens(stale_tokens)
+
+    fresh_payload = {
+        "access_token": "AT-FRESH",
+        "expires_in": 86400,
+        "scope": "r:devices:*",
+    }
+    fake_proc = MagicMock(returncode=0, stdout=json.dumps(fresh_payload), stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        token = st_auth.get_valid_access_token()
+    assert token == "AT-FRESH"
+
+
+def test_get_valid_access_token_returns_cached_when_not_stale() -> None:
+    fresh_tokens = {
+        "access_token": "AT-FRESH",
+        "refresh_token": "RT",
+        "expires_in": 86400,
+        "obtained_at": int(time.time()),
+    }
+    st_auth.save_tokens(fresh_tokens)
+
+    def boom(*a, **kw):  # noqa: ANN001
+        raise AssertionError("subprocess.run must NOT be called when token is fresh")
+
+    with patch("subprocess.run", side_effect=boom):
+        token = st_auth.get_valid_access_token()
+    assert token == "AT-FRESH"
+
+
+def test_get_valid_access_token_force_refresh_overrides_min_gap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """force_refresh=True ignores SMARTTHINGS_TOKEN_REFRESH_MIN_INTERVAL_SECONDS."""
+    monkeypatch.setattr(app_config, "SMARTTHINGS_TOKEN_REFRESH_MIN_INTERVAL_SECONDS", 3600)
+    tokens = {
+        "access_token": "AT-OLD",
+        "refresh_token": "RT",
+        "expires_in": 86400,
+        "obtained_at": int(time.time()),  # not stale
+    }
+    st_auth.save_tokens(tokens)
+    fresh_payload = {"access_token": "AT-FORCED", "expires_in": 86400}
+    fake_proc = MagicMock(returncode=0, stdout=json.dumps(fresh_payload), stderr="")
+    with patch("subprocess.run", return_value=fake_proc):
+        token = st_auth.get_valid_access_token(force_refresh=True)
+    assert token == "AT-FORCED"

--- a/tests/smartthings/test_client.py
+++ b/tests/smartthings/test_client.py
@@ -40,7 +40,7 @@ def _http_error(status: int, body: bytes = b""):
 
 
 def test_request_sets_bearer_header():
-    client = SmartThingsClient(pat="test-pat", base_url="https://api.smartthings.com/v1")
+    client = SmartThingsClient(access_token="test-pat", base_url="https://api.smartthings.com/v1")
     captured: dict = {}
 
     def fake_urlopen(req, timeout=None):
@@ -59,45 +59,75 @@ def test_request_sets_bearer_header():
     assert auth == "Bearer test-pat"
 
 
-def test_401_raises_pat_invalid():
-    client = SmartThingsClient(pat="bad-pat")
+def test_401_raises_auth_invalid_with_explicit_token():
+    """Explicit-token clients (test fixtures) get auth_invalid on 401 — no
+    refresh attempt because there's no refresh_token in the test path."""
+    client = SmartThingsClient(access_token="bad-pat")
     with patch("urllib.request.urlopen", side_effect=_http_error(401, b"unauthorized")):
         with pytest.raises(SmartThingsError) as ex:
             client.list_devices()
-    assert ex.value.code == "pat_invalid"
+    assert ex.value.code == "auth_invalid"
     assert ex.value.http_status == 401
 
 
+def test_401_triggers_refresh_when_using_oauth_token_file():
+    """Production path: client without access_token sources via auth.get_valid_access_token.
+    On 401, must call get_valid_access_token(force_refresh=True) and retry."""
+    from unittest.mock import MagicMock
+
+    client = SmartThingsClient()  # no explicit token → uses auth module
+    calls = {"refresh_count": 0, "request_count": 0}
+
+    def fake_token(*, force_refresh=False):
+        calls["refresh_count"] += int(force_refresh)
+        return "fresh-token-after-refresh" if force_refresh else "stale-token"
+
+    def fake_urlopen(req, timeout=None):
+        calls["request_count"] += 1
+        auth_hdr = dict(req.header_items()).get("Authorization", "")
+        if "stale-token" in auth_hdr:
+            raise _http_error(401, b"expired")
+        # Refreshed token → success
+        return _resp(200, {"items": []})
+
+    with patch("src.smartthings.client._auth.get_valid_access_token", side_effect=fake_token):
+        with patch("urllib.request.urlopen", fake_urlopen):
+            client.list_devices()
+
+    assert calls["request_count"] == 2  # initial + retry-after-refresh
+    assert calls["refresh_count"] == 1  # exactly one forced refresh
+
+
 def test_get_remote_control_enabled_parses_string_true():
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
     payload = {"remoteControlEnabled": {"value": "true"}}
     with patch("urllib.request.urlopen", return_value=_resp(200, payload)):
         assert client.get_remote_control_enabled("dev-1") is True
 
 
 def test_get_remote_control_enabled_parses_native_bool():
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
     payload = {"remoteControlEnabled": {"value": True}}
     with patch("urllib.request.urlopen", return_value=_resp(200, payload)):
         assert client.get_remote_control_enabled("dev-1") is True
 
 
 def test_get_remote_control_enabled_false_when_string_false():
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
     payload = {"remoteControlEnabled": {"value": "false"}}
     with patch("urllib.request.urlopen", return_value=_resp(200, payload)):
         assert client.get_remote_control_enabled("dev-1") is False
 
 
 def test_get_remote_control_enabled_false_on_unparseable():
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
     payload = {"remoteControlEnabled": {"value": None}}
     with patch("urllib.request.urlopen", return_value=_resp(200, payload)):
         assert client.get_remote_control_enabled("dev-1") is False
 
 
 def test_start_cycle_body_shape():
-    client = SmartThingsClient(pat="x", base_url="https://api.smartthings.com/v1")
+    client = SmartThingsClient(access_token="x", base_url="https://api.smartthings.com/v1")
     captured: dict = {}
 
     def fake_urlopen(req, timeout=None):
@@ -129,7 +159,7 @@ def test_start_cycle_body_shape():
 
 def test_start_cycle_skipped_in_read_only(monkeypatch):
     """OPENCLAW_READ_ONLY=true → no HTTP call, response says skipped."""
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
 
     def boom(*a, **kw):
         raise AssertionError("urlopen must NOT be called in read-only mode")
@@ -142,7 +172,7 @@ def test_start_cycle_skipped_in_read_only(monkeypatch):
 
 
 def test_5xx_retries_once_then_raises():
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
     calls = {"n": 0}
 
     def fake_urlopen(req, timeout=None):
@@ -158,7 +188,7 @@ def test_5xx_retries_once_then_raises():
 
 
 def test_list_devices_returns_items():
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
     payload = {
         "items": [
             {"deviceId": "dev-1", "label": "Washer"},
@@ -172,7 +202,7 @@ def test_list_devices_returns_items():
 
 
 def test_list_devices_empty_when_no_items_key():
-    client = SmartThingsClient(pat="x")
+    client = SmartThingsClient(access_token="x")
     with patch("urllib.request.urlopen", return_value=_resp(200, {})):
         devices = client.list_devices()
     assert devices == []


### PR DESCRIPTION
## Summary

Replaces the Phase 1 PAT auth (#206) with proper OAuth 2.0 Authorization Code flow + token refresh, mirroring `src/daikin/auth.py`. Schema, dispatch logic, MCP tools, and the appliance DB tables stay untouched — only the auth surface is swapped.

## Why

PAT was a Phase 1 simplification on the original draft. User flagged they expected OAuth for parity with Daikin (revocable from Samsung's "Connected Services" UI, scoped permissions, refreshable tokens, no plaintext PAT lying around).

## Architecture (mirror Daikin)

| File | Change |
|---|---|
| `src/smartthings/auth.py` (NEW, 340 LoC) | OAuth code exchange + refresh + circuit breaker + callback HTTP server. Uses HTTP **Basic Auth** at the token endpoint (Samsung-specific; Daikin sends form fields). |
| `src/smartthings/__main__.py` (NEW) | `python -m src.smartthings` → `auth.run_setup()` for the enrollment container. |
| `deploy/compose.smartthings-auth.yaml` (NEW) | One-shot container for the OAuth bootstrap. Mirrors `compose.daikin-auth.yaml`. |
| `src/smartthings/client.py` | Drops `pat=` arg. New `access_token=None` (OAuth-managed) or explicit (tests). 401 → refresh + retry once. |
| `src/smartthings/service.py` | Singleton stays; PAT loader removed. `tokens_present()` / `delete_tokens()` replace PAT equivalents. |
| `src/api/routers/appliances.py` | `POST /credentials` (raw PAT) **removed**. New `GET /oauth/start` returns the Samsung authorize URL + state. `DELETE /credentials` revokes local OAuth state. |
| `src/mcp_server.py` | `get_smartthings_status` exposes `tokens_present` + `client_id_configured`. Description rewritten with bootstrap container instructions. |
| `src/config.py` | `SMARTTHINGS_CLIENT_ID`, `_CLIENT_SECRET`, `_REDIRECT_URI`, `_AUTHORIZE_URL`, `_TOKEN_URL`, `_OAUTH_SCOPES`, refresh-leeway + min-gap knobs. Token file default: `.smartthings-token` → `.smartthings-tokens.json`. |

## Bootstrap flow (after merge + deploy)

```bash
# 1. Append OAuth creds to /srv/hem/.env (client_id + client_secret + redirect_uri)
# 2. systemctl restart hem (picks up env)
# 3. From your laptop:
ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
# 4. On the host:
docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm smartthings-auth
# 5. Container prints the Samsung authorize URL → open in your laptop browser
# 6. Samsung redirects → tokens land in /srv/hem/data/.smartthings-tokens.json
# 7. systemctl restart hem (picks up tokens)
```

## Test plan

- [x] `pytest tests/smartthings/ tests/api/test_appliances.py tests/scheduler/test_appliance_dispatch.py` — 56/56 pass in 6s
- [x] 11 new auth tests cover Basic Auth header, save/load + 0600 perms, exchange_code shape, refresh-token-carryover, circuit breaker, refresh-on-stale, cached-when-fresh, force_refresh override
- [x] Updated client tests cover the new OAuth 401-refresh-and-retry path
- [ ] Full CI suite (will run on push)
- [ ] Post-deploy: smartthings-auth container completes flow + tokens persist
- [ ] Post-deploy: appliance discovery via MCP returns the washer
- [ ] Post-deploy: when LP sees `remoteControlEnabled=true` for a registered washer, it schedules + fires the cycle in the cheapest window

🤖 Generated with [Claude Code](https://claude.com/claude-code)