### PR TITLE
fix(appliance): use Samsung's machineState.timestamp + measured kWh

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -736,6 +736,14 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     aj_cols = {str(r[1]) for r in cur.fetchall()}
     if "completed_at_utc" not in aj_cols:
         conn.execute("ALTER TABLE appliance_jobs ADD COLUMN completed_at_utc TEXT")
+    # PR #235: capture actual energy via SmartThings powerConsumptionReport.
+    # energy_start_wh = lifetime Wh counter at cycle start; actual_kwh =
+    # (counter_at_complete − counter_at_start) / 1000. Both NULL when the
+    # device doesn't report the capability or the snapshot was missed.
+    if "energy_start_wh" not in aj_cols:
+        conn.execute("ALTER TABLE appliance_jobs ADD COLUMN energy_start_wh REAL")
+    if "actual_kwh" not in aj_cols:
+        conn.execute("ALTER TABLE appliance_jobs ADD COLUMN actual_kwh REAL")
 
 
 def init_db() -> None:
@@ -4108,6 +4116,8 @@ _APPLIANCE_JOB_UPDATABLE_FIELDS = {
     "avg_price_pence", "actual_start_utc", "error_msg",
     "last_replan_at_utc", "duration_minutes", "deadline_utc",
     "completed_at_utc",
+    "energy_start_wh",
+    "actual_kwh",
 }
 
 

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -401,17 +401,31 @@ def notify_appliance_finished(
     estimated_kwh: float | None = None,
     estimated_cost_p: float | None = None,
     brief_md: str | None = None,
+    kwh_is_measured: bool = False,
 ) -> None:
     """✅ Cycle has finished (poll detected state transition out of ``run``).
 
     Includes a concise outcome line + same 4-line brief so the family closes
     the loop on cost and sees what's coming next.
+
+    ``kwh_is_measured`` distinguishes a real measurement (Samsung
+    ``powerConsumptionReport`` delta — PR #235) from a static
+    ``typical_kw × duration`` fallback. When measured, the message renders
+    without the ``≈`` ambiguity prefix and the structured extra carries
+    ``actual_kwh`` / ``actual_cost_pence`` instead of the ``estimated_*`` keys.
     """
-    cost_line = ""
     if estimated_kwh is not None and estimated_cost_p is not None:
-        cost_line = f"≈ {estimated_kwh:.2f} kWh ≈ {estimated_cost_p:.1f}p"
+        if kwh_is_measured:
+            cost_line = f"{estimated_kwh:.2f} kWh · {estimated_cost_p:.1f}p"
+        else:
+            cost_line = f"≈ {estimated_kwh:.2f} kWh ≈ {estimated_cost_p:.1f}p"
+    elif estimated_kwh is not None:
+        prefix = "" if kwh_is_measured else "≈ "
+        cost_line = f"{prefix}{estimated_kwh:.2f} kWh"
     elif avg_price_pence is not None:
         cost_line = f"avg {avg_price_pence:.1f}p/kWh"
