### PR TITLE
feat(appliance): PV-aware window picker + cycle-aware duration

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -370,6 +370,19 @@ class Config:
     APPLIANCE_RECONCILE_ERROR_PING_THRESHOLD: int = int(
         os.getenv("APPLIANCE_RECONCILE_ERROR_PING_THRESHOLD", "3")
     )
+    # PV-aware appliance window dispatch (PR #219). When True (default), the
+    # cheapest-window picker scores candidate windows by marginal cost
+    # (= forgone export revenue + grid import for the appliance load) instead
+    # of raw Agile import price. Captures free-PV opportunities the legacy
+    # path misses on sunny days. Set False to revert to import-only picker.
+    APPLIANCE_PV_AWARE_DISPATCH: bool = os.getenv(
+        "APPLIANCE_PV_AWARE_DISPATCH", "true"
+    ).strip().lower() in ("true", "1", "yes")
+    # Static default for the household residual base load when the per-hour-of-day
+    # profile has no row for a given slot (cold start / sparse history).
+    APPLIANCE_DEFAULT_BASE_LOAD_KW: float = float(
+        os.getenv("APPLIANCE_DEFAULT_BASE_LOAD_KW", "0.4")
+    )
 
     DHW_TEMP_MAX_C: float = float(os.getenv("DHW_TEMP_MAX_C", "65"))
     # Plunge-only ceiling (≥ DHW_TEMP_COMFORT_C and ≤ DHW_TEMP_MAX_C is allowed only when price < 0).

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -128,28 +128,203 @@ def _ceil_to_half_hour_utc(dt: datetime) -> datetime:
 # Cheapest-window picker
 # ---------------------------------------------------------------------------
 
