### PR TITLE
feat: legionella-aware LP + Daikin/Fox MCP semantics for OpenClaw

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,13 +68,16 @@ TARGET_DHW_TEMP_MAX_C=65.0
 # DHW_TEMP_COMFORT_C=48.0
 # DHW_TEMP_MAX_C=65.0
 
-# DEPRECATED: Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously
-# (Sunday ~11:00 local). These knobs are unused by the LP / dispatch as of PR #50 and
-# will be removed in a follow-up — leaving them in an existing .env is safe.
-# DHW_LEGIONELLA_TEMP_C=60
-# DHW_LEGIONELLA_DAY=6
-# DHW_LEGIONELLA_HOUR_START=11
-# DHW_LEGIONELLA_HOUR_END=13
+# Legionella thermal-shock awareness. The Daikin Onecta firmware fires the cycle
+# autonomously on a user-configured day/hour (set in the Onecta app); the LP cannot
+# command it. Setting these tells the LP to PREDICT the resulting DHW pulse and
+# allocate PV/battery/grid around it. DAY=-1 disables the prediction. All four
+# keys are also exposed via PUT /api/v1/settings + MCP set_setting (no restart).
+# DAY: 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun.
+# DHW_LEGIONELLA_DAY=-1
+# DHW_LEGIONELLA_HOUR_LOCAL=13
+# DHW_LEGIONELLA_DURATION_MIN=60
+# DHW_LEGIONELLA_TANK_TARGET_C=60
 
 # Anti-sauna LWT cap (issue #50): reduce radiator overshoot during max_heat to +5 °C.
 # OPTIMIZATION_LWT_OFFSET_MAX=5

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -873,6 +873,26 @@ async def cockpit_now():
             "energy_strategy_mode": config.ENERGY_STRATEGY_MODE,
         },
         "plan_date": plan_block["plan_date"],
+        # Sign conventions for state.grid_kw / state.battery_kw / current_slot
+        # prices. LLM consumers (notably OpenClaw) cannot see Pydantic Field
+        # descriptions in this raw dict, so we surface them inline so a sign
+        # cannot be misread as an unsigned magnitude.
+        "_legend": {
+            "soc_pct": "battery state of charge, percent 0–100",
+            "soc_kwh": "battery energy stored, kWh",
+            "solar_kw": "PV generation, kW (always ≥ 0)",
+            "load_kw": "house total consumption, kW (always ≥ 0)",
+            "grid_kw": "grid power: positive=IMPORTING from grid, negative=EXPORTING to grid",
+            "battery_kw": "battery power: positive=CHARGING, negative=DISCHARGING",
+            "price_import_p": "Octopus Agile import rate, p/kWh (incl VAT)",
+            "price_export_p": "Octopus Outgoing rate, p/kWh (incl VAT). Null when no export tariff configured.",
+            "tank_c": "DHW tank current temperature, °C. Null when DHW zone reports no telemetry.",
+            "indoor_c": "indoor (room) temperature, °C. Null when climate zone is idle / room sensor reports null.",
+            "outdoor_c": "outdoor air temperature, °C (from Daikin gateway sensor)",
+            "lwt_c": "leaving water temperature, °C",
+            "fox_mode": "Fox inverter work mode (e.g. SelfUse, ForceCharge, ForceDischarge)",
+            "daikin_mode": "Daikin operation mode (heating/cooling/auto/dry/fan_only)",
+        },
     }
 
 
@@ -1054,6 +1074,23 @@ async def cockpit_at(when: str):
         "planned_slot": planned_slot,  # LP's decision for that slot, or None
         "lp_inputs": lp_inputs,        # Full inputs row at solve time, or None
         "slot_kind": realised.get("slot_kind"),
+        # Same legend as /cockpit/now — keeps signs / units unambiguous for
+        # historical replays consumed by LLM agents.
+        "_legend": {
+            "soc_pct": "battery state of charge, percent 0–100",
+            "soc_kwh": "battery energy stored, kWh",
+            "load_kw": "house total consumption, kW (always ≥ 0)",
+            "grid_kw": "grid power: positive=IMPORTING, negative=EXPORTING (often null in replay because execution_log only logs SoC + consumption)",
+            "battery_kw": "battery power: positive=CHARGING, negative=DISCHARGING (often null in replay; see fox_mode + soc trajectory instead)",
+            "price_import_p": "Octopus Agile import rate at the slot, p/kWh (incl VAT)",
+            "price_export_p": "Octopus Outgoing rate at the slot, p/kWh (incl VAT). Null when no export tariff configured at that time.",
+            "tank_c": "DHW tank temperature at the slot, °C",
+            "indoor_c": "indoor room temperature at the slot, °C",
+            "outdoor_c": "outdoor temperature at the slot, °C",
+            "lwt_c": "leaving water temperature at the slot, °C",
+            "fox_mode": "Fox inverter work mode that was committed for the slot",
+            "slot_kind": "tariff classification: cheap / mid / peak / negative",
+        },
     }
 
 
@@ -1426,6 +1463,7 @@ async def daikin_status(refresh: bool = False):
         devices = cached.devices
         client = get_daikin_client()
         result = []
+        from .mcp_server import _daikin_state_summary
         for dev in devices:
             s = client.get_status(dev)
             result.append(DaikinStatusResponse(
@@ -1433,6 +1471,8 @@ async def daikin_status(refresh: bool = False):
                 device_name=s.device_name,
                 model=dev.model,
                 is_on=s.is_on,
+                climate_on=s.climate_on,
+                dhw_on=s.dhw_on,
                 mode=s.mode,
                 room_temp=s.room_temp,
                 target_temp=s.target_temp,
@@ -1443,6 +1483,7 @@ async def daikin_status(refresh: bool = False):
                 tank_target=s.tank_target,
                 weather_regulation=s.weather_regulation,
                 control_mode=config.DAIKIN_CONTROL_MODE,
+                state_summary=_daikin_state_summary(s, config.DAIKIN_CONTROL_MODE),
             ))
         logger.info(
             "Daikin status: %d device(s) source=%s stale=%s",

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -34,7 +34,21 @@ class DaikinStatusResponse(BaseModel):
     device_id: str
     device_name: str
     model: str
-    is_on: bool
+    is_on: bool = Field(
+        description=(
+            "Climate (room-heating) zone onOffMode. NOT 'is the heat pump on'. "
+            "Prefer climate_on / dhw_on for unambiguous semantics — kept here "
+            "for v9 dashboard back-compat."
+        ),
+    )
+    climate_on: bool | None = Field(
+        default=None,
+        description="Climate (space-heating) zone onOffMode. None = unknown.",
+    )
+    dhw_on: bool | None = Field(
+        default=None,
+        description="DHW (tank) zone onOffMode. None = unknown.",
+    )
     mode: str
     room_temp: float | None = None
     target_temp: float | None = None
@@ -47,6 +61,14 @@ class DaikinStatusResponse(BaseModel):
     control_mode: str = Field(
         default="passive",
         description="DAIKIN_CONTROL_MODE: 'passive' (service never writes) or 'active' (legacy v9 control).",
+    )
+    state_summary: str | None = Field(
+        default=None,
+        description=(
+            "Deterministic one-line description of current Daikin state, "
+            "safe to relay verbatim to a user. Built from the per-zone fields "
+            "above so consumers don't have to interpret null vs idle."
+        ),
     )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -583,9 +583,6 @@ class Config:
     # Round each slot price to this grid (pence) before the MILP objective — ignores sub‑grid price noise.
     # 0 = use exact Agile prices. Try 1–3 for less “fidgety” schedules.
     LP_PRICE_QUANTIZE_PENCE: float = float(os.getenv("LP_PRICE_QUANTIZE_PENCE", "0"))
-    # Legacy (unused): was “gap bridge” in lp_dispatch; removed in Phase 1 — keep keys so .env
-    # does not break. Values are ignored.
-    FOX_LP_BRIDGE_GAP_SLOTS: int = int(os.getenv("FOX_LP_BRIDGE_GAP_SLOTS", "2"))
     # Daikin: minimum consecutive slots (half-hours) for a non-standard window to be scheduled.
     # Cheap/negative windows shorter than this are merged forward or dropped to avoid rapid heat-pump
     # cycling.  2 = 1 hour minimum (recommended).  0 = disabled (legacy behaviour, any length).
@@ -593,7 +590,6 @@ class Config:
     # Delay between critical Onecta writes (climate power, DHW) so the 3-way valve can settle (#18).
     # 0 = skip sleeps (tests).
     DAIKIN_VALVE_SETTLE_SECONDS: int = int(os.getenv("DAIKIN_VALVE_SETTLE_SECONDS", "10"))
-    FOX_LP_BRIDGE_MAX_PRICE_PENCE: float = float(os.getenv("FOX_LP_BRIDGE_MAX_PRICE_PENCE", "0"))
     SOLAR_GAIN_FRACTION: float = float(os.getenv("SOLAR_GAIN_FRACTION", "0.15"))
     COP_DHW_PENALTY: float = float(os.getenv("COP_DHW_PENALTY", "0.5"))
     # Pre-PuLP COP lift (#29): scale COP_curve(T_out) by mult(LWT_supply − T_out). 0 = disabled.

--- a/src/daikin/client.py
+++ b/src/daikin/client.py
@@ -241,6 +241,8 @@ class DaikinClient:
             tank_temp=device.tank_temperature,
             tank_target=device.tank_target,
             weather_regulation=device.weather_regulation_enabled,
+            climate_on=device.is_on,
+            dhw_on=device.tank_on,
         )
 
     def _climate_path(self, device: DaikinDevice, characteristic: str) -> str:

