### PR TITLE
feat(daikin): persist 2-hourly consumption from Onecta cache

### DIFF
--- a/src/daikin/client.py
+++ b/src/daikin/client.py
@@ -450,6 +450,89 @@ class DaikinClient:
             b["dhw_kwh"] = round(b["dhw_kwh"], 3)
         return out
 
+    def get_2hourly_consumption_from_cache(
+        self, today_local: "_datetime.date | None" = None
+    ) -> dict[str, dict[int, dict[str, float]]]:
+        """Parse 2-hourly consumption from the cached ``/gateway-devices`` payload (#238).
+
+        Onecta exposes ``consumptionData.value.electrical.<mode>.d`` as a
+        24-element array layout: indices 0–11 = yesterday's 2-hour buckets
+        (00:00–02:00 ... 22:00–24:00), indices 12–23 = today's 2-hour buckets,
+        with future buckets reported as ``None``. The Onecta app's "DAY"
+        view labels this resolution as **2-hourly average** — that's the
+        finest granularity the public API offers. Anchored to the user's
+        local TZ (matches the app's bar-chart x-axis).
+
+        Returns ``{date_iso: {bucket_idx: {"heating_kwh": x, "dhw_kwh": y, "total_kwh": z}}}``
+        with ``bucket_idx`` in ``[0, 11]`` (0 = 00:00–02:00, 11 = 22:00–24:00).
+        Buckets reported as ``None`` are silently skipped — the upsert's
+        ``ON CONFLICT DO UPDATE`` lets later polls overwrite once the value
+        materialises.
+
+        ``today_local`` is injectable for tests; defaults to ``date.today()``.
+        Zero extra Daikin API quota — read-only over an already-cached payload.
+        """
+        from datetime import date as _date, timedelta as _td
+
+        if today_local is None:
+            today_local = _date.today()
+        yesterday_local = today_local - _td(days=1)
+
+        out: dict[str, dict[int, dict[str, float]]] = {}
+        try:
+            devices = self.get_devices()
+        except Exception:
+            return out
+
+        def _bucket(date_iso: str, idx: int) -> dict[str, float]:
+            day_buckets = out.setdefault(date_iso, {})
+            return day_buckets.setdefault(idx, {"heating_kwh": 0.0, "dhw_kwh": 0.0})
+
+        for device in devices:
+            for mp in device.raw.get("managementPoints", []):
+                mp_type = mp.get("managementPointType", "")
+                cd = mp.get("consumptionData")
+                if not isinstance(cd, dict):
+                    continue
+                cdv = cd.get("value")
+                if not isinstance(cdv, dict):
+                    continue
+                electrical = cdv.get("electrical")
+                if not isinstance(electrical, dict):
+                    continue
+                is_dhw = "domesticHotWater" in mp_type or "dhw" in mp_type.lower()
+                bucket_key = "dhw_kwh" if is_dhw else "heating_kwh"
+
+                for mode_name in ("heating", "cooling"):
+                    mode_data = electrical.get(mode_name)
+                    if not isinstance(mode_data, dict):
+                        continue
+                    arr = mode_data.get("d")
+                    if not isinstance(arr, list) or len(arr) != 24:
+                        continue  # defensive — only proceed when the array is the expected shape
+                    for i, val in enumerate(arr):
+                        if val is None:
+                            continue
+                        try:
+                            kwh = float(val)
+                        except (TypeError, ValueError):
+                            continue
+                        if i < 12:
+                            date_iso = yesterday_local.isoformat()
+                            bucket_idx = i
+                        else:
+                            date_iso = today_local.isoformat()
+                            bucket_idx = i - 12
+                        b = _bucket(date_iso, bucket_idx)
+                        b[bucket_key] += kwh
+
+        for date_iso, day in out.items():
+            for bucket_idx, b in day.items():
+                b["total_kwh"] = round(b["heating_kwh"] + b["dhw_kwh"], 3)
+                b["heating_kwh"] = round(b["heating_kwh"], 3)
+                b["dhw_kwh"] = round(b["dhw_kwh"], 3)
+        return out
+
     def get_heating_daily_kwh(self, year: int, month: int) -> list[float] | None:
         """
         Get daily heating consumption (kWh) for the month when available.

--- a/src/db.py
+++ b/src/db.py
@@ -333,6 +333,24 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         )"""
     )
 
