### PR TITLE
fix(smartthings): OAuth via Tailscale Funnel + correct scopes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,21 +136,43 @@ device API call. Refresh circuit breaker after 3 consecutive failures
 
 ### One-time bootstrap (after `.env` has CLIENT_ID + CLIENT_SECRET set)
 
+**Samsung's WAF rejects `http://localhost` redirect URIs** (silent 404 on
+consent — confirmed against AWS ELB at `api.smartthings.com`). Bootstrap
+flow uses **Tailscale Funnel** to expose the callback over public HTTPS:
+
 ```bash
-# 1. From your laptop, tunnel :8080:
-ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
+# 1. On the host, expose the auth container's :8080 via Tailscale Funnel
+#    on port 8443 (separate from the existing :443 OpenClaw serve). This
+#    is PUBLICLY reachable for the duration of the bootstrap only.
+tailscale funnel --bg --https=8443 http://localhost:8080
 
-# 2. On the host, launch the auth-only container:
-docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm smartthings-auth
+# 2. (Once per app registration) Register the redirect URI with the SmartApp
+#    via `smartthings apps:oauth:update <appId>`:
+#      https://<host>.<tailnet>.ts.net:8443/oauth/smartthings/callback
+#    Also set the same value in /srv/hem/.env as SMARTTHINGS_REDIRECT_URI.
 
-# 3. Open the URL the container prints in your local browser. Samsung
-#    redirects to http://localhost:8080/oauth/smartthings/callback
-#    (= the container, via your SSH tunnel). Tokens land in
-#    /srv/hem/data/.smartthings-tokens.json. Container exits.
+# 3. Launch the auth container — MUST pass --service-ports because
+#    `docker compose run` drops the `ports:` section by default (without
+#    this, host :8080 doesn't bind and Funnel returns 502):
+docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm \
+  --service-ports smartthings-auth
 
-# 4. Restart hem so the service picks up the new tokens.
+# 4. Open the printed URL in your laptop browser (no SSH tunnel needed).
+#    Samsung redirects to the Funnel URL → forwards to localhost:8080
+#    → container handles → tokens land in /srv/hem/data/.smartthings-tokens.json.
+
+# 5. Tear down Funnel + restart hem.
+tailscale funnel --https=8443 off
 systemctl restart hem
 ```
+
+**Required OAuth scopes** (set on both the SmartApp and in `.env`):
+`r:devices:* x:devices:* r:installedapps w:installedapps`
+
+The two `installedapps` scopes are required by Samsung's OAuth flow to
+install the SmartApp into the user's location during consent. Without
+them the authorize endpoint 403s before login (matches Home Assistant's
+working integration `SCOPES`).
 
 ### Refresh access token (refresh_token still valid)
 

--- a/deploy/compose.smartthings-auth.yaml
+++ b/deploy/compose.smartthings-auth.yaml
@@ -1,20 +1,25 @@
 # One-shot SmartThings OAuth enrollment.
 #
-# Usage:
-#   1. From your laptop, tunnel :8080 to the Hetzner host:
-#        ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
-#   2. On the host, launch the auth-only container:
-#        docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm smartthings-auth
-#   3. The container prints an authorize URL — open it in your local browser.
-#      Samsung redirects to http://localhost:8080/oauth/smartthings/callback
-#      (= the container, via your SSH tunnel). Tokens land in
-#      /srv/hem/data/.smartthings-tokens.json.
-#   4. After the container exits, restart the main service so it picks up
-#      the new tokens:
-#        systemctl restart hem
+# Differs from compose.daikin-auth.yaml: Samsung's OAuth WAF rejects
+# ``http://localhost`` redirect URIs (silent 404 on consent). Workaround:
+# use Tailscale Funnel to expose the callback over public HTTPS on port 8443
+# during the bootstrap, then tear down.
 #
-# Mirrors the shape of compose.daikin-auth.yaml — same SSH-tunnel pattern,
-# same token-file convention.
+# Usage:
+#   1. (Once per Funnel) Enable Funnel for the callback path on the host:
+#        tailscale funnel --bg --https=8443 http://localhost:8080
+#   2. (Once per app registration) Set redirect_uri on the SmartApp + .env to:
+#        https://<host>.<tailnet>.ts.net:8443/oauth/smartthings/callback
+#   3. Launch the auth-only container WITH --service-ports (compose run drops
+#      ports: by default — without it the host's :8080 won't bind, Funnel 502s):
+#        docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm \
+#          --service-ports smartthings-auth
+#   4. The container prints an authorize URL. Open in your laptop browser.
+#      Samsung redirects to the Funnel URL → forwards to localhost:8080 →
+#      container handles → tokens land in /srv/hem/data/.smartthings-tokens.json.
+#   5. After container exits, tear down Funnel + restart hem:
+#        tailscale funnel --https=8443 off
+#        systemctl restart hem
 services:
   smartthings-auth:
     image: ghcr.io/albinati/home-energy-manager:${HEM_IMAGE_TAG:-main}