--- a/src/daikin/models.py
+++ b/src/daikin/models.py
@@ -50,9 +50,16 @@ class DaikinDevice:
 
 @dataclass
 class DaikinStatus:
-    """Summarised status for display."""
+    """Summarised status for display.
+
+    Naming caveat for downstream consumers (especially LLM agents): ``is_on``
+    is **only** the climate (room-heating) zone's onOffMode — it does NOT
+    mean "is the heat pump powered on" and it does NOT cover DHW. Use
+    ``climate_on`` / ``dhw_on`` for unambiguous semantics; ``is_on`` is kept
+    for backwards-compatibility with existing callers.
+    """
     device_name: str
-    is_on: bool
+    is_on: bool             # alias of climate_on (deprecated label kept for compat)
     mode: str
     room_temp: float | None
     target_temp: float | None
@@ -62,3 +69,5 @@ class DaikinStatus:
     tank_temp: float | None
     tank_target: float | None
     weather_regulation: bool
+    climate_on: bool | None = None  # climate (space-heating) zone onOffMode
+    dhw_on: bool | None = None      # DHW (tank) zone onOffMode

--- a/src/db.py
+++ b/src/db.py
@@ -301,6 +301,9 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     # V2 cleanup: pnl_execution_log was a never-populated stale schema (helper
     # functions existed but had zero call sites). Drop it on existing prod DBs.
     conn.execute("DROP TABLE IF EXISTS pnl_execution_log")