+def build_marginal_cost_per_slot(
+    earliest_start_utc: datetime,
+    deadline_utc: datetime,
+    appliance_kw: float,
+) -> dict[datetime, float] | None:
+    """Build a per-slot marginal-cost map for running the appliance in that slot.
+
+    The dispatcher uses this to **price PV opportunity correctly**: running the
+    washer when PV is exporting costs us the *forgone export revenue*, not the
+    *Agile import price* (which we wouldn't pay anyway because PV covers the
+    load). Without this, ``find_cheapest_window`` picks the cheapest Agile slot
+    even when daytime PV is genuinely cheaper.
+
+    Per-slot marginal cost (pence) for ``washer_kwh = appliance_kw × 0.5``::
+
+        residual_pv = max(0, pv_forecast_kwh - base_load_kwh)
+        if residual_pv >= washer_kwh:
+            cost = washer_kwh × export_rate    # we forgo export revenue
+        else:
+            cost = (washer_kwh - residual_pv) × import_rate
+                 + residual_pv × export_rate
+
+    Returns ``None`` when forecasts are unavailable (caller falls back to the
+    legacy import-only path). Forecast inputs:
+
+      - PV: ``weather.fetch_forecast`` × hourly calibration table
+      - Base load: ``db.half_hourly_residual_load_profile_kwh()`` (post-Daikin)
+      - Import rate: ``agile_rates`` for the period
+      - Export rate: ``agile_export_rates`` (or flat ``EXPORT_RATE_PENCE`` fallback)
+    """
+    if not getattr(config, "APPLIANCE_PV_AWARE_DISPATCH", True):
+        return None
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    if not tariff:
+        return None
+    earliest_start_utc = _ceil_to_half_hour_utc(earliest_start_utc)
+
+    # Import rates
+    try:
+        import_rows = db.get_rates_for_period(tariff, earliest_start_utc, deadline_utc)
+    except Exception as e:
+        logger.warning("appliance pv-aware: get_rates_for_period failed: %s", e)
+        return None
+    if not import_rows:
+        return None
+    import_by_start: dict[datetime, float] = {}
+    for r in import_rows:
+        try:
+            import_by_start[_parse_iso(r["valid_from"])] = float(r["value_inc_vat"])
+        except (KeyError, ValueError, TypeError):
+            continue
+    if not import_by_start:
+        return None
+
+    # Export rates (best-effort; fall back to flat EXPORT_RATE_PENCE per slot)
+    flat_export = float(config.EXPORT_RATE_PENCE)
+    export_by_start: dict[datetime, float] = {}
+    if (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip():
+        try:
+            export_rows = db.get_agile_export_rates_in_range(
+                earliest_start_utc.isoformat(), deadline_utc.isoformat(),
+            )
+            for r in export_rows:
+                export_by_start[_parse_iso(r["valid_from"])] = float(r["value_inc_vat"])
+        except Exception as e:
+            logger.warning("appliance pv-aware: export rates fetch failed: %s", e)
+
+    # PV forecast (kWh per slot)
+    pv_per_slot = _residual_pv_kwh_per_slot(
+        sorted(import_by_start.keys()),
+    )
+
+    # Base-load profile (kWh/half-hour by hour-of-day)
+    try:
+        base_load_profile = db.half_hourly_residual_load_profile_kwh()
+    except Exception as e:
+        logger.warning("appliance pv-aware: load profile fetch failed: %s", e)
+        base_load_profile = {}
+    base_load_flat = float(getattr(config, "APPLIANCE_DEFAULT_BASE_LOAD_KW", 0.4))
+
+    washer_kwh_per_slot = float(appliance_kw) * 0.5
+
+    out: dict[datetime, float] = {}
+    tz_name = config.BULLETPROOF_TIMEZONE
+    from zoneinfo import ZoneInfo
+    tz = ZoneInfo(tz_name)
+    for slot_start in sorted(import_by_start.keys()):
+        if slot_start < earliest_start_utc:
+            continue
+        if slot_start + timedelta(minutes=30) > deadline_utc:
+            break
+        local = slot_start.astimezone(tz)
+        bucket = (local.hour, 30 if local.minute >= 30 else 0)
+        base_load = base_load_profile.get(bucket, base_load_flat)
+        pv = pv_per_slot.get(slot_start, 0.0)
+        residual_pv = max(0.0, pv - base_load)
+        import_p = import_by_start[slot_start]
+        export_p = export_by_start.get(slot_start, flat_export)
+        if residual_pv >= washer_kwh_per_slot:
+            cost = washer_kwh_per_slot * export_p
+        else:
+            grid_share = washer_kwh_per_slot - residual_pv
+            cost = grid_share * import_p + residual_pv * export_p
+        out[slot_start] = cost
+
+    return out if out else None
+
+
+def _residual_pv_kwh_per_slot(
+    slot_starts_utc: list[datetime],
+) -> dict[datetime, float]:
+    """Return ``{slot_start_utc: pv_kwh}`` per half-hour using the Open-Meteo
+    forecast + per-hour-of-day calibration table the LP uses.
+
+    Empty dict when the forecast fetch fails — caller's marginal-cost path
+    treats missing slots as ``pv=0`` (purely-import cost = legacy behavior).
+    """
+    if not slot_starts_utc:
+        return {}
+    horizon_h = max(
+        4,
+        int(
+            (slot_starts_utc[-1] - slot_starts_utc[0]).total_seconds() // 3600 + 2,
+        ),
+    )
+    try:
+        from ..weather import compute_pv_calibration_factor, fetch_forecast
+
+        forecast = fetch_forecast(hours=horizon_h)
+    except Exception as e:
+        logger.warning("appliance pv-aware: fetch_forecast failed: %s", e)
+        return {}
+    if not forecast:
+        return {}
+
+    cal_hourly = {}
+    try:
+        cal_hourly = db.get_pv_calibration_hourly()
+    except Exception:
+        cal_hourly = {}
+    flat_cal = 1.0
+    if not cal_hourly:
+        try:
+            flat_cal = float(compute_pv_calibration_factor() or 1.0)
+        except Exception:
+            flat_cal = 1.0
+
+    # forecast is hourly; expand to half-hourly by halving the hourly kWh
+    # estimate (good enough for this dispatch decision).
+    by_hour: dict[datetime, float] = {f.time_utc: float(f.estimated_pv_kw) for f in forecast}
+    out: dict[datetime, float] = {}
+    for slot_start in slot_starts_utc:
+        hour_anchor = slot_start.replace(minute=0, second=0, microsecond=0)
+        pv_kw = by_hour.get(hour_anchor, 0.0)
+        scale = float(cal_hourly.get(hour_anchor.hour, flat_cal)) if cal_hourly else flat_cal
+        # Half-hour kWh = kW × 0.5h × calibration factor
+        out[slot_start] = pv_kw * 0.5 * scale
+    return out
+
+
 def find_cheapest_window(
     earliest_start_utc: datetime,
     deadline_utc: datetime,
     duration_minutes: int,
+    *,
+    marginal_cost_per_slot: dict[datetime, float] | None = None,
 ) -> tuple[datetime, datetime, float]:
     """Return ``(planned_start_utc, planned_end_utc, avg_price_pence)`` for the
     cheapest contiguous window of ``duration_minutes`` whose end ≤ ``deadline_utc``.
 
-    Sliding-window minimum over half-hourly Agile rates from the
-    ``agile_rates`` table. When the table is empty for the horizon, falls
-    back to ``config.APPLIANCE_FALLBACK_WINDOW_LOCAL`` interpreted in the
-    BULLETPROOF_TIMEZONE.
+    When ``marginal_cost_per_slot`` is supplied (PV-aware dispatch — see
+    :func:`build_marginal_cost_per_slot`), the chosen window minimises total
+    marginal cost (= forgone export + grid import for the appliance), not
+    raw Agile import price. The reported ``avg_price_pence`` then reflects
+    pence/kWh of *real opportunity cost* per slot.
+
+    When ``marginal_cost_per_slot`` is ``None`` (legacy / no forecasts), the
+    function falls back to sliding-window minimum on Agile import rates from
+    the ``agile_rates`` table. Cold-start fallback uses
+    ``APPLIANCE_FALLBACK_WINDOW_LOCAL``.
     """
     tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
     duration = max(30, int(duration_minutes))
-    # Slot grid: 30-minute slots starting at the next half-hour boundary.
     earliest_start_utc = _ceil_to_half_hour_utc(earliest_start_utc)
     if deadline_utc - earliest_start_utc < timedelta(minutes=duration):
         raise ValueError(
             f"deadline_utc {deadline_utc.isoformat()} is < {duration}min after "
             f"earliest_start_utc {earliest_start_utc.isoformat()}"
         )
+
+    if marginal_cost_per_slot:
+        result = _cheapest_from_marginal_cost(
+            marginal_cost_per_slot, earliest_start_utc, deadline_utc, duration,
+        )
+        if result is not None:
+            return result
+        # fall through to import-only when marginal-cost path can't fit a window
 
     rates: list[dict[str, Any]] = []
     if tariff:
@@ -163,6 +338,47 @@ def find_cheapest_window(
         return _cheapest_from_rates(rates, deadline_utc, duration)
 
     return _fallback_window(earliest_start_utc, deadline_utc, duration)
+
+
+def _cheapest_from_marginal_cost(
+    marginal_cost_per_slot: dict[datetime, float],
+    earliest_start_utc: datetime,
+    deadline_utc: datetime,
+    duration_minutes: int,
+) -> tuple[datetime, datetime, float] | None:
+    """Sliding-window minimum on the marginal-cost map. Returns ``None`` when
+    no contiguous window of ``duration_minutes`` fits before ``deadline_utc``."""
+    n_slots = max(1, duration_minutes // 30)
+    starts = sorted(s for s in marginal_cost_per_slot if s >= earliest_start_utc)
+    if len(starts) < n_slots:
+        return None
+
+    best_total: float | None = None
+    best_start: datetime | None = None
+    for i in range(len(starts) - n_slots + 1):
+        window = starts[i : i + n_slots]
+        # Contiguity check
+        contiguous = all(
+            window[j + 1] - window[j] == timedelta(minutes=30)
+            for j in range(n_slots - 1)
+        )
+        if not contiguous:
+            continue
+        end_utc = window[-1] + timedelta(minutes=30)
+        if end_utc > deadline_utc:
+            continue
+        total = sum(marginal_cost_per_slot[s] for s in window)
+        if best_total is None or total < best_total:
+            best_total = total
+            best_start = window[0]
+
+    if best_start is None or best_total is None:
+        return None
+    end_utc = best_start + timedelta(minutes=duration_minutes)
+    # Convert total pence → avg pence/kWh for back-compat (callers expect it)
+    # We don't know exact kWh here, so report total/n_slots as "p per slot avg".
+    avg_per_slot_p = best_total / float(n_slots)
+    return best_start, end_utc, avg_per_slot_p
 
 
 def _cheapest_from_rates(
@@ -324,10 +540,38 @@ def _arm_or_replan(
     existing_job: dict[str, Any] | None,
 ) -> None:
     appliance_id = int(appliance["id"])
-    duration = int(appliance.get("default_duration_minutes") or 120)
     deadline_local = appliance.get("deadline_local_time") or config.APPLIANCE_DEFAULT_DEADLINE_LOCAL
     deadline_utc = _next_deadline_utc(deadline_local)
     now = _now_utc()
+
+    # Cycle-aware duration: when the washer exposes
+    # ``samsungce.washerDelayEnd.minimumReservableTime``, prefer it over the
+    # static ``default_duration_minutes`` from registration. The live value
+    # reflects the user's actual cycle selection (eco vs cotton vs hot wash);
+    # the static default is a guess. Falls back gracefully when the capability
+    # is absent or the value is null/zero.
+    static_duration = int(appliance.get("default_duration_minutes") or 120)
+    duration = static_duration
+    try:
+        client = _get_st_client()
+        live_status = client.get_full_status(appliance["vendor_device_id"])
+        delay = live_status.get("components", {}).get("main", {}).get(
+            "samsungce.washerDelayEnd", {}
+        )
+        live_min_reservable = delay.get("minimumReservableTime", {}).get("value")
+        if isinstance(live_min_reservable, (int, float)) and live_min_reservable >= 30:
+            duration = int(live_min_reservable)
+            if duration != static_duration:
+                logger.info(
+                    "appliance #%d: cycle-aware duration %d min "
+                    "(static default was %d min)",
+                    appliance_id, duration, static_duration,
+                )
+    except Exception as e:  # noqa: BLE001 — fall back to static, never fatal
+        logger.debug(
+            "appliance #%d: cycle-aware duration read failed (%s) — using static %d min",
+            appliance_id, type(e).__name__, static_duration,
+        )
 
     # Reject if there isn't enough headroom before the deadline.
     if deadline_utc - now < timedelta(minutes=duration):
@@ -344,8 +588,21 @@ def _arm_or_replan(
             )
         return
 
+    appliance_kw = float(appliance.get("typical_kw") or 0.5)
+    marginal = build_marginal_cost_per_slot(now, deadline_utc, appliance_kw)
+    if marginal:
+        logger.info(
+            "appliance #%d: PV-aware dispatch (%d candidate slots, "
+            "marginal-cost range %.2f-%.2f pence)",
+            appliance_id, len(marginal),
+            min(marginal.values()), max(marginal.values()),
+        )
+
     try:
-        start_utc, end_utc, avg_price = find_cheapest_window(now, deadline_utc, duration)
+        start_utc, end_utc, avg_price = find_cheapest_window(
+            now, deadline_utc, duration,
+            marginal_cost_per_slot=marginal,
+        )
     except ValueError as e:
         logger.warning("appliance #%d: cheapest-window infeasible: %s", appliance_id, e)
         return

--- a/tests/test_appliance_pv_aware.py
+++ b/tests/test_appliance_pv_aware.py
@@ -1,0 +1,156 @@
+"""PV-aware appliance window picker (#219).
+
+Audit finding (2026-05-02): ``find_cheapest_window`` picked the cheapest
+*Agile import* slot, even when daytime PV would have made the run free.
+Live prod check at 15:20 BST showed 2.4 kW solar / 0.6 kW load / 100% SoC
+/ -1.8 kW grid (exporting). Marginal cost of running the washer THEN was
+~equal to forgone export revenue ≈ 18p/kWh. The dispatcher picked
+21:00–23:00 (Agile cheapest at 20.6p), missing the free-PV pocket.
+
+These tests lock the new marginal-cost path: PV-rich slots beat
+slightly-cheaper night slots, and absence of forecasts falls back to the
+legacy import-only behavior.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.scheduler import appliance_dispatch
+
+
+def _slots(n: int, base: datetime | None = None) -> list[datetime]:
+    base = base or datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    return [base + i * timedelta(minutes=30) for i in range(n)]
+
+
+def test_marginal_cost_pv_surplus_beats_export_rate() -> None:
+    """When residual_pv >= washer_kwh, marginal cost = washer_kwh × export_rate."""
+    starts = _slots(2)
+    # Build the marginal_cost_per_slot map directly (skip the forecast plumbing)
+    # 0.5 kW washer × 0.5 h = 0.25 kWh per slot
+    # If PV residual > 0.25 kWh: cost = 0.25 × export_rate
+    # At export rate 18p, cost = 4.5p per slot
+    marginal = {
+        starts[0]: 0.25 * 18.0,        # 4.5p — PV-covered (sunny)
+        starts[1]: 0.25 * 25.0,        # 6.25p — partial PV + grid
+    }
+    start, end, avg = appliance_dispatch.find_cheapest_window(
+        starts[0], starts[-1] + timedelta(minutes=30),
+        duration_minutes=30,
+        marginal_cost_per_slot=marginal,
+    )
+    assert start == starts[0]
+    assert end == starts[0] + timedelta(minutes=30)
+    assert avg == pytest.approx(4.5)
+
+
+def test_pv_aware_picks_pv_rich_window_over_cheaper_night() -> None:
+    """The user's case: 21:00 has cheaper Agile import (20p), but 14:00 has
+    free PV → dispatcher should pick 14:00."""
+    starts = _slots(20)  # 14:00–23:30 across 10 hours
+    # Slots 0–3 (14:00–15:30): PV is exporting at 18p → marginal cost = 0.25×18 = 4.5p
+    # Slots 4–15 (16:00–21:30): no PV, normal Agile (~25p) → 0.25×25 = 6.25p
+    # Slots 16–19 (22:00–23:30): cheap Agile (20p), no PV → 0.25×20 = 5p
+    marginal = {}
+    for i, s in enumerate(starts):
+        if i < 4:
+            marginal[s] = 4.5
+        elif i >= 16:
+            marginal[s] = 5.0
+        else:
+            marginal[s] = 6.25
+    start, end, avg = appliance_dispatch.find_cheapest_window(
+        starts[0], starts[-1] + timedelta(minutes=30),
+        duration_minutes=120,                # 4 slots
+        marginal_cost_per_slot=marginal,
+    )
+    # Expected: pick slots 0–3 (14:00) because 4 × 4.5p = 18p < 4 × 5p = 20p
+    assert start == starts[0], f"Expected 14:00 PV window, got {start}"
+    assert avg == pytest.approx(4.5)
+
+
+def test_falls_back_to_import_only_when_no_marginal_map(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """No marginal_cost_per_slot supplied → legacy import-only path
+    (sliding-window minimum on agile_rates)."""
+    from src import db
+    monkeypatch.setattr("src.config.config.DB_PATH", str(tmp_path / "t.db"), raising=False)
+    db.init_db()
+    tariff = "AGILE-TEST-FALLBACK"
+    monkeypatch.setattr("src.config.config.OCTOPUS_TARIFF_CODE", tariff)
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    rows = []
+    for i in range(8):
+        st = base + i * timedelta(minutes=30)
+        # Slot 4 (14:00): super cheap (1p). Others: 20p.
+        price = 1.0 if i == 4 else 20.0
+        rows.append({
+            "valid_from": st.isoformat().replace("+00:00", "Z"),
+            "valid_to": (st + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+            "value_inc_vat": price,
+        })
+    db.save_agile_rates(rows, tariff)
+
+    start, end, avg = appliance_dispatch.find_cheapest_window(
+        base, base + timedelta(hours=4),
+        duration_minutes=30,
+        marginal_cost_per_slot=None,        # legacy
+    )
+    assert start == base + timedelta(minutes=120), (
+        f"Should pick slot 4 (the 1p slot), got {start.isoformat()}"
+    )
+    assert avg == pytest.approx(1.0)
+
+
+def test_marginal_cost_window_must_be_contiguous() -> None:
+    """A 60-min window can't span over a missing slot — picker must reject
+    gaps and fall through to the import-only path or raise."""
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    # Slot 0 cheap, slot 1 missing, slot 2 cheap → should NOT pick slots 0+2
+    marginal = {
+        base: 1.0,
+        base + timedelta(hours=1): 1.0,    # gap! skipped slot at +30 min
+    }
+    # Without a contiguous window the marginal-cost path returns None and
+    # the function falls through to the import-only path. With no DB rows
+    # set up here, that returns the fallback window.
+    from src.config import config as app_config
+    # APPLIANCE_FALLBACK_WINDOW_LOCAL default is "02:00-05:00" — picker uses it.
+    start, end, avg = appliance_dispatch.find_cheapest_window(
+        base, base + timedelta(hours=4),
+        duration_minutes=60,                # 2 slots
+        marginal_cost_per_slot=marginal,
+    )
+    # Should NOT have picked a non-contiguous combination
+    # (avg=0 indicates fallback path used; that's the documented contract)
+    assert avg == 0.0 or start != base, (
+        f"Picker should not stitch non-contiguous slots; got start={start}, avg={avg}"
+    )
+
+
+def test_build_marginal_cost_returns_none_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``APPLIANCE_PV_AWARE_DISPATCH=false`` → builder returns None
+    (legacy fallback path is taken)."""
+    monkeypatch.setattr("src.config.config.APPLIANCE_PV_AWARE_DISPATCH", False)
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    result = appliance_dispatch.build_marginal_cost_per_slot(
+        base, base + timedelta(hours=4), appliance_kw=0.5,
+    )
+    assert result is None
+
+
+def test_build_marginal_cost_returns_none_when_no_tariff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("src.config.config.APPLIANCE_PV_AWARE_DISPATCH", True)
+    monkeypatch.setattr("src.config.config.OCTOPUS_TARIFF_CODE", "")
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    result = appliance_dispatch.build_marginal_cost_per_slot(
+        base, base + timedelta(hours=4), appliance_kw=0.5,
+    )
+    assert result is None


### PR DESCRIPTION
## Summary

Audit finding #5 (PR #2 of three from the LP audit split). Bundles **two** improvements that directly address the user-spotted bug:

> 15:20 BST today: 2.4 kW solar, 0.6 kW load, 100% SoC, **−1.8 kW grid (exporting)**. Marginal cost of running the washer THEN ≈ 18 p/kWh (forgone export). Dispatcher picked 21:00–23:00 (cheapest Agile import at 20.6 p) — missed the free-PV pocket.

## Fix 1: PV-aware marginal-cost window scoring

New `build_marginal_cost_per_slot(start, deadline, appliance_kw)`:

```
residual_pv = max(0, pv_forecast_kwh − base_load_kwh)
if residual_pv >= washer_kwh:  cost = washer_kwh × export_rate     # forgo export
else:                          cost = (washer_kwh − residual_pv) × import_rate
                                    + residual_pv × export_rate
```

`find_cheapest_window` accepts an optional `marginal_cost_per_slot` kwarg. New private `_cheapest_from_marginal_cost` slides over the map and picks lowest-total-cost contiguous window. Existing callers without the kwarg unchanged (back-compat preserved).

## Fix 2: Cycle-aware duration

`_arm_or_replan` now reads `samsungce.washerDelayEnd.minimumReservableTime` from the live washer state. Today: **163 min** (vs static default 120 min). Pre-fix would have planned a 2 h window and bled 43 min into the next slot at higher price. Post-fix plans the actual cycle length.

## Config knobs (both default true / sensible)

```
APPLIANCE_PV_AWARE_DISPATCH=true    # set false to revert to import-only
APPLIANCE_DEFAULT_BASE_LOAD_KW=0.4  # fallback when load profile cold
```

## Test plan
- [x] `pytest tests/test_appliance_pv_aware.py -v` — 6/6 new cases pass
- [x] `pytest tests/scheduler/test_appliance_dispatch.py tests/api/test_appliances.py -q` — 25/25 (no regression)
- [x] Combined LP+appliance: 74 passed, 1 skipped
- [ ] Post-deploy: dry-run replays today's 15:20 state and picks the PV-rich window (will show in journal logs)
- [ ] Live test: press Smart Control on washer; observe journal `appliance #1: PV-aware dispatch (N candidate slots, marginal-cost range X-Y pence)`

## Depends on
- #218 (independent — both can merge in either order)

## Audit findings still open
- **#220:** Price quantization edge case (rounds near-zero negatives to 0p). Tiny scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)