+    # 2-hourly Daikin consumption (#238). The Onecta API exposes
+    # ``consumptionData.value.electrical.<mode>.d`` as a 24-element array =
+    # 12 yesterday + 12 today (2-hour buckets). bucket_idx 0 = 00:00–02:00,
+    # bucket_idx 11 = 22:00–24:00, both anchored to the user's local TZ.
+    # Already in the cached /gateway-devices payload — zero extra Daikin quota.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS daikin_consumption_2hourly (
+            date TEXT NOT NULL,
+            bucket_idx INTEGER NOT NULL CHECK (bucket_idx BETWEEN 0 AND 11),
+            kwh_total REAL,
+            kwh_heating REAL,
+            kwh_dhw REAL,
+            source TEXT NOT NULL DEFAULT 'unknown',
+            fetched_at TEXT NOT NULL,
+            PRIMARY KEY (date, bucket_idx)
+        )"""
+    )
+
     # V4: fox_realtime_snapshot — single-row live telemetry for MPC seeding
     conn.execute(
         """CREATE TABLE IF NOT EXISTS fox_realtime_snapshot (
@@ -2609,6 +2627,64 @@ def upsert_daikin_consumption_daily(
                 (date, kwh_total, kwh_heating, kwh_dhw, cop_daily, source, now),
             )
             conn.commit()
+        finally:
+            conn.close()
+
+
+def upsert_daikin_consumption_2hourly(
+    *,
+    date: str,
+    bucket_idx: int,
+    kwh_total: float | None,
+    kwh_heating: float | None = None,
+    kwh_dhw: float | None = None,
+    source: str = "onecta",
+) -> None:
+    """Upsert one ``daikin_consumption_2hourly`` row (#238). Idempotent.
+
+    Re-polling the same day overwrites the previous row, which is the
+    correct semantics: future buckets arrive as later polls fetch the
+    payload, and earlier-bucket values can also revise as Onecta's
+    aggregator settles.
+    """
+    if not (0 <= int(bucket_idx) <= 11):
+        raise ValueError(f"bucket_idx must be in [0, 11], got {bucket_idx}")
+    now = datetime.now(UTC).isoformat()
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT INTO daikin_consumption_2hourly
+                   (date, bucket_idx, kwh_total, kwh_heating, kwh_dhw, source, fetched_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(date, bucket_idx) DO UPDATE SET
+                     kwh_total=excluded.kwh_total,
+                     kwh_heating=excluded.kwh_heating,
+                     kwh_dhw=excluded.kwh_dhw,
+                     source=excluded.source,
+                     fetched_at=excluded.fetched_at""",
+                (date, int(bucket_idx), kwh_total, kwh_heating, kwh_dhw, source, now),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def get_daikin_consumption_2hourly_range(
+    start_date: str, end_date: str
+) -> list[dict[str, Any]]:
+    """All 2-hourly Daikin consumption rows in ``[start_date, end_date]`` inclusive,
+    ordered by (date ASC, bucket_idx ASC)."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM daikin_consumption_2hourly "
+                "WHERE date >= ? AND date <= ? "
+                "ORDER BY date ASC, bucket_idx ASC",
+                (start_date, end_date),
+            )
+            return [dict(r) for r in cur.fetchall()]
         finally:
             conn.close()
 

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -308,20 +308,44 @@ def bulletproof_daikin_consumption_rollup_job() -> None:
         per_day = client.get_daily_consumption_from_cache()
         if not per_day:
             logger.info("daikin rollup: no consumption data in cached payload — skipped")
-            return
-        n = 0
-        for day, b in per_day.items():
-            db.upsert_daikin_consumption_daily(
-                date=day,
-                kwh_total=b.get("total_kwh"),
-                kwh_heating=b.get("heating_kwh"),
-                kwh_dhw=b.get("dhw_kwh"),
-                source="onecta_cache",
-            )
-            n += 1
-        logger.info("daikin_consumption_daily rollup: %d days written from cache", n)
+        else:
+            n = 0
+            for day, b in per_day.items():
+                db.upsert_daikin_consumption_daily(
+                    date=day,
+                    kwh_total=b.get("total_kwh"),
+                    kwh_heating=b.get("heating_kwh"),
+                    kwh_dhw=b.get("dhw_kwh"),
+                    source="onecta_cache",
+                )
+                n += 1
+            logger.info("daikin_consumption_daily rollup: %d days written from cache", n)
     except Exception as e:
         logger.warning("daikin rollup failed (non-fatal): %s", e)
+
+    # 2-hourly rollup (#238) — feeds the future Daikin physics calibration.
+    # Same cached payload, different array (``d`` vs ``w``). Independent
+    # try/except so a parse failure here doesn't drop the daily rollup above.
+    try:
+        per_2h = client.get_2hourly_consumption_from_cache()
+        if not per_2h:
+            logger.info("daikin 2h rollup: no consumption data in cached payload — skipped")
+            return
+        n = 0
+        for day, day_buckets in per_2h.items():
+            for bucket_idx, b in day_buckets.items():
+                db.upsert_daikin_consumption_2hourly(
+                    date=day,
+                    bucket_idx=bucket_idx,
+                    kwh_total=b.get("total_kwh"),
+                    kwh_heating=b.get("heating_kwh"),
+                    kwh_dhw=b.get("dhw_kwh"),
+                    source="onecta_cache",
+                )
+                n += 1
+        logger.info("daikin_consumption_2hourly rollup: %d (date,bucket) rows written from cache", n)
+    except Exception as e:
+        logger.warning("daikin 2h rollup failed (non-fatal): %s", e)
 
 
 def bulletproof_fox_energy_rollup_job() -> None:

--- a/tests/test_daikin_2hourly_consumption.py
+++ b/tests/test_daikin_2hourly_consumption.py
@@ -1,0 +1,157 @@
+"""DaikinClient.get_2hourly_consumption_from_cache — parse 'd' array (#238).
+
+Daikin Onecta layout: ``consumptionData.value.electrical.<mode>.d`` is a
+24-element list mapping array indices → 2-hour buckets as:
+  arr[0..11]  = yesterday's 12 × 2-hour buckets (00:00–02:00 ... 22:00–24:00)
+  arr[12..23] = today's 12 × 2-hour buckets (same layout)
+
+Confirmed empirically — the Onecta app's "DAY" view labels the resolution as
+"2-hourly average" and renders 12 bars across a 24-hour x-axis.
+"""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.daikin.client import DaikinClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+
+
+class _FakeDevice:
+    def __init__(self, mp_payloads: list[dict]) -> None:
+        self.id = "test-device"
+        self.raw = {"managementPoints": mp_payloads}
+
+
+def _build_client_with_devices(devices: list[_FakeDevice]) -> DaikinClient:
+    c = DaikinClient.__new__(DaikinClient)
+    c.get_devices = lambda **_: devices  # type: ignore[method-assign]
+    return c
+
+
+def _d_array(values_by_idx: dict[int, float]) -> list[float | None]:
+    arr: list[float | None] = [None] * 24
+    for idx, v in values_by_idx.items():
+        arr[idx] = v
+    return arr
+
+
+def _consumption_data(*, heating_d: list, mp_type: str = "climateControl") -> dict:
+    return {
+        "managementPointType": mp_type,
+        "consumptionData": {"value": {"electrical": {"heating": {"d": heating_d}}}},
+    }
+
+
+def test_idx_0_to_11_maps_to_yesterday() -> None:
+    today = date(2026, 5, 2)
+    # idx 0 = yesterday 00:00–02:00, idx 11 = yesterday 22:00–24:00
+    heating_d = _d_array({0: 0.5, 11: 1.2})
+    devices = [_FakeDevice([_consumption_data(heating_d=heating_d)])]
+    client = _build_client_with_devices(devices)
+
+    out = client.get_2hourly_consumption_from_cache(today_local=today)
+    assert "2026-05-01" in out  # yesterday
+    yest = out["2026-05-01"]
+    assert yest[0]["heating_kwh"] == pytest.approx(0.5)
+    assert yest[0]["total_kwh"] == pytest.approx(0.5)
+    assert yest[11]["heating_kwh"] == pytest.approx(1.2)
+
+
+def test_idx_12_to_23_maps_to_today() -> None:
+    today = date(2026, 5, 2)
+    # idx 12 = today 00:00–02:00, idx 23 = today 22:00–24:00
+    heating_d = _d_array({12: 0.3, 14: 0.8})  # 00–02 and 04–06
+    devices = [_FakeDevice([_consumption_data(heating_d=heating_d)])]
+    client = _build_client_with_devices(devices)
+
+    out = client.get_2hourly_consumption_from_cache(today_local=today)
+    assert "2026-05-02" in out
+    today_b = out["2026-05-02"]
+    assert today_b[0]["heating_kwh"] == pytest.approx(0.3)
+    assert today_b[2]["heating_kwh"] == pytest.approx(0.8)
+
+
+def test_dhw_management_point_routes_to_dhw_bucket() -> None:
+    today = date(2026, 5, 2)
+    dhw_mp = _consumption_data(heating_d=_d_array({12: 0.4}), mp_type="domesticHotWaterTank")
+    space_mp = _consumption_data(heating_d=_d_array({12: 0.6}))
+    devices = [_FakeDevice([dhw_mp, space_mp])]
+    client = _build_client_with_devices(devices)
+
+    out = client.get_2hourly_consumption_from_cache(today_local=today)
+    today_bucket0 = out["2026-05-02"][0]
+    assert today_bucket0["heating_kwh"] == pytest.approx(0.6)
+    assert today_bucket0["dhw_kwh"] == pytest.approx(0.4)
+    assert today_bucket0["total_kwh"] == pytest.approx(1.0)
+
+
+def test_none_values_skipped_so_only_populated_buckets_returned() -> None:
+    today = date(2026, 5, 2)
+    heating_d = _d_array({0: 0.5, 12: 0.3})  # one yesterday bucket, one today bucket; rest None
+    devices = [_FakeDevice([_consumption_data(heating_d=heating_d)])]
+    client = _build_client_with_devices(devices)
+
+    out = client.get_2hourly_consumption_from_cache(today_local=today)
+    # Only one bucket per day populated
+    assert set(out["2026-05-01"].keys()) == {0}
+    assert set(out["2026-05-02"].keys()) == {0}
+
+
+def test_wrong_array_length_silently_skipped() -> None:
+    """Defensive — only the documented 24-element shape is parsed.
+    A 12- or 48-element array should not crash, just yield nothing."""
+    today = date(2026, 5, 2)
+    weird = [0.5] * 12  # wrong shape
+    devices = [_FakeDevice([_consumption_data(heating_d=weird)])]
+    client = _build_client_with_devices(devices)
+    out = client.get_2hourly_consumption_from_cache(today_local=today)
+    assert out == {}
+
+
+def test_db_upsert_round_trip() -> None:
+    db.upsert_daikin_consumption_2hourly(
+        date="2026-05-01", bucket_idx=3, kwh_total=0.55,
+        kwh_heating=0.55, kwh_dhw=0.0, source="onecta_cache",
+    )
+    rows = db.get_daikin_consumption_2hourly_range("2026-05-01", "2026-05-01")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["bucket_idx"] == 3
+    assert r["kwh_total"] == pytest.approx(0.55)
+    assert r["source"] == "onecta_cache"
+
+
+def test_db_upsert_idempotent_overwrites() -> None:
+    """Re-polling the same (date, bucket_idx) overwrites — the correct semantics
+    when Onecta later revises an earlier-reported value."""
+    db.upsert_daikin_consumption_2hourly(
+        date="2026-05-01", bucket_idx=5, kwh_total=0.10, source="onecta_cache",
+    )
+    db.upsert_daikin_consumption_2hourly(
+        date="2026-05-01", bucket_idx=5, kwh_total=0.42, source="onecta_cache",
+    )
+    rows = db.get_daikin_consumption_2hourly_range("2026-05-01", "2026-05-01")
+    assert len(rows) == 1
+    assert rows[0]["kwh_total"] == pytest.approx(0.42)
+
+
+def test_db_rejects_out_of_range_bucket() -> None:
+    with pytest.raises(ValueError):
+        db.upsert_daikin_consumption_2hourly(
+            date="2026-05-01", bucket_idx=12, kwh_total=0.0,
+        )
+    with pytest.raises(ValueError):
+        db.upsert_daikin_consumption_2hourly(
+            date="2026-05-01", bucket_idx=-1, kwh_total=0.0,
+        )


### PR DESCRIPTION
Phase B prerequisite for #238. Independent of #237 — can land in either order.

## Summary

- **New table `daikin_consumption_2hourly`** — `(date, bucket_idx 0..11, kwh_total, kwh_heating, kwh_dhw, source, fetched_at)`, PK `(date, bucket_idx)`. `bucket_idx 0` = `00:00–02:00`, `bucket_idx 11` = `22:00–24:00`, anchored to user's local TZ (matches the Onecta app's bar-chart x-axis).
- **New `DaikinClient.get_2hourly_consumption_from_cache()`** — parses the `consumptionData.value.electrical.<mode>.d` 24-element array we're already caching on every `/gateway-devices` poll. Indices 0–11 → yesterday's 12 × 2-hour buckets, 12–23 → today's. Mirrors the existing `get_daily_consumption_from_cache()` (which parses the `w` array). Zero additional Daikin API quota.
- **Extended `bulletproof_daikin_consumption_rollup_job`** — same scheduled job now produces both daily and 2-hourly rollups. Independent `try/except` blocks so a parse failure on either side doesn't drop the other.
- **8 new tests** in `tests/test_daikin_2hourly_consumption.py` covering: yesterday/today bucket mapping, DHW vs heating routing by management point type, `None` handling, defensive rejection of wrong-shape arrays, DB round-trip, idempotent overwrite (later polls revising earlier values), and `bucket_idx` range validation.

