### PR TITLE
feat(load): forecast accuracy evaluator + regression baseline

### DIFF
--- a/scripts/check_load_forecast_accuracy.py
+++ b/scripts/check_load_forecast_accuracy.py
@@ -1,0 +1,87 @@
+"""Compare current load forecast accuracy vs the locked baseline.
+
+Run AFTER any change that could affect load prediction — Daikin physics
+calibration (Phase B), DHW draw learning (#196 V11-C), occupancy inference
+(#197 V11-D), residual_load profile changes — to verify it actually improved
+point-forecast accuracy on the trailing 30 days of prod data.
+
+A change that doesn't reduce MAE/RMSE is noise; a change that grows |bias| is
+a regression even if MAE looks similar.
+
+Usage (on prod):
+
+    docker exec hem python /tmp/check_load_forecast_accuracy.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    from src.analytics.load_forecast_accuracy import evaluate_load_forecast_accuracy
+
+    current = evaluate_load_forecast_accuracy(window_days=30)
+    baseline_path = (
+        Path(__file__).parent.parent / "tests" / "fixtures" / "load_forecast_baseline.json"
+    )
+    if not baseline_path.exists():
+        print(f"Baseline not found at {baseline_path}; printing current only.")
+        print(json.dumps(current, indent=2))
+        return 0
+
+    baseline = json.loads(baseline_path.read_text())
+
+    print("LOAD FORECAST ACCURACY: current vs baseline\n")
+    print(f"{'metric':<28} | {'baseline':>10} | {'current':>10} | {'Δ':>10}")
+    print("-" * 70)
+    for k in (
+        "mae_kwh_per_slot",
+        "rmse_kwh_per_slot",
+        "bias_kwh_per_slot",
+        "mape_pct",
+    ):
+        b = baseline["overall"].get(k, 0.0)
+        c = current["overall"].get(k, 0.0)
+        delta = c - b
+        marker = ""
+        if k in ("mae_kwh_per_slot", "rmse_kwh_per_slot", "mape_pct"):
+            marker = " ⬇️ better" if delta < -0.001 else (" ⚠️ worse" if delta > 0.001 else "")
+        elif k == "bias_kwh_per_slot":
+            marker = " ⬇️ closer" if abs(c) < abs(b) else (" ⚠️ further" if abs(c) > abs(b) else "")
+        print(f"{k:<28} | {b:>10.4f} | {c:>10.4f} | {delta:>+10.4f}{marker}")
+
+    n_b = baseline["overall"]["n"]
+    n_c = current["overall"]["n"]
+    print(f"\nSamples: baseline={n_b}, current={n_c}")
+
+    # Daikin daily diagnostic
+    bd = baseline.get("daikin_daily_check", {})
+    cd = current.get("daikin_daily_check", {})
+    if bd.get("n_days") or cd.get("n_days"):
+        print("\nDaikin daily check (predicted vs Onecta-measured):")
+        print(f"{'metric':<28} | {'baseline':>10} | {'current':>10} | {'Δ':>10}")
+        print("-" * 70)
+        for k in ("mae_kwh_per_day", "rmse_kwh_per_day", "bias_kwh_per_day", "mape_pct"):
+            b = bd.get(k, 0.0)
+            c = cd.get(k, 0.0)
+            print(f"{k:<28} | {b:>10.4f} | {c:>10.4f} | {c - b:>+10.4f}")
+
+    # Verdict
+    mae_b = baseline["overall"]["mae_kwh_per_slot"]
+    mae_c = current["overall"]["mae_kwh_per_slot"]
+    rmse_b = baseline["overall"]["rmse_kwh_per_slot"]
+    rmse_c = current["overall"]["rmse_kwh_per_slot"]
+    if mae_c < mae_b and rmse_c < rmse_b:
+        print("\n✅ IMPROVEMENT — both MAE and RMSE reduced.")
+        return 0
+    if mae_c > mae_b * 1.05 or rmse_c > rmse_b * 1.05:
+        print("\n❌ REGRESSION — MAE or RMSE grew >5% vs baseline.")
+        return 1
+    print("\n➖ NEUTRAL — accuracy roughly unchanged.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/analytics/load_forecast_accuracy.py
+++ b/src/analytics/load_forecast_accuracy.py
@@ -1,0 +1,255 @@
+"""Regression-baseline evaluator for *load* forecast accuracy (#231 analog for load).
+
+Compares the LP's per-slot predicted total household load against measured load
+from ``pv_realtime_history.load_power_kw``. Per-slot predicted total reconstructs
+as ``base_load_json[slot_index] + dhw_kwh + space_kwh`` from the most recent
+LP snapshot for that slot.
+
+Also runs a daily aggregate check of *predicted* Daikin (``Σ dhw_kwh + space_kwh``)
+against Onecta-measured ``daikin_consumption_daily.kwh_total``. We have no
+per-slot Daikin meter, so this is the only way to quantify the physics-model
+bias — and it's the diagnostic that drives any future Daikin calibration work.
+
+Hour-of-day buckets are local (``BULLETPROOF_TIMEZONE``) because load is tied
+to occupancy, not solar position. This matches the residual-load profile
+in :func:`db.half_hourly_residual_load_profile_kwh`.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+
+def evaluate_load_forecast_accuracy(
+    window_days: int = 30,
+    *,
+    min_kwh: float = 0.01,
+) -> dict[str, Any]:
+    """Compare predicted vs realized household load across the last N days.
+
+    For each unique ``slot_time_utc`` in the window, picks the latest LP run
+    (``MAX(run_id)``) that produced a prediction for that slot. Predicted
+    total = ``base_load_json[slot_index] + dhw_kwh + space_kwh``. Actual = mean
+    ``load_power_kw`` in the 30-min slot window × 0.5 h.
+
+    Slots where both predicted AND actual fall below ``min_kwh`` are excluded.
+
+    Returns::
+
+        {
+            "window_days": 30,
+            "n_paired": 1340,
+            "overall": { mae_kwh_per_slot, rmse_kwh_per_slot, bias_kwh_per_slot,
+                         mean_actual_kwh_per_slot, mean_pred_kwh_per_slot,
+                         mape_pct, n },
+            "per_hour_local": { 0..23 → same stats, keyed by local hour },
+            "daikin_daily_check": { n_days, mae_kwh_per_day, rmse_kwh_per_day,
+                                    bias_kwh_per_day,
+                                    mean_predicted_daikin_kwh_per_day,
+                                    mean_actual_daikin_kwh_per_day,
+                                    mape_pct },
+        }
+    """
+    from .. import db as _db
+    from ..config import config
+
+    end = date.today()
+    start = end - timedelta(days=window_days)
+
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+
+    # 1. Pull latest predicted load per slot (joined with inputs for base_load_json)
+    pred_by_slot: dict[str, dict[str, Any]] = {}
+    with _db._lock:
+        conn = _db.get_connection()
+        try:
+            cur = conn.execute(
+                """
+                SELECT s.slot_time_utc,
+                       s.run_id,
+                       s.slot_index,
+                       s.dhw_kwh,
+                       s.space_kwh,
+                       i.base_load_json
+                  FROM lp_solution_snapshot s
+                  JOIN lp_inputs_snapshot   i  ON i.run_id = s.run_id
+                  JOIN (
+                        SELECT slot_time_utc, MAX(run_id) AS max_run
+                          FROM lp_solution_snapshot
+                         WHERE substr(slot_time_utc, 1, 10) BETWEEN ? AND ?
+                         GROUP BY slot_time_utc
+                       ) latest
+                       ON latest.slot_time_utc = s.slot_time_utc
+                      AND latest.max_run       = s.run_id
+                """,
+                (start.isoformat(), end.isoformat()),
+            )
+            for row in cur.fetchall():
+                slot = _normalise_iso(row["slot_time_utc"])
+                if slot is None:
+                    continue
+                try:
+                    base_loads = json.loads(row["base_load_json"] or "[]")
+                except (TypeError, ValueError):
+                    continue
+                idx = int(row["slot_index"])
+                if idx >= len(base_loads):
+                    continue
+                base = float(base_loads[idx])
+                dhw = float(row["dhw_kwh"] or 0.0)
+                space = float(row["space_kwh"] or 0.0)
+                pred_by_slot[slot] = {
+                    "predicted_kwh": base + dhw + space,
+                    "predicted_daikin_kwh": dhw + space,
+                }
+
+            # 2. Pull all load samples in window
+            cur = conn.execute(
+                """SELECT captured_at, load_power_kw
+                     FROM pv_realtime_history
+                    WHERE substr(captured_at, 1, 10) BETWEEN ? AND ?
+                      AND load_power_kw IS NOT NULL""",
+                (start.isoformat(), end.isoformat()),
+            )
+            samples = cur.fetchall()
+
+            # 3. Pull Daikin daily ground truth
+            cur = conn.execute(
+                """SELECT date, kwh_total FROM daikin_consumption_daily
+                    WHERE date BETWEEN ? AND ?
+                      AND kwh_total IS NOT NULL""",
+                (start.isoformat(), end.isoformat()),
+            )
+            daikin_actual_by_date = {row["date"]: float(row["kwh_total"]) for row in cur.fetchall()}
+        finally:
+            conn.close()
+
+    # 4. Bucket samples into 30-min slots → mean load_kw × 0.5 = slot kWh
+    actual_kw_by_slot: dict[str, list[float]] = defaultdict(list)
+    for row in samples:
+        ts = _parse_iso(row["captured_at"])
+        if ts is None:
+            continue
+        slot_start = ts.replace(minute=0 if ts.minute < 30 else 30, second=0, microsecond=0)
+        actual_kw_by_slot[slot_start.isoformat()].append(float(row["load_power_kw"]))
+
+    # 5. Pair + bucket per local hour-of-day
+    pairs_per_hour: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    all_pairs: list[tuple[float, float]] = []
+    pred_daikin_by_date: dict[str, float] = defaultdict(float)
+
+    for slot_iso, pred in pred_by_slot.items():
+        ts = _parse_iso(slot_iso)
+        if ts is None:
+            continue
+        local_hour = ts.astimezone(tz).hour
+        local_date_iso = ts.astimezone(tz).date().isoformat()
+        pred_daikin_by_date[local_date_iso] += pred["predicted_daikin_kwh"]
+
+        kw_samples = actual_kw_by_slot.get(slot_iso)
+        if not kw_samples:
+            continue
+        actual_kwh = (sum(kw_samples) / len(kw_samples)) * 0.5
+        pred_kwh = pred["predicted_kwh"]
+        if pred_kwh < min_kwh and actual_kwh < min_kwh:
+            continue
+        all_pairs.append((pred_kwh, actual_kwh))
+        pairs_per_hour[local_hour].append((pred_kwh, actual_kwh))
+
+    # 6. Daikin daily check (only days where Onecta actual is available)
+    daikin_pairs: list[tuple[float, float]] = []
+    for d_iso, actual_kwh in daikin_actual_by_date.items():
+        if d_iso in pred_daikin_by_date:
+            daikin_pairs.append((pred_daikin_by_date[d_iso], actual_kwh))
+
+    return {
+        "window_days": window_days,
+        "n_paired": len(all_pairs),
+        "overall": _slot_stats(all_pairs),
+        "per_hour_local": {h: _slot_stats(p) for h, p in sorted(pairs_per_hour.items())},
+        "daikin_daily_check": _daily_stats(daikin_pairs),
+    }
+
+
+def _slot_stats(pairs: list[tuple[float, float]]) -> dict[str, float]:
+    if not pairs:
+        return {
+            "mae_kwh_per_slot": 0.0,
+            "rmse_kwh_per_slot": 0.0,
+            "bias_kwh_per_slot": 0.0,
+            "mean_actual_kwh_per_slot": 0.0,
+            "mean_pred_kwh_per_slot": 0.0,
+            "mape_pct": 0.0,
+            "n": 0,
+        }
+    n = len(pairs)
+    errs = [a - p for p, a in pairs]
+    mae = sum(abs(e) for e in errs) / n
+    rmse = (sum(e * e for e in errs) / n) ** 0.5
+    bias = sum(errs) / n
+    mean_actual = sum(a for _, a in pairs) / n
+    mean_pred = sum(p for p, _ in pairs) / n
+    ape = [abs(a - p) / a * 100 for p, a in pairs if a > 0.05]
+    mape = sum(ape) / len(ape) if ape else 0.0
+    return {
+        "mae_kwh_per_slot": round(mae, 4),
+        "rmse_kwh_per_slot": round(rmse, 4),
+        "bias_kwh_per_slot": round(bias, 4),
+        "mean_actual_kwh_per_slot": round(mean_actual, 4),
+        "mean_pred_kwh_per_slot": round(mean_pred, 4),
+        "mape_pct": round(mape, 2),
+        "n": n,
+    }
+
+
+def _daily_stats(pairs: list[tuple[float, float]]) -> dict[str, float]:
+    if not pairs:
+        return {
+            "n_days": 0,
+            "mae_kwh_per_day": 0.0,
+            "rmse_kwh_per_day": 0.0,
+            "bias_kwh_per_day": 0.0,
+            "mean_predicted_daikin_kwh_per_day": 0.0,
+            "mean_actual_daikin_kwh_per_day": 0.0,
+            "mape_pct": 0.0,
+        }
+    n = len(pairs)
+    errs = [a - p for p, a in pairs]
+    mae = sum(abs(e) for e in errs) / n
+    rmse = (sum(e * e for e in errs) / n) ** 0.5
+    bias = sum(errs) / n
+    mean_pred = sum(p for p, _ in pairs) / n
+    mean_actual = sum(a for _, a in pairs) / n
+    ape = [abs(a - p) / a * 100 for p, a in pairs if a > 0.5]
+    mape = sum(ape) / len(ape) if ape else 0.0
+    return {
+        "n_days": n,
+        "mae_kwh_per_day": round(mae, 4),
+        "rmse_kwh_per_day": round(rmse, 4),
+        "bias_kwh_per_day": round(bias, 4),
+        "mean_predicted_daikin_kwh_per_day": round(mean_pred, 4),
+        "mean_actual_daikin_kwh_per_day": round(mean_actual, 4),
+        "mape_pct": round(mape, 2),
+    }
+
+
+def _parse_iso(raw: Any) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        ts = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return ts.astimezone(UTC)
+
+
+def _normalise_iso(raw: Any) -> str | None:
+    """Return a canonical UTC ISO key for slot_time_utc — matches the format
+    used when bucketing pv_realtime_history samples into 30-min slots."""
+    ts = _parse_iso(raw)
+    return ts.isoformat() if ts else None

--- a/tests/test_load_forecast_accuracy.py
+++ b/tests/test_load_forecast_accuracy.py
@@ -1,0 +1,221 @@
+"""Regression-baseline evaluator for load forecast accuracy (#231 analog).
+
+Mirrors tests/test_pv_forecast_accuracy.py — locks the dict shape so any future
+calibration improvement (Phase B Daikin physics correction, etc.) can be
+measured against a stable baseline.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+
+
+def _seed_lp_run(
+    *,
+    run_at: datetime,
+    slot_starts: list[datetime],
+    base_loads: list[float],
+    dhw_kwhs: list[float],
+    space_kwhs: list[float],
+) -> int:
+    """Insert one optimizer_log + matching lp_inputs_snapshot + lp_solution_snapshot rows.
+
+    All three lists must be the same length (one per slot).
+    """
+    n = len(slot_starts)
+    assert len(base_loads) == n == len(dhw_kwhs) == len(space_kwhs)
+
+    run_id = db.log_optimizer_run({
+        "run_at": run_at.isoformat(),
+        "rates_count": n,
+        "cheap_slots": 0, "peak_slots": 0, "standard_slots": n, "negative_slots": 0,
+        "target_vwap": 0.0, "actual_agile_mean": 0.0,
+        "battery_warning": False, "strategy_summary": "test",
+        "fox_schedule_uploaded": False, "daikin_actions_count": 0,
+    })
+
+    inputs = {
+        "run_at_utc": run_at.isoformat(),
+        "plan_date": run_at.date().isoformat(),
+        "horizon_hours": 24,
+        "soc_initial_kwh": 5.0, "tank_initial_c": 45.0, "indoor_initial_c": 21.0,
+        "soc_source": "test", "tank_source": "test", "indoor_source": "test",
+        "base_load_json": json.dumps(base_loads),
+        "micro_climate_offset_c": 0.0,
+        "config_snapshot_json": "{}",
+        "price_quantize_p": 0.0, "peak_threshold_p": 30.0, "cheap_threshold_p": 10.0,
+        "daikin_control_mode": "passive", "optimization_preset": "test",
+        "energy_strategy_mode": "savings_first",
+    }
+    solution = []
+    for i, start in enumerate(slot_starts):
+        solution.append({
+            "slot_index": i,
+            "slot_time_utc": start.isoformat(),
+            "price_p": 20.0,
+            "import_kwh": 0.0, "export_kwh": 0.0,
+            "charge_kwh": 0.0, "discharge_kwh": 0.0,
+            "pv_use_kwh": 0.0, "pv_curtail_kwh": 0.0,
+            "dhw_kwh": dhw_kwhs[i], "space_kwh": space_kwhs[i],
+            "soc_kwh": 5.0, "tank_temp_c": 45.0, "indoor_temp_c": 21.0,
+            "outdoor_temp_c": 10.0, "lwt_offset_c": 0.0,
+        })
+    db.save_lp_snapshots(run_id, inputs, solution)
+    return run_id
+
+
+def _seed_load_samples(slot_start: datetime, load_kw: float, n_samples: int = 6) -> None:
+    """Seed n_samples load_power_kw rows inside a 30-min slot window."""
+    step_min = 30 // n_samples
+    for i in range(n_samples):
+        ts = slot_start + timedelta(minutes=i * step_min)
+        db.save_pv_realtime_sample(
+            captured_at=ts.isoformat().replace("+00:00", "Z"),
+            solar_power_kw=0.0, soc_pct=50.0, load_power_kw=load_kw,
+            grid_import_kw=0.0, grid_export_kw=0.0,
+            battery_charge_kw=0.0, battery_discharge_kw=0.0, source="seed",
+        )
+
+
+def test_evaluator_returns_zero_when_no_data() -> None:
+    from src.analytics.load_forecast_accuracy import evaluate_load_forecast_accuracy
+    out = evaluate_load_forecast_accuracy(window_days=7)
+    assert out["n_paired"] == 0
+    assert out["overall"]["n"] == 0
+    assert out["per_hour_local"] == {}
+    assert out["daikin_daily_check"]["n_days"] == 0
+
+
+def test_perfect_prediction_zero_error() -> None:
+    """Predicted total = base_load + dhw + space. If actual matches exactly,
+    MAE/RMSE/bias should all be ~0."""
+    from src.analytics.load_forecast_accuracy import evaluate_load_forecast_accuracy
+
+    yesterday = date.today() - timedelta(days=1)
+    slot_start = datetime.combine(yesterday, datetime.min.time(), tzinfo=UTC).replace(hour=12)
+    # Predicted: 0.20 base + 0.05 dhw + 0.10 space = 0.35 kWh per slot
+    # Actual at 0.70 kW × 0.5 h = 0.35 kWh per slot — perfect match
+    _seed_lp_run(
+        run_at=slot_start - timedelta(hours=1),
+        slot_starts=[slot_start],
+        base_loads=[0.20], dhw_kwhs=[0.05], space_kwhs=[0.10],
+    )
+    _seed_load_samples(slot_start, load_kw=0.70)
+
+    out = evaluate_load_forecast_accuracy(window_days=2)
+    assert out["n_paired"] >= 1
+    assert out["overall"]["mae_kwh_per_slot"] < 0.01
+    assert abs(out["overall"]["bias_kwh_per_slot"]) < 0.01
+
+
+def test_systematic_over_prediction_shows_negative_bias() -> None:
+    """Predicted 0.55 but actual 0.22 — LP over-predicts (the live spot-check pattern).
+    bias_kwh_per_slot should be NEGATIVE (actual − predicted < 0)."""
+    from src.analytics.load_forecast_accuracy import evaluate_load_forecast_accuracy
+
+    yesterday = date.today() - timedelta(days=1)
+    slot_start = datetime.combine(yesterday, datetime.min.time(), tzinfo=UTC).replace(hour=3)
+    # Predicted: 0.10 base + 0.20 dhw + 0.25 space = 0.55 kWh
+    # Actual: 0.44 kW × 0.5 = 0.22 kWh
+    _seed_lp_run(
+        run_at=slot_start - timedelta(hours=1),
+        slot_starts=[slot_start],
+        base_loads=[0.10], dhw_kwhs=[0.20], space_kwhs=[0.25],
+    )
+    _seed_load_samples(slot_start, load_kw=0.44)
+
+    out = evaluate_load_forecast_accuracy(window_days=2)
+    assert out["overall"]["bias_kwh_per_slot"] < -0.2, (
+        f"expected over-prediction (negative bias), got {out['overall']['bias_kwh_per_slot']}"
+    )
+
+
+def test_per_hour_breakdown_uses_local_time() -> None:
+    """Hour buckets should be local (BULLETPROOF_TIMEZONE) since load is occupancy-driven.
+    UTC 03:00 in Europe/London BST is local 04:00."""
+    from src.analytics.load_forecast_accuracy import evaluate_load_forecast_accuracy
+
+    yesterday = date.today() - timedelta(days=1)
+    # Pick 03:00 UTC — in BST that's 04:00 local. (In GMT it's 03:00 local.)
+    slot_start_utc = datetime.combine(yesterday, datetime.min.time(), tzinfo=UTC).replace(hour=3)
+    _seed_lp_run(
+        run_at=slot_start_utc - timedelta(hours=1),
+        slot_starts=[slot_start_utc],
+        base_loads=[0.30], dhw_kwhs=[0.10], space_kwhs=[0.10],
+    )
+    _seed_load_samples(slot_start_utc, load_kw=0.20)
+
+    out = evaluate_load_forecast_accuracy(window_days=2)
+    assert len(out["per_hour_local"]) == 1
+    # Either 3 (GMT) or 4 (BST) is acceptable — exact value depends on DST
+    h = next(iter(out["per_hour_local"].keys()))
+    assert h in (3, 4)
+    assert out["per_hour_local"][h]["n"] == 1
+
+
+def test_dual_window_uses_latest_run_id() -> None:
+    """When two LP runs predict the same slot, the evaluator must pick the latest."""
+    from src.analytics.load_forecast_accuracy import evaluate_load_forecast_accuracy
+
+    yesterday = date.today() - timedelta(days=1)
+    slot_start = datetime.combine(yesterday, datetime.min.time(), tzinfo=UTC).replace(hour=14)
+
+    # Older run: predicts 0.80 (badly wrong)
+    _seed_lp_run(
+        run_at=slot_start - timedelta(hours=12),
+        slot_starts=[slot_start],
+        base_loads=[0.50], dhw_kwhs=[0.15], space_kwhs=[0.15],
+    )
+    # Newer run: predicts 0.30 (close to actual)
+    _seed_lp_run(
+        run_at=slot_start - timedelta(minutes=30),
+        slot_starts=[slot_start],
+        base_loads=[0.20], dhw_kwhs=[0.05], space_kwhs=[0.05],
+    )
+    _seed_load_samples(slot_start, load_kw=0.60)  # actual = 0.30 kWh
+
+    out = evaluate_load_forecast_accuracy(window_days=2)
+    # Should pair against the newer 0.30 prediction → near-zero error
+    assert out["n_paired"] == 1
+    assert out["overall"]["mae_kwh_per_slot"] < 0.05
+
+
+def test_daikin_daily_check_compares_predicted_vs_onecta() -> None:
+    """Predicted Daikin daily = Σ (dhw + space) across slots. Compared against
+    daikin_consumption_daily.kwh_total. Surfaces the daily physics-model bias."""
+    from src.analytics.load_forecast_accuracy import evaluate_load_forecast_accuracy
+
+    yesterday = date.today() - timedelta(days=1)
+    base = datetime.combine(yesterday, datetime.min.time(), tzinfo=UTC)
+    slots = [base.replace(hour=h) for h in range(0, 24, 6)]  # 4 slots
+    # Each slot predicts 0.50 dhw + 0.50 space = 1.00 → daily total predicted = 4.0 kWh
+    _seed_lp_run(
+        run_at=base - timedelta(hours=1),
+        slot_starts=slots,
+        base_loads=[0.0] * 4, dhw_kwhs=[0.5] * 4, space_kwhs=[0.5] * 4,
+    )
+    # Actual Onecta says 3.0 kWh — physics over-predicted by 1.0 kWh
+    db.upsert_daikin_consumption_daily(
+        date=yesterday.isoformat(), kwh_total=3.0, source="onecta",
+    )
+
+    out = evaluate_load_forecast_accuracy(window_days=2)
+    chk = out["daikin_daily_check"]
+    assert chk["n_days"] == 1
+    assert chk["mean_predicted_daikin_kwh_per_day"] == pytest.approx(4.0, abs=0.01)
+    assert chk["mean_actual_daikin_kwh_per_day"] == pytest.approx(3.0, abs=0.01)
+    # Onecta < predicted → bias = actual − pred = -1.0 (physics over-predicts)
+    assert chk["bias_kwh_per_day"] == pytest.approx(-1.0, abs=0.01)


### PR DESCRIPTION
Closes #236.

## Summary

- New `src/analytics/load_forecast_accuracy.py::evaluate_load_forecast_accuracy(window_days=30)` — direct mirror of `evaluate_pv_forecast_accuracy` (#231), but for total household load.
- For each slot in window, pairs the most-recent (`MAX(run_id)`) LP prediction (`base_load_json[slot_index] + dhw_kwh + space_kwh`) against measured `pv_realtime_history.load_power_kw` averaged into the 30-min slot × 0.5 h. Returns overall + per-local-hour MAE/RMSE/bias/MAPE.
- New `daikin_daily_check` block compares predicted Daikin daily Σ (`Σ dhw_kwh + space_kwh`) against Onecta-measured `daikin_consumption_daily.kwh_total`. This is the diagnostic that drives any future Daikin physics calibration — without per-slot Daikin metering (which doesn't exist), daily aggregate is the only ground-truth comparison available.
- `scripts/check_load_forecast_accuracy.py` CI gate — fails on >5 % MAE/RMSE regression vs the locked baseline. Mirrors `scripts/check_pv_forecast_accuracy.py`.
- `tests/test_load_forecast_accuracy.py` — 6 tests covering empty data, perfect prediction, biased fixture, local-time bucketing (load is occupancy-driven, not solar-driven), latest-run-id selection across multiple LP runs for the same slot, and the Daikin daily check.

## Live spot-check that motivated this PR (last 24h prod)

| Metric | Value | Meaning |
|---|---|---|
| MAE / slot | 0.257 kWh | ~12 kWh/day cumulative |
| RMSE / slot | 0.340 kWh | |
| Bias / slot | −0.136 kWh | LP **over-predicts** ~6.5 kWh/day |

Bias is concentrated overnight (00:30–08:00 BST): LP says ~0.55 kWh/slot, reality is ~0.22 kWh/slot — 2.5× over-prediction when the only meaningful load is the heat pump on weather compensation. Almost certainly the uncalibrated Daikin physics model leaking into the LP's residual+physics composition.

Same problem class as the PV under-prediction fixed in #229/#232, opposite sign. Locking a baseline now means any future calibration improvement is measurable.

## Out of scope (Phase B follow-up)

- Daikin physics calibration table — natural follow-up once `daikin_daily_check.bias_kwh_per_day` confirms the magnitude bias. May intersect with #196 V11-C (DHW prior) once Phase A's per-hour breakdown shows whether the bias is mostly DHW or mostly space.
- Note for Phase B design: the Onecta `consumptionData.value.electrical.{heating|dhw}.d` array is 24 elements = 12 yesterday + 12 today (2-hour buckets), already in the cached `/gateway-devices` payload — zero extra Daikin quota to surface 2-hour-resolution measured Daikin instead of daily-only.

## Test plan

- [x] `pytest tests/test_load_forecast_accuracy.py` — 6/6 green locally.
- [x] `pytest tests/test_pv_forecast_accuracy.py` — 5/5 green (no regression in PV evaluator from shared utilities).
- [x] Smoke run on local DB (no LP snapshots) — graceful zeros, no crashes.
- [ ] **Post-merge step**: capture baseline by running `docker exec hem python /tmp/check_load_forecast_accuracy.py` on prod and committing the printed JSON to `tests/fixtures/load_forecast_baseline.json`. The check script handles the missing-baseline case gracefully (prints current, returns 0) until that's done.
- [ ] Verify on prod: `per_hour_local[2..7]` MAE ≥ 0.30 kWh/slot per the live spot-check.
- [ ] Verify on prod: `daikin_daily_check.bias_kwh_per_day` is **negative** (LP over-predicts vs Onecta) — green-light for Phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)