### PR TITLE
chore(privacy): redact personal identifiers from public docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ said 18080 — that was wrong; the code at `src/daikin/auth.py:328` always bound
 
 ```bash
 # 1. From your laptop, tunnel :8080:
-ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
+ssh -L 8080:localhost:8080 root@<hem-host>.ts.net
 
 # 2. On the host, launch the auth-only container:
 docker compose -f /srv/hem/compose.daikin-auth.yaml run --rm daikin-auth
@@ -138,7 +138,7 @@ device API call. Refresh circuit breaker after 3 consecutive failures
 
 ```bash
 # 1. From your laptop, tunnel :8080:
-ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
+ssh -L 8080:localhost:8080 root@<hem-host>.ts.net
 
 # 2. On the host, launch the auth-only container:
 docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm smartthings-auth

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Every solve is snapshotted to SQLite so any past day's plan can be re-run under 
 
 ## Status
 
-This is a working personal project running 24/7 on one site (W4 1DZ, London). It is **public so the architecture and accuracy work are open**, not because it is a turn-key product. Hardware specs, integrations, and tariff defaults are tuned to one installation:
+This is a working personal project running 24/7 on one UK site. It is **public so the architecture and accuracy work are open**, not because it is a turn-key product. Hardware specs, integrations, and tariff defaults are tuned to one installation:
 
 - 4.5 kW PV array, Fox H1-5.0-E-G2 inverter, EP11 battery
 - Daikin Altherma 3 H HT (passive mode in summer, active LWT modulation in heating season)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -47,7 +47,7 @@ systemctl daemon-reload
 ```bash
 cat > /srv/hem/.compose.env <<'EOF'
 HEM_IMAGE_TAG=main
-HEM_TAILSCALE_IP=100.104.115.85
+HEM_TAILSCALE_IP=100.x.y.z
 EOF
 chmod 640 /srv/hem/.compose.env
 ```
@@ -171,7 +171,7 @@ O `refresh_token` da Daikin expira a cada ~30 dias. Quando o heartbeat começar 
 
 ```bash
 # Do laptop, abre tunnel SSH pra publicar :8080 local.
-ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
+ssh -L 8080:localhost:8080 root@<hem-host>.ts.net
 # Então no host:
 docker compose -f /srv/hem/compose.daikin-auth.yaml run --rm daikin-auth
 # Abre a URL impressa no browser local; faz login Daikin; tokens caem em

--- a/deploy/compose.smartthings-auth.yaml
+++ b/deploy/compose.smartthings-auth.yaml
@@ -2,7 +2,7 @@
 #
 # Usage:
 #   1. From your laptop, tunnel :8080 to the Hetzner host:
-#        ssh -L 8080:localhost:8080 root@openclaw-overbot.tail0dbf20.ts.net
+#        ssh -L 8080:localhost:8080 root@<hem-host>.ts.net
 #   2. On the host, launch the auth-only container:
 #        docker compose -f /srv/hem/compose.smartthings-auth.yaml run --rm smartthings-auth
 #   3. The container prints an authorize URL — open it in your local browser.

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -7,7 +7,7 @@ services:
 
     ports:
       - "127.0.0.1:8000:8000"
-      # Tailscale interface — override HEM_TAILSCALE_IP per host (Hetzner prod = 100.104.115.85).
+      # Tailscale interface — override HEM_TAILSCALE_IP per host (Hetzner prod = 100.x.y.z).
       # When unset, the second binding collapses to loopback (harmless duplicate).
       - "${HEM_TAILSCALE_IP:-127.0.0.1}:8000:8000"
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -8,8 +8,8 @@ Day-to-day operations, deployment, and debugging for the Home Energy Manager on 
 
 | Component | Detail |
 |-----------|--------|
-| Server | Hetzner (Tailscale: `openclaw-overbot.tail0dbf20.ts.net`, `100.104.115.85`) |
-| SSH | `ssh root@openclaw-overbot.tail0dbf20.ts.net` |
+| Server | Hetzner (Tailscale: `<hem-host>.ts.net`, `100.x.y.z`) |
+| SSH | `ssh root@<hem-host>.ts.net` |
 | Project dir | `/root/home-energy-manager` |
 | Active DB | `/root/home-energy-manager/data/energy_state.db` ← **not** the project root |
 | Venv | `/root/home-energy-manager/.venv` |
@@ -406,7 +406,7 @@ After editing the unit file: `systemctl daemon-reload`
 ./scripts/deploy_hetzner.sh --backup-only
 
 # To send backups off-server via Tailscale (saves Hetzner disk space):
-export LOCAL_BACKUP_DEST='root@over-surface.tail0dbf20.ts.net:/root/em-backups'
+export LOCAL_BACKUP_DEST='root@<workstation>.ts.net:/root/em-backups'
 ./scripts/deploy_hetzner.sh --backup-only
-# Requires SSH server running on over-surface (see deploy script comments)
+# Requires SSH server running on <workstation> (see deploy script comments)
 ```