@@ -34,7 +39,10 @@ services:
     environment:
       DB_PATH: /app/data/energy_state.db
       SMARTTHINGS_TOKEN_FILE: /app/data/.smartthings-tokens.json
-      SMARTTHINGS_REDIRECT_URI: http://localhost:8080/oauth/smartthings/callback
+      # NOTE: leave SMARTTHINGS_REDIRECT_URI unset here so the value flows from
+      # ``/srv/hem/.env`` (the same source the runtime service uses). Samsung's
+      # WAF blocks ``http://localhost`` redirect URIs (404 on consent), so prod
+      # uses a Tailscale Funnel HTTPS URL instead — see CLAUDE.md.
       TZ: Europe/London
       PYTHONPATH: /app
 

--- a/src/config.py
+++ b/src/config.py
@@ -338,8 +338,15 @@ class Config:
         os.getenv("SMARTTHINGS_TOKEN_URL")
         or "https://auth-global.api.smartthings.com/oauth/token"
     ).strip().rstrip("/")
+    # OAuth scopes: r/x:devices:* are the runtime data path (read state, run cycles).
+    # ``r:installedapps`` + ``w:installedapps`` are REQUIRED for the OAuth authorize
+    # endpoint to proceed at all — without them Samsung returns 403 before login because
+    # the OAuth flow can't install the app into the user's location. Confirmed against
+    # Home Assistant's working SmartThings integration (`SCOPES` in
+    # https://github.com/home-assistant/core/blob/dev/homeassistant/components/smartthings/const.py).
     SMARTTHINGS_OAUTH_SCOPES: str = (
-        os.getenv("SMARTTHINGS_OAUTH_SCOPES") or "r:devices:* x:devices:*"
+        os.getenv("SMARTTHINGS_OAUTH_SCOPES")
+        or "r:devices:* x:devices:* r:installedapps w:installedapps"
     ).strip()
     SMARTTHINGS_TOKEN_FILE: Path = Path(
         os.getenv("SMARTTHINGS_TOKEN_FILE", "data/.smartthings-tokens.json")


### PR DESCRIPTION
## Summary

After #216 shipped the PAT→OAuth swap, the OAuth flow hit two empirically-discovered Samsung-side gotchas during the live bootstrap. Both fixed here so the next clean deploy doesn't repeat the discovery.

## Bug 1: 403 on authorize endpoint before login

Samsung silently requires `r:installedapps` + `w:installedapps` in the OAuth scope set. Without them the authorize endpoint returns 403 because Samsung can't install the SmartApp into your location during consent.

**Fix:** added both to the default `SMARTTHINGS_OAUTH_SCOPES`. Cross-referenced against [Home Assistant's working SmartThings integration](https://github.com/home-assistant/core/blob/dev/homeassistant/components/smartthings/const.py).

## Bug 2: `http://localhost` redirect URIs blocked by Samsung's WAF

Bisecting confirmed: AWS ELB in front of `api.smartthings.com` returns 403 to any authorize request whose `redirect_uri` contains `localhost` or `http://`. HTTPS public URL is required.

**Fix:** swapped the bootstrap pattern. Daikin's "SSH tunnel + localhost callback" doesn't work for Samsung. New pattern uses **Tailscale Funnel** to expose the auth container's :8080 over public HTTPS on port **8443** for the duration of the bootstrap, then tear down. Funnel rule lives only on :8443 (separate from the existing tailnet-only :443 OpenClaw serve), so the public surface during bootstrap is one path on one port.

## What changed

- `src/config.py` — default `SMARTTHINGS_OAUTH_SCOPES` now includes the two `installedapps` scopes
- `deploy/compose.smartthings-auth.yaml` — removed the hardcoded `SMARTTHINGS_REDIRECT_URI: http://localhost...` (now flows from `.env`); inlined doc comments about `--service-ports` requirement (`docker compose run` drops `ports:` by default — without this the host's :8080 doesn't bind and Funnel returns 502)
- `CLAUDE.md` — bootstrap section rewritten with Funnel pattern + WAF rule + required scopes

## Live verification

Bootstrap completed on prod 2026-05-02 14:07 UTC using these fixes (applied via `.env` overrides during debug):
- Tokens persisted at `/srv/hem/data/.smartthings-tokens.json` (0600)
- `GET /api/v1/integrations/smartthings/status` → `tokens_present:true reachable:true device_count:7`
- Washer (`1074a393-...`) registered as `appliance_id=1`
- `client.get_remote_control_enabled()` returns `false` (correct — washer currently off)

This commit promotes the `.env` overrides to in-repo defaults.

## Test plan
- [x] Manual end-to-end on prod (bootstrap + discover + register + status)
- [x] CI tests still green (no test changes — pure config/docs)
- [ ] Next clean deploy from main: env doesn't need `SMARTTHINGS_OAUTH_SCOPES` or `SMARTTHINGS_REDIRECT_URI` overrides (defaults pick up correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)