### PR TITLE
chore(brief): surface raw-tariff peak windows + drop dead pnl_execution_log

### DIFF
--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -70,6 +70,12 @@ def build_morning_payload() -> str:
     ]
     if tier_summary:
         lines.extend(["**Tariff windows today:**", tier_summary, ""])
+    # Tomorrow's peak windows surfaced separately so a low-action day
+    # (no LP `peak` slots) doesn't read as "no peaks tomorrow" when
+    # Octopus actually has an expensive evening.
+    tomorrow_peaks = _tariff_peak_windows_summary(today + timedelta(days=1), tz)
+    if tomorrow_peaks:
+        lines.extend([f"**Tomorrow ({today + timedelta(days=1)}):**", tomorrow_peaks, ""])
     if pe_summary:
         lines.extend(["**Peak-export plan:**", pe_summary, ""])
 
@@ -120,6 +126,12 @@ def build_night_payload() -> str:
     lines.append(f"- SLA sample: {sla.get('sample_size', 0)} actions")
     if pe_today:
         lines.extend(["", "**Peak-export verdicts today:**", pe_today])
+    # Heads-up for tomorrow's expensive windows so the family knows when
+    # to expect the LP to draw the battery hardest. Independent of the
+    # LP `peak` classification (which counts shave actions, not raw price).
+    tomorrow_peaks = _tariff_peak_windows_summary(today + timedelta(days=1), tz)
+    if tomorrow_peaks:
+        lines.extend(["", f"**Heads-up for tomorrow:** {tomorrow_peaks}"])
     return "\n".join(lines)
 
 