+    # occupancy_settings — superseded by runtime_settings + presence_periods.
+    # No call site since the runtime-settings refactor; drop on existing DBs.
+    conn.execute("DROP TABLE IF EXISTS occupancy_settings")
 
     # V3: fox_energy_daily — actual daily PV, load, import, export from Fox ESS
     conn.execute(

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -33,7 +33,7 @@ from mcp.server.fastmcp import FastMCP
 from .api import safeguards
 from .config import config
 from .daikin.client import DaikinClient, DaikinError
-from .daikin.models import DaikinDevice
+from .daikin.models import DaikinDevice, DaikinStatus
 from .foxess.client import WORK_MODE_VALID, FoxESSClient, FoxESSError
 from .foxess.service import get_cached_realtime, get_refresh_stats
 from .scheduler.lp_replay import (
@@ -403,11 +403,17 @@ def _plan_date_today(tz_name: str) -> str:
 
 def _device_status_dict(client: DaikinClient, dev: DaikinDevice) -> dict[str, Any]:
     s = client.get_status(dev)
+    summary = _daikin_state_summary(s, config.DAIKIN_CONTROL_MODE)
     return {
         "device_id": dev.id,
         "device_name": s.device_name,
         "model": dev.model or "",
+        # `is_on` is the CLIMATE zone's onOffMode (kept for back-compat). Use
+        # climate_on / dhw_on for unambiguous semantics.
         "is_on": s.is_on,
+        "climate_on": s.climate_on,
+        "dhw_on": s.dhw_on,
+        "control_mode": config.DAIKIN_CONTROL_MODE,
         "mode": s.mode,
         "room_temp": s.room_temp,
         "target_temp": s.target_temp,
@@ -417,7 +423,43 @@ def _device_status_dict(client: DaikinClient, dev: DaikinDevice) -> dict[str, An
         "tank_temp": s.tank_temp,
         "tank_target": s.tank_target,
         "weather_regulation": s.weather_regulation,
+        # One-liner safe for LLM consumption — derived deterministically from
+        # the fields above so an agent never has to "interpret" null vs idle.
+        "state_summary": summary,
     }
+
+
+def _daikin_state_summary(s: DaikinStatus, control_mode: str) -> str:
+    """Deterministic, LLM-safe one-line description of the unit's current state.
+
+    Built from the ground truth fields so callers (OpenClaw, Telegram briefs)
+    don't have to guess from `room_temp=null` whether the unit is "off" or
+    just idle. Output is always non-empty, English, and stable across runs.
+    """
+    parts: list[str] = []
+    if s.dhw_on is False:
+        parts.append("DHW zone OFF")
+    elif s.tank_temp is not None and s.tank_target is not None:
+        if s.tank_temp + 0.5 < s.tank_target:
+            parts.append(f"DHW heating (tank {s.tank_temp:.0f}→{s.tank_target:.0f}°C)")
+        else:
+            parts.append(f"DHW maintaining (tank {s.tank_temp:.0f}/{s.tank_target:.0f}°C)")
+    else:
+        parts.append("DHW state unknown")
+
+    if s.climate_on is False:
+        parts.append("climate OFF")
+    elif s.weather_regulation:
+        lwt_str = f"LWT {s.lwt:.0f}°C" if s.lwt is not None else "LWT unknown"
+        parts.append(f"climate weather-regulated ({lwt_str})")
+    elif s.room_temp is not None and s.target_temp is not None:
+        verb = "heating" if s.room_temp + 0.3 < s.target_temp else "satisfied"
+        parts.append(f"climate {verb} (room {s.room_temp:.1f}/{s.target_temp:.1f}°C)")
+    else:
+        parts.append("climate idle")
+
+    parts.append(f"hem-control={control_mode}")
+    return "; ".join(parts)
 
 
 def build_mcp() -> FastMCP:
@@ -444,8 +486,11 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="get_soc",
         description=(
-            "Return battery state of charge (%) from Fox ESS. "
-            "Uses the same cached realtime path as the REST API (respects API call limits)."
+            "Return Fox ESS battery state of charge as a percentage 0–100. "
+            "The `soc_percent` field is canonical; `soc` is kept as a back-"
+            "compat alias holding the same percentage value (NOT a 0–1 "
+            "fraction and NOT kWh). Uses the cached realtime path — does "
+            "not consume Fox API quota."
         ),
     )
     def get_soc() -> dict[str, Any]:
@@ -462,7 +507,8 @@ def build_mcp() -> FastMCP:
         last_ts, refresh_count = get_refresh_stats()
         return {
             "ok": True,
-            "soc": d.soc,
+            "soc_percent": d.soc,
+            "soc": d.soc,  # back-compat alias — same value (percent 0–100)
             "work_mode": d.work_mode,
             "last_updated_epoch": last_ts,
             "refresh_count_24h": refresh_count,
@@ -473,10 +519,14 @@ def build_mcp() -> FastMCP:
         name="set_inverter_mode",
         description=(
             "Set Fox ESS inverter work mode. Valid modes: Self Use, Feed-in Priority, "
-            "Back Up, Force charge, Force discharge."
+            "Back Up, Force charge, Force discharge. Pass confirmed=True to override "
+            "an active LP plan for today (otherwise the call returns "
+            "requires_confirmation=True with the conflict warning, leaving the live "
+            "Fox V3 schedule untouched). Hardware-significant — agents should surface "
+            "the proposed mode to the user before invoking with confirmed=True."
         ),
     )
-    def set_inverter_mode(mode: str) -> dict[str, Any]:
+    def set_inverter_mode(mode: str, confirmed: bool = False) -> dict[str, Any]:
         from . import db as _db
         if config.OPENCLAW_READ_ONLY:
             safeguards.audit_log(FOXESS_MODE_ACTION, {"mode": mode}, "mcp", False, _write_blocked_message())
@@ -486,6 +536,12 @@ def build_mcp() -> FastMCP:
                 "ok": False,
                 "error": f"Invalid mode {mode!r}. Use one of: {sorted(WORK_MODE_VALID)}",
             }
+        # Plan-conflict gate matches the Daikin write tools — overriding a
+        # committed LP plan with a manual Fox mode is hardware-significant.
+        plan_date = _plan_date_today(config.BULLETPROOF_TIMEZONE)
+        conflict_warn = _check_plan_consent_conflict(plan_date)
+        if conflict_warn and not confirmed:
+            return {"ok": False, "requires_confirmation": True, "warning": conflict_warn}
         allowed, wait_time = safeguards.check_rate_limit(FOXESS_MODE_ACTION)
         if not allowed:
             return {
@@ -509,13 +565,25 @@ def build_mcp() -> FastMCP:
             return {"ok": False, "error": str(e)}
         safeguards.record_action_time(FOXESS_MODE_ACTION)
         safeguards.audit_log(FOXESS_MODE_ACTION, {"mode": mode}, "mcp", True, "Mode set")
-        return {"ok": True, "message": f"Work mode set to: {mode}"}
+        result: dict[str, Any] = {"ok": True, "message": f"Work mode set to: {mode}"}
+        if conflict_warn:
+            result["warning"] = conflict_warn
+        return result
 
     @mcp.tool(
         name="get_daikin_status",
         description=(
-            "Return status for all Daikin (Onecta) devices: temperatures, LWT offset, "
-            "tank, weather regulation flag, etc. Requires Daikin OAuth token file."
+            "Return status for all Daikin (Onecta) devices. Per device: "
+            "`climate_on` (room/space-heating zone onOffMode), `dhw_on` (tank "
+            "zone onOffMode), `control_mode` (passive=HEM never writes; "
+            "active=legacy v9 control), tank/room temps, LWT, outdoor temp, "
+            "weather regulation flag, plus a deterministic `state_summary` "
+            "one-liner safe to relay verbatim to a user. "
+            "IMPORTANT for downstream agents: do NOT use the legacy `is_on` "
+            "field as 'the unit is on' — it only reflects the climate zone. "
+            "A Daikin can have climate_on=false (e.g. summer / outdoor>20°C) "
+            "while DHW is actively heating the tank. Use `state_summary` or "
+            "the per-zone flags. Requires Daikin OAuth token file."
         ),
     )
     def get_daikin_status() -> dict[str, Any]:
@@ -537,8 +605,10 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="set_daikin_power",
         description=(
-            "Turn Daikin climate control on or off for all gateway devices. "
-            "When a plan is pending approval, pass confirmed=True to override it."
+            "Turn the Daikin CLIMATE (room/space-heating) zone on or off. "
+            "DOES NOT affect the DHW (hot water tank) zone — use "
+            "set_daikin_tank_power for that. Both zones run independently. "
+            "When a plan is pending approval, pass confirmed=True to override."
         ),
     )
     def set_daikin_power(on: bool, confirmed: bool = False) -> dict[str, Any]:
@@ -559,7 +629,13 @@ def build_mcp() -> FastMCP:
             return _daikin_write_api_error(DAIKIN_POWER_ACTION, params, e)
         safeguards.record_action_time(DAIKIN_POWER_ACTION)
         safeguards.audit_log(DAIKIN_POWER_ACTION, params, "mcp", True, "Power set")
-        result: dict[str, Any] = {"ok": True, "message": f"Daikin climate turned {'ON' if on else 'OFF'}"}
+        result: dict[str, Any] = {
+            "ok": True,
+            "message": (
+                f"Daikin CLIMATE zone turned {'ON' if on else 'OFF'} "
+                "(DHW tank zone unchanged)"
+            ),
+        }
         if conflict_warn:
             result["warning"] = conflict_warn
         return result
@@ -609,8 +685,12 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="set_daikin_lwt_offset",
         description=(
-            "Set leaving-water temperature offset (-10 to +10) for all devices. "
-            "Preferred when weather regulation is active. Pass confirmed=True to override a pending plan."
+            "Set the climate-zone leaving-water temperature offset in degrees "
+            "Celsius (range -10 to +10 °C). Adds to the firmware's weather-"
+            "compensation curve target — positive = warmer water, negative = "
+            "cooler. Preferred over set_daikin_temperature when weather "
+            "regulation is active. Affects climate zone only; DHW tank "
+            "unchanged. Pass confirmed=True to override a pending plan."
         ),
     )
     def set_daikin_lwt_offset(offset: float, mode: str | None = None, confirmed: bool = False) -> dict[str, Any]:
@@ -641,8 +721,11 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="set_daikin_mode",
         description=(
-            "Set Daikin operation mode: heating, cooling, auto, fan_only, or dry. "
-            "Pass confirmed=True to override a pending plan."
+            "Set the climate-zone operation mode: heating, cooling, auto, "
+            "fan_only, or dry. This is the room/space mode only — DHW tank "
+            "zone has its own independent on/off + setpoint controls (see "
+            "set_daikin_tank_power, set_daikin_tank_temperature). Pass "
+            "confirmed=True to override a pending plan."
         ),
     )
     def set_daikin_mode(mode: str, confirmed: bool = False) -> dict[str, Any]:
@@ -766,8 +849,14 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="get_optimization_plan",
         description=(
-            "Today's SQLite action_schedule rows and last Fox Scheduler V3 snapshot "
-            "(replaces the retired 48-slot V7 solver table)."
+            "Today's SQLite action_schedule rows and last Fox Scheduler V3 "
+            "snapshot. NOTE: 'today' here is the current local calendar date. "
+            "After ~16:00 local (when Octopus publishes tomorrow's Agile "
+            "rates), the LP optimises a 48 h horizon and the freshest plan "
+            "anchors to TOMORROW's date — use get_plan_timeline for the "
+            "explicit run_at + plan_date pair, and prefer that tool when "
+            "the user asks 'what's the plan for tomorrow' near the day "
+            "boundary."
         ),
     )
     def get_optimization_plan() -> dict[str, Any]:
@@ -2056,7 +2145,12 @@ def build_mcp() -> FastMCP:
 
     @mcp.tool(
         name="get_battery_forecast",
-        description="Bulletproof: current SoC and daily_targets snapshot.",
+        description=(
+            "Current Fox ESS battery SoC (% — same value as get_soc.soc_percent) "
+            "and the LP's daily_targets row for today (cheap/peak threshold "
+            "pence, planned end-of-day SoC, peak-export floor). Read-only — "
+            "no cloud calls."
+        ),
     )
     def get_battery_forecast() -> dict[str, Any]:
         from datetime import datetime
@@ -2082,7 +2176,13 @@ def build_mcp() -> FastMCP:
 
     @mcp.tool(
         name="get_weather_context",
-        description="Bulletproof: Open-Meteo forecast plus live Daikin temps when available.",
+        description=(
+            "Open-Meteo hourly outdoor temperature forecast for the next 48 h "
+            "(°C) plus the live Daikin device snapshot (same shape as "
+            "get_daikin_status — read its `state_summary` for an unambiguous "
+            "current-state line). Useful to answer 'will tomorrow be cold "
+            "enough that the heat pump runs hard'."
+        ),
     )
     def get_weather_context() -> dict[str, Any]:
         from .weather import fetch_forecast
@@ -2100,7 +2200,12 @@ def build_mcp() -> FastMCP:
 
     @mcp.tool(
         name="get_action_log",
-        description="Bulletproof: recent device commands from SQLite.",
+        description=(
+            "Recent device-command rows from action_log: who triggered what, "
+            "when, with what params, and whether it succeeded. Filter by "
+            "`device` (e.g. 'daikin', 'foxess') and/or `trigger` (e.g. 'mcp', "
+            "'cron', 'heartbeat'). Use to debug 'did my command actually fire'."
+        ),
     )
     def get_action_log(device: str | None = None, trigger: str | None = None, limit: int = 100) -> dict[str, Any]:
         from . import db
@@ -2109,7 +2214,12 @@ def build_mcp() -> FastMCP:
 
     @mcp.tool(
         name="get_optimizer_log",
-        description="Bulletproof: recent optimizer runs.",
+        description=(
+            "Recent LP solver runs from optimizer_log: run_id, run_at_utc, "
+            "trigger (cron/mpc/manual), solver status, objective value. "
+            "Pair with explain_dispatch_decisions(run_id) to see per-slot LP "
+            "decisions for one specific run."
+        ),
     )
     def get_optimizer_log(limit: int = 20) -> dict[str, Any]:
         from . import db
@@ -2119,7 +2229,16 @@ def build_mcp() -> FastMCP:
     @mcp.tool(
         name="override_schedule",
         description=(
-            "Bulletproof: temporary Daikin boost window. Requires OPENCLAW_READ_ONLY=false."
+            "Insert a one-shot Daikin pre-heat / boost window. Inserts a "
+            "pre_heat action now and a paired restore action `hours` later. "
+            "Args: `hours` (window length, default 2.0); `lwt_offset` "
+            "(climate-zone LWT delta in °C, default +3); `tank_temp` "
+            "(absolute DHW target °C — when set, the DHW tank also boosts "
+            "to this value alongside the climate offset; when null, only "
+            "climate boosts and DHW continues per its schedule). After the "
+            "window, both zones return to LWT offset 0 and tank target "
+            "DHW_TEMP_NORMAL_C. Requires OPENCLAW_READ_ONLY=false. Returns "
+            "`action_id` (boost) and `restore_id` (revert)."
         ),
     )
     def override_schedule(
@@ -2174,7 +2293,12 @@ def build_mcp() -> FastMCP:
 
     @mcp.tool(
         name="acknowledge_warning",
-        description="Bulletproof: acknowledge a warning_key to reduce repeat alerts.",
+        description=(
+            "Acknowledge a warning_key in acknowledged_warnings so subsequent "
+            "heartbeats stop re-emitting the same alert. Use when the user "
+            "has seen the warning and accepted it. Pass the exact warning_key "
+            "from the alert payload (e.g. 'daikin_low_quota_2026-05-03')."
+        ),
     )
     def acknowledge_warning(warning_key: str) -> dict[str, Any]:
         from . import db
@@ -2471,7 +2595,10 @@ def build_mcp() -> FastMCP:
             "Agile slot + price kind, Fox SoC/solar/load/grid, Daikin "
             "temps + mode, next Fox-mode transition, per-source "
             "freshness. Same data the web cockpit's NOW hero panel uses. "
-            "Never triggers cloud calls; pure cache + SQLite."
+            "Never triggers cloud calls; pure cache + SQLite. "
+            "Read `_legend` for sign conventions and units BEFORE "
+            "interpreting state.grid_kw, state.battery_kw, or any "
+            "*_p price field — signs are NOT magnitudes."
         ),
     )
     async def get_cockpit_now() -> dict[str, Any]:
@@ -2493,7 +2620,10 @@ def build_mcp() -> FastMCP:
             "LP run that was active at ``when`` (joining lp_solution_snapshot "
             "+ lp_inputs_snapshot + execution_log + agile_rates). Accepts "
             "ISO-UTC timestamps like 2026-04-24T10:30:00Z. Use this to "
-            "compare what the LP decided vs what actually happened."
+            "compare what the LP decided vs what actually happened. "
+            "Read `_legend` for field semantics — many fields (grid_kw, "
+            "battery_kw, solar_kw) are null in replay because execution_log "
+            "only logs SoC + consumption per slot."
         ),
     )
     async def get_cockpit_at(when: str) -> dict[str, Any]:

--- a/src/physics.py
+++ b/src/physics.py
@@ -167,6 +167,8 @@ def predict_passive_daikin_load(
     *,
     slot_h: float = 0.5,
     max_kwh_per_slot: float | None = None,
+    slot_starts_utc: list[datetime] | None = None,
+    tz: ZoneInfo | None = None,
 ) -> tuple[list[float], list[float]]:
     """Predict the Daikin's autonomous electrical draw per slot in passive mode.
 
@@ -180,10 +182,19 @@ def predict_passive_daikin_load(
     - DHW: steady-state top-up to maintain ``DHW_TEMP_NORMAL_C`` against tank
       standing loss, divided by the slot's COP.
 
+    When ``slot_starts_utc`` and ``tz`` are both supplied AND the runtime
+    settings ``DHW_LEGIONELLA_DAY`` is in [0,6], slots whose local timestamp
+    matches the legionella window get a one-shot DHW uplift on top of the
+    steady-state baseline. Energy = ``DHW_TANK_LITRES × c_water × ΔT / COP``,
+    spread evenly across ``ceil(DHW_LEGIONELLA_DURATION_MIN / 30)`` consecutive
+    slots starting at ``DHW_LEGIONELLA_HOUR_LOCAL`` local. Callers without
+    those args (e.g. the calibration backtest in db.py) are unchanged.
+
     Returns ``(e_space_kwh_per_slot, e_dhw_kwh_per_slot)`` — both clipped into
     ``[0, max_kwh_per_slot]`` when ``max_kwh_per_slot`` is provided.
     """
     from .config import config  # local import avoids circular deps
+    from . import runtime_settings as rts
 
     n = len(temp_outdoor_c)
     if not (len(cop_dhw) == len(cop_space) == n):
@@ -202,6 +213,33 @@ def predict_passive_daikin_load(
         tank_loss_kw * slot_h / max(1.0, float(cop_dhw[i]))
         for i in range(n)
     ]
