### PR TITLE
feat(pv): forecast accuracy evaluator + post-#230 regression baseline

### DIFF
--- a/scripts/check_pv_forecast_accuracy.py
+++ b/scripts/check_pv_forecast_accuracy.py
@@ -1,0 +1,68 @@
+"""Compare current PV forecast accuracy vs the post-PR-#230 baseline.
+
+Run AFTER any calibration change (cloud-aware bias, MOS regression, quantile
+bands, etc.) to verify the change actually improved point-forecast accuracy
+on the trailing 30 days of prod data. A change that doesn't reduce MAE/RMSE
+is noise; a change that grows bias (especially > 0.1 kW absolute) is a
+regression even if MAE looks similar.
+
+Usage (on prod):
+
+    docker exec hem python /tmp/check_pv_forecast_accuracy.py
+
+Or copy this script into the container and run from src.weather directly.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    from src.weather import evaluate_pv_forecast_accuracy
+
+    current = evaluate_pv_forecast_accuracy(window_days=30)
+    baseline_path = Path(__file__).parent.parent / "tests" / "fixtures" / "pv_forecast_baseline.json"
+    if not baseline_path.exists():
+        print(f"Baseline not found at {baseline_path}; printing current only.")
+        print(json.dumps(current, indent=2))
+        return 0
+
+    baseline = json.loads(baseline_path.read_text())
+
+    print("PV FORECAST ACCURACY: current vs baseline (post-PR-#230)\n")
+    print(f"{'metric':<15} | {'baseline':>10} | {'current':>10} | {'Δ':>10}")
+    print("-" * 55)
+    for k in ("mae_kw", "rmse_kw", "bias_kw", "mape_pct"):
+        b = baseline["overall"].get(k, 0.0)
+        c = current["overall"].get(k, 0.0)
+        delta = c - b
+        marker = ""
+        if k in ("mae_kw", "rmse_kw", "mape_pct"):
+            marker = " ⬇️ better" if delta < -0.001 else (" ⚠️ worse" if delta > 0.001 else "")
+        elif k == "bias_kw":
+            marker = " ⬇️ closer" if abs(c) < abs(b) else (" ⚠️ further" if abs(c) > abs(b) else "")
+        print(f"{k:<15} | {b:>10.4f} | {c:>10.4f} | {delta:>+10.4f}{marker}")
+
+    n_b = baseline["overall"]["n"]
+    n_c = current["overall"]["n"]
+    print(f"\nSamples: baseline={n_b}, current={n_c}")
+
+    # Verdict
+    mae_b = baseline["overall"]["mae_kw"]
+    mae_c = current["overall"]["mae_kw"]
+    rmse_b = baseline["overall"]["rmse_kw"]
+    rmse_c = current["overall"]["rmse_kw"]
+    if mae_c < mae_b and rmse_c < rmse_b:
+        print("\n✅ IMPROVEMENT — both MAE and RMSE reduced.")
+        return 0
+    if mae_c > mae_b * 1.05 or rmse_c > rmse_b * 1.05:
+        print("\n❌ REGRESSION — MAE or RMSE grew >5% vs baseline.")
+        return 1
+    print("\n➖ NEUTRAL — accuracy roughly unchanged. Consider whether the change is worth shipping.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/weather.py
+++ b/src/weather.py
@@ -720,6 +720,147 @@ def compute_today_pv_correction_factor(
     }
 
 
+def evaluate_pv_forecast_accuracy(
+    window_days: int = 30,
+    *,
+    min_kw: float = 0.05,
+) -> dict[str, Any]:
+    """Compare predicted vs realized PV across the last N days.
+
+    Used as a **regression baseline** for any forecast-accuracy work. Output
+    captures MAE / RMSE / bias / sample count, both per-hour-of-day and
+    overall. After shipping a calibration improvement, re-run and compare:
+    a real improvement reduces MAE/RMSE; "improvement" that doesn't
+    measurably move these metrics is noise.
+
+    Pipeline replicated for each (day, hour):
+        prediction = estimate_pv_kw(forecast_irradiance) × calibration[hour]
+        actual = mean(pv_realtime_history.solar_power_kw for that hour)
+        error = actual - prediction (positive = under-prediction)
+
+    Hours/days where prediction OR actual < ``min_kw`` are excluded as
+    dawn/dusk noise (default 0.05 kW).
+
+    The today-aware adjuster is NOT applied for historical days — we use the
+    current per-hour table only. This gives "what would today's calibration
+    have predicted historically" — apples-to-apples vs any future
+    calibration change.
+
+    Returns a dict with:
+
+        {
+            "window_days": 30,
+            "n_paired": 245,
+            "overall": {
+                "mae_kw": 0.42, "rmse_kw": 0.61,
+                "bias_kw": -0.08,    # negative = system over-predicts
+                "mean_actual_kw": 0.78, "mean_pred_kw": 0.86,
+                "mape_pct": 38.4,
+            },
+            "per_hour": {
+                7:  {"mae_kw": 0.21, "rmse_kw": 0.32, "bias_kw": +0.04, "n": 18},
+                ...
+            },
+        }
+    """
+    from . import db as _db
+    from collections import defaultdict
+    from datetime import UTC as _UTC, date as _date, datetime as _dt, timedelta as _td
+
+    end = _date.today()
+    start = end - _td(days=window_days)
+
+    cal_hourly = _db.get_pv_calibration_hourly()
+    flat_cal = compute_pv_calibration_factor() if not cal_hourly else 1.0
+
+    # Pull all measurements + forecasts in window
+    actual_kw_samples: dict[tuple[str, int], list[float]] = defaultdict(list)
+    forecast_radiation: dict[tuple[str, int], float] = {}
+
+    with _db._lock:
+        conn = _db.get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT captured_at, solar_power_kw FROM pv_realtime_history
+                   WHERE substr(captured_at, 1, 10) BETWEEN ? AND ?
+                     AND solar_power_kw IS NOT NULL""",
+                (start.isoformat(), end.isoformat()),
+            )
+            for ts_raw, kw in cur.fetchall():
+                try:
+                    ts = _dt.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=_UTC)
+                actual_kw_samples[(ts.date().isoformat(), ts.hour)].append(float(kw or 0.0))
+
+            cur = conn.execute(
+                """SELECT slot_time, solar_w_m2 FROM meteo_forecast
+                   WHERE substr(slot_time, 1, 10) BETWEEN ? AND ?""",
+                (start.isoformat(), end.isoformat()),
+            )
+            for ts_raw, rad in cur.fetchall():
+                try:
+                    ts = _dt.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=_UTC)
+                forecast_radiation[(ts.date().isoformat(), ts.hour)] = float(rad or 0.0)
+        finally:
+            conn.close()
+
+    # Build paired (predicted_kw, actual_kw) tuples
+    pairs_per_hour: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    all_pairs: list[tuple[float, float]] = []
+    for key, samples in actual_kw_samples.items():
+        if not samples:
+            continue
+        actual_kw = sum(samples) / len(samples)
+        rad = forecast_radiation.get(key)
+        if rad is None:
+            continue
+        cal = float(cal_hourly.get(key[1], flat_cal)) if cal_hourly else flat_cal
+        predicted_kw = estimate_pv_kw(rad) * cal
+        if predicted_kw < min_kw and actual_kw < min_kw:
+            continue                      # both negligible — skip dawn/dusk
+        pairs_per_hour[key[1]].append((predicted_kw, actual_kw))
+        all_pairs.append((predicted_kw, actual_kw))
+
+    def _stats(pairs: list[tuple[float, float]]) -> dict[str, float]:
+        if not pairs:
+            return {"mae_kw": 0.0, "rmse_kw": 0.0, "bias_kw": 0.0,
+                    "mean_actual_kw": 0.0, "mean_pred_kw": 0.0, "mape_pct": 0.0, "n": 0}
+        n = len(pairs)
+        errs = [a - p for p, a in pairs]
+        mae = sum(abs(e) for e in errs) / n
+        rmse = (sum(e * e for e in errs) / n) ** 0.5
+        bias = sum(errs) / n
+        mean_actual = sum(a for _, a in pairs) / n
+        mean_pred = sum(p for p, _ in pairs) / n
+        # MAPE: skip points where actual ~ 0 to avoid div-by-zero
+        ape = [abs(a - p) / a * 100 for p, a in pairs if a > 0.1]
+        mape = sum(ape) / len(ape) if ape else 0.0
+        return {
+            "mae_kw": round(mae, 4),
+            "rmse_kw": round(rmse, 4),
+            "bias_kw": round(bias, 4),
+            "mean_actual_kw": round(mean_actual, 4),
+            "mean_pred_kw": round(mean_pred, 4),
+            "mape_pct": round(mape, 2),
+            "n": n,
+        }
+
+    return {
+        "window_days": window_days,
+        "n_paired": len(all_pairs),
+        "calibration_method": "per_hour_table" if cal_hourly else f"flat({flat_cal:.4f})",
+        "overall": _stats(all_pairs),
+        "per_hour": {h: _stats(p) for h, p in sorted(pairs_per_hour.items())},
+    }
+
+
 def forecast_to_lp_inputs(
     forecast: list[HourlyForecast],
     slot_starts_utc: list[datetime],

--- a/tests/fixtures/pv_forecast_baseline.json
+++ b/tests/fixtures/pv_forecast_baseline.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "captured_at_utc": "2026-05-02T16:05:00Z",
+    "captured_after_pr": 230,
+    "calibration_method": "per_hour_table",
+    "rationale": "Post-PR-#230 baseline: per-hour calibration table now uses mean kW (sample-density-independent) instead of broken sum × (5/60) which assumed 12 samples/hour. Future calibration improvements (#A cloud-aware bias, #B MOS regression, #C quantile bands) MUST beat these MAE/RMSE numbers to justify shipping. Compare via scripts/check_pv_forecast_accuracy.py."
+  },
+  "window_days": 30,
+  "n_paired": 169,
+  "calibration_method": "per_hour_table",
+  "overall": {
+    "n": 169,
+    "mae_kw": 0.2081,
+    "rmse_kw": 0.3571,
+    "bias_kw": 0.0251,
+    "mean_actual_kw": 1.1681,
+    "mean_pred_kw": 1.1431,
+    "mape_pct": 30.04
+  },
+  "per_hour": {
+    "5":  {"n": 7,  "mae_kw": 0.0269, "rmse_kw": 0.0294, "bias_kw":  0.0100, "mean_actual_kw": 0.0607, "mean_pred_kw": 0.0508, "mape_pct":  0.00},
+    "6":  {"n": 12, "mae_kw": 0.0278, "rmse_kw": 0.0332, "bias_kw": -0.0110, "mean_actual_kw": 0.2253, "mean_pred_kw": 0.2364, "mape_pct": 13.89},
+    "7":  {"n": 12, "mae_kw": 0.0843, "rmse_kw": 0.1157, "bias_kw": -0.0304, "mean_actual_kw": 0.3947, "mean_pred_kw": 0.4251, "mape_pct": 27.17},
+    "8":  {"n": 11, "mae_kw": 0.1364, "rmse_kw": 0.1660, "bias_kw": -0.0011, "mean_actual_kw": 0.6035, "mean_pred_kw": 0.6046, "mape_pct": 26.00},
+    "9":  {"n": 12, "mae_kw": 0.3040, "rmse_kw": 0.4690, "bias_kw":  0.2379, "mean_actual_kw": 1.0340, "mean_pred_kw": 0.7961, "mape_pct": 23.91},
+    "10": {"n": 13, "mae_kw": 0.4222, "rmse_kw": 0.5478, "bias_kw":  0.1058, "mean_actual_kw": 1.4424, "mean_pred_kw": 1.3365, "mape_pct": 28.12},
+    "11": {"n": 13, "mae_kw": 0.3162, "rmse_kw": 0.5399, "bias_kw": -0.0701, "mean_actual_kw": 2.3634, "mean_pred_kw": 2.4335, "mape_pct": 18.48},
+    "12": {"n": 13, "mae_kw": 0.1750, "rmse_kw": 0.2592, "bias_kw": -0.0513, "mean_actual_kw": 2.5047, "mean_pred_kw": 2.5560, "mape_pct":  9.18},
+    "13": {"n": 13, "mae_kw": 0.2658, "rmse_kw": 0.3583, "bias_kw":  0.0275, "mean_actual_kw": 2.3807, "mean_pred_kw": 2.3532, "mape_pct": 12.76},
+    "14": {"n": 13, "mae_kw": 0.3437, "rmse_kw": 0.5983, "bias_kw":  0.1049, "mean_actual_kw": 2.0224, "mean_pred_kw": 1.9175, "mape_pct": 20.76},
+    "15": {"n": 12, "mae_kw": 0.2529, "rmse_kw": 0.3526, "bias_kw":  0.0547, "mean_actual_kw": 1.4139, "mean_pred_kw": 1.3592, "mape_pct": 55.51},
+    "16": {"n": 12, "mae_kw": 0.2450, "rmse_kw": 0.3442, "bias_kw": -0.0176, "mean_actual_kw": 0.7552, "mean_pred_kw": 0.7727, "mape_pct": 33.64},
+    "17": {"n": 12, "mae_kw": 0.1699, "rmse_kw": 0.2196, "bias_kw": -0.0166, "mean_actual_kw": 0.3398, "mean_pred_kw": 0.3565, "mape_pct": 89.39},
+    "18": {"n": 11, "mae_kw": 0.0474, "rmse_kw": 0.0604, "bias_kw":  0.0179, "mean_actual_kw": 0.0983, "mean_pred_kw": 0.0804, "mape_pct": 45.19},
+    "19": {"n": 3,  "mae_kw": 0.0483, "rmse_kw": 0.0486, "bias_kw": -0.0483, "mean_actual_kw": 0.0130, "mean_pred_kw": 0.0613, "mape_pct":  0.00}
+  }
+}

