### PR TITLE
fix(pv): calibration math assumed 12 samples/hour but heartbeat writes 1-3

### DIFF
--- a/src/weather.py
+++ b/src/weather.py
@@ -494,8 +494,14 @@ def compute_pv_calibration_hourly_table(
     start = end - _td(days=window_days)
 
     # Pull measured PV per UTC hour from pv_realtime_history.
+    # NOTE: average kW × 1h, NOT sum × (5/60). The previous "kw × (5/60)" formula
+    # assumed 12 samples/hour (5-min cadence). In practice the heartbeat writes
+    # samples sparsely (often 1-3/hour), so the sum-based formula collapses
+    # by ~10× — the resulting "ratio" was artificially low and made the per-hour
+    # calibration table over-correct against forecast (audit 2026-05-02:
+    # factors at the 0.10 floor when reality should give 0.5-0.7).
     measured_per_hour: dict[int, list[float]] = {h: [] for h in range(24)}
-    measured_per_day_hour: dict[tuple[str, int], float] = {}
+    measured_kw_samples: dict[tuple[str, int], list[float]] = {}
     with _db._lock:
         conn = _db.get_connection()
         try:
@@ -517,12 +523,13 @@ def compute_pv_calibration_hourly_table(
                     ts = ts.replace(tzinfo=UTC)
                 day = ts.date().isoformat()
                 hour = ts.hour
-                # 5-min sample × (5/60)h = kWh contribution to that hour
-                measured_per_day_hour[(day, hour)] = (
-                    measured_per_day_hour.get((day, hour), 0.0) + kw * (5.0 / 60.0)
-                )
+                measured_kw_samples.setdefault((day, hour), []).append(kw)
         finally:
             conn.close()
+    # mean kW × 1h = kWh per hour (sample-density-independent)
+    measured_per_day_hour: dict[tuple[str, int], float] = {
+        k: (sum(samples) / len(samples)) for k, samples in measured_kw_samples.items() if samples
+    }
 
     if not measured_per_day_hour:
         return {"status": "skipped", "reason": "no pv_realtime_history in window"}
@@ -630,7 +637,10 @@ def compute_today_pv_correction_factor(
     today = datetime.now(UTC).date().isoformat()
 
     # 1. Pull today's measured PV per UTC hour from pv_realtime_history.
-    actual_per_hour: dict[int, float] = {}
+    # Use mean kW × 1h (sample-density-independent), not sum × (5/60).
+    # Sparse heartbeat (1-3 samples/hour, not 12) made the old formula collapse
+    # the ratio by ~10× — fixed in this commit alongside the per-hour table.
+    actual_kw_samples: dict[int, list[float]] = {}
     with _db._lock:
         conn = _db.get_connection()
         try:
@@ -648,12 +658,12 @@ def compute_today_pv_correction_factor(
                     continue
                 if ts.tzinfo is None:
                     ts = ts.replace(tzinfo=UTC)
-                # 5-min sample → kWh contribution
-                actual_per_hour[ts.hour] = (
-                    actual_per_hour.get(ts.hour, 0.0) + float(kw or 0.0) * (5.0 / 60.0)
-                )
+                actual_kw_samples.setdefault(ts.hour, []).append(float(kw or 0.0))
         finally:
             conn.close()
+    actual_per_hour: dict[int, float] = {
+        h: (sum(s) / len(s)) for h, s in actual_kw_samples.items() if s
+    }
 
     if not actual_per_hour:
         return 1.0, {"reason": "no pv_realtime_history yet today"}


### PR DESCRIPTION
## Summary

Sister-fix to #229. Live verification on prod after deploying #229 showed `today_factor = 0.30` (clamped from median 0.0893). Investigated and found the **same bug** in both `compute_pv_calibration_hourly_table` and `compute_today_pv_correction_factor`:

```python
# WRONG — assumes 12 samples per hour
measured_kwh_per_hour = sum_over_samples(kw × (5/60))
```

In production, the heartbeat writes to `pv_realtime_history` sparsely (1-3 samples/hour, not 12). The formula collapses by ~10×: a 1.0 kW reading captured once becomes 0.083 kWh "per hour" instead of 1.0 kWh.

## Fix

Sample-density-independent:
```python
measured_kwh_per_hour = mean(samples) × 1 h
```

Applied in both functions.

## Expected impact

| | Before | After |
|---|---|---|
| Hour 14 actual (prod, sparse) | 0.082 kWh | 0.984 kWh |
| Hour 14 forecast | 2.59 kWh | 2.59 kWh |
| Ratio | **3.2%** (clamped to 30%) | **38%** (genuine) |
| Per-hour table | floors at 0.10 | should rise to 0.5-0.7 |

The per-hour table will recompute at the next nightly cron — OR I can force `compute_pv_calibration_hourly_table()` immediately post-deploy to show the dramatic before/after.

## Test plan
- [x] Existing 7 today-adjuster tests pass (they seeded 12 samples/hour, math gives same result)
- [ ] Post-deploy: force-recompute per-hour table; verify hours 6-18 UTC factors rise from 0.10-0.50 to 0.5-0.9
- [ ] Post-deploy: rerun appliance-dispatch diagnostic; verify `pv` column shows non-zero for sunny afternoon hours
- [ ] Post-deploy 24h: slippage regression continues to close

🤖 Generated with [Claude Code](https://claude.com/claude-code)