@@ -262,6 +274,56 @@ def _forecasted_export_for_day(day: date, tz: ZoneInfo) -> tuple[float, float, i
 # --------------------------------------------------------------------------
 # Helpers — tier windows + peak-export read-out
 # --------------------------------------------------------------------------
+
+def _tariff_peak_windows_summary(day: date, tz: ZoneInfo) -> str | None:
+    """Surface raw-tariff peak windows independent of LP slot classification.
+
+    Originally the brief only quoted the LP's ``kind_counts`` summary
+    (``peak=N``). That count is **dispatch action**, not tariff signal: when
+    PV+battery cover load through expensive hours, slots stay ``standard`` and
+    ``peak=0`` even though Octopus has a 36p evening. The family reads
+    "peak=0" as "no expensive slots tomorrow", which is wrong.
+
+    This helper queries Octopus rates directly for ``day`` and returns a one-line
+    summary of consecutive slots ≥ ``BRIEF_TARIFF_PEAK_THRESHOLD_PENCE`` (default
+    25 p). Returns None when the day has no peak window or rates aren't loaded.
+    """
+    threshold = float(getattr(config, "BRIEF_TARIFF_PEAK_THRESHOLD_PENCE", 25.0))
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    if not tariff:
+        return None
+    try:
+        rows = db.get_agile_rates_slots_for_local_day(tariff, day, tz_name=str(tz))
+    except Exception:
+        return None
+    if not rows:
+        return None
+    peaks = [r for r in rows if float(r["value_inc_vat"]) >= threshold]
+    if not peaks:
+        return None
+    # Find the longest contiguous block of peak slots (most useful summary)
+    peak_starts = sorted(
+        datetime.fromisoformat(str(r["valid_from"]).replace("Z", "+00:00"))
+        for r in peaks
+    )
+    if not peak_starts:
+        return None
+    blocks: list[list[datetime]] = [[peak_starts[0]]]
+    for ts in peak_starts[1:]:
+        prev = blocks[-1][-1]
+        if (ts - prev).total_seconds() <= 30 * 60 + 1:   # contiguous half-hours
+            blocks[-1].append(ts)
+        else:
+            blocks.append([ts])
+    longest = max(blocks, key=len)
+    block_start_local = longest[0].astimezone(tz)
+    block_end_local = (longest[-1] + timedelta(minutes=30)).astimezone(tz)
+    max_p = max(float(r["value_inc_vat"]) for r in peaks)
+    return (
+        f"⚠️ Tariff peak: **{block_start_local:%H:%M}–{block_end_local:%H:%M}** "
+        f"(max {max_p:.1f}p, {len(peaks)} slots ≥ {threshold:.0f}p)"
+    )
+
 
 def _today_tier_window_summary(today: date, tz: ZoneInfo) -> str | None:
     """Reuse the family-calendar tier classification for the morning brief.

--- a/src/db.py
+++ b/src/db.py
@@ -161,17 +161,6 @@ CREATE TABLE IF NOT EXISTS meteo_forecast (
     UNIQUE(slot_time)
 );
 
-CREATE TABLE IF NOT EXISTS pnl_execution_log (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    slot_time TEXT NOT NULL,
-    kwh_consumed REAL,
-    agile_price_pence REAL,
-    svt_price_pence REAL,
-    delta_pence REAL
-);
-
-CREATE INDEX IF NOT EXISTS idx_pnl_execution_log_slot ON pnl_execution_log(slot_time);
-
 CREATE TABLE IF NOT EXISTS api_call_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     vendor TEXT NOT NULL,
@@ -292,7 +281,7 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     if "overridden_by_user_at" not in as_cols:
         conn.execute("ALTER TABLE action_schedule ADD COLUMN overridden_by_user_at TEXT")
 
-    # V2: meteo_forecast and pnl_execution_log tables (may already exist via SCHEMA)
+    # V2: meteo_forecast (may already exist via SCHEMA constant)
     conn.execute(
         """CREATE TABLE IF NOT EXISTS meteo_forecast (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -309,19 +298,9 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     mf_cols = {str(r[1]) for r in cur.fetchall()}
     if "cloud_cover_pct" not in mf_cols:
         conn.execute("ALTER TABLE meteo_forecast ADD COLUMN cloud_cover_pct REAL")
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS pnl_execution_log (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            slot_time TEXT NOT NULL,
-            kwh_consumed REAL,
-            agile_price_pence REAL,
-            svt_price_pence REAL,
-            delta_pence REAL
-        )"""
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_pnl_execution_log_slot ON pnl_execution_log(slot_time)"
-    )
+    # V2 cleanup: pnl_execution_log was a never-populated stale schema (helper
+    # functions existed but had zero call sites). Drop it on existing prod DBs.
+    conn.execute("DROP TABLE IF EXISTS pnl_execution_log")
 
     # V3: fox_energy_daily — actual daily PV, load, import, export from Fox ESS
     conn.execute(
@@ -2335,93 +2314,6 @@ def get_micro_climate_offset_c(lookback: int = 96) -> float:
             return float(val)
         finally:
             conn.close()
-
-
-# ---------------------------------------------------------------------------
-# V2: pnl_execution_log
-# ---------------------------------------------------------------------------
-
-def log_pnl_execution(row: dict[str, Any]) -> int:
-    """Insert one row into pnl_execution_log. Returns new row id."""
-    with _lock:
-        conn = get_connection()
-        try:
-            cur = conn.execute(
-                """INSERT INTO pnl_execution_log
-                   (slot_time, kwh_consumed, agile_price_pence, svt_price_pence, delta_pence)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (
-                    row.get("slot_time"),
-                    row.get("kwh_consumed"),
-                    row.get("agile_price_pence"),
-                    row.get("svt_price_pence"),
-                    row.get("delta_pence"),
-                ),
-            )
-            conn.commit()
-            return int(cur.lastrowid)
-        finally:
-            conn.close()
-
-
-def get_pnl_execution_logs(
-    from_slot: str | None = None,
-    to_slot: str | None = None,
-    limit: int = 500,
-) -> list[dict[str, Any]]:
-    """Return pnl_execution_log rows in descending slot_time order."""
-    with _lock:
-        conn = get_connection()
-        try:
-            q = "SELECT * FROM pnl_execution_log WHERE 1=1"
-            args: list[Any] = []
-            if from_slot:
-                q += " AND slot_time >= ?"
-                args.append(from_slot)
-            if to_slot:
-                q += " AND slot_time <= ?"
-                args.append(to_slot)
-            q += " ORDER BY slot_time DESC LIMIT ?"
-            args.append(limit)
-            cur = conn.execute(q, args)
-            return [dict(r) for r in cur.fetchall()]
-        finally:
-            conn.close()
-
-
-def get_pnl_summary_for_date(date_str: str) -> dict[str, Any]:
-    """Return PnL summary metrics (VWAP, total kWh, total saving) for one day."""
-    rows = get_pnl_execution_logs(
-        from_slot=f"{date_str}T00:00:00Z",
-        to_slot=f"{date_str}T23:59:59Z",
-        limit=10000,
-    )
-    if not rows:
-        return {"date": date_str, "slots": 0, "total_kwh": 0.0, "total_cost_pence": 0.0,
-                "total_saving_pence": 0.0, "vwap_pence": 0.0, "slippage_pence": 0.0}
-
-    total_kwh = sum(float(r.get("kwh_consumed") or 0) for r in rows)
-    total_cost = sum(
-        float(r.get("kwh_consumed") or 0) * float(r.get("agile_price_pence") or 0) for r in rows
-    )
-    total_svt = sum(
-        float(r.get("kwh_consumed") or 0) * float(r.get("svt_price_pence") or 0) for r in rows
-    )
-    total_saving = sum(float(r.get("delta_pence") or 0) for r in rows)
-    vwap = total_cost / total_kwh if total_kwh else 0.0
-    svt_vwap = total_svt / total_kwh if total_kwh else 0.0
-    slippage = svt_vwap - vwap
-
-    return {
-        "date": date_str,
-        "slots": len(rows),
-        "total_kwh": round(total_kwh, 3),
-        "total_cost_pence": round(total_cost, 2),
-        "total_saving_pence": round(total_saving, 2),
-        "vwap_pence": round(vwap, 3),
-        "svt_vwap_pence": round(svt_vwap, 3),
-        "slippage_pence": round(slippage, 3),
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_brief_tariff_peak_windows.py
+++ b/tests/test_brief_tariff_peak_windows.py
@@ -1,0 +1,99 @@
+"""Tariff peak windows surfaced in brief — independent of LP `peak` count.
+
+When PV+battery cover load through expensive Octopus hours, LP `kind_counts`
+shows ``peak=0`` even though the tariff has a 36p evening. The family reads
+"peak=0" as "no expensive slots tomorrow", which is wrong.
+
+`_tariff_peak_windows_summary` is the fix: it queries Octopus rates directly
+and returns a one-line "Tariff peak: 17:00–19:30 (max 36.4p, 6 slots ≥ 25p)"
+that the morning + night briefs include unconditionally.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db
+from src.analytics.daily_brief import _tariff_peak_windows_summary
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", "AGILE-TEST")
+
+
+def _seed_day(target_local_date: date, evening_peak_p: float = 36.0,
+              cheap_p: float = 9.0, peak_block_hours: tuple[int, int] = (17, 19)) -> None:
+    """Seed 48 half-hour rates for a local day. Peak block in BST hours given."""
+    tz = ZoneInfo("Europe/London")
+    rates: list[dict] = []
+    # Iterate 48 half-hour slots in local time, then convert to UTC for storage.
+    start_local = datetime.combine(target_local_date, datetime.min.time(), tzinfo=tz)
+    for i in range(48):
+        slot_start_local = start_local + timedelta(minutes=30 * i)
+        slot_end_local = slot_start_local + timedelta(minutes=30)
+        local_hour = slot_start_local.hour
+        if peak_block_hours[0] <= local_hour < peak_block_hours[1] + 1:
+            price = evening_peak_p
+        else:
+            price = cheap_p
+        rates.append({
+            "valid_from": slot_start_local.astimezone(UTC).isoformat(),
+            "valid_to": slot_end_local.astimezone(UTC).isoformat(),
+            "value_inc_vat": price,
+        })
+    db.save_agile_rates(rates, "AGILE-TEST")
+
+
+def test_returns_none_when_no_rates_loaded() -> None:
+    out = _tariff_peak_windows_summary(date.today(), ZoneInfo("Europe/London"))
+    assert out is None
+
+
+def test_returns_none_when_no_slots_above_threshold() -> None:
+    """All-cheap day → no peak window to surface."""
+    target = date.today() + timedelta(days=1)
+    _seed_day(target, evening_peak_p=12.0, cheap_p=8.0)   # both well below 25p
+    out = _tariff_peak_windows_summary(target, ZoneInfo("Europe/London"))
+    assert out is None
+
+
+def test_surfaces_evening_peak_block() -> None:
+    """Sun 17:00–19:30 BST at 36p → expected one-line summary covering that window."""
+    target = date.today() + timedelta(days=1)
+    _seed_day(target, evening_peak_p=36.4, cheap_p=15.0,
+              peak_block_hours=(17, 19))                  # 17:00 → 19:59 BST
+    out = _tariff_peak_windows_summary(target, ZoneInfo("Europe/London"))
+    assert out is not None
+    assert "Tariff peak" in out
+    assert "17:00" in out
+    assert "20:00" in out                                  # block end is exclusive end of last slot
+    assert "36.4p" in out
+
+
+def test_threshold_configurable() -> None:
+    """Lower threshold should surface windows that the default 25p hides."""
+    target = date.today() + timedelta(days=1)
+    _seed_day(target, evening_peak_p=22.0, cheap_p=8.0,
+              peak_block_hours=(17, 19))
+    # Default threshold (25p) → no peak
+    out_default = _tariff_peak_windows_summary(target, ZoneInfo("Europe/London"))
+    assert out_default is None
+    # Lowered threshold (20p) → window surfaces
+    import src.config as cfg_mod
+    cfg_mod.config.BRIEF_TARIFF_PEAK_THRESHOLD_PENCE = 20.0
+    try:
+        out_low = _tariff_peak_windows_summary(target, ZoneInfo("Europe/London"))
+        assert out_low is not None
+        assert "22.0p" in out_low
+    finally:
+        delattr(cfg_mod.config, "BRIEF_TARIFF_PEAK_THRESHOLD_PENCE")


### PR DESCRIPTION
## Summary

Two post-audit cleanups bundled (small enough that one PR is cleaner than two).

### A. Brief — tomorrow's tariff peaks surfaced independently of LP classification

When PV+battery cover load through expensive Octopus hours, the LP's
\`kind_counts.peak\` shows 0 even though the tariff has a 36p evening. The
family was reading that as "no expensive slots tomorrow", which is wrong.

Adds \`_tariff_peak_windows_summary\` that queries Octopus rates directly
and returns a one-line summary like \`Tariff peak: 17:00–20:00 (max 36.4p, 6 slots ≥ 25p)\`.
Wired into both morning + night briefs as a tomorrow heads-up.

Threshold tunable via \`BRIEF_TARIFF_PEAK_THRESHOLD_PENCE\` (default 25 p).

### B. Drop dead \`pnl_execution_log\` table + readers

Removed:
- The \`CREATE TABLE pnl_execution_log\` from the SCHEMA constant + the duplicate in \`_migrate_schema\`
- \`log_pnl_execution\`, \`get_pnl_execution_logs\`, \`get_pnl_summary_for_date\` (all had zero call sites)
- Added \`DROP TABLE IF EXISTS pnl_execution_log\` migration so existing prod DBs lose it on next boot

The active table is \`execution_log\`, populated daily by \`bulletproof_consumption_backfill_job\` (verified on prod: 15 days × 48 rows; latest row 17:01 UTC today).

## Test plan

- [x] 4 new unit tests covering: no rates → None; all-cheap day → None; evening peak surfaces correctly; threshold configurable
- [x] Full suite green: 818 passed / 1 skipped
- [ ] Live verify next morning brief shows the tomorrow heads-up line when the day has > 25p slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)