--- a/tests/test_pv_forecast_accuracy.py
+++ b/tests/test_pv_forecast_accuracy.py
@@ -1,0 +1,126 @@
+"""Regression-baseline evaluator for PV forecast accuracy.
+
+Captures MAE/RMSE/bias per hour and overall. Used to compare any
+calibration improvement (cloud-aware bias, MOS regression, etc.) against
+the post-#230 baseline. A real improvement reduces these metrics; a
+no-op change leaves them unchanged.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+
+
+def _seed_day_with_samples(d: date, hour_kw: dict[int, float],
+                            forecast_irr: dict[int, float]) -> None:
+    """Seed a day's worth of measurements + forecast for given hours."""
+    for h, kw in hour_kw.items():
+        for minute in (0, 15, 30, 45):
+            ts = datetime.combine(d, datetime.min.time()).replace(hour=h, minute=minute, tzinfo=UTC)
+            db.save_pv_realtime_sample(
+                captured_at=ts.isoformat().replace("+00:00", "Z"),
+                solar_power_kw=kw, soc_pct=50.0, load_power_kw=0.5,
+                grid_import_kw=0.0, grid_export_kw=kw,
+                battery_charge_kw=0.0, battery_discharge_kw=0.0, source="seed",
+            )
+    rows = []
+    for h, irr in forecast_irr.items():
+        ts = datetime.combine(d, datetime.min.time()).replace(hour=h, tzinfo=UTC)
+        rows.append({"slot_time": ts.isoformat(), "temp_c": 15.0, "solar_w_m2": irr})
+    db.save_meteo_forecast(rows, d.isoformat())
+
+
+def test_evaluator_returns_zero_when_no_data() -> None:
+    from src.weather import evaluate_pv_forecast_accuracy
+    out = evaluate_pv_forecast_accuracy(window_days=7)
+    assert out["n_paired"] == 0
+    assert out["overall"]["n"] == 0
+
+
+def test_perfect_prediction_zero_error() -> None:
+    """Forecast 800 W/m² → estimate_pv_kw ≈ 3.06 kW, calibration 1.0 → predicted 3.06.
+    If actual is also 3.06 kW: MAE/RMSE/bias all ~0."""
+    from src.weather import evaluate_pv_forecast_accuracy
+
+    # No per-hour calibration table → uses flat calibration
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    # Calibrate predicted to actual: pick irradiance such that estimate_pv_kw × flat_cal = 3.06
+    # estimate_pv_kw(800) = 4.5 × 0.8 × 0.85 = 3.06
+    # We want actual = 3.06 too. With flat cal computed from history... too complex.
+    # Simpler: insert a calibration factor 1.0 directly so predicted == raw forecast.
+    db.upsert_pv_calibration_hourly({h: 1.0 for h in range(6, 19)},
+                                     {h: 50 for h in range(6, 19)}, window_days=14)
+    _seed_day_with_samples(yesterday, hour_kw={12: 3.06}, forecast_irr={12: 800.0})
+
+    out = evaluate_pv_forecast_accuracy(window_days=2)
+    assert out["n_paired"] >= 1
+    assert out["overall"]["mae_kw"] < 0.1  # near-zero
+    assert abs(out["overall"]["bias_kw"]) < 0.1
+
+
+def test_systematic_under_prediction_shows_positive_bias() -> None:
+    """Forecast says 1.5 kW but reality is 3.0 kW (system under-predicts).
+    bias_kw should be positive (actual > predicted)."""
+    from src.weather import evaluate_pv_forecast_accuracy
+
+    db.upsert_pv_calibration_hourly({h: 1.0 for h in range(6, 19)},
+                                     {h: 50 for h in range(6, 19)}, window_days=14)
+    yesterday = date.today() - timedelta(days=1)
+    # estimate_pv_kw(400) = 1.53 kW. Reality is 3.0 kW.
+    _seed_day_with_samples(yesterday, hour_kw={12: 3.0}, forecast_irr={12: 400.0})
+
+    out = evaluate_pv_forecast_accuracy(window_days=2)
+    assert out["overall"]["bias_kw"] > 0.5, (
+        f"Expected positive bias (actual > predicted), got {out['overall']['bias_kw']}"
+    )
+
+
+def test_per_hour_breakdown_present() -> None:
+    """The per_hour dict should have one entry per hour with measurements."""
+    from src.weather import evaluate_pv_forecast_accuracy
+
+    db.upsert_pv_calibration_hourly({h: 1.0 for h in range(6, 19)},
+                                     {h: 50 for h in range(6, 19)}, window_days=14)
+    yesterday = date.today() - timedelta(days=1)
+    _seed_day_with_samples(yesterday,
+                            hour_kw={10: 1.5, 12: 3.0, 14: 2.5},
+                            forecast_irr={10: 500.0, 12: 800.0, 14: 700.0})
+
+    out = evaluate_pv_forecast_accuracy(window_days=2)
+    assert set(out["per_hour"].keys()) == {10, 12, 14}
+    for h, stats in out["per_hour"].items():
+        assert stats["n"] >= 1
+        for k in ("mae_kw", "rmse_kw", "bias_kw", "mean_actual_kw", "mean_pred_kw"):
+            assert k in stats
+
+
+def test_dawn_dusk_excluded_when_both_below_threshold() -> None:
+    """Both predicted AND actual < 0.05 kW → exclude (dawn/dusk noise)."""
+    from src.weather import evaluate_pv_forecast_accuracy
+
+    db.upsert_pv_calibration_hourly({h: 1.0 for h in range(0, 24)},
+                                     {h: 50 for h in range(0, 24)}, window_days=14)
+    yesterday = date.today() - timedelta(days=1)
+    # Tiny dawn samples: predicted estimate_pv_kw(5) = 0.019 kW, actual 0.01 kW — both excluded
+    _seed_day_with_samples(yesterday,
+                            hour_kw={5: 0.01, 12: 2.0},
+                            forecast_irr={5: 5.0, 12: 600.0})
+
+    out = evaluate_pv_forecast_accuracy(window_days=2, min_kw=0.05)
+    # Hour 5 should be excluded (both < 0.05)
+    assert 5 not in out["per_hour"]
+    # Hour 12 still present
+    assert 12 in out["per_hour"]


