### PR TITLE
docs: relicense to Apache 2.0 + public-project polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Something the LP, dispatch, or hardware integration is doing wrong.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing! Please include enough detail that I can reproduce or replay the bug — for LP / dispatch issues, the `run_id` of the optimizer run that misbehaved is the single most useful piece of information.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A short description of the bug. Lead with the observable symptom (e.g. "LP committed peak_export at 14:00 even though Daikin was running Powerful").
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: One sentence is fine.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `docker exec hem cat /app/.git-sha`, or the tag you're running.
+      placeholder: e.g. v10.2.0 or commit 8304fb7
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: |
+        For LP issues: which `run_id` (from `optimizer_log`)? What was the SoC/tank/indoor state? Output of `replay_run(run_id)` if you have it.
+
+        For hardware issues: what did the heartbeat log show? Did `action_schedule` have the row?
+    validations:
+      required: false
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Anything non-default in `.env` that's relevant — e.g. `LP_PEAK_EXPORT_PESSIMISTIC_FLOOR_KWH`, `DAIKIN_CONTROL_MODE`, `ENERGY_STRATEGY_MODE`. Don't paste secrets.
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        `journalctl -u hem --since "1 hour ago" | grep -i <subsystem>` is usually a good source.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/albinati/home-energy-manager/blob/main/SECURITY.md
+    about: Don't file security issues publicly — see SECURITY.md for the disclosure process.
+  - name: V11 accuracy roadmap
+    url: https://github.com/albinati/home-energy-manager/issues/193
+    about: The active epic for past-data integration + uncertainty modelling.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest a new capability or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Lead with the *goal*, not the *implementation*. "I want to know if guests are home so the LP plans extra DHW" is more useful than "add an `is_guests` boolean to config."
+
+        For accuracy / LP changes specifically, check the [V11 epic (#193)](https://github.com/albinati/home-energy-manager/issues/193) — your idea may already have a story.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to achieve?
+      description: The user-facing or financial outcome. One paragraph.
+    validations:
+      required: true
+
+  - type: textarea
+    id: status-quo
+    attributes:
+      label: How does it work today?
+      description: What's the current behaviour, and why is it insufficient?
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: Proposed approach (optional)
+      description: |
+        Implementation thoughts if you have them. It's fine to skip this — sometimes the right shape only emerges in discussion.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds, related issues, or off-the-shelf tools you looked at first.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Personal site (this installation only)
+        - Generalisable (could help others adopting the project)
+        - Unsure
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+This is a personal project running 24/7 against one specific UK installation. Public contributions are welcome — but the PR bar is "does this make my installation strictly better, with evidence, without breaking the regression gate?"
+
+## Before opening a PR
+
+1. **Open an issue first** for anything beyond a typo or one-line fix. Saves both of us time if the change isn't a fit.
+2. **Check the [V11 roadmap epic (#193)](https://github.com/albinati/home-energy-manager/issues/193)** — most accuracy work has a designated story already.
+3. **Run the test suite locally** — `pytest` (~3 min, 837+ tests). All tests must pass.
+4. **Run the regression gate** if you touch `src/scheduler/`:
+   ```bash
+   DB_PATH=/path/to/prod-snapshot.db .venv/bin/python scripts/check_lp_regression.py --mode=both
+   ```
+   Both `forward` and `honest` modes must pass. If you intentionally regressed the planner (new objective term, tuned weights), refresh the baseline JSON in the same PR.
+
+## Local dev setup
+
+```bash
+git clone https://github.com/albinati/home-energy-manager.git
+cd home-energy-manager
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+cp .env.example .env
+# Set OPENCLAW_READ_ONLY=true — this is the kill switch for any hardware writes.
+pytest
+```
+
+## Code conventions
+
+- **Python 3.12+**, type-hinted where it adds clarity (don't dogmatically annotate every variable).
+- **Ruff** for linting + formatting: `ruff check src tests` and `ruff format src tests`. CI enforces this.
+- **No new dependencies** without an issue discussing why. The dependency tree is intentionally small.
+- **No emojis in code or commits** (READMEs and PR bodies are fine).
+- **Comments are for the *why*, not the *what*.** Well-named identifiers describe what; comments justify hidden constraints, surprising invariants, or workarounds for specific bugs.
+
+## Commit style
+
+Follow the existing log: `<type>(<scope>): <subject>`, e.g. `fix(lp): residual-load profile no longer pollutes itself in passive mode`. Types in active use: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`. Reference the issue number in the body or trailing line so the squash-merge auto-closes it.
+
+## Hardware-touching changes
+
+This codebase controls real hardware: a heat pump that heats a house and a battery worth real money. Be paranoid about:
+
+- **Quota**: Daikin Onecta has a hard 200/day limit. Test changes against `OPENCLAW_READ_ONLY=true` first.
+- **Idempotency**: writes are issued repeatedly by the heartbeat. Anything that depends on "this is the first call this minute" is a bug waiting to happen.
+- **Comfort slack**: tank target floors and indoor temperature setpoints are LP soft constraints, not hard ones. Don't tighten them without evidence (a PnL improvement that's not from making the household colder).
+
+## Reviewing
+
+PRs run `pytest`, `lint-imports`, and (for any LP-touching code) the `--mode=both` regression gate. CI runs are required before merge. Ask for a re-review after pushing fixes — don't squash-and-force-push (it loses review history); push fix-up commits and let the squash-merge collapse them on land.
+
+## Issues
+
+Bug reports → [`Bug report` template](.github/ISSUE_TEMPLATE/bug_report.yml). Include the prod or sim DB row counts, the relevant `optimizer_log` `run_id`, and ideally a `replay_run` output if the LP made a surprising decision.
+
+Feature ideas → [`Feature request` template](.github/ISSUE_TEMPLATE/feature_request.yml). Lead with the goal (`I want X because Y`), not the implementation.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2026 Luis Albinati (luis.albinati@gmail.com)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+home-energy-manager
+Copyright 2026 Luis Albinati
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,401 +1,154 @@
 # home-energy-manager
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Tests](https://github.com/albinati/home-energy-manager/actions/workflows/tests.yml/badge.svg)](https://github.com/albinati/home-energy-manager/actions/workflows/tests.yml)
+[![Latest release](https://img.shields.io/github/v/release/albinati/home-energy-manager)](https://github.com/albinati/home-energy-manager/releases)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
+[![Container image](https://img.shields.io/badge/ghcr.io-home--energy--manager-blue?logo=docker)](https://github.com/albinati/home-energy-manager/pkgs/container/home-energy-manager)
 
-**Standalone home energy controller** for Fox ESS battery + Daikin Altherma heat pump (Onecta). It runs the automation (schedules, SQLite state, bulletproof heartbeat) on your hardware; the FastAPI server is the **machine interface** for dashboards, scripts, and optional tools (**OpenClaw** REST + MCP). **Core scheduling and hardware writes do not depend on OpenClaw**—OpenClaw is for visibility, reports, and optional remote control when you enable it.
+> A single planning brain for a UK home running **Octopus Agile** + **Fox ESS battery** + **Daikin Altherma heat pump**. Solves a 24–48 h MILP every few minutes, uploads a Fox ESS Scheduler V3, drives Daikin via Onecta, and exposes a 57-tool MCP surface for Claude / OpenClaw.
 
-**Notifications:** this service does **not** call Telegram or any chat API directly. When enabled, it sends a single **`POST` to the OpenClaw Gateway** (`OPENCLAW_HOOKS_URL`, e.g. `/hooks/agent`) with optional `channel` / `to` fields so the Gateway can deliver downstream. See [CHANGELOG.md](CHANGELOG.md) and [GitHub Releases](https://github.com/albinati/home-energy-manager/releases) for version history (e.g. **v9.1.0** hardening).
+## Why it exists
 
-### The planning brain
+Most home-battery controllers run hand-coded rules per appliance. Multi-vendor optimisation against half-hourly Agile prices, weather-dependent heat-pump demand, and DHW pre-heat windows is the sort of thing rules get wrong. So this is a real solver — `PuLP` over a 96-slot horizon — that minimises grid cost while respecting:
 
-This app is the **brain** for the installation: it **captures half-hourly Agile tariffs** into SQLite, **pulls weather forecasts** (PV and heating demand), **learns typical half-hourly load** from `execution_log`, **classifies tomorrow’s slots** (cheap / peak / negative + battery margin), and **writes** Fox Scheduler V3 plus Daikin `action_schedule`. A **heartbeat** reconciles live hardware with that plan. Details and data-flow: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
+- Battery RT efficiency, SoC bounds, ramp limits, peak-export robustness
+- Heat-pump COP curve vs outdoor temperature, weather-compensation curve, DHW tank thermal mass
+- Octopus Agile import + Outgoing Agile export prices, SVT shadow cost for accountability
+- Negative-price plunges, peak windows, scenario perturbations for cold-night safety
 
-**V7 removal:** The legacy `src/optimization/` solver/consent stack is gone (single Bulletproof brain). Rollback source: git tag **`pre-v7-removal`** — see **[CHANGELOG.md](CHANGELOG.md)**.
+Every solve is snapshotted to SQLite so any past day's plan can be re-run under today's code (closed-loop replay) — that's the regression gate that lets you tune the model without breaking last week's planner.
+
+```
+                ┌─────────────────────────────┐
+  Octopus Agile ──→  half-hourly tariff       │
+  Open-Meteo    ──→  temp + cloud + radiation │
+  Fox ESS       ──→  load, PV, SoC, schedule  │
+  Daikin Onecta ──→  tank, indoor, outdoor    │     PuLP MILP
+  SmartThings   ──→  appliance state          │ ──→ 24–48h plan ──→  Fox V3 schedule
+                │                             │                      Daikin action_schedule
+  Past data     ──→  PV calibration table     │                      OpenClaw consent hooks
+                ──→  load profile             │
+                ──→  Daikin physics priors    │
+                └─────────────────────────────┘
+                            ↑                                 ↓
+                            │                            ┌────────┐
+                            └─── snapshots ────────────  │ replay │  ← regression gate
+                                 (closed-loop)           └────────┘
+```
+
+## Status
+
+This is a working personal project running 24/7 on one site (W4 1DZ, London). It is **public so the architecture and accuracy work are open**, not because it is a turn-key product. Hardware specs, integrations, and tariff defaults are tuned to one installation:
+
+- 4.5 kW PV array, Fox H1-5.0-E-G2 inverter, EP11 battery
+- Daikin Altherma 3 H HT (passive mode in summer, active LWT modulation in heating season)
+- G98 single-phase export limit 3.68 kW
+- Octopus Agile import + Outgoing Agile export
+- Heat pump runs on Daikin's own weather curve; LP shifts demand, doesn't override the curve
+
+Everything is parameterised via `.env`. Adapting it to a different setup is feasible but undocumented — open a discussion if you want to try.
 
 ## What it does
 
-- **Fox ESS**: Read real-time battery SoC, solar production, grid import/export, inverter stats. Control charge/discharge mode and time-of-use schedules.
-- **Daikin Onecta**: Read heat pump status, radiator temperature, outdoor temperature, DHW tank temperature. Control power, temperature targets, heating curve offset, and weather regulation.
-- **Smart scheduling**: Time-of-use optimisation — charge battery on cheap-rate periods, pre-heat with solar surplus.
-- **Energy / tariffs**: Octopus Agile rates ingested and stored; shadow pricing, PnL, VWAP, and reports use the same state the planner uses.
-- **OpenClaw**: Optional remote visibility/control via HTTP API (`HOME_ENERGY_API_URL`) or MCP; **user notifications** use **Gateway hooks only** (`OPENCLAW_HOOKS_URL` + `OPENCLAW_HOOKS_TOKEN`). There is no `openclaw message send` subprocess and no direct channel API from this repo. Default `OPENCLAW_READ_ONLY=true` keeps agent executes gated unless you opt in.
+- **Octopus Agile fetch** every 30 min. Stores import + Outgoing Agile rates in SQLite for the next ~36 h.
+- **Open-Meteo forecast** every LP solve — temperature, shortwave radiation, cloud cover. Snapshotted per fetch for replay.
+- **PV forecast calibration** — three-tier resolver: cloud-aware `(hour, cloud bucket)` table → per-hour-of-day table → flat factor. Today-aware OCF Quartz-style adjuster on top.
+- **Load forecast accuracy evaluator** — per-slot MAE/RMSE/bias broken down by local hour, plus a daily Daikin physics check against Onecta-measured kWh. Captures the biases the LP hasn't yet learned.
+- **MILP solver (PuLP)** — 96-slot horizon, soft penalties for cycling/comfort/inverter stress, scenario LP for peak-export robustness, twice-daily and tier-boundary MPC.
+- **Fox ESS Scheduler V3** — single daily upload of the optimised charge/discharge windows. Heuristic fallback if the LP fails.
+- **Daikin Onecta** — `action_schedule` rows that the heartbeat applies; LWT offset, tank target, weather regulation toggles. OAuth2 with auto-refresh.
+- **SmartThings appliance dispatch** — washer/dryer/dishwasher start times picked by the LP given a deadline; physical Smart Control button is the consent gate.
+- **Notifications via OpenClaw hook** — twice-daily digest, plan-revision pings, negative-price alerts. No direct chat APIs from this repo.
+- **57-tool MCP surface** — Fox, Daikin, Octopus, optimization, replay, dispatch decisions. Bearer-guarded HTTP transport.
+- **Closed-loop replay + regression gate** — every LP solve is a frozen, replayable snapshot; `scripts/check_lp_regression.py --mode=both` blocks merges that make the planner worse.
 
-## Quick start
+## How it works
+
+The full architecture is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). The short version:
+
+1. A scheduler tick fetches the latest Agile rates + weather forecast.
+2. Past-data layers (load profile, residual-load profile minus physics-Daikin, PV calibration, dispatch decisions) feed into `lp_inputs_snapshot`.
+3. `solve_lp()` runs PuLP/CBC over the 96-slot horizon with soft objective penalties for cycling, comfort slack, and inverter stress.
+4. A scenario LP (optimistic / nominal / pessimistic perturbations) filters `peak_export` slots that would lose money under cold-night conditions.
+5. The plan is persisted (`lp_solution_snapshot`), uploaded to Fox V3, and emitted as `action_schedule` rows for Daikin.
+6. The 2-minute heartbeat reconciles live hardware with the schedule and writes `execution_log`.
+7. MPC re-solves trigger on tier boundaries, forecast revisions, and Octopus fetches.
+
+For decisions about peak-export robustness, see [docs/DISPATCH_DECISIONS.md](docs/DISPATCH_DECISIONS.md). For the OpenClaw boundary contract, [docs/OPENCLAW_BOUNDARY.md](docs/OPENCLAW_BOUNDARY.md). For the live-ops runbook, [docs/RUNBOOK.md](docs/RUNBOOK.md).
+
+## Quick start (local sim box)
+
+The local checkout is for development and replay against a copy of prod state — **it must never touch live hardware**.
 
 ```bash
-python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
-pip install -r requirements-dev.txt   # optional: pytest + Ruff for tests/lint
+git clone https://github.com/albinati/home-energy-manager.git
+cd home-energy-manager
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+
 cp .env.example .env
-# Edit .env — see setup sections below
-python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000
+# Edit .env — at minimum set OPENCLAW_READ_ONLY=true so nothing dials out.
+
+pytest                                    # 837+ tests, ~3 min on a laptop
+python -m src.cli serve                   # FastAPI on :8000, MCP at /mcp
 ```
 
-### Docker (Bulletproof + SQLite persistence)
+The web UI is at `http://localhost:8000/`, OpenAPI docs at `/docs`, MCP transport at `/mcp` (bearer-guarded; token at `data/.openclaw-token`).
 
-> **Note:** Docker is not used in the current production deployment (removed 2026-04-18 in favour of systemd). These instructions are kept for local dev convenience.
+## Production deployment
+
+The production target is an **immutable container** pulled from GHCR — the application code is never editable on the host after cutover. State and secrets are bind-mounted; everything else is replaced by a new image pull.
 
 ```bash
-cp .env.example .env   # configure first
-docker compose up --build -d
+docker pull ghcr.io/albinati/home-energy-manager:latest
+# See deploy/README.md for the systemd unit + compose.yaml + cutover runbook.
 ```
 
-- SQLite file: stored in the `energy_state_data` Docker volume (path inside container: `/app/data/energy_state.db`).
-- Same REST port **8000**. Mount or back up the named volume for backups.
+| Concern | Path |
+|---|---|
+| Image | `ghcr.io/albinati/home-energy-manager:<sha>` (linux/arm64) |
+| State volume | `/srv/hem/data/` (SQLite + tokens + snapshots) |
+| Config | `/srv/hem/.env` (mounted ro) |
+| Service | `hem.service` (wraps `docker compose up`) |
+| API | `http://127.0.0.1:8000` (loopback + Tailscale) |
 
-### Bulletproof engine (default)
+OAuth bootstrap (Daikin + SmartThings) uses one-shot containers documented in [`deploy/README.md`](deploy/README.md).
 
-When `USE_BULLETPROOF_ENGINE=true` (default):
+## Hardware & integrations
 
-- **SQLite** (`DB_PATH`) stores Agile rates, `action_schedule`, `execution_log`, optimizer logs, Fox schedule snapshots.
-- **Fox Scheduler V3** (requires `FOXESS_API_KEY`): one schedule upload after the daily Octopus fetch (not per-tick mode changes).
-- **Heartbeat** (every `HEARTBEAT_INTERVAL_SECONDS`, default 120s): Daikin actions from SQLite, cached Fox realtime, scheduler flag check every 30 min, half-hourly `execution_log` samples.
-- **REST**: `GET /api/v1/metrics`, `GET /api/v1/schedule`, `GET /api/v1/schedule/history`, `GET /api/v1/weather`.
-- **MCP** (optional sidecar for OpenClaw or other clients): `get_energy_metrics`, `get_schedule`, `get_daily_brief`, `get_battery_forecast`, `get_weather_context`, `get_action_log`, `get_optimizer_log`, `override_schedule`, `acknowledge_warning`.
-
-See `.env.example` for `OCTOPUS_FETCH_*`, `DAILY_BRIEF_*`, `SVT_RATE_PENCE`, and weather thresholds.
-
-### Production (recommended)
-
-On a VPS or home server, run the API **as a service** (e.g. **systemd**), not via ad-hoc shells:
-
-```bash
-# After venv + pip install -r requirements.txt and a configured .env:
-python -m src.cli serve    # foreground; point unit ExecStart at this
-```
-
-Use `python -m src.cli serve` as the long-running process; optional `daemon` / `./bin/start` are for workstations. See [CLAUDE.md](CLAUDE.md) for paths and `systemctl` examples on a typical deployment.
-
-## Setup
-
-### 1. Fox ESS — Open API key
-
-1. Log in to [foxesscloud.com](https://www.foxesscloud.com)
-2. Go to **User Profile → API Management** and generate an API key
-3. Copy your **Device SN** from Settings → Device
-4. Set `FOXESS_API_KEY` and `FOXESS_DEVICE_SN` in `.env`
-
-The client uses the official Open API (`/op/v0/`) with MD5-signature authentication. The old username/password API (`/c/v0/`) is deprecated and returns HTTP 406.
-
-### 2. Daikin Onecta — OAuth2 (the tricky part)
-
-Daikin uses OAuth2 with a registration hook — their portal pings your redirect URI when you create an app. Since you're running locally, that ping will fail unless you expose the server publicly during registration.
-
-#### First-time setup (recommended)
-
-The `--setup` mode handles everything: it creates a public SSH tunnel via [localhost.run](https://localhost.run), starts a local callback server, and walks you through app registration + authentication in one go.
-
-```bash
-python -m src.daikin.auth --setup
-```
-
-This will:
-1. Start a local HTTP server on port 8080
-2. Create a free public HTTPS tunnel (e.g. `https://abc123.lhr.life`)
-3. Print the redirect URI — paste it into the Daikin developer portal
-4. Handle the registration hook ping (responds 200 OK)
-5. Prompt for Client ID and Client Secret → saves to `.env`
-6. Open a browser for Daikin login → captures the OAuth callback
-7. Exchange the auth code for tokens → saves to `.daikin-tokens.json`
-
-#### Why the tunnel hack?
-
-Daikin's developer portal at [developer.cloud.daikineurope.com](https://developer.cloud.daikineurope.com) has two quirks:
-
-1. **Registration hook**: When you create or update an app, the portal makes an HTTP request to your redirect URI to verify it's reachable. If it can't reach it, you get `unable to send add registration hook from HTTP (403)`. Since `localhost` / `127.0.0.1` / `lvh.me` all resolve to loopback and Daikin's servers have SSRF protection, they can't reach your machine.
-
-2. **CloudFront WAF**: Daikin's IDP (`idp.onecta.daikineurope.com`) is behind AWS CloudFront, which blocks requests that contain `localhost` in the `redirect_uri` query parameter. Python's `urllib` also gets blocked (likely user-agent filtering), so token exchange uses `curl` via subprocess as a workaround.
-
-The SSH tunnel solves both problems: it gives you a real public HTTPS URL that Daikin can ping during registration AND that the browser can redirect to during the OAuth flow.
-
-#### Subsequent auth (token expired / re-auth needed)
-
-Once the app is registered, you don't need the tunnel again — just run:
-
-```bash
-python -m src.daikin.auth
-```
-
-Or exchange a code manually:
-
-```bash
-python -m src.daikin.auth --code <PASTE_CODE_HERE>
-```
-
-Tokens auto-refresh — you shouldn't need to re-auth unless the refresh token expires (typically months).
-
-### 3. Environment variables
-
-See `.env.example` for all options. Key variables:
-
-| Variable | Required | Description |
+| Vendor | What we use | Auth |
 |---|---|---|
-| `FOXESS_API_KEY` | Yes* | Fox ESS Open API key |
-| `FOXESS_DEVICE_SN` | Yes | Inverter serial number |
-| `DAIKIN_CLIENT_ID` | Yes | From Daikin developer portal |
-| `DAIKIN_CLIENT_SECRET` | Yes | From Daikin developer portal |
-| `DAIKIN_REDIRECT_URI` | No | Defaults to `http://localhost:8080/callback` |
-| `OCTOPUS_API_KEY` | No | Octopus Energy API key (for tariff tracking) |
-| `OCTOPUS_ACCOUNT_NUMBER` | No | Octopus Energy account number |
-| `BRITISH_GAS_API_KEY` | No | Reserved for future British Gas integration (unused until implemented) |
-| `OPENCLAW_HOOKS_URL` | Yes† | **Only** outbound URL for notifications — Gateway `POST /hooks/agent` |
-| `OPENCLAW_HOOKS_TOKEN` | Yes† | Bearer token matching Gateway `hooks.token` |
-| `OPENCLAW_NOTIFY_ENABLED` | No | Default `true`; set `false` to skip hook POSTs (stdout / `action_log` still run) |
-| `OPENCLAW_NOTIFY_CHANNEL` | No | Sent **in the hook JSON** as `channel` (e.g. `telegram`) — hint for the Gateway, not a direct send from this app |
-| `OPENCLAW_NOTIFY_TARGET` | No | Sent as `to` (e.g. chat id) — destination hint for the Gateway |
-| `OPENCLAW_INTERNAL_API_BASE_URL` | No | Base URL embedded in some messages so OpenClaw can call back into this API (default `http://127.0.0.1:8000`) |
-| `OPENCLAW_READ_ONLY` | No | If `true` (default), OpenClaw `execute` is blocked; use dashboard/CLI or set `false` to allow executes |
+| Octopus Energy | Agile import + Outgoing Agile export rates, optional consumption backfill | API key (read-only) |
+| Open-Meteo | Hourly forecast (temp, radiation, cloud cover) | None — public |
+| Fox ESS | SoC, PV, load, grid, Scheduler V3 upload | Open API key + signature |
+| Daikin Altherma | Status read + LWT/tank writes via Onecta | OAuth2 (auto-refresh) |
+| Samsung SmartThings | Washer/dryer/dishwasher schedule | OAuth2 (auto-refresh) |
+| OpenClaw / Claude | Reads state, requests plan changes, gets notifications | Bearer-guarded HTTP MCP |
 
-Legacy `ALERT_OPENCLAW_URL` / `ALERT_CHANNEL` are **removed** — use the `OPENCLAW_*` variables above.
-| `ANTHROPIC_API_KEY` | No | Primary API key for AI Assistant (Anthropic Claude). If unset, falls back to `OPENAI_API_KEY` when provider is `openai`. |
-| `OPENAI_API_KEY` | No | Fallback for AI Assistant when using OpenAI provider; also used if `ANTHROPIC_API_KEY` is unset and provider is `openai`. |
-| `AI_ASSISTANT_PROVIDER` | No | Default `anthropic` |
-| `AI_ASSISTANT_MODEL` | No | Default `claude-haiku-4-5` |
-| `MANUAL_TARIFF_IMPORT_PENCE` | No | Import rate (p/kWh) for cost-aware suggestions when no provider is connected |
-| `MANUAL_TARIFF_EXPORT_PENCE` | No | Export rate (p/kWh) for cost-aware suggestions |
+## Roadmap
 
-† Required (with a notify target / route) when `OPENCLAW_NOTIFY_ENABLED=true` for user-visible deliveries.
+Active epic: **[#193 V11 — Accuracy via past-data integration & uncertainty modelling](https://github.com/albinati/home-energy-manager/issues/193)**.
 
-## Web UI & API Server
+| | Story | Status |
+|---|---|---|
+| ✅ | V11-A — Cloud-cover & full-input snapshot capture | shipped (#240) |
+| ✅ | V11-E — Adaptive PV calibration trigger | shipped (#198) |
+| 🟡 | V11-B — Quantile-based scenario perturbations | pending |
+| 🟡 | V11-C — DHW draw learning (rolling 14-day prior) | pending |
+| 🟡 | V11-D — Occupancy & variable-load inference | pending |
 
-Start the web server for browser-based control and REST API access:
+Other open work: [Daikin physics calibration via 2-hourly Onecta consumption](https://github.com/albinati/home-energy-manager/issues/238), [Travel-period aware load profile](https://github.com/albinati/home-energy-manager/issues/161), [Daikin tank reheat anomaly detection](https://github.com/albinati/home-energy-manager/issues/184).
 
-```bash
-python -m src.cli serve                    # Default port 8000 (foreground — use with systemd in production)
-python -m src.cli serve --port 3000        # Custom port
-```
+The full backlog is on the [issues board](https://github.com/albinati/home-energy-manager/issues).
 
-**Optional — daemon mode** (background process on a dev machine; production usually uses systemd + `serve`):
+## Contributing
 
-```bash
-python -m src.cli daemon start             # Background API
-python -m src.cli daemon status             # PID and URLs
-python -m src.cli daemon stop               # Stop
-```
+Adding a feature, reproducing a bug, or porting to a different installation? See [CONTRIBUTING.md](CONTRIBUTING.md). Security issues — see [SECURITY.md](SECURITY.md).
 
-The daemon writes `.home-energy-manager.pid` and `daemon.log` in the project root.
-
-**Shell scripts** (from project root):
-
-| Command | Description |
-|---------|-------------|
-| `./bin/run help` | Show all commands |
-| `./bin/start` | Start daemon (same as `daemon start`) |
-| `./bin/stop` | Stop daemon |
-| `./bin/status` | Daemon status and API URL |
-| `./bin/serve` | Run server in foreground |
-| `./bin/test-foxess` | Test Fox ESS API (reads `.env`) |
-
-See `bin/README.md` for details. Scripts do not contain any secrets; credentials are read from `.env` only.
-
-- **Web Dashboard**: `http://localhost:8000/` — visual status + control buttons, **AI Assistant** tab for optimization
-- **API Docs**: `http://localhost:8000/docs` — interactive Swagger UI
-- **OpenClaw API**: `http://localhost:8000/api/v1/openclaw/capabilities`
-
-### AI Assistant
-
-The dashboard includes an **AI Assistant** tab that suggests optimizations for the heat pump and battery based on a **comfort vs cost** balance:
-
-1. Open the **AI Assistant** tab and choose **Comfort**, **Balanced**, or **Cost savings**.
-2. Optionally enter a message (e.g. “Lower heating at night”, “Charge on cheap rate”).
-3. Click **Get recommendations** — the assistant returns a short explanation and a list of suggested actions (temperature, LWT offset, tank, battery mode, charge periods).
-4. Select the actions you want and click **Apply selected**. Actions that require confirmation (e.g. power off, mode change) show a **Confirm** button; use it to complete the change.
-
-Without an API key (no `ANTHROPIC_API_KEY` and no `OPENAI_API_KEY` when using OpenAI), the assistant uses built-in rule-based suggestions. With a key, it uses the configured model for richer, context-aware recommendations. `ANTHROPIC_API_KEY` is the primary key (default provider is Anthropic); `OPENAI_API_KEY` still works as fallback when using the OpenAI provider. Set `MANUAL_TARIFF_IMPORT_PENCE` (and optionally `MANUAL_TARIFF_EXPORT_PENCE`) in `.env` for cost-aware suggestions when no energy provider is connected.
-
-### API Endpoints
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v1/daikin/status` | GET | Get Daikin device status |
-| `/api/v1/daikin/power` | POST | Turn on/off (requires confirmation) |
-| `/api/v1/daikin/temperature` | POST | Set target temperature (15-30°C) |
-| `/api/v1/daikin/lwt-offset` | POST | Set LWT offset (-10 to +10) |
-| `/api/v1/daikin/mode` | POST | Set operation mode |
-| `/api/v1/daikin/tank-temperature` | POST | Set DHW tank target (30-60°C) |
-| `/api/v1/foxess/status` | GET | Get battery/solar status |
-| `/api/v1/foxess/mode` | POST | Set work mode (requires confirmation) |
-| `/api/v1/foxess/charge-period` | POST | Set charge schedule |
-| `/api/v1/assistant/recommend` | POST | Get optimization suggestions (preference + optional message) |
-| `/api/v1/assistant/apply` | POST | Apply suggested actions (returns confirmation tokens where needed) |
-| `/api/v1/energy/providers` | GET | List energy providers and config status |
-| `/api/v1/energy/tariff` | GET | Get current tariff info (coming soon) |
-| `/api/v1/energy/usage` | GET | Get energy usage summary (coming soon) |
-| `/api/v1/openclaw/capabilities` | GET | List all actions for AI agents |
-| `/api/v1/openclaw/execute` | POST | Execute action with confirmation flow |
-| `/api/v1/scheduler/status` | GET | Agile scheduler: current price, next cheap window, planned LWT adjustment |
-| `/api/v1/scheduler/pause` | POST | Pause Agile-based Daikin LWT adjustments |
-| `/api/v1/scheduler/resume` | POST | Resume Agile scheduler |
-| `/api/v1/health` | GET | Lightweight health check |
-
-### Safeguards
-
-- **Confirmation flow**: Destructive actions (power off, mode changes) require a 2-step confirmation
-- **Weather regulation guard**: Room temperature changes are blocked when weather regulation is active (use LWT offset instead)
-- **Range validation**: Temperature setpoints validated against safe limits
-- **Rate limiting**: 5-second cooldown between commands
-- **Audit logging**: All control actions logged with timestamp
-
-### OpenClaw skill
-
-To use the **home-energy-manager** skill from OpenClaw chat:
-
-1. **Install the skill**: `cp -r skills/home-energy-manager ~/.openclaw/skills/`
-2. **Configure** `~/.openclaw/openclaw.json` with the skill and `HOME_ENERGY_API_URL` (e.g. `http://localhost:8000`). Use the JSON example under **OpenClaw integration** below.
-3. **Health check**: On gateway boot, call `GET {HOME_ENERGY_API_URL}/api/v1/health` and ensure the API service is running (see **Production** above).
-
-### OpenClaw integration
-
-**No API keys or secrets go in OpenClaw.** Credentials (Fox ESS, Daikin, etc.) stay in `.env` on the machine where the Home Energy Manager API runs. OpenClaw only needs the **base URL** of that API.
-
-1. **Start the API** on the host that has `.env` configured (systemd unit or foreground):
-   ```bash
-   python -m src.cli serve
-   # optional dev: ./bin/start  OR  python -m src.cli daemon start
-   ```
-
-2. **From OpenClaw**, point the skill at that host and port. Copy the skill and set the URL (use your server’s IP or hostname and port; no credentials):
-   ```bash
-   cp -r skills/home-energy-manager ~/.openclaw/skills/
-   ```
-   In `~/.openclaw/openclaw.json` (or your OpenClaw config):
-   ```json
-   {
-     "skills": {
-       "entries": {
-         "home-energy-manager": {
-           "enabled": true,
-           "env": { "HOME_ENERGY_API_URL": "http://YOUR_SERVER_IP:8000" }
-         }
-       }
-     }
-   }
-   ```
-   Replace `YOUR_SERVER_IP` with the host where the API runs (e.g. `192.168.1.100` or `localhost` if OpenClaw runs on the same machine).
-
-3. **Endpoints** the agent uses (all unauthenticated REST; auth is handled by the server’s `.env`):
-   - `GET {HOME_ENERGY_API_URL}/api/v1/openclaw/capabilities` — list actions
-   - `POST {HOME_ENERGY_API_URL}/api/v1/openclaw/execute` — run an action (with confirmation flow when required)
-
-4. **Recommendation-only safeguard**: By default `OPENCLAW_READ_ONLY=true`. The agent can read status and capabilities but **cannot execute** changes; `POST .../execute` returns 403. The agent should only recommend; you apply changes via the dashboard or CLI. Set `OPENCLAW_READ_ONLY=false` in `.env` if you want the agent to execute actions (after confirmation where required).
-
-See `skills/home-energy-manager/SKILL.md` for the full instruction set and action list.
-
-### Agile scheduler (Daikin LWT by price)
-
-When on **Octopus Agile**, you can automatically shift heat pump load to cheap slots:
-
-- **Cheap slots** (e.g. &lt; 12p/kWh, often 01:00–06:00): LWT offset is raised slightly to pre-heat (thermal mass stores cheap energy).
-- **Peak window** (e.g. 16:00–19:00): LWT offset is lowered to coast on stored heat.
-- **Normal**: Hold at 0.
-
-Set `SCHEDULER_ENABLED=true` and `OCTOPUS_TARIFF_CODE` (e.g. `E-1R-AGILE-24-10-01-C`) in `.env`. The API runs a background job every 30 minutes and adjusts Daikin LWT via the first device. Use `GET /api/v1/scheduler/status` to see current price and planned adjustment; `POST /api/v1/scheduler/pause` and `resume` to turn the scheduler off or on without changing `.env`. See `.env.example` for `SCHEDULER_CHEAP_THRESHOLD_PENCE`, `SCHEDULER_PEAK_START`/`SCHEDULER_PEAK_END`, and `SCHEDULER_PREHEAT_LWT_BOOST`.
-
-## CLI usage
-
-```bash
-# Full dashboard (Fox ESS + Daikin)
-python -m src.cli status
-
-# --- Fox ESS ---
-python -m src.cli foxess status
-python -m src.cli foxess mode "Self Use"
-python -m src.cli foxess charge --from 00:30 --to 05:00 --soc 90
-
-# --- Daikin ---
-python -m src.cli daikin status
-python -m src.cli daikin on                # Turn climate control on
-python -m src.cli daikin off               # Turn climate control off
-python -m src.cli daikin temp 21           # Set room temperature target
-python -m src.cli daikin lwt-offset -3     # Set leaving water temp offset
-python -m src.cli daikin tank-temp 45      # Set DHW tank target (30–60°C)
-python -m src.cli daikin mode heating      # heating / cooling / auto
-
-# --- Monitor ---
-python -m src.cli monitor                  # Continuous loop with alerts
-
-# --- Options ---
-python -m src.cli status --json            # JSON output for OpenClaw
-python -m src.cli daikin status --api      # Route through API server
-```
-
-### Example output
-
-```
-┌─ Daikin: Altherma ────────────────────
-│ Power       : ON
-│ Mode        : heating
-│ Outdoor     : 15°C
-│ Radiator    : 22°C
-│ Curve adj.  : -5
-│ DHW tank    : 44°C (target 45°C)
-│ Weather reg : on
-└──────────────────────────────────────
-```
-
-## Project structure
-
-```
-src/
-  api/
-    main.py         # FastAPI app + REST endpoints
-    routers/        # Included routers (e.g. energy provider stubs)
-    models.py       # Pydantic request/response schemas
-    safeguards.py   # Confirmation tokens, rate limiting, audit
-    templates/      # Jinja2 web UI templates (tabbed dashboard)
-  foxess/
-    client.py       # Fox ESS Open API client (signature auth)
-    models.py       # Data models for device telemetry
-  daikin/
-    client.py       # Daikin Onecta API client (OAuth2)
-    auth.py         # OAuth2 flow + tunnel-based setup
-    models.py       # Data models for devices and status
-  energy/
-    models.py       # Energy provider data models
-    provider.py     # Abstract base class for provider clients
-  cli/
-    __main__.py     # CLI entrypoint
-  config.py         # Config + .env loader
-  notifier.py       # OpenClaw Gateway hook delivery (no direct chat APIs)
-skills/
-  home-energy-manager/
-    SKILL.md        # OpenClaw / AgentSkills skill definition
-tests/
-  test_foxess.py    # Fox ESS client unit tests
-  test_daikin.py    # Daikin client unit tests (14 tests)
-pyproject.toml      # Ruff config; package metadata
-requirements-dev.txt # pytest, ruff (optional dev install)
-```
-
-**Lint / tests (optional):** after `pip install -r requirements-dev.txt`, run `ruff check src tests` and `pytest`.
-
-## Credentials & security
-
-- All credentials live in `.env` (gitignored — never committed)
-- Token files (`*.json`) are gitignored
-- SSL certificates (`*.pem`) for the local callback server are gitignored
-- The `--setup` tunnel is ephemeral — the URL expires when the SSH session ends
-
-## Energy provider API (partial)
-
-Octopus Agile rates are ingested by the bulletproof planner from public/product APIs; **live Octopus/British Gas account tariff and usage REST** integrations are still **stubbed** (`501` / manual tariff path). The provider list includes **British Gas** as *reserved* until a client exists.
-
-- **`/api/v1/energy/monthly`** and related insights use Fox ESS + stored state where configured.
-- **`/api/v1/energy/tariff`** / **`usage`**: not fully implemented for API-key providers yet — see [CHANGELOG.md](CHANGELOG.md).
-
-The web **Energy** tab may still show placeholders for some provider UI features.
+The PR template requires the LP regression gate (`scripts/check_lp_regression.py --mode=both`) to pass for any change under `src/scheduler/` — that's how we keep "the LP must outperform every earlier version always" honest.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Known issues & workarounds
-
-| Issue | Workaround |
-|---|---|
-| Daikin portal "unable to send add registration hook" (403) | Use `--setup` mode to create a public tunnel |
-| CloudFront blocks `urllib` requests to Daikin IDP | Token exchange uses `curl` subprocess |
-| CloudFront blocks `redirect_uri` containing `localhost` | The tunnel provides a real public HTTPS URL |
-| Daikin portal "Refresh Secret" button returns 400 | Delete and recreate the app instead |
-| Fox ESS unofficial API returns HTTP 406 | Use the official Open API with `FOXESS_API_KEY` |
-| Daikin API reads lag ~2-3s after writes | Normal for cloud-connected devices; not a bug |
+[Apache 2.0](LICENSE). Attribution requirements live in [NOTICE](NOTICE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security
+
+## Reporting a vulnerability
+
+If you find a security issue — **please don't file a public GitHub issue.**
+
+Email **luis.albinati@gmail.com** with:
+
+- A description of the vulnerability and the affected component.
+- Steps to reproduce, or a proof-of-concept if relevant.
+- Any logs or commit hashes that help diagnose it.
+
+I'll acknowledge within 5 working days and aim to ship a fix within 30 days for anything actionable. If you want disclosure credit in the release notes, say so in the report.
+
+## Threat model — what this project guards against
+
+This is a self-hosted controller running on private infrastructure (Tailscale / loopback only). It does not expose anything to the public internet by design. The interesting attack surface is:
+
+| Asset | Threat | Mitigation |
+|---|---|---|
+| Daikin / Fox ESS / SmartThings tokens | Theft via filesystem read | Tokens stored in `data/` mounted into the container with restrictive perms. Container runs as uid 1001 with read-only rootfs. |
+| OpenClaw MCP transport | Unauthenticated access | Bearer token at `data/.openclaw-token`, generated on first boot. `BearerAuthMiddleware` rejects all requests without it. |
+| Hardware-write actions | Misuse via MCP | `OPENCLAW_READ_ONLY=true` kill switch in `.env`. Plan-approval flow with consent gates for high-impact changes. |
+| Database | Tampering with state | SQLite at `data/energy_state.db` mounted with restrictive perms. Snapshot-based replay can detect plan tampering after the fact. |
+| Octopus / OAuth credentials | Leak via logs | Secrets are read from `.env` only; redacted in logs by convention (audit `src/notifier.py` etc. if you suspect a leak). |
+
+## Out of scope
+
+- Denial-of-service (the service is single-tenant and rate-limited internally).
+- Issues in upstream dependencies (Open-Meteo, Octopus, Fox ESS, Daikin, SmartThings) unless we're handling their responses unsafely.
+- Local-host attacks where the attacker already has root on the host running the container.
+
+## Dependencies
+
+The dependency tree is intentionally small (see `requirements.txt`). If you spot a CVE in something we pull in, file via the email above; I'll either bump the dep or remove it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "home-energy-manager"
 version = "10.2.0"
 description = "Home energy orchestration (Fox ESS, Daikin, Octopus)"
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.12"
 
 [tool.ruff]


### PR DESCRIPTION
Polish pass for the public GitHub presence.

## Summary

- **Relicense MIT → Apache 2.0.** Apache adds an explicit patent grant from contributors (matters because the LP solver, scenario LP filter, and peak-export robustness logic are non-trivial algorithmic work — without Apache's patent clause, a contributor could later patent the technique and sue users), and a `NOTICE` mechanism that preserves attribution durably as the project is forked. Modern infra projects (Kubernetes, Terraform, Postgres ecosystem) all chose Apache 2.0 over MIT for these reasons. Permissive intent is preserved — corporate readers, internal use, commercial use all still allowed.
- **README rewritten end-to-end.** The previous README was 401 lines of v9-era instructions (`uvicorn` quick-start, "AI Assistant" tab, OpenClaw REST capabilities endpoint) that no longer reflect the system. New README leads with what HEM is, an ASCII architecture sketch of the planning brain, the V10/V11 accuracy story, and links out to `docs/ARCHITECTURE.md` + `docs/DISPATCH_DECISIONS.md` + `deploy/README.md`.
- **NOTICE** — Apache 2.0 attribution file at the repo root.
- **CONTRIBUTING.md** — local dev setup, code conventions, commit style, hardware-touching-change checklist, the LP regression-gate workflow as a hard PR requirement.
- **SECURITY.md** — private vulnerability disclosure (`luis.albinati@gmail.com`), threat model, out-of-scope list.
- **.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml** — structured forms with the most useful prompts (run_id for LP bugs, goal-vs-implementation framing for features). Blank issues disabled. Contact links to SECURITY.md and the V11 epic.
- **pyproject.toml** gains `license = "Apache-2.0"`.

No code changes, no functional impact.

## Companion housekeeping (already done outside this PR)

- Closed #180 (Epic 11), #157 (Epic 9), #158, #160 — all superseded by V11 (#193) or naturally elapsed.
- Reparented #161 — now standalone since #157 closed.
- Pinned #193 (V11 epic) so the active roadmap is visible from the issues tab.

## Test plan

- [x] No code changes — full suite expected unchanged. Running locally as a sanity check.
- [ ] CI: `pytest`, `lint-imports` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)