## Why now

#238 (Phase B Daikin physics calibration) needs a 14+ day window of 2-hourly Daikin consumption data before the calibration table can be meaningfully fit. The data is already arriving in the cached Onecta payload — we just weren't persisting it. **Shipping this PR starts the data clock**; the calibration table itself is a follow-up.

## Evidence the resolution is real 2-hourly

The Onecta app's "Total → DAY" view explicitly labels the metric as **"2-hourly average"** in its Data insights panel and renders 12 bars across a 24-hour x-axis. The `d` array layout (24 elements split as 12 yesterday + 12 today) matches exactly — same data the app uses, just persisted at the source.

## Test plan

- [x] `pytest tests/test_daikin_2hourly_consumption.py` — 8/8 green.
- [x] `pytest tests/test_daikin_daily_consumption.py tests/test_daikin_daily_cache.py` — no regression in the existing daily parser (9/9 green).
- [x] Full suite (`pytest tests/ --ignore=tests/test_mcp_singleton.py`) — **837 passed, 1 skipped** in 3m27s. (`test_mcp_singleton.py` is pre-broken from the singleton-flock removal noted in CLAUDE.md, unrelated to this PR.)
- [ ] On prod after merge: `docker exec hem sqlite3 /app/data/energy_state.db "SELECT date, bucket_idx, kwh_total FROM daikin_consumption_2hourly ORDER BY date DESC, bucket_idx DESC LIMIT 24"` — should show buckets accumulating after the next consumption-rollup tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)