+    else:
+        cost_line = ""
     body_lines = [
         f"✅ **{appliance_name}** cycle complete",
         f"{started_local} → {ended_local} ({duration_minutes} min)" + (f" · {cost_line}" if cost_line else ""),
@@ -424,11 +438,14 @@ def notify_appliance_finished(
         "started_local": started_local,
         "ended_local": ended_local,
         "duration_minutes": int(duration_minutes),
+        "kwh_is_measured": bool(kwh_is_measured),
     }
     if estimated_kwh is not None:
-        extra["estimated_kwh"] = round(float(estimated_kwh), 3)
+        key = "actual_kwh" if kwh_is_measured else "estimated_kwh"
+        extra[key] = round(float(estimated_kwh), 3)
     if estimated_cost_p is not None:
-        extra["estimated_cost_pence"] = round(float(estimated_cost_p), 2)
+        key = "actual_cost_pence" if kwh_is_measured else "estimated_cost_pence"
+        extra[key] = round(float(estimated_cost_p), 2)
     _dispatch(AlertType.APPLIANCE_FINISHED, body, urgent=False, extra=extra)
 
 

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -563,7 +563,7 @@ def _poll_running_jobs() -> None:
             appliance = db.get_appliance(int(job["appliance_id"]))
             if appliance is None:
                 continue
-            state = client.get_machine_state(appliance["vendor_device_id"])
+            state, state_changed_at = client.get_machine_state(appliance["vendor_device_id"])
         except SmartThingsError as e:
             logger.debug(
                 "poll_running: machine_state lookup failed for job %s (%s) — retry next pass",
@@ -576,18 +576,52 @@ def _poll_running_jobs() -> None:
             continue
 
         # Transitioned out → mark complete and notify.
+        # Prefer Samsung's machineState.timestamp (the actual moment the unit
+        # transitioned to stop/finish) over our detection time (PR #235).
+        # Without this, the message reads "ended at 18:34" when the cycle
+        # actually ended at 18:00 — up to one reconcile cycle (5 min) of
+        # skew, larger when the service was offline / just restarted.
         ended_at = _iso(_now_utc())
+        if state_changed_at:
+            try:
+                # Normalise to canonical UTC Z for storage/display
+                _dt = datetime.fromisoformat(state_changed_at.replace("Z", "+00:00"))
+                if _dt.tzinfo is None:
+                    _dt = _dt.replace(tzinfo=UTC)
+                ended_at = _iso(_dt.astimezone(UTC))
+            except (ValueError, TypeError):
+                logger.debug(
+                    "poll_running: ignoring unparseable state_changed_at=%s for job %s",
+                    state_changed_at, job.get("id"),
+                )
+        # PR #235: read the lifetime energy counter NOW and compute actual
+        # cycle kWh as a delta vs the snapshot taken at fire-time. Falls back
+        # to the static typical_kw × duration estimate when either snapshot
+        # is missing (capability absent / older job pre-#235 / fire-time
+        # snapshot failed).
+        actual_kwh: float | None = None
+        try:
+            energy_now_wh = client.get_power_consumption_energy_wh(appliance["vendor_device_id"])
+            energy_start_raw = job.get("energy_start_wh")
+            if energy_now_wh is not None and energy_start_raw is not None:
+                delta_wh = float(energy_now_wh) - float(energy_start_raw)
+                if delta_wh >= 0:                  # guard against counter reset
+                    actual_kwh = round(delta_wh / 1000.0, 3)
+        except SmartThingsError:
+            actual_kwh = None
+
         try:
             db.update_appliance_job(
                 int(job["id"]), status="completed", completed_at_utc=ended_at,
+                actual_kwh=actual_kwh,
             )
         except Exception:
             logger.exception("poll_running: DB update_appliance_job failed for %s", job.get("id"))
             continue
 
         logger.info(
-            "appliance complete: job %s state=%s, marking completed",
-            job.get("id"), state,
+            "appliance complete: job %s state=%s, marking completed (actual_kwh=%s)",
+            job.get("id"), state, actual_kwh,
         )
 
         # Build the finished notification (best-effort)
@@ -607,16 +641,22 @@ def _poll_running_jobs() -> None:
                 duration_min = max(1, int((end_dt - start_dt).total_seconds() // 60))
             ended_local_dt = datetime.fromisoformat(ended_at.replace("Z", "+00:00")).astimezone(tz)
             avg_p = job.get("avg_price_pence")
-            est_kwh = None
-            est_cost_p = None
-            try:
-                typical_kw = float(appliance.get("typical_kw") or 0.0)
-                if typical_kw > 0 and duration_min > 0:
-                    est_kwh = typical_kw * (duration_min / 60.0)
-                    if avg_p is not None:
-                        est_cost_p = est_kwh * float(avg_p)
-            except (TypeError, ValueError):
-                pass
+
+            # Prefer measured kWh (PR #235). Fall back to typical_kw × duration
+            # only when the energy delta couldn't be computed.
+            kwh: float | None = actual_kwh
+            cost_p: float | None = None
+            measured = actual_kwh is not None
+            if not measured:
+                try:
+                    typical_kw = float(appliance.get("typical_kw") or 0.0)
+                    if typical_kw > 0 and duration_min > 0:
+                        kwh = typical_kw * (duration_min / 60.0)
+                except (TypeError, ValueError):
+                    kwh = None
+            if kwh is not None and avg_p is not None:
+                cost_p = float(kwh) * float(avg_p)
+
             notify_appliance_finished(
                 appliance_name=str(
                     appliance.get("name") or appliance.get("device_type") or "Appliance"
@@ -625,9 +665,10 @@ def _poll_running_jobs() -> None:
                 ended_local=ended_local_dt.strftime("%H:%M"),
                 duration_minutes=duration_min,
                 avg_price_pence=float(avg_p) if avg_p is not None else None,
-                estimated_kwh=est_kwh,
-                estimated_cost_p=est_cost_p,
+                estimated_kwh=kwh,
+                estimated_cost_p=cost_p,
                 brief_md=build_brief_48h_summary(),
+                kwh_is_measured=measured,
             )
         except Exception:
             logger.exception(
@@ -936,10 +977,25 @@ def _fire_cron(job_id: int) -> None:
         )
         return
 
+    # PR #235: capture lifetime energy counter at cycle start, so the
+    # completion poller can compute actual cycle kWh as a delta. Best-effort:
+    # capability may be absent on some firmwares.
+    energy_start_wh: int | None = None
+    try:
+        raw = client.get_power_consumption_energy_wh(appliance["vendor_device_id"])
+        if isinstance(raw, (int, float)):
+            energy_start_wh = int(raw)
+    except SmartThingsError:
+        energy_start_wh = None
+
     db.update_appliance_job(
         int(job_id), status="running", actual_start_utc=actual_start,
+        energy_start_wh=energy_start_wh,
     )
-    logger.info("appliance fire: job %d → running", job_id)
+    logger.info(
+        "appliance fire: job %d → running (energy_start_wh=%s)",
+        job_id, energy_start_wh,
+    )
 
     # PR #234: notify the family that laundry is starting + inline forward brief.
     # Best-effort — never let a notification failure block the dispatch path.

--- a/src/smartthings/client.py
+++ b/src/smartthings/client.py
@@ -112,13 +112,18 @@ class SmartThingsClient:
             return v.strip().lower() == "true"
         return False
 
-    def get_machine_state(self, device_id: str) -> str | None:
-        """Return ``washerOperatingState.machineState`` value (run/pause/stop/finish/...).
+    def get_machine_state(self, device_id: str) -> tuple[str | None, str | None]:
+        """Return ``(machineState_value, machineState_timestamp_iso)``.
 
-        Returns ``None`` when the capability isn't present in the response or
-        the value isn't parseable. Used by the cycle-completion poller
-        (PR #234) — caller treats anything that isn't ``run`` or ``pause`` as
-        "cycle has ended".
+        Samsung reports both the current value AND the ISO timestamp of the
+        last state transition. PR #235 — using that timestamp for the
+        ``ended_at`` field on the cycle-completion notification (instead of
+        ``now()``) eliminates the up-to-5-min skew from the reconcile cadence.
+
+        Both elements default to ``None`` when the capability isn't present
+        or the value isn't parseable. Used by the completion poller
+        (PR #234) — caller treats anything that isn't ``run`` or ``pause``
+        as "cycle has ended".
         """
         try:
             data = self._request(
@@ -126,13 +131,40 @@ class SmartThingsClient:
                 f"/devices/{device_id}/components/main/capabilities/washerOperatingState/status",
             )
         except SmartThingsError:
-            return None
+            return None, None
         attr = data.get("machineState") if isinstance(data, dict) else None
         if not isinstance(attr, dict):
-            return None
+            return None, None
         v = attr.get("value")
+        ts_raw = attr.get("timestamp")
+        ts: str | None = ts_raw.strip() if isinstance(ts_raw, str) and ts_raw.strip() else None
         if isinstance(v, str):
-            return v.strip().lower()
+            return v.strip().lower(), ts
+        return None, ts
+
+    def get_power_consumption_energy_wh(self, device_id: str) -> int | None:
+        """Return ``powerConsumptionReport.powerConsumption.energy`` in Wh.
+
+        This is a **cumulative lifetime counter** (monotonic; only resets on
+        firmware reset). Subtract two snapshots taken at cycle fire-time and
+        completion to get the actual energy consumed by the cycle (PR #235).
+        Returns ``None`` when the capability isn't reported by the device or
+        the value isn't an integer.
+        """
+        try:
+            data = self._request(
+                "GET",
+                f"/devices/{device_id}/components/main/capabilities/powerConsumptionReport/status",
+            )
+        except SmartThingsError:
+            return None
+        pc = data.get("powerConsumption") if isinstance(data, dict) else None
+        val = pc.get("value") if isinstance(pc, dict) else None
+        if not isinstance(val, dict):
+            return None
+        e = val.get("energy")
+        if isinstance(e, (int, float)):
+            return int(e)
         return None
 
     def start_cycle(self, device_id: str) -> dict:

--- a/tests/test_appliance_notifications.py
+++ b/tests/test_appliance_notifications.py
@@ -56,6 +56,7 @@ def test_notify_appliance_starting_dispatches_with_correct_alert_type() -> None:
 
 
 def test_notify_appliance_finished_dispatches_with_correct_alert_type() -> None:
+    """Default path (kwh_is_measured=False) → uses ≈ prefix + estimated_* keys."""
     with patch("src.notifier._dispatch") as mock_dispatch:
         notify_appliance_finished(
             appliance_name="Washer",
@@ -74,9 +75,37 @@ def test_notify_appliance_finished_dispatches_with_correct_alert_type() -> None:
     assert "Washer" in body
     assert "04:30" in body and "05:47" in body
     assert "77 min" in body
-    assert "0.60 kWh" in body
+    assert "≈ 0.60 kWh" in body
     assert kwargs["extra"]["estimated_kwh"] == 0.6
     assert kwargs["extra"]["estimated_cost_pence"] == 2.22
+    assert kwargs["extra"]["kwh_is_measured"] is False
+
+
+def test_notify_appliance_finished_measured_path_drops_approx_prefix() -> None:
+    """PR #235: when Samsung powerConsumptionReport gave us a real delta,
+    body uses the value without the ≈ ambiguity marker, and the structured
+    extra carries actual_kwh + actual_cost_pence (not the estimated_* keys)."""
+    with patch("src.notifier._dispatch") as mock_dispatch:
+        notify_appliance_finished(
+            appliance_name="Washer",
+            started_local="16:16",
+            ended_local="18:00",
+            duration_minutes=104,
+            avg_price_pence=3.7,
+            estimated_kwh=0.87,
+            estimated_cost_p=3.22,
+            kwh_is_measured=True,
+        )
+    args, kwargs = mock_dispatch.call_args
+    body = args[1]
+    assert "0.87 kWh" in body
+    assert "≈" not in body                          # measured → no approximation marker
+    extra = kwargs["extra"]
+    assert extra["kwh_is_measured"] is True
+    assert extra["actual_kwh"] == 0.87
+    assert extra["actual_cost_pence"] == 3.22
+    assert "estimated_kwh" not in extra
+    assert "estimated_cost_pence" not in extra
 
 
 def test_notify_appliance_finished_handles_missing_cost_estimate() -> None:
@@ -107,9 +136,16 @@ def test_brief_48h_summary_returns_string_with_no_data() -> None:
 
 # ---------- Completion poll ----------
 
-def _seed_running_job(state_returns: list[str | None]) -> tuple[int, MagicMock]:
+def _seed_running_job(
+    state_returns: list[str | None],
+    state_timestamps: list[str | None] | None = None,
+) -> tuple[int, MagicMock]:
     """Insert one running job + a mock SmartThings client whose
-    `get_machine_state` returns each value in `state_returns` per call."""
+    ``get_machine_state`` returns each ``(state, timestamp)`` tuple per call.
+
+    ``state_timestamps`` defaults to ``[None] * len(state_returns)`` (no
+    Samsung timestamp returned → caller falls back to ``now()``).
+    """
     appliance_id = db.add_appliance(
         vendor="smartthings", vendor_device_id="dev-test",
         name="Washer", device_type="washer",
@@ -132,7 +168,11 @@ def _seed_running_job(state_returns: list[str | None]) -> tuple[int, MagicMock]:
         actual_start_utc=now.isoformat().replace("+00:00", "Z"),
     )
     mock_client = MagicMock()
-    mock_client.get_machine_state.side_effect = state_returns
+    if state_timestamps is None:
+        state_timestamps = [None] * len(state_returns)
+    mock_client.get_machine_state.side_effect = list(
+        zip(state_returns, state_timestamps, strict=True)
+    )
     return job_id, mock_client
 
 
@@ -191,3 +231,48 @@ def test_poll_treats_finish_state_as_completion() -> None:
         _poll_running_jobs()
     job = db.get_appliance_job(job_id)
     assert job["status"] == "completed"
+
+
+def test_poll_uses_samsung_timestamp_over_detection_time() -> None:
+    """PR #235: when Samsung returns the actual state-change timestamp, use that
+    as ``completed_at_utc`` instead of ``now()``. Eliminates the up-to-5-min
+    skew from the reconcile cadence."""
+    actual_end_iso = "2026-05-02T17:00:10Z"
+    job_id, mock_client = _seed_running_job(
+        state_returns=["stop"],
+        state_timestamps=[actual_end_iso],
+    )
+    with patch("src.scheduler.appliance_dispatch._get_st_client", return_value=mock_client), \
+         patch("src.notifier._dispatch") as mock_dispatch:
+        from src.scheduler.appliance_dispatch import _poll_running_jobs
+        _poll_running_jobs()
+    job = db.get_appliance_job(job_id)
+    assert job["status"] == "completed"
+    # Must persist Samsung's timestamp (normalised to canonical UTC Z), not now().
+    assert job["completed_at_utc"] == actual_end_iso
+    finish_call = next(
+        c for c in mock_dispatch.call_args_list
+        if c.args[0] == AlertType.APPLIANCE_FINISHED
+    )
+    extra = finish_call.kwargs["extra"]
+    # The dispatched ``ended_local`` field is rendered from Samsung's timestamp.
+    # Independent of the test runner's wall clock — locks in the fix.
+    assert "17:00" in extra["ended_local"] or "18:00" in extra["ended_local"]
+    # 18:00 BST during DST, 17:00 UTC otherwise — both acceptable.
+
+
+def test_poll_falls_back_to_now_when_samsung_timestamp_missing() -> None:
+    """No timestamp → must still mark complete; ended_at degrades to now()."""
+    job_id, mock_client = _seed_running_job(
+        state_returns=["stop"], state_timestamps=[None],
+    )
+    with patch("src.scheduler.appliance_dispatch._get_st_client", return_value=mock_client), \
+         patch("src.notifier._dispatch") as mock_dispatch:
+        from src.scheduler.appliance_dispatch import _poll_running_jobs
+        _poll_running_jobs()
+    job = db.get_appliance_job(job_id)
+    assert job["status"] == "completed"
+    assert job["completed_at_utc"] is not None       # populated, just from now()
+    assert any(
+        c.args[0] == AlertType.APPLIANCE_FINISHED for c in mock_dispatch.call_args_list
+    )


### PR DESCRIPTION
## Summary

Two related defects in the cycle-finished notification, surfaced by the user reading their first real Telegram message after PR #234 deployed:

### 1. End time was wrong (off by ~one reconcile cadence)

The poll used \`_now_utc()\` as \`ended_at\` — that's the **detection** time, not the actual cycle end. The user's message read \"ended at 18:34\" when the cycle actually ended at **18:00** (34-min skew because the service restarted at 18:33 right when we deployed #234).

Samsung exposes the real state-transition timestamp at \`washerOperatingState.machineState.timestamp\`. Use that directly, fall back to \`now()\` only when the field is absent or unparseable.

### 2. kWh was estimated, not measured

The notification used \`typical_kw × duration\` (default 0.5 kW × cycle minutes) → today read **1.14 kWh**. Real Samsung lifetime counter shows **0.87 kWh** actual — 30 % too high.

Samsung washers expose \`powerConsumptionReport.powerConsumption.energy\` as a monotonic lifetime Wh counter. Snapshot at fire-time + at completion + subtract = real cycle kWh. Persist as a new column \`appliance_jobs.actual_kwh\`; fall back to the static estimate only when either snapshot is missing.

\`notify_appliance_finished\` now takes a \`kwh_is_measured\` flag. When true:
- message body drops the \`≈\` ambiguity prefix
- structured \`extra\` carries \`actual_kwh\` / \`actual_cost_pence\` instead of \`estimated_*\` keys, so OpenClaw can paraphrase truthfully

### Schema (one ALTER TABLE in \`_migrate_schema\`)

| Column | Type | Purpose |
|---|---|---|
| \`appliance_jobs.energy_start_wh\` | REAL | lifetime counter at fire |
| \`appliance_jobs.actual_kwh\` | REAL | cycle delta (NULL → fell back to estimate) |

## Test plan

- [x] 11 unit tests covering: Samsung-timestamp-wins, fallback when timestamp missing, measured-path drops ≈ marker, structured extra keys differ, completion poll correctness
- [x] Full suite: 829 passed / 1 skipped
- [ ] Next live cycle exercises both fixes end-to-end. Compare new Telegram message to today's: end time should match Samsung's actual transition, and kWh should match what the washer's energy counter says (no 30% estimate-bias)

## Out of scope

- Backfilling the old job_1 row's \`actual_kwh\` (would need stored snapshots we don't have; deliberately left NULL)
- Per-cycle \`actual_kwh\` aggregation into daily PnL — separate concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)