### PR DESCRIPTION
## Summary

Per user request before shipping (A) cloud-aware bias: capture an objective baseline so any future calibration change can be measured, not vibed.

## What's in

| File | Purpose |
|---|---|
| `src/weather.py::evaluate_pv_forecast_accuracy()` | Per-hour + overall MAE/RMSE/bias/MAPE for the trailing N days |
| `tests/fixtures/pv_forecast_baseline.json` | Snapshot of post-#230 prod accuracy (30 days, 169 paired hours) |
| `scripts/check_pv_forecast_accuracy.py` | Post-deploy diff against baseline; exit 1 on >5% regression |
| `tests/test_pv_forecast_accuracy.py` | 5 unit cases |

## Post-#230 baseline (captured 2026-05-02T16:05Z, 30-day prod window)

| | |
|---|---|
| Overall MAE | **0.21 kW** |
| Overall RMSE | **0.36 kW** |
| Overall bias | **+0.025 kW** (near-zero — sparse-fix worked) |
| MAPE | **30%** |
| n_paired | 169 hours |

**Per-hour highlights:**
- Best: hour 12 (MAE 0.18 / actual 2.5 = 7%)
- Worst abs: hour 10 (MAE 0.42 — biggest cloud variance)
- Bias > 0.1 kW under-prediction: hours 9, 10, 14 → prime candidates for cloud-aware lifting

## Workflow for future calibration PRs (#A, #B, #C)

1. Implement change
2. Deploy
3. `scripts/check_pv_forecast_accuracy.py` on prod
4. If ✅ improvement → ship with the comparison output in the PR
5. If ❌ regression → abandon
6. If ➖ neutral → reconsider whether worth the maintenance

## Test plan
- [x] `pytest tests/test_pv_forecast_accuracy.py -v` — 5/5 pass
- [x] Baseline captured live on prod (numbers above)
- [ ] After cloud-aware bias (PR #A) ships: re-run script, attach output to that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)