### PR TITLE
feat(appliance): laundry start/finish notifications via OpenClaw hook

### DIFF
--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -263,6 +263,97 @@ def _forecasted_export_for_day(day: date, tz: ZoneInfo) -> tuple[float, float, i
 # Helpers — tier windows + peak-export read-out
 # --------------------------------------------------------------------------
 
+def build_brief_48h_summary(now_utc: datetime | None = None) -> str:
+    """Compact 4-line forward-looking summary for inline notifications.
+
+    Designed for laundry-start / laundry-finish hooks (PR #234) — short
+    enough to read on a phone, structured enough to skim. Lines:
+
+      🔆 Today: <tier windows>
+      🔆 Tomorrow: <tier windows>
+      💰 Today net so far: <amount> (vs SVT shadow <amount>)
+      🔋 Battery <soc>% · slots scheduled: ...
+
+    Each line silently degrades to "n/a" rather than crashing when its
+    upstream data is missing (no PnL row yet, no rates loaded, snapshot
+    stale). Caller can string-append into a longer body.
+    """
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+    today = datetime.now(tz).date() if now_utc is None else now_utc.astimezone(tz).date()
+    tomorrow = today + timedelta(days=1)
+
+    # Line 1 + 2 — today / tomorrow tier classification (compact form)
+    def _compact_tier(day: date) -> str:
+        try:
+            from ..google_calendar.tiers import Slot, classify_day
+        except Exception:
+            return "n/a"
+        tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+        if not tariff:
+            return "n/a"
+        try:
+            rows = db.get_agile_rates_slots_for_local_day(tariff, day, tz_name=str(tz))
+        except Exception:
+            return "n/a"
+        if not rows:
+            return "n/a"
+        slots = [
+            Slot(
+                start_utc=datetime.fromisoformat(str(r["valid_from"]).replace("Z", "+00:00")),
+                end_utc=datetime.fromisoformat(str(r["valid_to"]).replace("Z", "+00:00")),
+                price_p=float(r["value_inc_vat"]),
+            )
+            for r in rows
+        ]
+        windows = classify_day(slots) or []
+        if not windows:
+            return "no tier classification"
+        # Compact: just the cheapest + most expensive blocks
+        parts: list[str] = []
+        for w in windows:
+            if w.tier.title.lower() in {"cheap", "negative", "peak"}:
+                local_start = w.start_utc.astimezone(tz).strftime("%H:%M")
+                local_end = w.end_utc.astimezone(tz).strftime("%H:%M")
+                parts.append(
+                    f"{w.tier.emoji} {local_start}–{local_end} "
+                    f"({w.price_min:.1f}–{w.price_max:.1f}p)"
+                )
+        return " · ".join(parts) if parts else "all standard"
+
+    today_line = _compact_tier(today)
+    tomorrow_line = _compact_tier(tomorrow)
+
+    # Line 3 — running PnL today (best-effort)
+    pnl_line = "n/a"
+    try:
+        pnl = compute_daily_pnl(today)
+        if pnl and "realised_cost_gbp" in pnl:
+            net = pnl["realised_cost_gbp"]
+            svt = pnl.get("svt_shadow_gbp")
+            if svt is not None:
+                pnl_line = f"net £{net:+.2f} (SVT shadow £{svt:+.2f})"
+            else:
+                pnl_line = f"net £{net:+.2f}"
+    except Exception:
+        pass
+
+    # Line 4 — battery SoC + small forward indicator
+    bat_line = "n/a"
+    try:
+        snap = db.get_fox_realtime_snapshot()
+        if snap and snap.get("soc_pct") is not None:
+            bat_line = f"SoC {float(snap['soc_pct']):.0f}%"
+    except Exception:
+        pass
+
+    return (
+        f"🔆 Today: {today_line}\n"
+        f"🔆 Tomorrow: {tomorrow_line}\n"
+        f"💰 Today PnL: {pnl_line}\n"
+        f"🔋 Battery {bat_line}"
+    )
+
+
 def _today_tier_window_summary(today: date, tz: ZoneInfo) -> str | None:
     """Reuse the family-calendar tier classification for the morning brief.
 

--- a/src/db.py
+++ b/src/db.py
@@ -750,6 +750,13 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         "ON appliance_jobs(appliance_id) "
         "WHERE status IN ('scheduled', 'running')"
     )
+    # PR #234: cycle-completion poll. Records when the post-fire poller
+    # detected the unit transition out of `run`/`pause` (used to time the
+    # finished-laundry notification + downstream metrics).
+    cur = conn.execute("PRAGMA table_info(appliance_jobs)")
+    aj_cols = {str(r[1]) for r in cur.fetchall()}
+    if "completed_at_utc" not in aj_cols:
+        conn.execute("ALTER TABLE appliance_jobs ADD COLUMN completed_at_utc TEXT")
 
 
 def init_db() -> None:
@@ -4208,6 +4215,7 @@ _APPLIANCE_JOB_UPDATABLE_FIELDS = {
     "status", "planned_start_utc", "planned_end_utc",
     "avg_price_pence", "actual_start_utc", "error_msg",
     "last_replan_at_utc", "duration_minutes", "deadline_utc",
+    "completed_at_utc",
 }
 
 

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -44,6 +44,9 @@ class AlertType(str, Enum):
     NIGHT_BRIEF = "night_brief"
     PLAN_REVISION = "plan_revision"
     NEGATIVE_WINDOW_START = "negative_window_start"
+    # PR #234 — appliance lifecycle (laundry start/finish)
+    APPLIANCE_STARTING = "appliance_starting"
+    APPLIANCE_FINISHED = "appliance_finished"
 
 
 # OpenClaw hook payload ``name`` field (one stable label per alert key)
@@ -60,6 +63,8 @@ _HOOK_PAYLOAD_NAMES: dict[str, str] = {
     "night_brief": "EnergyNightBrief",
     "plan_revision": "EnergyPlanRevision",
     "negative_window_start": "EnergyNegativeWindow",
+    "appliance_starting": "EnergyApplianceStart",
+    "appliance_finished": "EnergyApplianceFinish",
 }
 
 
@@ -352,6 +357,79 @@ def notify_night_brief(body: str) -> None:
     can be configured per-AlertType in the ``notification_routes`` table.
     """
     _dispatch(AlertType.NIGHT_BRIEF, body, urgent=False)
+
+
+def notify_appliance_starting(
+    *,
+    appliance_name: str,
+    planned_start_local: str,
+    deadline_local: str,
+    avg_price_pence: float,
+    duration_minutes: int,
+    brief_md: str | None = None,
+) -> None:
+    """🧺 Cycle is starting now (LP-armed cron just fired ``setMachineState run``).
+
+    Inlines a 4-line forward-looking brief so the family sees today + tomorrow
+    tariff windows and the running PnL alongside the start confirmation.
+    """
+    body_lines = [
+        f"🧺 **{appliance_name}** starting now",
+        f"Window: {planned_start_local} → end ≤ {deadline_local}",
+        f"Cycle: {duration_minutes} min · avg {avg_price_pence:.1f}p/kWh",
+    ]
+    if brief_md:
+        body_lines.extend(["", brief_md])
+    body = "\n".join(body_lines)
+    extra = {
+        "appliance": appliance_name,
+        "planned_start_local": planned_start_local,
+        "deadline_local": deadline_local,
+        "avg_price_pence": round(float(avg_price_pence), 2),
+        "duration_minutes": int(duration_minutes),
+    }
+    _dispatch(AlertType.APPLIANCE_STARTING, body, urgent=False, extra=extra)
+
+
+def notify_appliance_finished(
+    *,
+    appliance_name: str,
+    started_local: str,
+    ended_local: str,
+    duration_minutes: int,
+    avg_price_pence: float | None = None,
+    estimated_kwh: float | None = None,
+    estimated_cost_p: float | None = None,
+    brief_md: str | None = None,
+) -> None:
+    """✅ Cycle has finished (poll detected state transition out of ``run``).
+
+    Includes a concise outcome line + same 4-line brief so the family closes
+    the loop on cost and sees what's coming next.
+    """
+    cost_line = ""
+    if estimated_kwh is not None and estimated_cost_p is not None:
+        cost_line = f"≈ {estimated_kwh:.2f} kWh ≈ {estimated_cost_p:.1f}p"
+    elif avg_price_pence is not None:
+        cost_line = f"avg {avg_price_pence:.1f}p/kWh"
+    body_lines = [
+        f"✅ **{appliance_name}** cycle complete",
+        f"{started_local} → {ended_local} ({duration_minutes} min)" + (f" · {cost_line}" if cost_line else ""),
+    ]
+    if brief_md:
+        body_lines.extend(["", brief_md])
+    body = "\n".join(body_lines)
+    extra = {
+        "appliance": appliance_name,
+        "started_local": started_local,
+        "ended_local": ended_local,
+        "duration_minutes": int(duration_minutes),
+    }
+    if estimated_kwh is not None:
+        extra["estimated_kwh"] = round(float(estimated_kwh), 3)
+    if estimated_cost_p is not None:
+        extra["estimated_cost_pence"] = round(float(estimated_cost_p), 2)
+    _dispatch(AlertType.APPLIANCE_FINISHED, body, urgent=False, extra=extra)
 
 
 def notify_plan_revision(body: str, *, trigger_reason: str | None = None) -> None:

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -503,6 +503,10 @@ def reconcile() -> None:
     Reads the current SmartThings ``remoteControlEnabled`` for each appliance
     and arms / cancels / re-plans accordingly. Never raises — failures are
     logged + counted; callers see best-effort behaviour.
+
+    Also polls running jobs for cycle completion (PR #234) — single SmartThings
+    call per running job, fires ``notify_appliance_finished`` on transition
+    out of ``run``/``pause``.
     """
     if not config.APPLIANCE_DISPATCH_ENABLED:
         return
@@ -520,6 +524,115 @@ def reconcile() -> None:
             logger.exception(
                 "appliance reconcile: _reconcile_one failed for #%s",
                 appliance.get("id"),
+            )
+    # PR #234: cycle-completion poll. Runs after the arm/cancel pass so we
+    # don't re-fire a notification for a job that just got armed.
+    try:
+        _poll_running_jobs()
+    except Exception:
+        logger.exception("appliance reconcile: _poll_running_jobs failed (non-fatal)")
+
+
+def _poll_running_jobs() -> None:
+    """Detect cycle completion on every running job and fire the finished hook.
+
+    A job stays in ``status='running'`` until SmartThings reports the unit
+    has left ``run``/``pause``. On detection: mark ``status='completed'``,
+    stamp ``completed_at_utc``, and dispatch one ``APPLIANCE_FINISHED``
+    notification (idempotent — DB update is the dedup key).
+
+    Best-effort: any error short-circuits this single job, never blocks
+    the broader reconcile pass.
+    """
+    try:
+        running_jobs = db.get_appliance_jobs(status="running", limit=20)
+    except Exception:
+        logger.exception("poll_running: list jobs failed")
+        return
+    if not running_jobs:
+        return
+
+    try:
+        client = _get_st_client()
+    except SmartThingsError as e:
+        logger.debug("poll_running: SmartThings client unavailable (%s) — skipping pass", e.code)
+        return
+
+    for job in running_jobs:
+        try:
+            appliance = db.get_appliance(int(job["appliance_id"]))
+            if appliance is None:
+                continue
+            state = client.get_machine_state(appliance["vendor_device_id"])
+        except SmartThingsError as e:
+            logger.debug(
+                "poll_running: machine_state lookup failed for job %s (%s) — retry next pass",
+                job.get("id"), e.code,
+            )
+            continue
+
+        if state in (None, "run", "pause"):
+            # Still running (or capability unavailable — don't guess).
+            continue
+
+        # Transitioned out → mark complete and notify.
+        ended_at = _iso(_now_utc())
+        try:
+            db.update_appliance_job(
+                int(job["id"]), status="completed", completed_at_utc=ended_at,
+            )
+        except Exception:
+            logger.exception("poll_running: DB update_appliance_job failed for %s", job.get("id"))
+            continue
+
+        logger.info(
+            "appliance complete: job %s state=%s, marking completed",
+            job.get("id"), state,
+        )
+
+        # Build the finished notification (best-effort)
+        try:
+            from ..analytics.daily_brief import build_brief_48h_summary
+            from ..notifier import notify_appliance_finished
+            tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+            actual_start = job.get("actual_start_utc") or job.get("planned_start_utc")
+            started_local_str = "—"
+            duration_min = int(job.get("duration_minutes") or 0)
+            if actual_start:
+                start_dt = datetime.fromisoformat(
+                    str(actual_start).replace("Z", "+00:00")
+                ).astimezone(tz)
+                started_local_str = start_dt.strftime("%H:%M")
+                end_dt = datetime.fromisoformat(ended_at.replace("Z", "+00:00")).astimezone(tz)
+                duration_min = max(1, int((end_dt - start_dt).total_seconds() // 60))
+            ended_local_dt = datetime.fromisoformat(ended_at.replace("Z", "+00:00")).astimezone(tz)
+            avg_p = job.get("avg_price_pence")
+            est_kwh = None
+            est_cost_p = None
+            try:
+                typical_kw = float(appliance.get("typical_kw") or 0.0)
+                if typical_kw > 0 and duration_min > 0:
+                    est_kwh = typical_kw * (duration_min / 60.0)
+                    if avg_p is not None:
+                        est_cost_p = est_kwh * float(avg_p)
+            except (TypeError, ValueError):
+                pass
+            notify_appliance_finished(
+                appliance_name=str(
+                    appliance.get("name") or appliance.get("device_type") or "Appliance"
+                ),
+                started_local=started_local_str,
+                ended_local=ended_local_dt.strftime("%H:%M"),
+                duration_minutes=duration_min,
+                avg_price_pence=float(avg_p) if avg_p is not None else None,
+                estimated_kwh=est_kwh,
+                estimated_cost_p=est_cost_p,
+                brief_md=build_brief_48h_summary(),
+            )
+        except Exception:
+            logger.exception(
+                "poll_running: finished-notification failed for job %s (non-fatal)",
+                job.get("id"),
             )
 
 
@@ -827,6 +940,29 @@ def _fire_cron(job_id: int) -> None:
         int(job_id), status="running", actual_start_utc=actual_start,
     )
     logger.info("appliance fire: job %d → running", job_id)
+
+    # PR #234: notify the family that laundry is starting + inline forward brief.
+    # Best-effort — never let a notification failure block the dispatch path.
+    try:
+        from ..analytics.daily_brief import build_brief_48h_summary
+        from ..notifier import notify_appliance_starting
+        tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+        planned_start = datetime.fromisoformat(
+            str(job["planned_start_utc"]).replace("Z", "+00:00")
+        ).astimezone(tz)
+        deadline = datetime.fromisoformat(
+            str(job["deadline_utc"]).replace("Z", "+00:00")
+        ).astimezone(tz)
+        notify_appliance_starting(
+            appliance_name=str(appliance.get("name") or appliance.get("device_type") or "Appliance"),
+            planned_start_local=planned_start.strftime("%a %H:%M"),
+            deadline_local=deadline.strftime("%a %H:%M"),
+            avg_price_pence=float(job.get("avg_price_pence") or 0.0),
+            duration_minutes=int(job.get("duration_minutes") or 0),
+            brief_md=build_brief_48h_summary(),
+        )
+    except Exception:
+        logger.exception("appliance fire: starting-notification failed (non-fatal)")
 
 
 # ---------------------------------------------------------------------------

--- a/src/smartthings/client.py
+++ b/src/smartthings/client.py
@@ -112,6 +112,29 @@ class SmartThingsClient:
             return v.strip().lower() == "true"
         return False
 
+    def get_machine_state(self, device_id: str) -> str | None:
+        """Return ``washerOperatingState.machineState`` value (run/pause/stop/finish/...).
+
+        Returns ``None`` when the capability isn't present in the response or
+        the value isn't parseable. Used by the cycle-completion poller
+        (PR #234) — caller treats anything that isn't ``run`` or ``pause`` as
+        "cycle has ended".
+        """
+        try:
+            data = self._request(
+                "GET",
+                f"/devices/{device_id}/components/main/capabilities/washerOperatingState/status",
+            )
+        except SmartThingsError:
+            return None
+        attr = data.get("machineState") if isinstance(data, dict) else None
+        if not isinstance(attr, dict):
+            return None
+        v = attr.get("value")
+        if isinstance(v, str):
+            return v.strip().lower()
+        return None
+
     def start_cycle(self, device_id: str) -> dict:
         """POST /devices/{id}/commands — washerOperatingState.setMachineState run.
 

--- a/tests/test_appliance_notifications.py
+++ b/tests/test_appliance_notifications.py
@@ -1,0 +1,193 @@
+"""Laundry start/finish notifications via OpenClaw hook (PR #234).
+
+Two new ``AlertType`` values + helpers + a 5-min reconcile-driven completion
+poll. The poll fires the finished hook exactly once per cycle (DB transition
+is the dedup key).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.notifier import (
+    AlertType,
+    notify_appliance_finished,
+    notify_appliance_starting,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+
+
+# ---------- Notifier helpers ----------
+
+def test_notify_appliance_starting_dispatches_with_correct_alert_type() -> None:
+    with patch("src.notifier._dispatch") as mock_dispatch:
+        notify_appliance_starting(
+            appliance_name="Washer",
+            planned_start_local="Sat 04:30",
+            deadline_local="Sun 06:00",
+            avg_price_pence=3.7,
+            duration_minutes=77,
+            brief_md="🔆 Today: ...",
+        )
+    assert mock_dispatch.called
+    args, kwargs = mock_dispatch.call_args
+    assert args[0] == AlertType.APPLIANCE_STARTING
+    body = args[1]
+    assert "Washer" in body
+    assert "Sat 04:30" in body
+    assert "77 min" in body
+    assert "3.7p/kWh" in body
+    assert "🔆 Today" in body
+    assert kwargs["urgent"] is False
+    extra = kwargs["extra"]
+    assert extra["appliance"] == "Washer"
+    assert extra["duration_minutes"] == 77
+
+
+def test_notify_appliance_finished_dispatches_with_correct_alert_type() -> None:
+    with patch("src.notifier._dispatch") as mock_dispatch:
+        notify_appliance_finished(
+            appliance_name="Washer",
+            started_local="04:30",
+            ended_local="05:47",
+            duration_minutes=77,
+            avg_price_pence=3.7,
+            estimated_kwh=0.6,
+            estimated_cost_p=2.22,
+            brief_md="🔆 Today: ...",
+        )
+    assert mock_dispatch.called
+    args, kwargs = mock_dispatch.call_args
+    assert args[0] == AlertType.APPLIANCE_FINISHED
+    body = args[1]
+    assert "Washer" in body
+    assert "04:30" in body and "05:47" in body
+    assert "77 min" in body
+    assert "0.60 kWh" in body
+    assert kwargs["extra"]["estimated_kwh"] == 0.6
+    assert kwargs["extra"]["estimated_cost_pence"] == 2.22
+
+
+def test_notify_appliance_finished_handles_missing_cost_estimate() -> None:
+    """No estimated_kwh + no avg_price → still emits a clean body without crashing."""
+    with patch("src.notifier._dispatch") as mock_dispatch:
+        notify_appliance_finished(
+            appliance_name="Washer",
+            started_local="04:30",
+            ended_local="05:47",
+            duration_minutes=77,
+        )
+    assert mock_dispatch.called
+
+
+# ---------- build_brief_48h_summary degrades gracefully ----------
+
+def test_brief_48h_summary_returns_string_with_no_data() -> None:
+    """Empty DB → still produces 4 lines, all gracefully reading n/a."""
+    from src.analytics.daily_brief import build_brief_48h_summary
+    out = build_brief_48h_summary()
+    lines = out.split("\n")
+    assert len(lines) == 4
+    assert lines[0].startswith("🔆 Today:")
+    assert lines[1].startswith("🔆 Tomorrow:")
+    assert lines[2].startswith("💰 Today PnL:")
+    assert lines[3].startswith("🔋 Battery")
+
+
+# ---------- Completion poll ----------
+
+def _seed_running_job(state_returns: list[str | None]) -> tuple[int, MagicMock]:
+    """Insert one running job + a mock SmartThings client whose
+    `get_machine_state` returns each value in `state_returns` per call."""
+    appliance_id = db.add_appliance(
+        vendor="smartthings", vendor_device_id="dev-test",
+        name="Washer", device_type="washer",
+        default_duration_minutes=77, deadline_local_time="07:00",
+        typical_kw=0.5,
+    )
+    now = datetime.now(UTC)
+    job_id = db.create_appliance_job(
+        appliance_id=appliance_id,
+        armed_at_utc=now.isoformat().replace("+00:00", "Z"),
+        deadline_utc=(now + timedelta(hours=12)).isoformat().replace("+00:00", "Z"),
+        duration_minutes=77,
+        planned_start_utc=now.isoformat().replace("+00:00", "Z"),
+        planned_end_utc=(now + timedelta(minutes=77)).isoformat().replace("+00:00", "Z"),
+        avg_price_pence=3.7,
+        status="scheduled",
+    )
+    db.update_appliance_job(
+        job_id, status="running",
+        actual_start_utc=now.isoformat().replace("+00:00", "Z"),
+    )
+    mock_client = MagicMock()
+    mock_client.get_machine_state.side_effect = state_returns
+    return job_id, mock_client
+
+
+def test_poll_skips_when_state_still_run() -> None:
+    """Job stays running, no notification, no DB change."""
+    job_id, mock_client = _seed_running_job(state_returns=["run"])
+    with patch("src.scheduler.appliance_dispatch._get_st_client", return_value=mock_client), \
+         patch("src.notifier._dispatch") as mock_dispatch:
+        from src.scheduler.appliance_dispatch import _poll_running_jobs
+        _poll_running_jobs()
+    job = db.get_appliance_job(job_id)
+    assert job["status"] == "running"
+    assert job.get("completed_at_utc") is None
+    assert not mock_dispatch.called
+
+
+def test_poll_marks_completed_and_fires_finish_hook_on_state_transition() -> None:
+    """Job sees state='stop' → marked completed + finish notification fires once."""
+    job_id, mock_client = _seed_running_job(state_returns=["stop"])
+    with patch("src.scheduler.appliance_dispatch._get_st_client", return_value=mock_client), \
+         patch("src.notifier._dispatch") as mock_dispatch:
+        from src.scheduler.appliance_dispatch import _poll_running_jobs
+        _poll_running_jobs()
+    job = db.get_appliance_job(job_id)
+    assert job["status"] == "completed"
+    assert job["completed_at_utc"] is not None
+    # Exactly one APPLIANCE_FINISHED dispatch
+    finish_calls = [
+        c for c in mock_dispatch.call_args_list
+        if c.args[0] == AlertType.APPLIANCE_FINISHED
+    ]
+    assert len(finish_calls) == 1
+
+
+def test_poll_idempotent_after_completion() -> None:
+    """Once marked completed, second poll pass should NOT re-fire (status filter excludes it)."""
+    job_id, mock_client = _seed_running_job(state_returns=["finish", "stop"])
+    with patch("src.scheduler.appliance_dispatch._get_st_client", return_value=mock_client), \
+         patch("src.notifier._dispatch") as mock_dispatch:
+        from src.scheduler.appliance_dispatch import _poll_running_jobs
+        _poll_running_jobs()
+        _poll_running_jobs()                                # second pass — no rows where status='running'
+    finish_calls = [
+        c for c in mock_dispatch.call_args_list
+        if c.args[0] == AlertType.APPLIANCE_FINISHED
+    ]
+    assert len(finish_calls) == 1
+
+
+def test_poll_treats_finish_state_as_completion() -> None:
+    """Samsung uses 'finish' too — must trigger completion same as 'stop'."""
+    job_id, mock_client = _seed_running_job(state_returns=["finish"])
+    with patch("src.scheduler.appliance_dispatch._get_st_client", return_value=mock_client), \
+         patch("src.notifier._dispatch") as mock_dispatch:
+        from src.scheduler.appliance_dispatch import _poll_running_jobs
+        _poll_running_jobs()
+    job = db.get_appliance_job(job_id)
+    assert job["status"] == "completed"


### PR DESCRIPTION
## Summary

Adds Telegram-style notifications (via OpenClaw hook) for the SmartThings washer lifecycle:
- 🧺 **Starting laundry** — fired when the LP-armed cron successfully runs \`setMachineState run\`
- ✅ **Finished** — fired when a 5-min reconcile poll detects the unit transition out of \`run\`/\`pause\`

Each notification inlines a 4-line **next-48h brief** (today + tomorrow tier windows, running PnL, current SoC) so the family closes the loop on cost AND sees what's coming next.

## Why

User asked for visibility on washer cycles after multiple silent dispatches. Beyond just notifications, the inline brief makes the message a useful family-facing checkpoint — \"laundry running until 05:47, tomorrow has a peak 17:00–19:30 at 33.5p, today's net is £-1.20 vs SVT £-3.40\".

## Implementation

| Layer | File | Change |
|---|---|---|
| Notifier | \`src/notifier.py\` | \`AlertType.APPLIANCE_STARTING/FINISHED\` + helpers |
| Forward brief | \`src/analytics/daily_brief.py\` | \`build_brief_48h_summary(now_utc)\` — gracefully degrades all 4 lines |
| Start ping | \`src/scheduler/appliance_dispatch.py:_fire_cron\` | Best-effort notify after successful run |
| Completion poll | \`src/scheduler/appliance_dispatch.py:_poll_running_jobs\` | New; runs after reconcile pass; one SmartThings call per running job |
| SmartThings | \`src/smartthings/client.py\` | New \`get_machine_state\` helper (washerOperatingState capability) |
| Schema | \`src/db.py:_migrate_schema\` | \`appliance_jobs.completed_at_utc\` ALTER TABLE |

## Why option A (poll) over webhook

Considered SmartThings webhooks (real-time) but: (1) needs another public callback URL re-using Tailscale Funnel + Samsung subscription registration, (2) more moving parts to maintain. The 5-min reconcile cadence is acceptable for "cycle has finished" — the user already gets the message before they walk past the machine. Webhook real-time is deferred until / if 5-min latency proves annoying.

## Test plan

- [x] 8 unit tests covering notifier helpers, brief degradation, completion poll behavior, idempotency, finish/stop state handling
- [x] Full suite green: 822 passed / 1 skipped
- [ ] After deploy: the existing user-started cycle (job_id=1, status=\"running\") will be picked up by the next reconcile pass — confirm Telegram receives the finished message within ≤ 5 min, with the 48h brief
- [ ] Next LP-armed cycle: confirm starting message arrives at fire time

## Out of scope (deferred per plan §C)

- Real-time webhook completion
- Mid-run cancel detection from poller (#221, separate scope)
- Per-cycle actual_kwh capture from \`powerConsumptionReport\` (#222)

🤖 Generated with [Claude Code](https://claude.com/claude-code)