--- a/scripts/deploy_hetzner.sh
+++ b/scripts/deploy_hetzner.sh
@@ -11,14 +11,14 @@
 #   ./scripts/deploy_hetzner.sh --backup --no-restart  # pull + deps only, skip restart
 #
 # Tailscale topology:
-#   Hetzner server : openclaw-overbot.tail0dbf20.ts.net  (100.104.115.85)
-#   Local machine  : over-surface.tail0dbf20.ts.net      (100.88.209.127, WSL/Linux)
-#   SSH to Hetzner : ssh root@openclaw-overbot.tail0dbf20.ts.net  (no keys needed)
+#   Hetzner server : <hem-host>.ts.net  (100.x.y.z)
+#   Local machine  : <workstation>.ts.net      (100.x.y.z, WSL/Linux)
+#   SSH to Hetzner : ssh root@<hem-host>.ts.net  (no keys needed)
 #
 # Backup (off-server via Tailscale — saves Hetzner disk space):
 #   Already set in Hetzner ~/.bashrc:
-#     LOCAL_BACKUP_DEST=root@over-surface.tail0dbf20.ts.net:/root/em-backups
-#   To activate: enable SSH on over-surface once (choose one):
+#     LOCAL_BACKUP_DEST=root@<workstation>.ts.net:/root/em-backups
+#   To activate: enable SSH on <workstation> once (choose one):
 #     Option A — Tailscale SSH:  sudo tailscale set --ssh
 #     Option B — OpenSSH:        sudo apt install openssh-server && sudo service ssh start
 #   If not set, backup stays locally (./backups/) — only 3 copies kept to protect disk.


### PR DESCRIPTION
Privacy audit follow-up to #241. Removes identifiers that don't belong in a public repo.

## Removed

| | What | Where |
|---|---|---|
| 🚨 | UK postcode \`W4 1DZ\` | README.md (introduced 30 min ago in #241 — geolocates the user's house) |
| ⚠️ | Tailscale tailnet ID \`tail0dbf20\` | CLAUDE.md, docs/RUNBOOK.md, deploy/README.md, deploy/compose.\*, scripts/deploy_hetzner.sh |
| ⚠️ | Tailscale machine names \`openclaw-overbot\` + \`over-surface\` | Same files |
| ⚠️ | Tailscale IPs \`100.104.115.85\` + \`100.88.209.127\` | deploy/README.md, deploy/compose.yaml, scripts/deploy_hetzner.sh |

All replaced with placeholder strings (\`<hem-host>\`, \`<workstation>\`, \`<your-tailnet>\`, \`100.x.y.z\`).

## Kept (intentional)

- Name **Luis Albinati** in NOTICE / SECURITY.md — Apache 2.0 requires a copyright holder.
- Email **luis.albinati@gmail.com** in SECURITY.md — vulnerability-report channel. *Recommendation*: switch to GitHub Private Vulnerability Reporting (Settings → Code security and analysis → enable). Lower-effort than a personal Gmail and keeps reports off your inbox.
- GitHub username \`albinati\` — public profile already.
- Docker bridge subnets \`172.30.0.0/24\`, \`172.17.0.1\` — RFC1918 internal, not identifying.

## Note on git history

This redacts the **working tree** only. Older commits on \`main\` still contain the same identifiers. Two options:

1. **Accept** (recommended unless you want to nuke history). Tailscale tailnet IDs leak no actual access — Tailscale ACLs gate connections; exposing the ID is poor opsec, not a vuln. Postcode is the more sensitive item but only sits in one squash-merge commit (\`#241\`) ~1h old.
2. **Rewrite history** with \`git filter-repo --replace-text replacements.txt\` then force-push. Breaks any forks / clones, but eradicates the leak. Only worth doing if the postcode disclosure feels material.

## Test plan

- [x] No code changes — full suite unchanged. Locally verified \`git grep\` returns no remaining matches for the redacted patterns.
- [ ] CI: \`pytest\`, \`lint-imports\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)