+
+    if slot_starts_utc is not None and tz is not None:
+        leg_day = int(rts.get_setting("DHW_LEGIONELLA_DAY"))
+        if 0 <= leg_day <= 6 and len(slot_starts_utc) == n:
+            leg_hour = int(rts.get_setting("DHW_LEGIONELLA_HOUR_LOCAL"))
+            leg_minutes = int(rts.get_setting("DHW_LEGIONELLA_DURATION_MIN"))
+            leg_target_c = float(rts.get_setting("DHW_LEGIONELLA_TANK_TARGET_C"))
+            slots_per_cycle = max(1, (leg_minutes + int(slot_h * 60) - 1) // int(slot_h * 60))
+            delta_c = max(0.0, leg_target_c - tank_target_c)
+            litres = float(config.DHW_TANK_LITRES)
+            cp_j_per_kg_k = float(config.DHW_WATER_CP)  # J/(kg·K) ≈ 4186
+            thermal_kwh = litres * cp_j_per_kg_k * delta_c / 3.6e6
+            # Match the cycle to consecutive slots starting at the configured
+            # local hour on the configured weekday. We mark each LP slot whose
+            # *start* falls inside [leg_hour, leg_hour + slots_per_cycle*slot_h)
+            # local on weekday == leg_day. Multiple LP horizons may straddle a
+            # cycle midnight; the per-slot test handles each independently.
+            cycle_window_h = slots_per_cycle * slot_h
+            for i, st in enumerate(slot_starts_utc):
+                local = st.astimezone(tz)
+                if local.weekday() != leg_day:
+                    continue
+                hour_frac = local.hour + local.minute / 60.0
+                if not (leg_hour <= hour_frac < leg_hour + cycle_window_h):
+                    continue
+                cop_i = max(1.0, float(cop_dhw[i]))
+                dhw_kwh[i] += thermal_kwh / slots_per_cycle / cop_i
 
     if max_kwh_per_slot is not None:
         cap = float(max_kwh_per_slot)

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -262,6 +262,59 @@ SCHEMA: dict[str, SettingSpec] = {
             "BATTERY_CAPACITY_KWH."
         ),
     ),
+    # Legionella thermal-shock awareness. The Daikin Onecta firmware fires the
+    # cycle autonomously on a user-configured day/hour (set in the Onecta app);
+    # the LP cannot command it. These knobs let the LP *predict* the resulting
+    # DHW pulse so it allocates PV/battery/grid correctly that hour. Set
+    # DHW_LEGIONELLA_DAY=-1 to disable the prediction (no uplift; firmware still
+    # fires whenever it pleases — LP just won't see it coming).
+    "DHW_LEGIONELLA_DAY": SettingSpec(
+        key="DHW_LEGIONELLA_DAY",
+        type_name="int",
+        env_default=_int_env("DHW_LEGIONELLA_DAY", "-1"),
+        min_value=-1,
+        max_value=6,
+        description=(
+            "Local weekday for predicted legionella thermal-shock cycle. "
+            "-1 disabled, 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun. "
+            "Must match what is configured in the Daikin Onecta app — the LP "
+            "uses this only to inject a predicted DHW pulse into passive-mode "
+            "load forecast; it does not command the firmware."
+        ),
+    ),
+    "DHW_LEGIONELLA_HOUR_LOCAL": SettingSpec(
+        key="DHW_LEGIONELLA_HOUR_LOCAL",
+        type_name="int",
+        env_default=_int_env("DHW_LEGIONELLA_HOUR_LOCAL", "13"),
+        min_value=0,
+        max_value=23,
+        description=(
+            "Local hour at which the legionella cycle starts (0–23). Must match "
+            "the Daikin Onecta schedule. Used only with DHW_LEGIONELLA_DAY ≥ 0."
+        ),
+    ),
+    "DHW_LEGIONELLA_DURATION_MIN": SettingSpec(
+        key="DHW_LEGIONELLA_DURATION_MIN",
+        type_name="int",
+        env_default=_int_env("DHW_LEGIONELLA_DURATION_MIN", "60"),
+        min_value=30,
+        max_value=240,
+        description=(
+            "Estimated cycle duration in minutes (rounded up to whole 30-min slots). "
+            "60 min ≈ 200 L tank from 50 → 60 °C at typical Altherma DHW power."
+        ),
+    ),
+    "DHW_LEGIONELLA_TANK_TARGET_C": SettingSpec(
+        key="DHW_LEGIONELLA_TANK_TARGET_C",
+        type_name="float",
+        env_default=_float_env("DHW_LEGIONELLA_TANK_TARGET_C", "60"),
+        min_value=50.0,
+        max_value=70.0,
+        description=(
+            "Tank temperature reached during the cycle (°C). The LP uses "
+            "(target − DHW_TEMP_NORMAL_C) to size the predicted electric pulse."
+        ),
+    ),
 }
 
 

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -288,7 +288,11 @@ def solve_lp(
     passive_daikin = config.DAIKIN_CONTROL_MODE == "passive"
     if passive_daikin:
         passive_e_space, passive_e_dhw = predict_passive_daikin_load(
-            t_out, cop_dhw, cop_space, slot_h=slot_h, max_kwh_per_slot=max_hp_kwh,
+            t_out, cop_dhw, cop_space,
+            slot_h=slot_h,
+            max_kwh_per_slot=max_hp_kwh,
+            slot_starts_utc=slot_starts_utc,
+            tz=tz,
         )
     else:
         passive_e_space = passive_e_dhw = []

--- a/tests/api/test_cockpit_now.py
+++ b/tests/api/test_cockpit_now.py
@@ -34,8 +34,15 @@ def test_cockpit_now_shape(client):
     # Top-level keys.
     assert set(body.keys()) == {
         "now_utc", "planner_tz", "current_slot", "next_transition",
-        "state", "freshness", "thresholds", "modes", "plan_date",
+        "state", "freshness", "thresholds", "modes", "plan_date", "_legend",
     }
+    # _legend disambiguates sign conventions for LLM consumers (OpenClaw etc.).
+    # The signed fields MUST carry a description so a negative value cannot be
+    # misread as an unsigned magnitude — see the 2026-05-03 OpenClaw "Daikin
+    # off" misread audit for context.
+    legend = body["_legend"]
+    assert "IMPORTING" in legend["grid_kw"] and "EXPORTING" in legend["grid_kw"]
+    assert "CHARGING" in legend["battery_kw"] and "DISCHARGING" in legend["battery_kw"]
 
     # current_slot always has the 5-key shape.
     assert set(body["current_slot"].keys()) == {

--- a/tests/test_daikin_passive_mode.py
+++ b/tests/test_daikin_passive_mode.py
@@ -208,12 +208,32 @@ def test_boost_preset_alias_maps_to_normal(caplog) -> None:
 
 
 # ---------------------------------------------------------------------------
-# S4: legionella env vars are gone
+# S4: legacy hard-coded legionella env vars stay gone; new shape is runtime-mutable
 # ---------------------------------------------------------------------------
 
-def test_legionella_env_vars_removed() -> None:
+def test_legacy_legionella_attrs_still_removed() -> None:
+    """The old v9-shape attrs were the LP-commands-the-cycle design. Keep them
+    out of `config` — anyone still wiring code against them is using the wrong
+    abstraction. The replacement is runtime_settings (mutable, prediction-only).
+    """
     for attr in (
-        "DHW_LEGIONELLA_TEMP_C", "DHW_LEGIONELLA_DAY",
-        "DHW_LEGIONELLA_HOUR_START", "DHW_LEGIONELLA_HOUR_END",
+        "DHW_LEGIONELLA_TEMP_C",
+        "DHW_LEGIONELLA_HOUR_START",
+        "DHW_LEGIONELLA_HOUR_END",
     ):
-        assert not hasattr(config, attr), f"{attr} should have been removed in v10"
+        assert not hasattr(config, attr), f"{attr} should not be a static config attr"
+
+
+def test_legionella_runtime_settings_present() -> None:
+    """Re-introduced as runtime_settings (mutable via PUT /api/v1/settings + MCP).
+    Used by predict_passive_daikin_load to inject a one-shot DHW pulse.
+    """
+    from src import runtime_settings as rts
+    for key in (
+        "DHW_LEGIONELLA_DAY",
+        "DHW_LEGIONELLA_HOUR_LOCAL",
+        "DHW_LEGIONELLA_DURATION_MIN",
+        "DHW_LEGIONELLA_TANK_TARGET_C",
+    ):
+        assert key in rts.SCHEMA, f"{key} should be a runtime_setting"
+    assert rts.get_setting("DHW_LEGIONELLA_DAY") == -1, "default disabled"

--- a/tests/test_daikin_status_summary.py
+++ b/tests/test_daikin_status_summary.py
@@ -1,0 +1,136 @@
+"""Daikin status semantics for LLM consumers (OpenClaw etc.).
+
+Regression: 2026-05-03 — OpenClaw reported "Daikin is off" because it read
+the legacy `is_on` field which only reflects the climate zone. With outdoor
+~19 °C the climate zone is idle (`is_on=true, room_temp=null`) while DHW is
+actively maintaining the tank — the unit is *not* off. These tests pin the
+enriched response shape so the misread cannot recur:
+
+  1. _daikin_state_summary builds an unambiguous one-liner from the typed
+     fields (no field is silently dropped).
+  2. _device_status_dict surfaces climate_on / dhw_on / control_mode /
+     state_summary so an agent never has to guess.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.daikin.models import DaikinDevice, DaikinStatus
+from src.mcp_server import _daikin_state_summary, _device_status_dict
+
+
+def _status(**overrides) -> DaikinStatus:
+    base = dict(
+        device_name="dev",
+        is_on=True,
+        mode="heating",
+        room_temp=None,
+        target_temp=None,
+        outdoor_temp=19.0,
+        lwt=22.0,
+        lwt_offset=-1.0,
+        tank_temp=41.0,
+        tank_target=40.0,
+        weather_regulation=True,
+        climate_on=True,
+        dhw_on=True,
+    )
+    base.update(overrides)
+    return DaikinStatus(**base)
+
+
+# ---------------------------------------------------------------------------
+# state_summary covers every cell of the truth table the LLM might face
+# ---------------------------------------------------------------------------
+
+def test_summary_dhw_maintaining_climate_weather_regulated() -> None:
+    s = _status()  # exact prod snapshot: tank near target, climate idle, WR on
+    out = _daikin_state_summary(s, "passive")
+    assert "DHW maintaining" in out
+    assert "climate weather-regulated" in out
+    assert "hem-control=passive" in out
+    assert "off" not in out.lower(), f"must not contain misleading 'off': {out!r}"
+
+
+def test_summary_dhw_actively_heating() -> None:
+    out = _daikin_state_summary(_status(tank_temp=35.0, tank_target=45.0), "passive")
+    assert "DHW heating (tank 35→45°C)" in out
+
+
+def test_summary_dhw_zone_explicitly_off() -> None:
+    out = _daikin_state_summary(_status(dhw_on=False), "passive")
+    assert "DHW zone OFF" in out
+
+
+def test_summary_climate_zone_explicitly_off() -> None:
+    out = _daikin_state_summary(
+        _status(climate_on=False, weather_regulation=False, room_temp=None, target_temp=None),
+        "passive",
+    )
+    assert "climate OFF" in out
+
+
+def test_summary_climate_room_setpoint_satisfied() -> None:
+    out = _daikin_state_summary(
+        _status(weather_regulation=False, room_temp=21.5, target_temp=21.0),
+        "active",
+    )
+    assert "climate satisfied" in out
+    assert "21.5/21.0" in out
+    assert "hem-control=active" in out
+
+
+def test_summary_climate_actively_heating() -> None:
+    out = _daikin_state_summary(
+        _status(weather_regulation=False, room_temp=18.0, target_temp=21.0),
+        "passive",
+    )
+    assert "climate heating" in out
+    assert "18.0/21.0" in out
+
+
+def test_summary_unknowns_do_not_say_off() -> None:
+    """The pre-fix bug: null fields read as 'off'. Now they read as 'unknown' / 'idle'."""
+    s = _status(
+        tank_temp=None, tank_target=None,
+        room_temp=None, target_temp=None,
+        weather_regulation=False,
+        climate_on=None, dhw_on=None,
+    )
+    out = _daikin_state_summary(s, "passive")
+    assert "DHW state unknown" in out
+    assert "climate idle" in out
+    assert "OFF" not in out, f"unknown != off: {out!r}"
+
+
+# ---------------------------------------------------------------------------
+# _device_status_dict shape — what OpenClaw actually receives
+# ---------------------------------------------------------------------------
+
+def test_device_status_dict_includes_unambiguous_fields() -> None:
+    """Pin the keys an LLM consumer can rely on."""
+    s = _status()
+    client = MagicMock()
+    client.get_status.return_value = s
+    dev = DaikinDevice(id="gw1", name="x", model="Altherma")
+
+    out = _device_status_dict(client, dev)
+    # Legacy field stays for back-compat
+    assert "is_on" in out
+    # New unambiguous fields
+    for key in ("climate_on", "dhw_on", "control_mode", "state_summary"):
+        assert key in out, f"missing {key!r} in {sorted(out)}"
+    # state_summary is a non-empty string
+    assert isinstance(out["state_summary"], str) and out["state_summary"].strip()
+
+
+def test_device_status_dict_state_summary_matches_helper() -> None:
+    """The dict's state_summary is byte-identical to the helper output."""
+    from src.config import config
+    s = _status()
+    client = MagicMock()
+    client.get_status.return_value = s
+    dev = DaikinDevice(id="gw1", name="x", model="Altherma")
+
+    out = _device_status_dict(client, dev)
+    assert out["state_summary"] == _daikin_state_summary(s, config.DAIKIN_CONTROL_MODE)

--- a/tests/test_legionella_uplift.py
+++ b/tests/test_legionella_uplift.py
@@ -1,0 +1,156 @@
+"""Legionella DHW uplift in predict_passive_daikin_load.
+
+Daikin Onecta firmware fires the thermal-shock cycle autonomously on a fixed
+weekday/hour configured in the Onecta app. The LP can't command it; it can
+only *predict* it so the passive-mode load forecast accounts for the pulse.
+These tests pin that prediction:
+
+  1. With DHW_LEGIONELLA_DAY=-1 (default) → no uplift, ever.
+  2. On the matching local weekday + hour window → uplift on those slots.
+  3. Outside the window (any other weekday, or earlier/later hour) → no uplift.
+  4. 60-min duration spreads across exactly two consecutive 30-min slots.
+  5. max_kwh_per_slot still caps the final value.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db, runtime_settings as rts
+from src.physics import predict_passive_daikin_load
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+    rts.clear_cache()
+    yield
+    # Clean up any settings these tests leak.
+    for key in (
+        "DHW_LEGIONELLA_DAY",
+        "DHW_LEGIONELLA_HOUR_LOCAL",
+        "DHW_LEGIONELLA_DURATION_MIN",
+        "DHW_LEGIONELLA_TANK_TARGET_C",
+    ):
+        try:
+            rts.delete_setting(key, actor="test_cleanup")
+        except Exception:
+            pass
+    rts.clear_cache()
+
+
+def _make_horizon(start_local: datetime, n: int, tz: ZoneInfo) -> list[datetime]:
+    """Return n half-hourly UTC slot starts beginning at ``start_local`` (in ``tz``)."""
+    base = start_local.replace(tzinfo=tz).astimezone(UTC)
+    return [base + timedelta(minutes=30 * i) for i in range(n)]
+
+
+def test_no_uplift_when_disabled() -> None:
+    tz = ZoneInfo("Europe/London")
+    # Wed 2026-05-06 12:00 → 6 slots covering 12:00–15:00 local
+    starts = _make_horizon(datetime(2026, 5, 6, 12, 0), 6, tz)
+    space, dhw = predict_passive_daikin_load(
+        [10.0] * 6, [3.0] * 6, [3.0] * 6,
+        slot_starts_utc=starts, tz=tz,
+    )
+    # Every slot is steady-state baseline only — identical because t_out + COP are flat.
+    assert all(abs(d - dhw[0]) < 1e-9 for d in dhw), dhw
+
+
+def test_uplift_on_matching_wednesday_13() -> None:
+    tz = ZoneInfo("Europe/London")
+    rts.set_setting("DHW_LEGIONELLA_DAY", 2, actor="test")  # Wed
+    rts.set_setting("DHW_LEGIONELLA_HOUR_LOCAL", 13, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_DURATION_MIN", 60, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_TANK_TARGET_C", 60.0, actor="test")
+    starts = _make_horizon(datetime(2026, 5, 6, 12, 0), 6, tz)  # Wed 12:00–14:30
+    space, dhw = predict_passive_daikin_load(
+        [10.0] * 6, [3.0] * 6, [3.0] * 6,
+        slot_starts_utc=starts, tz=tz,
+    )
+    # Slots: 12:00, 12:30, 13:00, 13:30, 14:00, 14:30
+    # Cycle window 13:00 → 14:00 → slots 2 and 3 get the uplift.
+    base = dhw[0]
+    assert dhw[0] == pytest.approx(base), "12:00 outside cycle"
+    assert dhw[1] == pytest.approx(base), "12:30 outside cycle"
+    assert dhw[2] > base + 1e-3, "13:00 must include uplift"
+    assert dhw[3] > base + 1e-3, "13:30 must include uplift"
+    assert dhw[4] == pytest.approx(base), "14:00 outside cycle (window ends)"
+    assert dhw[5] == pytest.approx(base), "14:30 outside cycle"
+    # Both uplifted slots get the same per-slot share.
+    assert dhw[2] == pytest.approx(dhw[3])
+
+
+def test_no_uplift_on_non_matching_day() -> None:
+    tz = ZoneInfo("Europe/London")
+    rts.set_setting("DHW_LEGIONELLA_DAY", 2, actor="test")  # Wed
+    rts.set_setting("DHW_LEGIONELLA_HOUR_LOCAL", 13, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_DURATION_MIN", 60, actor="test")
+    starts = _make_horizon(datetime(2026, 5, 7, 12, 0), 6, tz)  # Thu 12:00–14:30
+    space, dhw = predict_passive_daikin_load(
+        [10.0] * 6, [3.0] * 6, [3.0] * 6,
+        slot_starts_utc=starts, tz=tz,
+    )
+    assert all(abs(d - dhw[0]) < 1e-9 for d in dhw), dhw
+
+
+def test_uplift_magnitude_matches_water_thermal_capacity() -> None:
+    """Σ(uplift_dhw - baseline) should equal litres × c_water × ΔT / 3.6e6 / COP."""
+    tz = ZoneInfo("Europe/London")
+    rts.set_setting("DHW_LEGIONELLA_DAY", 2, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_HOUR_LOCAL", 13, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_DURATION_MIN", 60, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_TANK_TARGET_C", 60.0, actor="test")
+    starts = _make_horizon(datetime(2026, 5, 6, 12, 0), 6, tz)
+    cop = 3.0
+    _, dhw = predict_passive_daikin_load(
+        [10.0] * 6, [cop] * 6, [cop] * 6,
+        slot_starts_utc=starts, tz=tz,
+    )
+    _, baseline = predict_passive_daikin_load(
+        [10.0] * 6, [cop] * 6, [cop] * 6,
+        slot_starts_utc=None, tz=None,
+    )
+    delta = sum(dhw) - sum(baseline)
+    from src.config import config
+    expected_thermal_kwh = (
+        float(config.DHW_TANK_LITRES)
+        * float(config.DHW_WATER_CP)
+        * (60.0 - float(config.DHW_TEMP_NORMAL_C))
+        / 3.6e6
+    )
+    assert delta == pytest.approx(expected_thermal_kwh / cop, rel=1e-6)
+
+
+def test_uplift_capped_by_max_kwh_per_slot() -> None:
+    """When max_kwh_per_slot is small, the cap still binds (no LP-blowing huge value)."""
+    tz = ZoneInfo("Europe/London")
+    rts.set_setting("DHW_LEGIONELLA_DAY", 2, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_HOUR_LOCAL", 13, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_DURATION_MIN", 60, actor="test")
+    starts = _make_horizon(datetime(2026, 5, 6, 12, 0), 6, tz)
+    cap = 0.05
+    _, dhw = predict_passive_daikin_load(
+        [10.0] * 6, [3.0] * 6, [3.0] * 6,
+        slot_starts_utc=starts, tz=tz,
+        max_kwh_per_slot=cap,
+    )
+    assert max(dhw) <= cap + 1e-12
+
+
+def test_backwards_compatible_without_slot_args() -> None:
+    """db.py:1343 calls without slot_starts_utc/tz; uplift must be no-op there."""
+    tz = ZoneInfo("Europe/London")
+    rts.set_setting("DHW_LEGIONELLA_DAY", 2, actor="test")
+    rts.set_setting("DHW_LEGIONELLA_HOUR_LOCAL", 13, actor="test")
+    _, dhw_with = predict_passive_daikin_load(
+        [10.0] * 6, [3.0] * 6, [3.0] * 6,
+    )
+    rts.delete_setting("DHW_LEGIONELLA_DAY", actor="test")
+    rts.clear_cache()
+    _, dhw_disabled = predict_passive_daikin_load(
+        [10.0] * 6, [3.0] * 6, [3.0] * 6,
+    )
+    assert dhw_with == dhw_disabled, "no slot context → uplift must be skipped"

--- a/tests/test_mcp_boundary_selfcheck.py
+++ b/tests/test_mcp_boundary_selfcheck.py
@@ -19,13 +19,19 @@ from src.mcp_server import audit_mcp_tool_surface, build_mcp
 
 
 def test_audit_clean_on_current_surface() -> None:
-    """All set_daikin_* tools currently have a `confirmed` parameter — audit is clean for them."""
+    """Every set_daikin_* AND set_inverter_* tool now has a `confirmed` parameter.
+
+    Previously this test carved out set_inverter_mode (no `confirmed` — see git
+    log for the OpenClaw "Daikin off" misread audit). After the 2026-05-03 fix
+    `set_inverter_mode` matches the Daikin write-tools pattern, so the audit
+    must be completely clean.
+    """
     mcp = build_mcp()
     warnings = audit_mcp_tool_surface(mcp)
-    # We allow set_inverter_mode to show up (it doesn't have `confirmed`) but must not
-    # regress any `set_daikin_*` tool.
-    regressions = [w for w in warnings if "set_daikin_" in w]
-    assert regressions == [], f"set_daikin_* tools must retain `confirmed`: {regressions}"
+    assert warnings == [], (
+        "Hardware-write MCP tools must all expose a `confirmed` parameter. "
+        f"Audit emitted: {warnings}"
+    )
 
 
 def test_audit_errors_when_tool_registry_is_empty() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -24,6 +24,14 @@ def _fake_daikin_device(**kwargs: object) -> DaikinDevice:
 
 
 class TestMCPServerFoxTools(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        # safeguards holds module-level _last_action_time; the FOXESS_MODE rate
+        # limiter window is process-wide, so successive tests in this class can
+        # tickle each other if not cleared. Reset before each test.
+        from src.api import safeguards as _sg
+        with _sg._lock:
+            _sg._last_action_time.clear()
+
     async def test_get_soc_ok(self) -> None:
         mcp = build_mcp()
         with patch("src.mcp_server.get_cached_realtime") as gr, patch(
@@ -39,6 +47,9 @@ class TestMCPServerFoxTools(unittest.IsolatedAsyncioTestCase):
             )
             _blocks, out = await mcp.call_tool("get_soc", {})
         self.assertTrue(out["ok"])
+        # `soc_percent` is the canonical name; `soc` is the back-compat alias.
+        # Both must hold the same percent value (NOT a 0–1 fraction; NOT kWh).
+        self.assertEqual(out["soc_percent"], 62.0)
         self.assertEqual(out["soc"], 62.0)
         self.assertEqual(out["work_mode"], "Self Use")
         self.assertEqual(out["refresh_count_24h"], 5)
@@ -62,8 +73,61 @@ class TestMCPServerFoxTools(unittest.IsolatedAsyncioTestCase):
             "src.mcp_server._foxess_client", return_value=mock_client
         ):
             cfg.OPENCLAW_READ_ONLY = False
+            # Real tz string so _plan_date_today can construct a ZoneInfo;
+            # added 2026-05-03 when set_inverter_mode picked up the plan-
+            # conflict gate that all other write tools already had.
+            cfg.BULLETPROOF_TIMEZONE = "Europe/London"
             _blocks, out = await mcp.call_tool("set_inverter_mode", {"mode": "Force charge"})
         self.assertTrue(out["ok"])
+        mock_client.set_work_mode.assert_called_once_with("Force charge")
+
+    async def test_set_inverter_mode_blocked_by_pending_plan(self) -> None:
+        """`confirmed=False` (default) must refuse when a plan is pending approval.
+
+        Pinned 2026-05-03: previously set_inverter_mode lacked the `confirmed`
+        gate entirely, so OpenClaw could overwrite a pending LP plan's Fox
+        schedule without surfacing the conflict to the user.
+        """
+        from src import db as _db
+        _db.init_db()
+        mcp = build_mcp()
+        mock_client = MagicMock()
+        # Stub _check_plan_consent_conflict to simulate a pending plan.
+        with patch("src.mcp_server.config") as cfg, patch(
+            "src.mcp_server._foxess_client", return_value=mock_client
+        ), patch(
+            "src.mcp_server._check_plan_consent_conflict",
+            return_value="WARNING: plan lp-2026-05-03 is pending your approval.",
+        ):
+            cfg.OPENCLAW_READ_ONLY = False
+            cfg.BULLETPROOF_TIMEZONE = "Europe/London"
+            _blocks, out = await mcp.call_tool(
+                "set_inverter_mode", {"mode": "Force charge"}
+            )
+        self.assertFalse(out["ok"])
+        self.assertTrue(out.get("requires_confirmation"))
+        self.assertIn("pending", out.get("warning", "").lower())
+        mock_client.set_work_mode.assert_not_called()
+
+    async def test_set_inverter_mode_proceeds_with_confirmed(self) -> None:
+        """Same setup as above but `confirmed=True` proceeds + surfaces the warning."""
+        from src import db as _db
+        _db.init_db()
+        mcp = build_mcp()
+        mock_client = MagicMock()
+        with patch("src.mcp_server.config") as cfg, patch(
+            "src.mcp_server._foxess_client", return_value=mock_client
+        ), patch(
+            "src.mcp_server._check_plan_consent_conflict",
+            return_value="WARNING: plan lp-2026-05-03 is pending your approval.",
+        ):
+            cfg.OPENCLAW_READ_ONLY = False
+            cfg.BULLETPROOF_TIMEZONE = "Europe/London"
+            _blocks, out = await mcp.call_tool(
+                "set_inverter_mode", {"mode": "Force charge", "confirmed": True}
+            )
+        self.assertTrue(out["ok"])
+        self.assertIn("warning", out)
         mock_client.set_work_mode.assert_called_once_with("Force charge")
 
 


### PR DESCRIPTION
## Summary

Three coupled changes that all came out of today's 2026-05-03 OpenClaw \"Daikin off\" audit (OpenClaw reported the unit as off when in fact DHW was actively heating the tank — root cause was \`get_daikin_status.is_on\` exposing only the climate-zone flag, with no climate/dhw split or unambiguous state line):

1. **Re-introduce \`DHW_LEGIONELLA_*\` as runtime_settings** (mutable via PUT \`/api/v1/settings\` + MCP \`set_setting\`), feeding into \`predict_passive_daikin_load\` so the LP can predict the firmware-fired DHW pulse and allocate PV/battery/grid around it. \`DAY\` defaults to \`-1\` (disabled — pre-fix behaviour is byte-identical until you set the day/hour to match what's configured in Onecta).
2. **Enrich \`DaikinStatus\`** with explicit \`climate_on\` / \`dhw_on\` flags and a deterministic \`state_summary\` one-liner. MCP \`get_daikin_status\`, REST \`/api/v1/daikin/status\`, \`get_cockpit_now\` and \`get_cockpit_at\` all surface them. Tool description warns LLM consumers not to read the legacy \`is_on\` as \"the unit is on\".
3. **\`/api/v1/cockpit/{now,at}\` now carries a \`_legend\` block** explaining sign conventions for \`grid_kw\` / \`battery_kw\` and units for every other field (Pydantic \`Field\` descriptions don't reach the JSON consumer). \`set_inverter_mode\` now has \`confirmed=False\` matching the Daikin write tools — closes the long-standing OpenClaw-boundary banner.

Plus tightening of several terse MCP tool descriptions (\`get_battery_forecast\`, \`get_weather_context\`, \`get_action_log\`, \`get_optimizer_log\`, \`acknowledge_warning\`, \`override_schedule\`, \`get_optimization_plan\`, \`set_daikin_power\` / \`mode\` / \`lwt_offset\`, \`get_soc\`).

**Removed:** deprecated DHW_LEGIONELLA_* env block in \`.env.example\` (replaced with new commented examples for the runtime-settings shape); two legacy unused config keys (\`FOX_LP_BRIDGE_GAP_SLOTS\`, \`FOX_LP_BRIDGE_MAX_PRICE_PENCE\`); orphan \`occupancy_settings\` table (superseded by \`runtime_settings\` + \`presence_periods\`, dropped on service init via \`_migrate_schema\`).

## Test plan

- [x] \`pytest tests/ --ignore=tests/test_mcp_singleton.py\` → 866 passed (+18 from main), 1 skipped
- [x] New \`tests/test_legionella_uplift.py\` — 6 cases pinning the uplift truth table (no-uplift-disabled, uplift-on-Wed-13, no-uplift-Thu, energy balance vs litres·c·ΔT/COP, max-cap binds, backwards-compat)
- [x] New \`tests/test_daikin_status_summary.py\` — 9 cases pinning \`state_summary\` + the enriched \`_device_status_dict\` shape
- [x] \`tests/api/test_cockpit_now.py\` — pins \`_legend\` keys + IMPORTING/EXPORTING/CHARGING/DISCHARGING strings so a refactor can't drop them
- [x] \`tests/test_mcp_boundary_selfcheck.py\` — strictened to \`audit_mcp_tool_surface(mcp) == []\` (was: carve-out for \`set_inverter_mode\`)
- [x] \`tests/test_mcp_server.py\` — new tests for \`set_inverter_mode\` plan-conflict gate (blocked when plan pending; proceeds with \`confirmed=True\`)
- [ ] After merge: \`docker compose pull && systemctl restart hem\` on prod, then \`PUT /api/v1/settings/DHW_LEGIONELLA_DAY=6\` + \`PUT /api/v1/settings/DHW_LEGIONELLA_HOUR_LOCAL=13\` to wire to the Sun 13:00 cycle now configured in Onecta

🤖 Generated with [Claude Code](https://claude.com/claude-code)