### PR TITLE
feat(replay): canonical forecast schema + replay-by-fetch + history exogenous

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,9 @@ logic), BOTH of these gates must pass before merging.
 
 ### Gate 1 — LP regression (general) — BOTH modes must pass
 
-V11-A (#194). The LP must be no worse than the pinned baseline on the last
-14 days of historical runs in BOTH modes:
+V11-A (#194). The LP must be no worse than the pinned baseline on the same
+historical replay dates in BOTH modes. Individual moments may be worse, but
+aggregate cost must be better than or equal to the comparable baseline window:
 
   - **forward** (snapshot weather + current config) — catches behaviour change.
   - **honest**  (snapshot weather + snapshot config) — catches solver / framework
@@ -27,10 +28,10 @@ V11-A (#194). The LP must be no worse than the pinned baseline on the last
   → MODE = HONEST:  VERDICT PASS / FAIL
   → BOTH-MODE VERDICT: PASS / FAIL
 
-If VERDICT=FAIL on either, the LP got worse on past days — investigate before
-merging. If the regression is INTENTIONAL (new objective term, tuned weights),
-accept it as the new baseline by re-running with `--refresh-baseline` and
-committing both `tests/fixtures/lp_regression_baseline.forward.json` and
+If VERDICT=FAIL on either, aggregate cost got worse or the baseline dates could
+not all be replayed — investigate before merging. Only refresh the baseline
+after confirming the new strategy is better or equal on an agreed replay set,
+then commit both `tests/fixtures/lp_regression_baseline.forward.json` and
 `tests/fixtures/lp_regression_baseline.honest.json` in the same PR.
 
 ### Gate 2 — Scenario filter regression (peak_export specifically)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Everything is parameterised via `.env`. Adapting it to a different setup is feas
 - **SmartThings appliance dispatch** — washer/dryer/dishwasher start times picked by the LP given a deadline; physical Smart Control button is the consent gate.
 - **Notifications via OpenClaw hook** — twice-daily digest, plan-revision pings, negative-price alerts. No direct chat APIs from this repo.
 - **75-tool MCP surface** — Fox, Daikin, Octopus, optimization, replay, dispatch decisions. Bearer-guarded HTTP transport.
-- **Closed-loop replay + regression gate** — every LP solve is a frozen, replayable snapshot; `scripts/check_lp_regression.py --mode=both` blocks merges that make the planner worse.
+- **Closed-loop replay + regression gate** — every LP solve is a frozen, replayable snapshot; `scripts/check_lp_regression.py --mode=both` blocks merges when aggregate cost is worse on comparable baseline dates.
 
 ## How it works
 
@@ -147,7 +147,7 @@ The full backlog is on the [issues board](https://github.com/albinati/home-energ
 
 Adding a feature, reproducing a bug, or porting to a different installation? See [CONTRIBUTING.md](CONTRIBUTING.md). Security issues — see [SECURITY.md](SECURITY.md).
 
-The PR template requires the LP regression gate (`scripts/check_lp_regression.py --mode=both`) to pass for any change under `src/scheduler/` — that's how we keep "the LP must outperform every earlier version always" honest.
+The PR template requires the LP regression gate (`scripts/check_lp_regression.py --mode=both`) to pass for any change under `src/scheduler/`: individual moments can be worse, but comparable aggregate cost must be better than or equal to the baseline.
 
 ## License
 

--- a/docs/DISPATCH_DECISIONS.md
+++ b/docs/DISPATCH_DECISIONS.md
@@ -253,18 +253,19 @@ path. Both run locally against a prod DB snapshot (CI doesn't have prod data).
 For each historical day in the last 14, replays the LP via
 `replay_day(mode="forward")` and sums `total_replayed_cost_p` (planned
 dispatch scored against actually-published Agile rates). Compares the
-**aggregate** against a frozen baseline pinned in
-`tests/fixtures/lp_regression_baseline.json`.
+**aggregate over the same baseline dates** against a frozen baseline pinned in
+`tests/fixtures/lp_regression_baseline.json`. Missing baseline dates fail the
+gate because partial replay coverage can make the new total look falsely cheap.
 
 ```
 DB_PATH=/path/to/prod-snapshot.db python scripts/check_lp_regression.py
 ```
 
-* Exit 0 = LP no worse than baseline + 50 p threshold across the 14-day
-  window. Solver float drift is typically << 1 p across 14 days, so 50 p
-  is generous.
-* Exit 1 = regression. Either fix the change or, if the regression is
-  intentional (new objective term / tuned weight), refresh the baseline:
+* Exit 0 = aggregate LP cost is better than or equal to the comparable
+  baseline window. Individual moments may be worse; the total must not be.
+* Exit 1 = aggregate cost regressed or replay coverage is incomplete. Fix the
+  change, or refresh the baseline only after confirming the new strategy is
+  better or equal on an agreed replay set:
   ```
   python scripts/check_lp_regression.py --refresh-baseline
   git add tests/fixtures/lp_regression_baseline.json
@@ -272,8 +273,8 @@ DB_PATH=/path/to/prod-snapshot.db python scripts/check_lp_regression.py
   in the same PR. The baseline records the SHA it was frozen at, so a
   reviewer can always see when the bar was last reset.
 
-This is the "LP must outperform every earlier version" guarantee — every
-commit either matches or beats the prior baseline.
+This is the "LP must outperform every earlier version" guarantee: every
+commit either matches or beats the prior aggregate baseline.
 
 ### Gate 2 — `scripts/validate_scenario_filter.py` (peak_export-specific)
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance and validation scripts."""

--- a/scripts/check_lp_regression.py
+++ b/scripts/check_lp_regression.py
@@ -11,11 +11,11 @@ against a frozen baseline pinned in
 **Exit code semantics:**
 
 * 0 — total replayed cost ≤ baseline + ``--fail-above-pence`` threshold (default
-  50 p over the window). The new code is at least as good as the baseline.
-* 1 — the new code is materially worse than the baseline. **Do not merge** until
-  either (a) the regression is fixed, or (b) you intentionally accept it as the
-  new baseline by re-running with ``--refresh-baseline`` and committing the
-  updated JSON in the same PR.
+  0 p over the comparable window). The new code is at least as good as the
+  baseline overall. Individual moments may be worse; aggregate cost must not be.
+* 1 — the new code is worse than the comparable baseline, the baseline is
+  missing, or baseline replay coverage is incomplete. **Do not merge** until
+  the regression or replay data is fixed.
 
 **Usage:**
 
@@ -23,7 +23,7 @@ against a frozen baseline pinned in
 # Pre-merge gate (against your locally-mounted prod DB snapshot):
 DB_PATH=/path/to/prod-snapshot.db .venv/bin/python scripts/check_lp_regression.py
 
-# After an INTENTIONAL LP behaviour change (new objective term, tuned weights):
+# After proving a new LP strategy is better or equal on an agreed replay set:
 DB_PATH=/path/to/prod-snapshot.db .venv/bin/python scripts/check_lp_regression.py \
     --refresh-baseline
 git add tests/fixtures/lp_regression_baseline.json && git commit
@@ -77,13 +77,17 @@ class RegressionReport:
     days: list[DayResult] = field(default_factory=list)
     refreshed_baseline: bool = False
     no_baseline_yet: bool = False  # first run, baseline file empty/missing
+    baseline_missing_dates: list[str] = field(default_factory=list)
+    compared_dates: list[str] = field(default_factory=list)
 
     @property
     def passed(self) -> bool:
         if self.refreshed_baseline:
             return True
         if self.no_baseline_yet:
-            return True
+            return False
+        if self.baseline_missing_dates:
+            return False
         return self.delta_vs_baseline_p <= self.fail_threshold_p
 
 
@@ -234,20 +238,52 @@ def run_check(
         delta_vs_baseline_p=0.0,
     )
 
+    ok_by_date: dict[str, DayResult] = {}
     for d in dates:
         result = _replay_one_day(d, mode=mode)
         report.days.append(result)
         if result.ok:
-            report.new_total_replayed_cost_p += result.total_replayed_cost_p
+            ok_by_date[result.date] = result
 
     baseline = _load_baseline(baseline_path)
     if baseline is None:
         report.no_baseline_yet = True
-    else:
-        report.baseline_total_replayed_cost_p = float(baseline.get("total_replayed_cost_p", 0.0))
-        report.delta_vs_baseline_p = (
-            report.new_total_replayed_cost_p - report.baseline_total_replayed_cost_p
+        report.new_total_replayed_cost_p = sum(
+            d.total_replayed_cost_p for d in report.days if d.ok
         )
+    else:
+        per_date = baseline.get("per_date") if isinstance(baseline, dict) else None
+        if isinstance(per_date, dict) and per_date:
+            baseline_total = 0.0
+            current_total = 0.0
+            missing: list[str] = []
+            compared: list[str] = []
+            for day in sorted(str(k) for k in per_date.keys()):
+                row = per_date.get(day) or {}
+                try:
+                    baseline_day_cost = float(row.get("total_replayed_cost_p", 0.0))
+                except (AttributeError, TypeError, ValueError):
+                    baseline_day_cost = 0.0
+                current = ok_by_date.get(day)
+                if current is None:
+                    missing.append(day)
+                    continue
+                baseline_total += baseline_day_cost
+                current_total += current.total_replayed_cost_p
+                compared.append(day)
+            report.baseline_missing_dates = missing
+            report.compared_dates = compared
+            report.baseline_total_replayed_cost_p = baseline_total
+            report.new_total_replayed_cost_p = current_total
+            report.delta_vs_baseline_p = current_total - baseline_total
+        else:
+            report.new_total_replayed_cost_p = sum(
+                d.total_replayed_cost_p for d in report.days if d.ok
+            )
+            report.baseline_total_replayed_cost_p = float(baseline.get("total_replayed_cost_p", 0.0))
+            report.delta_vs_baseline_p = (
+                report.new_total_replayed_cost_p - report.baseline_total_replayed_cost_p
+            )
 
     if refresh_baseline:
         _write_baseline(baseline_path, report, _detect_git_sha())
@@ -277,24 +313,29 @@ def _print_report(report: RegressionReport) -> None:
         )
     print("-" * 80)
     print(f"NEW total replayed cost      : {report.new_total_replayed_cost_p / 100:>+9.2f} £")
+    if report.compared_dates:
+        print(f"Compared baseline dates      : {len(report.compared_dates)}")
+    if report.baseline_missing_dates:
+        print("Missing baseline dates       : " + ", ".join(report.baseline_missing_dates))
     if report.baseline_total_replayed_cost_p is None:
         if report.refreshed_baseline:
             print("Baseline                     : refreshed and written to "
                   f"{report.baseline_path}")
         else:
             print(f"Baseline                     : NOT FOUND at {report.baseline_path}")
-            print("                               Re-run with --refresh-baseline to "
-                  "freeze the current totals as the baseline.")
+            print("                               Approval requires a comparable baseline. "
+                  "Refresh only after proving the strategy is better or equal.")
     else:
         print(f"BASELINE total replayed cost : "
               f"{report.baseline_total_replayed_cost_p / 100:>+9.2f} £   "
-              f"(threshold +{report.fail_threshold_p / 100:.2f} £)")
+              f"(allowed worse +{report.fail_threshold_p / 100:.2f} £)")
         print(f"Δ vs baseline                : "
               f"{report.delta_vs_baseline_p / 100:>+9.2f} £")
     if report.passed:
-        print("VERDICT: PASS — LP is no worse than baseline.")
+        print("VERDICT: PASS — aggregate cost is no worse than baseline.")
     else:
-        print("VERDICT: FAIL — LP regressed beyond the threshold; "
+        print("VERDICT: FAIL — aggregate cost regressed, baseline is missing, "
+              "or baseline coverage is incomplete; "
               "investigate before merging.")
     print()
 
@@ -310,19 +351,19 @@ def main(argv: list[str]) -> int:
         help="Path to the JSON baseline file (default: tests/fixtures/lp_regression_baseline.json).",
     )
     parser.add_argument(
-        "--fail-above-pence", type=float, default=50.0,
+        "--fail-above-pence", type=float, default=0.0,
         help=(
             "Fail if (new total replayed cost − baseline) exceeds this many pence. "
-            "Default 50 (= £0.50 over the whole window). Solver float-precision drift "
-            "is typically << 1 p across 14 days, so 50 p is a generous tolerance."
+            "Default 0: individual moments may worsen, but aggregate replayed cost "
+            "must be better than or equal to the comparable baseline window."
         ),
     )
     parser.add_argument(
         "--refresh-baseline", action="store_true",
         help=(
-            "Overwrite the baseline file with the current totals. Use this AFTER "
-            "intentionally changing LP behaviour (new objective term, tuned weights, "
-            "rebased default config) — commit the updated JSON in the same PR."
+            "Overwrite the baseline file with the current totals. Use this only after "
+            "proving the new strategy is better or equal on an agreed replay set; "
+            "commit the updated JSON in the same PR."
         ),
     )
     parser.add_argument(

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1261,15 +1261,32 @@ async def optimization_inputs(horizon_hours: int | None = None):
     )
 
     # --- Meteo forecast (latest-per-slot, in the plan window) ---------------
+    # Use the canonical store (meteo_forecast_value, keyed by the latest
+    # ``meteo_forecast_latest_state`` fetch). Falls back to the legacy
+    # ``meteo_forecast`` table for rows predating the V11 canonical migration.
     conn = db.get_connection()
     try:
-        cur = conn.execute(
-            """SELECT slot_time, temp_c, solar_w_m2 FROM meteo_forecast
-               WHERE slot_time >= ? AND slot_time < ?
-               ORDER BY slot_time""",
-            (day_start.isoformat(), window_end.isoformat()),
-        )
-        meteo_rows = [dict(r) for r in cur.fetchall()]
+        latest_fetch_at = db._get_latest_meteo_forecast_fetch_at(conn)
+        if latest_fetch_at:
+            cur = conn.execute(
+                """SELECT slot_time, temp_c, solar_w_m2
+                   FROM meteo_forecast_value
+                   WHERE forecast_fetch_at_utc = ?
+                     AND slot_time >= ? AND slot_time < ?
+                   ORDER BY slot_time""",
+                (latest_fetch_at, day_start.isoformat(), window_end.isoformat()),
+            )
+            meteo_rows = [dict(r) for r in cur.fetchall()]
+        else:
+            meteo_rows = []
+        if not meteo_rows:
+            cur = conn.execute(
+                """SELECT slot_time, temp_c, solar_w_m2 FROM meteo_forecast
+                   WHERE slot_time >= ? AND slot_time < ?
+                   ORDER BY slot_time""",
+                (day_start.isoformat(), window_end.isoformat()),
+            )
+            meteo_rows = [dict(r) for r in cur.fetchall()]
     finally:
         conn.close()
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1056,12 +1056,105 @@ async def cockpit_at(when: str):
 
     # --- LP plan for the slot containing `when` ------------------------------
     planned_slot: dict[str, Any] | None = None
-    if lp_slots and slot_from:
-        iso_from = slot_from.replace("+00:00", "Z")
-        for s in lp_slots:
-            if s.get("slot_time_utc") in (iso_from, slot_from):
-                planned_slot = dict(s)
-                break
+    if lp_slots:
+        if slot_from:
+            iso_from = slot_from.replace("+00:00", "Z")
+            for s in lp_slots:
+                if s.get("slot_time_utc") in (iso_from, slot_from):
+                    planned_slot = dict(s)
+                    break
+        if planned_slot is None:
+            from datetime import timedelta as _td
+            for s in lp_slots:
+                try:
+                    slot_start = _dt.fromisoformat(str(s.get("slot_time_utc") or "").replace("Z", "+00:00"))
+                except Exception:
+                    continue
+                if slot_start.tzinfo is None:
+                    slot_start = slot_start.replace(tzinfo=_UTC)
+                slot_end = slot_start + _td(minutes=30)
+                if slot_start <= w < slot_end:
+                    planned_slot = dict(s)
+                    break
+
+    lp_why: list[str] = []
+    if planned_slot:
+        try:
+            slot_index = int(planned_slot.get("slot_index"))
+        except (TypeError, ValueError):
+            slot_index = -1
+        load_bits = (lp_exogenous or {}).get("base_load_components") or {}
+        weather_bits = (lp_exogenous or {}).get("weather_adjustment") or {}
+        tariff_bits = (lp_exogenous or {}).get("tariffs") or {}
+
+        residual_profile = load_bits.get("residual_profile_kwh") or []
+        appliance_profile = load_bits.get("appliance_profile_kwh") or []
+        residual_kwh = None
+        appliance_kwh = None
+        if 0 <= slot_index < len(residual_profile):
+            try:
+                residual_kwh = float(residual_profile[slot_index])
+            except (TypeError, ValueError):
+                residual_kwh = None
+        if 0 <= slot_index < len(appliance_profile):
+            try:
+                appliance_kwh = float(appliance_profile[slot_index])
+            except (TypeError, ValueError):
+                appliance_kwh = None
+
+        import_kwh = float(planned_slot.get("import_kwh") or 0.0)
+        charge_kwh = float(planned_slot.get("charge_kwh") or 0.0)
+        discharge_kwh = float(planned_slot.get("discharge_kwh") or 0.0)
+        dhw_kwh = float(planned_slot.get("dhw_kwh") or 0.0)
+        space_kwh = float(planned_slot.get("space_kwh") or 0.0)
+
+        if import_kwh > 0.01 and charge_kwh > 0.01:
+            price_txt = f"{price_i:.1f}p" if price_i is not None else "unknown price"
+            lp_why.append(
+                f"Battery charge was scheduled in this slot, so the LP imported {import_kwh:.3f} kWh at {price_txt}."
+            )
+        elif discharge_kwh > 0.01:
+            lp_why.append(
+                f"Battery discharge was scheduled here ({discharge_kwh:.3f} kWh), reducing grid import in this slot."
+            )
+
+        if dhw_kwh > 0.01 or space_kwh > 0.01:
+            parts: list[str] = []
+            if dhw_kwh > 0.01:
+                parts.append(f"DHW {dhw_kwh:.3f} kWh")
+            if space_kwh > 0.01:
+                parts.append(f"space heat {space_kwh:.3f} kWh")
+            lp_why.append(f"Comfort demand shaped this slot via {' and '.join(parts)}.")
+
+        if residual_kwh is not None:
+            if appliance_kwh and appliance_kwh > 0.01:
+                lp_why.append(
+                    f"Base load for this slot was built from residual load {residual_kwh:.3f} kWh plus appliance allowance {appliance_kwh:.3f} kWh."
+                )
+            else:
+                lp_why.append(
+                    f"Base load for this slot came from the residual-load profile at {residual_kwh:.3f} kWh."
+                )
+
+        today_factor = weather_bits.get("today_factor")
+        forecast_fetch = weather_bits.get("forecast_fetch_at_utc")
+        if today_factor is not None and forecast_fetch:
+            try:
+                today_factor_f = float(today_factor)
+                lp_why.append(
+                    f"Weather inputs came from forecast fetch {forecast_fetch}; PV was adjusted with today-factor {today_factor_f:.3f}."
+                )
+            except (TypeError, ValueError):
+                pass
+
+        export_prices = tariff_bits.get("export_price_pence")
+        if isinstance(export_prices, list) and 0 <= slot_index < len(export_prices):
+            try:
+                lp_why.append(
+                    f"Export economics for this slot used {float(export_prices[slot_index]):.1f}p/kWh rather than a flat export rate."
+                )
+            except (TypeError, ValueError):
+                pass
 
     return {
         "when_utc": when_iso.replace("+00:00", "Z"),
@@ -1082,6 +1175,7 @@ async def cockpit_at(when: str):
         "planned_slot": planned_slot,  # LP's decision for that slot, or None
         "lp_inputs": lp_inputs,        # Full inputs row at solve time, or None
         "lp_exogenous": lp_exogenous,  # Parsed LP-only derived inputs, or None
+        "lp_why": lp_why,              # Compact human-readable reasons for this slot
         "slot_kind": realised.get("slot_kind"),
         # Same legend as /cockpit/now — keeps signs / units unambiguous for
         # historical replays consumed by LLM agents.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -971,6 +971,7 @@ async def cockpit_at(when: str):
     """
     from datetime import UTC as _UTC
     from datetime import datetime as _dt
+    import json as _json
     from zoneinfo import ZoneInfo
 
     try:
@@ -988,6 +989,13 @@ async def cockpit_at(when: str):
     run_id = db.find_run_for_time(when_iso)
     lp_inputs = db.get_lp_inputs(run_id) if run_id is not None else None
     lp_slots = db.get_lp_solution_slots(run_id) if run_id is not None else []
+    lp_exogenous: dict[str, Any] | None = None
+    if lp_inputs and lp_inputs.get("exogenous_snapshot_json"):
+        try:
+            raw = _json.loads(lp_inputs["exogenous_snapshot_json"] or "{}")
+            lp_exogenous = raw if isinstance(raw, dict) else None
+        except Exception:
+            lp_exogenous = None
 
     # --- Price at the moment, from agile_rates -------------------------------
     tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
@@ -1073,6 +1081,7 @@ async def cockpit_at(when: str):
         "state": state_block,
         "planned_slot": planned_slot,  # LP's decision for that slot, or None
         "lp_inputs": lp_inputs,        # Full inputs row at solve time, or None
+        "lp_exogenous": lp_exogenous,  # Parsed LP-only derived inputs, or None
         "slot_kind": realised.get("slot_kind"),
         # Same legend as /cockpit/now — keeps signs / units unambiguous for
         # historical replays consumed by LLM agents.

--- a/src/api/static/js/history.js
+++ b/src/api/static/js/history.js
@@ -13,6 +13,11 @@
   function fmtP(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(1)}p`; }
   function fmtKwh(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(3)} kWh`; }
   function fmtPct(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(0)}%`; }
+  function sumList(v) {
+    if (!Array.isArray(v)) return null;
+    const nums = v.map(Number).filter(n => !Number.isNaN(n));
+    return nums.length ? nums.reduce((a, b) => a + b, 0) : null;
+  }
 
   function inputToIso(val) {
     // datetime-local gives "2026-04-24T10:00"; treat as UTC — the picker
@@ -34,6 +39,7 @@
     const state = data.state || {};
     const plan = data.planned_slot || {};
     const li = data.lp_inputs || {};
+    const lx = data.lp_exogenous || {};
     const src = data.source || {};
 
     // Source readout: which run + which log row fed this payload.
@@ -101,6 +107,31 @@
     $('#liPeak').textContent = fmtP(li.peak_threshold_p);
     $('#liDkMode').textContent = li.daikin_control_mode || '—';
     $('#liPreset').textContent = li.optimization_preset || '—';
+
+    const loadBits = lx.base_load_components || {};
+    const weatherBits = lx.weather_adjustment || {};
+    const tariffBits = lx.tariffs || {};
+    const residualTotal = sumList(loadBits.residual_profile_kwh);
+    const applianceTotal = sumList(loadBits.appliance_profile_kwh);
+    $('#lxResidual').textContent = fmtKwh(residualTotal);
+    $('#lxAppliance').textContent = fmtKwh(applianceTotal);
+    $('#lxFlat').textContent = fmtKwh(loadBits.flat_fallback_kwh);
+    $('#lxFoxMean').textContent = fmtKwh(loadBits.fox_mean_kwh_per_slot);
+    $('#lxBuckets').textContent = loadBits.profile_bucket_count != null
+      ? `${loadBits.profile_bucket_count} buckets`
+      : '—';
+    $('#lxFetch').textContent = weatherBits.forecast_fetch_at_utc || '—';
+    $('#lxPvAdjust').textContent = weatherBits.today_factor != null
+      ? `today=${Number(weatherBits.today_factor).toFixed(3)} flat=${Number(weatherBits.flat_scale ?? 1).toFixed(3)} cloud=${weatherBits.cloud_table_cells ?? 0} hourly=${weatherBits.hourly_table_cells ?? 0}`
+      : '—';
+    if (Array.isArray(tariffBits.export_price_pence) && tariffBits.export_price_pence.length) {
+      const xs = tariffBits.export_price_pence.map(Number).filter(n => !Number.isNaN(n));
+      const min = Math.min(...xs);
+      const max = Math.max(...xs);
+      $('#lxExport').textContent = `${xs.length} slots · ${fmtP(min)} to ${fmtP(max)}`;
+    } else {
+      $('#lxExport').textContent = tariffBits.uses_flat_export_rate ? 'flat export rate' : '—';
+    }
   }
 
   /**

--- a/src/api/static/js/history.js
+++ b/src/api/static/js/history.js
@@ -40,6 +40,7 @@
     const plan = data.planned_slot || {};
     const li = data.lp_inputs || {};
     const lx = data.lp_exogenous || {};
+    const why = Array.isArray(data.lp_why) ? data.lp_why : [];
     const src = data.source || {};
 
     // Source readout: which run + which log row fed this payload.
@@ -131,6 +132,15 @@
       $('#lxExport').textContent = `${xs.length} slots · ${fmtP(min)} to ${fmtP(max)}`;
     } else {
       $('#lxExport').textContent = tariffBits.uses_flat_export_rate ? 'flat export rate' : '—';
+    }
+
+    const whyEl = $('#historyWhy');
+    if (whyEl) {
+      if (!why.length) {
+        whyEl.textContent = 'No slot-specific explanation available for that moment.';
+      } else {
+        whyEl.innerHTML = `<ul>${why.map(line => `<li>${line}</li>`).join('')}</ul>`;
+      }
     }
   }
 

--- a/src/api/templates/history.html
+++ b/src/api/templates/history.html
@@ -89,6 +89,22 @@
     </table>
 </section>
 
+<section class="card">
+    <h3 class="card-title">LP exogenous build</h3>
+    <table class="fc-kv-table">
+        <tbody>
+            <tr><th>Residual base load</th><td id="lxResidual">—</td></tr>
+            <tr><th>Appliance-added load</th><td id="lxAppliance">—</td></tr>
+            <tr><th>Flat fallback</th><td id="lxFlat">—</td></tr>
+            <tr><th>Fox mean / slot</th><td id="lxFoxMean">—</td></tr>
+            <tr><th>Load buckets</th><td id="lxBuckets">—</td></tr>
+            <tr><th>Forecast fetch</th><td id="lxFetch">—</td></tr>
+            <tr><th>PV adjust</th><td id="lxPvAdjust">—</td></tr>
+            <tr><th>Export pricing</th><td id="lxExport">—</td></tr>
+        </tbody>
+    </table>
+</section>
+
 {% endblock %}
 
 {% block scripts %}

--- a/src/api/templates/history.html
+++ b/src/api/templates/history.html
@@ -105,6 +105,11 @@
     </table>
 </section>
 
+<section class="card">
+    <h3 class="card-title">Why This Slot</h3>
+    <div id="historyWhy" class="text-mute">—</div>
+</section>
+
 {% endblock %}
 
 {% block scripts %}

--- a/src/db.py
+++ b/src/db.py
@@ -554,6 +554,7 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             base_load_json           TEXT,
             micro_climate_offset_c   REAL,
             forecast_fetch_at_utc    TEXT,
+            exogenous_snapshot_json  TEXT,
             config_snapshot_json     TEXT,
             price_quantize_p         REAL,
             peak_threshold_p         REAL,
@@ -853,10 +854,25 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     lp_cols = {str(r[1]) for r in cur.fetchall()}
     if "forecast_fetch_at_utc" not in lp_cols:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN forecast_fetch_at_utc TEXT")
+    if "exogenous_snapshot_json" not in lp_cols:
+        conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN exogenous_snapshot_json TEXT")
     if "dhw_draw_prior_json" not in lp_cols:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN dhw_draw_prior_json TEXT")
     if "occupancy_prior_json" not in lp_cols:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN occupancy_prior_json TEXT")
+    # Older DBs predate the cloud-aware PV table (PR #232). Idempotent — when
+    # the table is already created at SCHEMA-load time this block is a no-op.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS pv_calibration_hourly_cloud (
+            hour_utc        INTEGER NOT NULL CHECK(hour_utc >= 0 AND hour_utc < 24),
+            cloud_bucket    INTEGER NOT NULL CHECK(cloud_bucket >= 0 AND cloud_bucket < 4),
+            factor          REAL NOT NULL,
+            samples         INTEGER NOT NULL,
+            window_days     INTEGER NOT NULL,
+            computed_at     TEXT NOT NULL,
+            PRIMARY KEY (hour_utc, cloud_bucket)
+        )"""
+    )
 
 
 def init_db() -> None:
@@ -3606,18 +3622,19 @@ def save_lp_snapshots(
                    (run_id, run_at_utc, plan_date, horizon_hours,
                     soc_initial_kwh, tank_initial_c, indoor_initial_c,
                     soc_source, tank_source, indoor_source,
-                    base_load_json, micro_climate_offset_c, forecast_fetch_at_utc, config_snapshot_json,
+                    base_load_json, micro_climate_offset_c, forecast_fetch_at_utc, exogenous_snapshot_json, config_snapshot_json,
                     price_quantize_p, peak_threshold_p, cheap_threshold_p,
                     daikin_control_mode, optimization_preset, energy_strategy_mode)
                    VALUES (:run_id, :run_at_utc, :plan_date, :horizon_hours,
                            :soc_initial_kwh, :tank_initial_c, :indoor_initial_c,
                            :soc_source, :tank_source, :indoor_source,
-                           :base_load_json, :micro_climate_offset_c, :forecast_fetch_at_utc, :config_snapshot_json,
+                           :base_load_json, :micro_climate_offset_c, :forecast_fetch_at_utc, :exogenous_snapshot_json, :config_snapshot_json,
                            :price_quantize_p, :peak_threshold_p, :cheap_threshold_p,
                            :daikin_control_mode, :optimization_preset, :energy_strategy_mode)""",
                 {
                     "run_id": run_id,
                     "forecast_fetch_at_utc": inputs_row.get("forecast_fetch_at_utc"),
+                    "exogenous_snapshot_json": inputs_row.get("exogenous_snapshot_json"),
                     **inputs_row,
                 },
             )

--- a/src/db.py
+++ b/src/db.py
@@ -567,9 +567,6 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_plan_date ON lp_inputs_snapshot(plan_date)"
     )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_forecast_fetch ON lp_inputs_snapshot(forecast_fetch_at_utc)"
-    )
 
     # V11b: meteo_forecast_history — append-only audit log of every forecast
     # fetch. The existing meteo_forecast table is latest-per-slot (overwrites on
@@ -860,6 +857,9 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN dhw_draw_prior_json TEXT")
     if "occupancy_prior_json" not in lp_cols:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN occupancy_prior_json TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_forecast_fetch ON lp_inputs_snapshot(forecast_fetch_at_utc)"
+    )
     # Older DBs predate the cloud-aware PV table (PR #232). Idempotent — when
     # the table is already created at SCHEMA-load time this block is a no-op.
     conn.execute(

--- a/src/db.py
+++ b/src/db.py
@@ -161,6 +161,36 @@ CREATE TABLE IF NOT EXISTS meteo_forecast (
     UNIQUE(slot_time)
 );
 
+CREATE TABLE IF NOT EXISTS meteo_forecast_snapshot (
+    forecast_fetch_at_utc TEXT PRIMARY KEY,
+    source TEXT,
+    model_name TEXT,
+    model_version TEXT,
+    raw_payload_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS meteo_forecast_value (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    forecast_fetch_at_utc TEXT NOT NULL,
+    slot_time TEXT NOT NULL,
+    temp_c REAL,
+    solar_w_m2 REAL,
+    cloud_cover_pct REAL,
+    UNIQUE(forecast_fetch_at_utc, slot_time)
+);
+
+CREATE INDEX IF NOT EXISTS idx_meteo_forecast_value_slot
+ON meteo_forecast_value(slot_time);
+
+CREATE INDEX IF NOT EXISTS idx_meteo_forecast_value_fetch
+ON meteo_forecast_value(forecast_fetch_at_utc);
+
+CREATE TABLE IF NOT EXISTS meteo_forecast_latest_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    forecast_fetch_at_utc TEXT
+);
+INSERT OR IGNORE INTO meteo_forecast_latest_state (id, forecast_fetch_at_utc) VALUES (1, NULL);
+
 CREATE TABLE IF NOT EXISTS api_call_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     vendor TEXT NOT NULL,
@@ -523,6 +553,7 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             indoor_source            TEXT,
             base_load_json           TEXT,
             micro_climate_offset_c   REAL,
+            forecast_fetch_at_utc    TEXT,
             config_snapshot_json     TEXT,
             price_quantize_p         REAL,
             peak_threshold_p         REAL,
@@ -534,6 +565,9 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_plan_date ON lp_inputs_snapshot(plan_date)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_forecast_fetch ON lp_inputs_snapshot(forecast_fetch_at_utc)"
     )
 
     # V11b: meteo_forecast_history — append-only audit log of every forecast
@@ -556,6 +590,41 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_meteo_forecast_history_fetch ON meteo_forecast_history(forecast_fetch_at_utc)"
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS meteo_forecast_snapshot (
+            forecast_fetch_at_utc TEXT PRIMARY KEY,
+            source TEXT,
+            model_name TEXT,
+            model_version TEXT,
+            raw_payload_json TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS meteo_forecast_value (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            forecast_fetch_at_utc TEXT NOT NULL,
+            slot_time TEXT NOT NULL,
+            temp_c REAL,
+            solar_w_m2 REAL,
+            cloud_cover_pct REAL,
+            UNIQUE(forecast_fetch_at_utc, slot_time)
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_meteo_forecast_value_slot ON meteo_forecast_value(slot_time)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_meteo_forecast_value_fetch ON meteo_forecast_value(forecast_fetch_at_utc)"
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS meteo_forecast_latest_state (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            forecast_fetch_at_utc TEXT
+        )"""
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO meteo_forecast_latest_state (id, forecast_fetch_at_utc) VALUES (1, NULL)"
     )
 
     # V11c: config_audit — append-only log of runtime_settings changes so a
@@ -782,6 +851,8 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     # reserves the columns so V11-C/D don't need their own migration.
     cur = conn.execute("PRAGMA table_info(lp_inputs_snapshot)")
     lp_cols = {str(r[1]) for r in cur.fetchall()}
+    if "forecast_fetch_at_utc" not in lp_cols:
+        conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN forecast_fetch_at_utc TEXT")
     if "dhw_draw_prior_json" not in lp_cols:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN dhw_draw_prior_json TEXT")
     if "occupancy_prior_json" not in lp_cols:
@@ -1285,9 +1356,9 @@ def half_hourly_residual_load_profile_kwh(
     (``predict_passive_daikin_load``) per past sample to back out the
     residual (non-Daikin) load.
 
-    Outdoor temperature per sample comes from ``meteo_forecast_history``
-    (append-only hourly forecasts). When no history match exists, fall through
-    to ``meteo_forecast`` (latest-per-slot table) for the same hour-of-year;
+    Outdoor temperature per sample comes from the canonical forecast snapshot
+    store. When no historical match exists, fall through to the latest marked
+    forecast snapshot for the same hour-of-year;
     if both miss, the sample is dropped rather than emitting a polluted
     residual. The previous behaviour used a 25 °C sentinel that pushed
     physics above the climate-curve cutoff and silently included un-subtracted
@@ -1314,11 +1385,19 @@ def half_hourly_residual_load_profile_kwh(
         try:
             cur = conn.execute(
                 """SELECT pv.captured_at, pv.load_power_kw,
-                          (SELECT temp_c FROM meteo_forecast_history mh
-                           WHERE substr(mh.slot_time, 1, 13) = substr(pv.captured_at, 1, 13)
-                           ORDER BY mh.id DESC LIMIT 1) AS outdoor_history_c,
-                          (SELECT temp_c FROM meteo_forecast mf
-                           WHERE substr(mf.slot_time, 1, 13) = substr(pv.captured_at, 1, 13)
+                          (SELECT mv.temp_c
+                           FROM meteo_forecast_value mv
+                           JOIN meteo_forecast_snapshot ms
+                             ON ms.forecast_fetch_at_utc = mv.forecast_fetch_at_utc
+                           WHERE substr(mv.slot_time, 1, 13) = substr(pv.captured_at, 1, 13)
+                             AND ms.forecast_fetch_at_utc < pv.captured_at
+                           ORDER BY ms.forecast_fetch_at_utc DESC LIMIT 1) AS outdoor_history_c,
+                          (SELECT mv.temp_c
+                           FROM meteo_forecast_value mv
+                           JOIN meteo_forecast_latest_state ls
+                             ON ls.id = 1
+                            AND ls.forecast_fetch_at_utc = mv.forecast_fetch_at_utc
+                           WHERE substr(mv.slot_time, 1, 13) = substr(pv.captured_at, 1, 13)
                            LIMIT 1) AS outdoor_latest_c
                    FROM pv_realtime_history pv
                    WHERE pv.captured_at > ? AND pv.load_power_kw IS NOT NULL""",
@@ -2287,33 +2366,46 @@ def schedule_for_date(plan_date: str) -> list[dict[str, Any]]:
 # V2: meteo_forecast
 # ---------------------------------------------------------------------------
 
-def save_meteo_forecast(rows: list[dict[str, Any]], forecast_date: str) -> int:
-    """Upsert hourly Open-Meteo forecast rows for *forecast_date*.
 
-    Each dict must have: slot_time (ISO), temp_c (float), solar_w_m2 (float).
-    Optional: cloud_cover_pct (float, 0-100) — used by the cloud-aware
-    PV calibration table (PR #232).
-    """
+def save_meteo_forecast_snapshot(
+    forecast_fetch_at_utc: str,
+    rows: list[dict[str, Any]],
+    *,
+    source: str = "open-meteo",
+    model_name: str | None = None,
+    model_version: str | None = None,
+    raw_payload_json: str | None = None,
+    mark_latest: bool = True,
+) -> int:
+    """Persist one canonical forecast fetch and its normalized slot rows."""
     if not rows:
         return 0
     n = 0
     with _lock:
         conn = get_connection()
         try:
+            conn.execute(
+                """INSERT OR IGNORE INTO meteo_forecast_snapshot
+                   (forecast_fetch_at_utc, source, model_name, model_version, raw_payload_json)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    str(forecast_fetch_at_utc),
+                    str(source),
+                    model_name,
+                    model_version,
+                    raw_payload_json,
+                ),
+            )
             for r in rows:
                 slot = r.get("slot_time")
                 if not slot:
                     continue
                 conn.execute(
-                    """INSERT INTO meteo_forecast (forecast_date, slot_time, temp_c, solar_w_m2, cloud_cover_pct)
-                       VALUES (?, ?, ?, ?, ?)
-                       ON CONFLICT(slot_time) DO UPDATE SET
-                         forecast_date=excluded.forecast_date,
-                         temp_c=excluded.temp_c,
-                         solar_w_m2=excluded.solar_w_m2,
-                         cloud_cover_pct=COALESCE(excluded.cloud_cover_pct, meteo_forecast.cloud_cover_pct)""",
+                    """INSERT OR IGNORE INTO meteo_forecast_value
+                       (forecast_fetch_at_utc, slot_time, temp_c, solar_w_m2, cloud_cover_pct)
+                       VALUES (?, ?, ?, ?, ?)""",
                     (
-                        forecast_date,
+                        str(forecast_fetch_at_utc),
                         str(slot),
                         r.get("temp_c"),
                         r.get("solar_w_m2"),
@@ -2321,17 +2413,61 @@ def save_meteo_forecast(rows: list[dict[str, Any]], forecast_date: str) -> int:
                     ),
                 )
                 n += 1
+            if mark_latest:
+                conn.execute(
+                    """INSERT INTO meteo_forecast_latest_state (id, forecast_fetch_at_utc)
+                       VALUES (1, ?)
+                       ON CONFLICT(id) DO UPDATE SET forecast_fetch_at_utc=excluded.forecast_fetch_at_utc""",
+                    (str(forecast_fetch_at_utc),),
+                )
             conn.commit()
         finally:
             conn.close()
     return n
 
 
+def _get_latest_meteo_forecast_fetch_at(conn: sqlite3.Connection) -> str | None:
+    cur = conn.execute(
+        "SELECT forecast_fetch_at_utc FROM meteo_forecast_latest_state WHERE id = 1"
+    )
+    row = cur.fetchone()
+    if row and row[0]:
+        return str(row[0])
+    cur = conn.execute(
+        "SELECT forecast_fetch_at_utc FROM meteo_forecast_snapshot ORDER BY forecast_fetch_at_utc DESC LIMIT 1"
+    )
+    row = cur.fetchone()
+    return str(row[0]) if row and row[0] else None
+
+def save_meteo_forecast(rows: list[dict[str, Any]], forecast_date: str) -> int:
+    """Legacy helper that writes a latest forecast snapshot.
+
+    ``forecast_date`` is retained for compatibility with older callers/tests,
+    but canonical production writes should use
+    :func:`save_meteo_forecast_snapshot`.
+    """
+    _ = forecast_date
+    return save_meteo_forecast_snapshot(datetime.now(UTC).isoformat(), rows, mark_latest=True)
+
+
 def get_meteo_forecast(forecast_date: str) -> list[dict[str, Any]]:
-    """Return all meteo_forecast rows for *forecast_date* ordered by slot_time."""
+    """Return latest forecast rows whose target slot falls on *forecast_date*."""
     with _lock:
         conn = get_connection()
         try:
+            latest_fetch_at = _get_latest_meteo_forecast_fetch_at(conn)
+            if latest_fetch_at:
+                cur = conn.execute(
+                    """SELECT ? AS forecast_date, slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                       FROM meteo_forecast_value
+                       WHERE forecast_fetch_at_utc = ?
+                         AND substr(slot_time, 1, 10) = ?
+                       ORDER BY slot_time""",
+                    (forecast_date, latest_fetch_at, forecast_date),
+                )
+                rows = [dict(r) for r in cur.fetchall()]
+                if rows:
+                    return rows
             cur = conn.execute(
                 "SELECT * FROM meteo_forecast WHERE forecast_date = ? ORDER BY slot_time",
                 (forecast_date,),
@@ -2339,6 +2475,100 @@ def get_meteo_forecast(forecast_date: str) -> list[dict[str, Any]]:
             return [dict(r) for r in cur.fetchall()]
         finally:
             conn.close()
+
+
+def get_meteo_forecast_for_slot_date(slot_date: str) -> list[dict[str, Any]]:
+    """Return meteo_forecast rows whose slot_time falls on *slot_date*.
+
+    This is distinct from ``forecast_date``: the latter is the solve date used
+    when rows were last upserted, while slot_time identifies the actual target
+    day the LP/heartbeat needs to reason about.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            latest_fetch_at = _get_latest_meteo_forecast_fetch_at(conn)
+            if latest_fetch_at:
+                cur = conn.execute(
+                    """SELECT substr(slot_time, 1, 10) AS forecast_date,
+                              slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                       FROM meteo_forecast_value
+                       WHERE forecast_fetch_at_utc = ?
+                         AND substr(slot_time, 1, 10) = ?
+                       ORDER BY slot_time""",
+                    (latest_fetch_at, slot_date),
+                )
+                rows = [dict(r) for r in cur.fetchall()]
+                if rows:
+                    return rows
+            cur = conn.execute(
+                """SELECT * FROM meteo_forecast
+                   WHERE substr(slot_time, 1, 10) = ?
+                   ORDER BY slot_time""",
+                (slot_date,),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def get_meteo_forecast_at_time(when_utc: str) -> dict[str, Any] | None:
+    """Return the forecast row active at *when_utc*.
+
+    Prefers the latest slot at or before ``when_utc``. If the request lands
+    before the first available slot, falls back to the earliest future slot so
+    bootstrapping still has something to work with.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            latest_fetch_at = _get_latest_meteo_forecast_fetch_at(conn)
+            if latest_fetch_at:
+                cur = conn.execute(
+                    """SELECT substr(slot_time, 1, 10) AS forecast_date,
+                              slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                       FROM meteo_forecast_value
+                       WHERE forecast_fetch_at_utc = ?
+                         AND slot_time <= ?
+                       ORDER BY slot_time DESC
+                       LIMIT 1""",
+                    (latest_fetch_at, when_utc),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    return dict(row)
+                cur = conn.execute(
+                    """SELECT substr(slot_time, 1, 10) AS forecast_date,
+                              slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                       FROM meteo_forecast_value
+                       WHERE forecast_fetch_at_utc = ?
+                       ORDER BY slot_time ASC
+                       LIMIT 1""",
+                    (latest_fetch_at,),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    return dict(row)
+            cur = conn.execute(
+                """SELECT * FROM meteo_forecast
+                   WHERE slot_time <= ?
+                   ORDER BY slot_time DESC
+                   LIMIT 1""",
+                (when_utc,),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                return dict(row)
+            cur = conn.execute(
+                """SELECT * FROM meteo_forecast
+                   ORDER BY slot_time ASC
+                   LIMIT 1""",
+            )
+            row = cur.fetchone()
+            return dict(row) if row else None
+        finally:
+            conn.close()
+
 
 
 def get_micro_climate_offset_c(lookback: int = 96) -> float:
@@ -3367,16 +3597,20 @@ def save_lp_snapshots(
                    (run_id, run_at_utc, plan_date, horizon_hours,
                     soc_initial_kwh, tank_initial_c, indoor_initial_c,
                     soc_source, tank_source, indoor_source,
-                    base_load_json, micro_climate_offset_c, config_snapshot_json,
+                    base_load_json, micro_climate_offset_c, forecast_fetch_at_utc, config_snapshot_json,
                     price_quantize_p, peak_threshold_p, cheap_threshold_p,
                     daikin_control_mode, optimization_preset, energy_strategy_mode)
                    VALUES (:run_id, :run_at_utc, :plan_date, :horizon_hours,
                            :soc_initial_kwh, :tank_initial_c, :indoor_initial_c,
                            :soc_source, :tank_source, :indoor_source,
-                           :base_load_json, :micro_climate_offset_c, :config_snapshot_json,
+                           :base_load_json, :micro_climate_offset_c, :forecast_fetch_at_utc, :config_snapshot_json,
                            :price_quantize_p, :peak_threshold_p, :cheap_threshold_p,
                            :daikin_control_mode, :optimization_preset, :energy_strategy_mode)""",
-                {"run_id": run_id, **inputs_row},
+                {
+                    "run_id": run_id,
+                    "forecast_fetch_at_utc": inputs_row.get("forecast_fetch_at_utc"),
+                    **inputs_row,
+                },
             )
             for row in solution_rows:
                 conn.execute(
@@ -3450,33 +3684,12 @@ def save_meteo_forecast_history(
     forecast_fetch_at_utc: str,
     rows: list[dict[str, Any]],
 ) -> None:
-    """Append a forecast fetch's per-slot rows to the history table.
-
-    Companion to :func:`save_meteo_forecast` (which is latest-per-slot). This
-    table preserves every fetch so the History view can show forecasts as they
-    were at past LP runs.
-    """
-    if not rows:
-        return
-    with _lock:
-        conn = get_connection()
-        try:
-            for r in rows:
-                conn.execute(
-                    """INSERT OR IGNORE INTO meteo_forecast_history
-                       (forecast_fetch_at_utc, slot_time, temp_c, solar_w_m2, cloud_cover_pct)
-                       VALUES (?, ?, ?, ?, ?)""",
-                    (
-                        forecast_fetch_at_utc,
-                        r.get("slot_time"),
-                        r.get("temp_c"),
-                        r.get("solar_w_m2"),
-                        r.get("cloud_cover_pct"),
-                    ),
-                )
-            conn.commit()
-        finally:
-            conn.close()
+    """Legacy wrapper for persisting a canonical forecast fetch without marking it latest."""
+    save_meteo_forecast_snapshot(
+        forecast_fetch_at_utc,
+        rows,
+        mark_latest=False,
+    )
 
 
 def get_meteo_forecast_at(fetch_at_utc: str) -> list[dict[str, Any]]:
@@ -3484,6 +3697,16 @@ def get_meteo_forecast_at(fetch_at_utc: str) -> list[dict[str, Any]]:
     with _lock:
         conn = get_connection()
         try:
+            cur = conn.execute(
+                """SELECT slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                   FROM meteo_forecast_value
+                   WHERE forecast_fetch_at_utc = ?
+                   ORDER BY slot_time""",
+                (fetch_at_utc,),
+            )
+            rows = [dict(r) for r in cur.fetchall()]
+            if rows:
+                return rows
             cur = conn.execute(
                 """SELECT slot_time, temp_c, solar_w_m2, cloud_cover_pct
                    FROM meteo_forecast_history
@@ -3611,6 +3834,26 @@ def get_meteo_forecast_history_latest_before(when_utc: str) -> list[dict[str, An
         try:
             cur = conn.execute(
                 """SELECT forecast_fetch_at_utc
+                   FROM meteo_forecast_snapshot
+                   WHERE forecast_fetch_at_utc < ?
+                   ORDER BY forecast_fetch_at_utc DESC
+                   LIMIT 1""",
+                (when_utc,),
+            )
+            row = cur.fetchone()
+            if row and row[0]:
+                cur = conn.execute(
+                    """SELECT slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                       FROM meteo_forecast_value
+                       WHERE forecast_fetch_at_utc = ?
+                       ORDER BY slot_time""",
+                    (str(row[0]),),
+                )
+                rows = [dict(r) for r in cur.fetchall()]
+                if rows:
+                    return rows
+            cur = conn.execute(
+                """SELECT forecast_fetch_at_utc
                    FROM meteo_forecast_history
                    WHERE forecast_fetch_at_utc < ?
                    ORDER BY forecast_fetch_at_utc DESC
@@ -3629,6 +3872,58 @@ def get_meteo_forecast_history_latest_before(when_utc: str) -> list[dict[str, An
                 (prev_fetch_at,),
             )
             return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def prune_meteo_forecast_snapshots(max_age_days: int) -> tuple[int, int]:
+    """Prune canonical forecast fetches and their slot rows as one unit.
+
+    Returns ``(deleted_snapshots, deleted_values)``. We prune by fetch timestamp
+    because the snapshot row is the source of truth; per-slot rows are just its
+    normalized expansion for replay/query efficiency.
+    """
+    if max_age_days <= 0:
+        return 0, 0
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+    from datetime import timedelta as _td
+
+    cutoff = (_dt.now(_UTC) - _td(days=max_age_days)).isoformat()
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT forecast_fetch_at_utc
+                   FROM meteo_forecast_snapshot
+                   WHERE forecast_fetch_at_utc < ?""",
+                (cutoff,),
+            )
+            old_fetches = [str(r[0]) for r in cur.fetchall() if r and r[0]]
+            if not old_fetches:
+                return 0, 0
+
+            latest_fetch_at = _get_latest_meteo_forecast_fetch_at(conn)
+            if latest_fetch_at and latest_fetch_at in old_fetches:
+                conn.execute(
+                    "UPDATE meteo_forecast_latest_state SET forecast_fetch_at_utc = NULL WHERE id = 1"
+                )
+
+            placeholders = ",".join("?" for _ in old_fetches)
+            cur = conn.execute(
+                f"""DELETE FROM meteo_forecast_value
+                    WHERE forecast_fetch_at_utc IN ({placeholders})""",
+                old_fetches,
+            )
+            deleted_values = int(cur.rowcount or 0)
+            cur = conn.execute(
+                f"""DELETE FROM meteo_forecast_snapshot
+                    WHERE forecast_fetch_at_utc IN ({placeholders})""",
+                old_fetches,
+            )
+            deleted_snapshots = int(cur.rowcount or 0)
+            conn.commit()
+            return deleted_snapshots, deleted_values
         finally:
             conn.close()
 
@@ -3688,7 +3983,7 @@ def prune_old_rows(
     """Delete rows from *table* older than *max_age_days*.
 
     Append-only tables (daikin_telemetry, meteo_forecast_history,
-    lp_solution_snapshot, lp_inputs_snapshot, config_audit) have no
+    meteo_forecast_snapshot/value, lp_solution_snapshot, lp_inputs_snapshot, config_audit) have no
     built-in purge policy. Without it they grow unbounded. This helper is
     called from :func:`prune_history_tables` on service startup + daily cron.
 
@@ -3746,6 +4041,16 @@ def prune_history_tables() -> dict[str, int]:
         ("acknowledged_warnings", "acknowledged_at", _config.ACKNOWLEDGED_WARNINGS_RETENTION_DAYS, False),
     ]
     results: dict[str, int] = {}
+    try:
+        deleted_snapshots, deleted_values = prune_meteo_forecast_snapshots(
+            _config.METEO_FORECAST_HISTORY_RETENTION_DAYS
+        )
+        results["meteo_forecast_snapshot"] = deleted_snapshots
+        results["meteo_forecast_value"] = deleted_values
+    except Exception as e:
+        logger.debug("prune meteo_forecast_snapshot/value failed: %s", e)
+        results["meteo_forecast_snapshot"] = -1
+        results["meteo_forecast_value"] = -1
     for table, col, days, epoch in policies:
         try:
             results[table] = prune_old_rows(table, col, days, epoch_seconds=epoch)

--- a/src/db.py
+++ b/src/db.py
@@ -2439,6 +2439,36 @@ def _get_latest_meteo_forecast_fetch_at(conn: sqlite3.Connection) -> str | None:
     row = cur.fetchone()
     return str(row[0]) if row and row[0] else None
 
+
+def _get_latest_meteo_forecast_rows_for_slot_date(
+    conn: sqlite3.Connection,
+    slot_date: str,
+) -> list[dict[str, Any]]:
+    """Return the latest canonical forecast row for each slot on *slot_date*.
+
+    Canonical forecast storage keeps one snapshot per fetch plus normalized slot
+    rows. For replay and live diagnostics we want the most recent row for each
+    slot_time, not just the most recent fetch as a whole.
+    """
+    cur = conn.execute(
+        """SELECT substr(mv.slot_time, 1, 10) AS forecast_date,
+                  mv.slot_time, mv.temp_c, mv.solar_w_m2, mv.cloud_cover_pct
+             FROM meteo_forecast_value mv
+             JOIN (
+                 SELECT slot_time, MAX(forecast_fetch_at_utc) AS forecast_fetch_at_utc
+                   FROM meteo_forecast_value
+                  WHERE substr(slot_time, 1, 10) = ?
+                  GROUP BY slot_time
+             ) latest
+               ON latest.slot_time = mv.slot_time
+              AND latest.forecast_fetch_at_utc = mv.forecast_fetch_at_utc
+            WHERE substr(mv.slot_time, 1, 10) = ?
+            ORDER BY mv.slot_time""",
+        (slot_date, slot_date),
+    )
+    return [dict(r) for r in cur.fetchall()]
+
+
 def save_meteo_forecast(rows: list[dict[str, Any]], forecast_date: str) -> int:
     """Legacy helper that writes a latest forecast snapshot.
 
@@ -2455,19 +2485,9 @@ def get_meteo_forecast(forecast_date: str) -> list[dict[str, Any]]:
     with _lock:
         conn = get_connection()
         try:
-            latest_fetch_at = _get_latest_meteo_forecast_fetch_at(conn)
-            if latest_fetch_at:
-                cur = conn.execute(
-                    """SELECT ? AS forecast_date, slot_time, temp_c, solar_w_m2, cloud_cover_pct
-                       FROM meteo_forecast_value
-                       WHERE forecast_fetch_at_utc = ?
-                         AND substr(slot_time, 1, 10) = ?
-                       ORDER BY slot_time""",
-                    (forecast_date, latest_fetch_at, forecast_date),
-                )
-                rows = [dict(r) for r in cur.fetchall()]
-                if rows:
-                    return rows
+            rows = _get_latest_meteo_forecast_rows_for_slot_date(conn, forecast_date)
+            if rows:
+                return rows
             cur = conn.execute(
                 "SELECT * FROM meteo_forecast WHERE forecast_date = ? ORDER BY slot_time",
                 (forecast_date,),
@@ -2487,20 +2507,9 @@ def get_meteo_forecast_for_slot_date(slot_date: str) -> list[dict[str, Any]]:
     with _lock:
         conn = get_connection()
         try:
-            latest_fetch_at = _get_latest_meteo_forecast_fetch_at(conn)
-            if latest_fetch_at:
-                cur = conn.execute(
-                    """SELECT substr(slot_time, 1, 10) AS forecast_date,
-                              slot_time, temp_c, solar_w_m2, cloud_cover_pct
-                       FROM meteo_forecast_value
-                       WHERE forecast_fetch_at_utc = ?
-                         AND substr(slot_time, 1, 10) = ?
-                       ORDER BY slot_time""",
-                    (latest_fetch_at, slot_date),
-                )
-                rows = [dict(r) for r in cur.fetchall()]
-                if rows:
-                    return rows
+            rows = _get_latest_meteo_forecast_rows_for_slot_date(conn, slot_date)
+            if rows:
+                return rows
             cur = conn.execute(
                 """SELECT * FROM meteo_forecast
                    WHERE substr(slot_time, 1, 10) = ?

--- a/src/scheduler/lp_overrides.py
+++ b/src/scheduler/lp_overrides.py
@@ -211,13 +211,6 @@ WHITELIST: dict[str, OverrideSpec] = {
         description="LP planning horizon (h). Rolling now → now+H.",
         group="solver",
     ),
-    "LP_HIGHS_TIME_LIMIT_SECONDS": OverrideSpec(
-        key="LP_HIGHS_TIME_LIMIT_SECONDS",
-        config_attr="LP_HIGHS_TIME_LIMIT_SECONDS",
-        type_name="int", min_value=5, max_value=600,
-        description="Solver wall-clock cap (s). Raise on infeasible.",
-        group="solver",
-    ),
     "LP_HP_MIN_ON_SLOTS": OverrideSpec(
         key="LP_HP_MIN_ON_SLOTS",
         config_attr="LP_HP_MIN_ON_SLOTS",

--- a/src/scheduler/lp_replay.py
+++ b/src/scheduler/lp_replay.py
@@ -276,8 +276,13 @@ def replay_run(
             indoor_source=str(inputs.get("indoor_source") or "snapshot"),
         )
 
-    # Weather: prefer the forecast snapshot at-or-before run_at_utc (closest fetch).
-    weather, weather_fidelity = _reconstruct_weather(run_at_utc, slot_starts_utc)
+    # Weather: prefer the exact forecast fetch referenced by the LP snapshot;
+    # otherwise fall back to the latest fetch before the run timestamp.
+    weather, weather_fidelity = _reconstruct_weather(
+        run_at_utc,
+        slot_starts_utc,
+        forecast_fetch_at_utc=str(inputs.get("forecast_fetch_at_utc") or ""),
+    )
     if weather_fidelity == "missing":
         return LpReplayResult(
             ok=False, error="weather snapshot missing for this run",
@@ -601,6 +606,8 @@ def _config_overrides(
 def _reconstruct_weather(
     run_at_utc: str,
     slot_starts_utc: list[datetime],
+    *,
+    forecast_fetch_at_utc: str = "",
 ) -> tuple[WeatherLpSeries, WeatherFidelity]:
     """Rebuild WeatherLpSeries from meteo_forecast_history.
 
@@ -616,7 +623,9 @@ def _reconstruct_weather(
     — same behaviour as before, just confined to ageing rows.
     """
     rows: list[dict[str, Any]] = []
-    if run_at_utc:
+    if forecast_fetch_at_utc:
+        rows = db.get_meteo_forecast_at(forecast_fetch_at_utc)
+    if not rows and run_at_utc:
         rows = db.get_meteo_forecast_history_latest_before(run_at_utc)
     # Empty array → no prior fetch existed.
     if not rows:

--- a/src/scheduler/lp_simulation.py
+++ b/src/scheduler/lp_simulation.py
@@ -137,7 +137,7 @@ def run_lp_simulation(
     if not plan.ok:
         return LpSimulationResult(
             ok=False,
-            error=f"LP solver status: {plan.status} (infeasible or timed out — try raising LP_HIGHS_TIME_LIMIT_SECONDS)",
+            error=f"LP solver status: {plan.status} (infeasible or timed out — try raising LP_CBC_TIME_LIMIT_SECONDS)",
             plan_date=plan_date,
             plan_window=plan_window_label,
             plan=plan,

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1072,6 +1072,7 @@ def _persist_lp_snapshots(
         "indoor_source": getattr(initial, "indoor_source", "unknown"),
         "base_load_json": json.dumps([round(float(x), 4) for x in base_load]),
         "micro_climate_offset_c": float(micro_climate_offset or 0.0),
+        "forecast_fetch_at_utc": None,
         "config_snapshot_json": json.dumps(cfg_snap),
         "price_quantize_p": float(getattr(config, "LP_PRICE_QUANTIZE_PENCE", 0.0)),
         "peak_threshold_p": float(plan.peak_threshold_pence),
@@ -1297,9 +1298,10 @@ def _run_optimizer_lp(
     starts = [s.start_utc for s in slots]
 
     forecast = fetch_forecast(hours=max(48, int(config.LP_HORIZON_HOURS) + 24))
-    # Persist forecast to DB so heartbeat can read real Open-Meteo temp (vs Daikin sensor)
+    forecast_fetch_at_utc = datetime.now(UTC).isoformat()
+    # Persist the canonical forecast snapshot once so heartbeat + replay can
+    # both reference the same fetch instead of duplicating latest/history rows.
     if forecast:
-        _today = datetime.now(UTC).date().isoformat()
         forecast_rows = [
             {
                 "slot_time": f.time_utc.isoformat(),
@@ -1309,15 +1311,12 @@ def _run_optimizer_lp(
             }
             for f in forecast
         ]
-        db.save_meteo_forecast(forecast_rows, _today)
-        # V11: append-only fetch history keyed by UTC fetch timestamp so a
-        # later LP run (or the History view) can see which forecast was active
-        # at any past moment, even after newer fetches have overwritten the
-        # latest-per-slot table.
-        db.save_meteo_forecast_history(
-            datetime.now(UTC).isoformat(),
+        db.save_meteo_forecast_snapshot(
+            forecast_fetch_at_utc,
             forecast_rows,
+            mark_latest=True,
         )
+        inputs_row["forecast_fetch_at_utc"] = forecast_fetch_at_utc
     # PV calibration — fallback chain (best to worst):
     #   1. cloud-aware (hour × cloud-bucket) table  — PR #232
     #   2. per-hour-of-day table                    — PR #186

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1023,6 +1023,8 @@ def _persist_lp_snapshots(
     initial: Any,  # LpInitialState
     base_load: list[float],
     micro_climate_offset: float,
+    forecast_fetch_at_utc: str | None = None,
+    exogenous_snapshot: dict[str, Any] | None = None,
 ) -> None:
     """Build and persist the inputs + per-slot rows for this LP run.
 
@@ -1072,7 +1074,8 @@ def _persist_lp_snapshots(
         "indoor_source": getattr(initial, "indoor_source", "unknown"),
         "base_load_json": json.dumps([round(float(x), 4) for x in base_load]),
         "micro_climate_offset_c": float(micro_climate_offset or 0.0),
-        "forecast_fetch_at_utc": None,
+        "forecast_fetch_at_utc": forecast_fetch_at_utc,
+        "exogenous_snapshot_json": json.dumps(exogenous_snapshot or {}),
         "config_snapshot_json": json.dumps(cfg_snap),
         "price_quantize_p": float(getattr(config, "LP_PRICE_QUANTIZE_PENCE", 0.0)),
         "peak_threshold_p": float(plan.peak_threshold_pence),
@@ -1252,6 +1255,8 @@ def _run_optimizer_lp(
         _local = s.start_utc.astimezone(tz)
         _bucket = (_local.hour, 30 if _local.minute >= 30 else 0)
         base_load.append(_load_profile.get(_bucket, _flat))
+    residual_base_load = list(base_load)
+    appliance_profile_kwh = [0.0] * len(base_load)
 
     # Smart appliance scheduling: bump residual load on slots covered by armed
     # sessions so peak_export / charge / DHW plans route around the wash.
@@ -1270,7 +1275,9 @@ def _run_optimizer_lp(
                     _kw = _appliance_kw.get(_s.start_utc, 0.0)
                     if _kw > 0:
                         # Half-hour slot → kWh = kW × 0.5 h.
-                        base_load[_i] += _kw * 0.5
+                        appliance_kwh = _kw * 0.5
+                        base_load[_i] += appliance_kwh
+                        appliance_profile_kwh[_i] += appliance_kwh
                         _added_slots += 1
                 if _added_slots:
                     logger.info(
@@ -1316,7 +1323,6 @@ def _run_optimizer_lp(
             forecast_rows,
             mark_latest=True,
         )
-        inputs_row["forecast_fetch_at_utc"] = forecast_fetch_at_utc
     # PV calibration — fallback chain (best to worst):
     #   1. cloud-aware (hour × cloud-bucket) table  — PR #232
     #   2. per-hour-of-day table                    — PR #186
@@ -1379,6 +1385,31 @@ def _run_optimizer_lp(
     # tariff configured / not yet fetched), the LP falls back to the flat
     # EXPORT_RATE_PENCE constant, preserving legacy behaviour.
     export_prices = _build_export_price_line(starts)
+    exogenous_snapshot = {
+        "base_load_components": {
+            "residual_profile_kwh": [round(float(x), 4) for x in residual_base_load],
+            "appliance_profile_kwh": [round(float(x), 4) for x in appliance_profile_kwh],
+            "flat_fallback_kwh": round(float(_flat), 4),
+            "fox_mean_kwh_per_slot": round(float(_fox_mean), 4) if _fox_mean is not None else None,
+            "profile_bucket_count": len(_load_profile),
+            "profile_limit_slots": int(_profile_limit),
+        },
+        "weather_adjustment": {
+            "forecast_fetch_at_utc": forecast_fetch_at_utc if forecast else None,
+            "cloud_table_cells": len(pv_scale_cloud),
+            "hourly_table_cells": len(pv_scale_hourly),
+            "flat_scale": round(float(flat_scale), 6),
+            "today_factor": round(float(today_factor), 6),
+            "today_diag": today_diag,
+        },
+        "tariffs": {
+            "export_price_pence": (
+                [round(float(x), 4) for x in export_prices]
+                if export_prices is not None else None
+            ),
+            "uses_flat_export_rate": export_prices is None,
+        },
+    }
 
     plan = solve_lp(
         slot_starts_utc=starts,
@@ -1524,6 +1555,8 @@ def _run_optimizer_lp(
             initial=initial,
             base_load=base_load,
             micro_climate_offset=micro_climate_offset,
+            forecast_fetch_at_utc=(forecast_fetch_at_utc if forecast else None),
+            exogenous_snapshot=exogenous_snapshot,
         )
     except Exception as e:
         logger.warning("LP snapshot persistence failed (non-fatal): %s", e)

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -814,9 +814,12 @@ def bulletproof_forecast_refresh_job() -> None:
             for f in new_fcst
         ]
         prev_rows = _db.get_meteo_forecast_history_latest_before(now_utc.isoformat())
-        # Persist new (always — keeps the LP's source of truth fresh + audit trail).
-        _db.save_meteo_forecast_history(now_utc.isoformat(), new_rows)
-        _db.save_meteo_forecast(new_rows, now_utc.date().isoformat())
+        # Persist once into the canonical forecast snapshot store and mark it latest.
+        _db.save_meteo_forecast_snapshot(
+            now_utc.isoformat(),
+            new_rows,
+            mark_latest=True,
+        )
 
         if not config.MPC_EVENT_DRIVEN_ENABLED:
             logger.debug("forecast refresh persisted; trigger disabled by kill switch")

--- a/src/scheduler/scenarios.py
+++ b/src/scheduler/scenarios.py
@@ -8,7 +8,7 @@ COP) and scales the base-load profile.
 
 The two side scenarios (optimistic, pessimistic) run **in parallel** via a
 ThreadPoolExecutor — each LP solve is independent (separate ``LpProblem``
-built per call, separate HiGHS solver instance) so the GIL releases during
+built per call, separate solver instance) so the GIL releases during
 solver execution and we get real wall-clock speedup. Total latency drops
 from ~3× single-solve to ~1× single-solve, which matters on the
 pre-peak ``octopus_fetch`` trigger that has a tight time budget before the
@@ -129,7 +129,7 @@ def _solve_one_scenario(
 
     Designed to run in a worker thread — module-level ``logger`` is
     thread-safe; ``solve_lp`` builds a fresh PuLP problem per call and
-    each HiGHS solver instance is independent, so two threads don't
+    each solver instance is independent, so two threads don't
     collide on solver state.
     """
     p = _perturbation_for(scenario)

--- a/src/weather.py
+++ b/src/weather.py
@@ -967,7 +967,7 @@ def evaluate_pv_forecast_accuracy(
     cal_cloud = _db.get_pv_calibration_hourly_cloud()
     flat_cal = compute_pv_calibration_factor() if not cal_hourly and not cal_cloud else 1.0
 
-    # Pull all measurements + forecasts in window
+    # Pull all measurements in window.
     actual_kw_samples: dict[tuple[str, int], list[float]] = defaultdict(list)
     forecast_radiation: dict[tuple[str, int], float] = {}
     forecast_cloud: dict[tuple[str, int], float | None] = {}
@@ -989,27 +989,26 @@ def evaluate_pv_forecast_accuracy(
                 if ts.tzinfo is None:
                     ts = ts.replace(tzinfo=_UTC)
                 actual_kw_samples[(ts.date().isoformat(), ts.hour)].append(float(kw or 0.0))
-
-            # cloud_cover_pct may not exist on older meteo_forecast rows; coalesce.
-            cur = conn.execute(
-                """SELECT slot_time, solar_w_m2,
-                          COALESCE(cloud_cover_pct, NULL) AS cloud_pct
-                     FROM meteo_forecast
-                    WHERE substr(slot_time, 1, 10) BETWEEN ? AND ?""",
-                (start.isoformat(), end.isoformat()),
-            )
-            for ts_raw, rad, cpct in cur.fetchall():
-                try:
-                    ts = _dt.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
-                except (ValueError, TypeError):
-                    continue
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=_UTC)
-                key = (ts.date().isoformat(), ts.hour)
-                forecast_radiation[key] = float(rad or 0.0)
-                forecast_cloud[key] = float(cpct) if cpct is not None else None
         finally:
             conn.close()
+
+    current_day = start
+    while current_day <= end:
+        try:
+            forecast_rows = _db.get_meteo_forecast_for_slot_date(current_day.isoformat())
+        except Exception:  # noqa: BLE001
+            forecast_rows = []
+        for r in forecast_rows:
+            try:
+                ts = _dt.fromisoformat(str(r["slot_time"]).replace("Z", "+00:00"))
+            except (ValueError, TypeError, KeyError):
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=_UTC)
+            key = (ts.date().isoformat(), ts.hour)
+            forecast_radiation[key] = float(r.get("solar_w_m2") or 0.0)
+            forecast_cloud[key] = float(r.get("cloud_cover_pct")) if r.get("cloud_cover_pct") is not None else None
+        current_day += _td(days=1)
 
     # Build paired (predicted_kw, actual_kw) tuples
     pairs_per_hour: dict[int, list[tuple[float, float]]] = defaultdict(list)

--- a/tests/api/test_cockpit_at.py
+++ b/tests/api/test_cockpit_at.py
@@ -6,6 +6,7 @@ lp_inputs_snapshot, agile_rates, and execution_log.
 """
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -43,6 +44,26 @@ def _seed_run_with_slot(run_at: datetime, slot_time: datetime) -> int:
             "soc_source": "fox_realtime_cache", "tank_source": "daikin_cache",
             "indoor_source": "daikin_cache",
             "base_load_json": "[]", "micro_climate_offset_c": 0.0,
+            "exogenous_snapshot_json": json.dumps({
+                "base_load_components": {
+                    "residual_profile_kwh": [0.2, 0.3],
+                    "appliance_profile_kwh": [0.0, 0.1],
+                    "flat_fallback_kwh": 0.25,
+                    "fox_mean_kwh_per_slot": 0.22,
+                    "profile_bucket_count": 48,
+                },
+                "weather_adjustment": {
+                    "forecast_fetch_at_utc": "2026-04-24T05:00:00+00:00",
+                    "today_factor": 0.95,
+                    "flat_scale": 1.0,
+                    "cloud_table_cells": 12,
+                    "hourly_table_cells": 24,
+                },
+                "tariffs": {
+                    "export_price_pence": [5.0, 7.5],
+                    "uses_flat_export_rate": False,
+                },
+            }),
             "config_snapshot_json": "{}",
             "price_quantize_p": 0.0, "peak_threshold_p": 25.0, "cheap_threshold_p": 12.0,
             "daikin_control_mode": "passive", "optimization_preset": "normal",
@@ -95,6 +116,9 @@ def test_at_rehydrates_from_snapshot(client):
     li = body.get("lp_inputs") or {}
     assert li.get("soc_source") == "fox_realtime_cache"
     assert li.get("tank_source") == "daikin_cache"
+    lx = body.get("lp_exogenous") or {}
+    assert lx["base_load_components"]["profile_bucket_count"] == 48
+    assert lx["weather_adjustment"]["today_factor"] == pytest.approx(0.95)
 
 
 def test_history_page_renders(client):

--- a/tests/api/test_cockpit_at.py
+++ b/tests/api/test_cockpit_at.py
@@ -119,6 +119,9 @@ def test_at_rehydrates_from_snapshot(client):
     lx = body.get("lp_exogenous") or {}
     assert lx["base_load_components"]["profile_bucket_count"] == 48
     assert lx["weather_adjustment"]["today_factor"] == pytest.approx(0.95)
+    why = body.get("lp_why") or []
+    assert why
+    assert any("forecast fetch" in line for line in why)
 
 
 def test_history_page_renders(client):

--- a/tests/test_check_lp_regression.py
+++ b/tests/test_check_lp_regression.py
@@ -58,7 +58,7 @@ def patched_replay(monkeypatch):
     return cs, by_date
 
 
-def test_no_baseline_yet_passes_with_message(tmp_path, patched_replay):
+def test_no_baseline_yet_fails_approval_gate(tmp_path, patched_replay):
     cs, _ = patched_replay
     baseline_path = tmp_path / "missing.json"
 
@@ -68,7 +68,7 @@ def test_no_baseline_yet_passes_with_message(tmp_path, patched_replay):
         fail_threshold_p=50.0,
         refresh_baseline=False,
     )
-    assert report.passed
+    assert not report.passed
     assert report.no_baseline_yet
     # Aggregate equals sum of replayed costs.
     assert report.new_total_replayed_cost_p == pytest.approx(95.0 + 200.0 + 140.0)
@@ -105,29 +105,80 @@ def test_pass_when_under_baseline(tmp_path, patched_replay):
     assert report.delta_vs_baseline_p == pytest.approx(-165.0)
 
 
-def test_fail_when_total_exceeds_baseline_plus_threshold(tmp_path, patched_replay):
+def test_fail_when_total_exceeds_baseline_with_zero_default_policy(tmp_path, patched_replay):
     cs, _ = patched_replay
     baseline_path = tmp_path / "baseline.json"
-    # Baseline 100 p, new = 435 p. Δ = +335 p, threshold 50 → FAIL.
-    baseline_path.write_text(json.dumps({"total_replayed_cost_p": 100.0}))
+    # Baseline 400 p, new = 435 p. Any aggregate cost increase fails.
+    baseline_path.write_text(json.dumps({"total_replayed_cost_p": 400.0}))
     report = cs.run_check(
         days_back=14, baseline_path=baseline_path,
-        fail_threshold_p=50.0, refresh_baseline=False,
+        fail_threshold_p=0.0, refresh_baseline=False,
     )
     assert not report.passed
-    assert report.delta_vs_baseline_p == pytest.approx(335.0)
+    assert report.delta_vs_baseline_p == pytest.approx(35.0)
 
 
-def test_within_threshold_still_passes(tmp_path, patched_replay):
+def test_explicit_positive_threshold_can_be_used_for_non_approval_experiments(tmp_path, patched_replay):
     cs, _ = patched_replay
     baseline_path = tmp_path / "baseline.json"
-    # Baseline 400 p, new 435 p. Δ = +35 p. Threshold 50 p → still pass.
+    # Baseline 400 p, new 435 p. Δ = +35 p. The approval path should not use
+    # this override, but the helper still supports local exploratory runs.
     baseline_path.write_text(json.dumps({"total_replayed_cost_p": 400.0}))
     report = cs.run_check(
         days_back=14, baseline_path=baseline_path,
         fail_threshold_p=50.0, refresh_baseline=False,
     )
     assert report.passed
+
+
+def test_baseline_per_date_compares_same_dates_only(tmp_path, patched_replay):
+    cs, _ = patched_replay
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({
+        "total_replayed_cost_p": 9999.0,
+        "per_date": {
+            "2026-04-25": {"total_replayed_cost_p": 100.0},
+            "2026-04-26": {"total_replayed_cost_p": 210.0},
+        },
+    }))
+    report = cs.run_check(
+        days_back=14, baseline_path=baseline_path,
+        fail_threshold_p=0.0, refresh_baseline=False,
+    )
+    assert report.compared_dates == ["2026-04-25", "2026-04-26"]
+    assert report.baseline_total_replayed_cost_p == pytest.approx(310.0)
+    assert report.new_total_replayed_cost_p == pytest.approx(295.0)
+    assert report.passed
+
+
+def test_missing_baseline_date_fails_even_when_current_total_looks_cheaper(tmp_path, monkeypatch):
+    from scripts import check_lp_regression as cs
+    from datetime import date
+
+    monkeypatch.setattr(cs, "_enumerate_dates_with_runs", lambda d: [date(2026, 4, 25)])
+    monkeypatch.setattr(
+        cs,
+        "_replay_one_day",
+        lambda target, *, mode="forward": cs.DayResult(
+            date=str(target), ok=True, error=None, recalc_count=1,
+            total_original_cost_p=100.0, total_replayed_cost_p=50.0,
+            total_delta_cost_p=-50.0,
+        ),
+    )
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({
+        "total_replayed_cost_p": 1000.0,
+        "per_date": {
+            "2026-04-25": {"total_replayed_cost_p": 100.0},
+            "2026-04-26": {"total_replayed_cost_p": 900.0},
+        },
+    }))
+    report = cs.run_check(
+        days_back=14, baseline_path=baseline_path,
+        fail_threshold_p=0.0, refresh_baseline=False,
+    )
+    assert not report.passed
+    assert report.baseline_missing_dates == ["2026-04-26"]
 
 
 def test_refresh_baseline_writes_file_and_returns_pass(tmp_path, patched_replay):
@@ -154,7 +205,7 @@ def test_malformed_baseline_treated_as_no_baseline(tmp_path, patched_replay):
         days_back=14, baseline_path=baseline_path,
         fail_threshold_p=50.0, refresh_baseline=False,
     )
-    assert report.passed  # vacuously
+    assert not report.passed
     assert report.no_baseline_yet
 
 

--- a/tests/test_db_residual_profile.py
+++ b/tests/test_db_residual_profile.py
@@ -30,7 +30,7 @@ def _seed_meteo(t: datetime, temp_c: float) -> None:
     """Seed a meteo_forecast_history row at the hour boundary so SUBSTR matching works."""
     hour_iso = t.replace(minute=0, second=0, microsecond=0).isoformat().replace("+00:00", "+00:00")
     db.save_meteo_forecast_history(
-        t.isoformat().replace("+00:00", "Z"),
+        (t - timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
         [{"slot_time": hour_iso, "temp_c": temp_c, "solar_w_m2": 0.0}],
     )
 

--- a/tests/test_db_retention.py
+++ b/tests/test_db_retention.py
@@ -100,6 +100,19 @@ def test_prune_old_rows_iso_timestamps():
     assert _count("meteo_forecast_history") == 1
 
 
+def test_prune_meteo_forecast_snapshots_deletes_fetches_and_slot_rows():
+    old = (datetime.now(UTC) - timedelta(days=40)).isoformat()
+    fresh = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    db.save_meteo_forecast_snapshot(old, [{"slot_time": "2026-03-15T00:00:00+00:00", "temp_c": 10.0, "solar_w_m2": 200.0}], mark_latest=False)
+    db.save_meteo_forecast_snapshot(fresh, [{"slot_time": "2026-04-23T00:00:00+00:00", "temp_c": 12.0, "solar_w_m2": 250.0}], mark_latest=True)
+
+    deleted_snapshots, deleted_values = db.prune_meteo_forecast_snapshots(max_age_days=30)
+    assert deleted_snapshots == 1
+    assert deleted_values == 1
+    assert _count("meteo_forecast_snapshot") == 1
+    assert _count("meteo_forecast_value") == 1
+
+
 # ---------------------------------------------------------------------------
 # prune_history_tables: sweep
 # ---------------------------------------------------------------------------
@@ -124,6 +137,8 @@ def test_prune_history_tables_returns_per_table_counts():
     results = db.prune_history_tables()
     assert set(results.keys()) == {
         "daikin_telemetry",
+        "meteo_forecast_snapshot",
+        "meteo_forecast_value",
         "meteo_forecast_history",
         "lp_solution_snapshot",
         "lp_inputs_snapshot",
@@ -176,4 +191,6 @@ def test_prune_history_tables_tolerates_one_bad_policy(monkeypatch):
 
     results = db.prune_history_tables()
     assert results["daikin_telemetry"] == -1  # failure sentinel
+    assert results["meteo_forecast_snapshot"] >= 0  # normal completion
+    assert results["meteo_forecast_value"] >= 0  # normal completion
     assert results["meteo_forecast_history"] >= 0  # normal completion

--- a/tests/test_db_snapshots.py
+++ b/tests/test_db_snapshots.py
@@ -63,8 +63,25 @@ def test_lp_inputs_snapshot_has_expected_columns():
         "base_load_json", "micro_climate_offset_c", "config_snapshot_json",
         "price_quantize_p", "peak_threshold_p", "cheap_threshold_p",
         "daikin_control_mode", "optimization_preset", "energy_strategy_mode",
+        "forecast_fetch_at_utc",
         # V11-A (#194): nullable columns reserved for V11-C/D
         "dhw_draw_prior_json", "occupancy_prior_json",
+    ):
+        assert expected in cols, f"missing column {expected}"
+
+
+def test_meteo_forecast_snapshot_has_expected_columns():
+    cols = _columns("meteo_forecast_snapshot")
+    for expected in (
+        "forecast_fetch_at_utc", "source", "model_name", "model_version", "raw_payload_json",
+    ):
+        assert expected in cols, f"missing column {expected}"
+
+
+def test_meteo_forecast_value_has_expected_columns():
+    cols = _columns("meteo_forecast_value")
+    for expected in (
+        "id", "forecast_fetch_at_utc", "slot_time", "temp_c", "solar_w_m2", "cloud_cover_pct",
     ):
         assert expected in cols, f"missing column {expected}"
 
@@ -113,6 +130,29 @@ def test_meteo_forecast_history_handles_missing_cloud_gracefully():
     fetched = db.get_meteo_forecast_history_latest_before(later)
     assert len(fetched) == 1
     assert fetched[0].get("cloud_cover_pct") is None
+
+
+def test_meteo_forecast_slot_date_lookup_uses_slot_time_not_forecast_date():
+    rows = [
+        {"slot_time": "2026-05-02T00:00:00+00:00", "temp_c": 10.0, "solar_w_m2": 100.0},
+    ]
+    db.save_meteo_forecast(rows, "2026-05-01")
+    fetched = db.get_meteo_forecast_for_slot_date("2026-05-02")
+    assert len(fetched) == 1
+    assert fetched[0]["slot_time"] == "2026-05-02T00:00:00+00:00"
+    assert fetched[0]["forecast_date"] == "2026-05-02"
+
+
+def test_meteo_forecast_active_at_time_prefers_latest_past_slot():
+    rows = [
+        {"slot_time": "2026-05-02T00:00:00+00:00", "temp_c": 10.0, "solar_w_m2": 100.0},
+        {"slot_time": "2026-05-02T01:00:00+00:00", "temp_c": 11.0, "solar_w_m2": 200.0},
+    ]
+    db.save_meteo_forecast(rows, "2026-05-01")
+    row = db.get_meteo_forecast_at_time("2026-05-02T00:30:00+00:00")
+    assert row is not None
+    assert row["slot_time"] == "2026-05-02T00:00:00+00:00"
+
 
 
 def test_config_audit_has_expected_columns():

--- a/tests/test_db_snapshots.py
+++ b/tests/test_db_snapshots.py
@@ -61,6 +61,7 @@ def test_lp_inputs_snapshot_has_expected_columns():
         "soc_initial_kwh", "tank_initial_c", "indoor_initial_c",
         "soc_source", "tank_source", "indoor_source",
         "base_load_json", "micro_climate_offset_c", "config_snapshot_json",
+        "exogenous_snapshot_json",
         "price_quantize_p", "peak_threshold_p", "cheap_threshold_p",
         "daikin_control_mode", "optimization_preset", "energy_strategy_mode",
         "forecast_fetch_at_utc",
@@ -202,6 +203,7 @@ def _mk_inputs_row() -> dict:
         "indoor_source": "daikin_cache",
         "base_load_json": json.dumps([0.4] * 48),
         "micro_climate_offset_c": 0.3,
+        "exogenous_snapshot_json": json.dumps({"base_load_components": {"appliance_profile_kwh": [0.0] * 48}}),
         "config_snapshot_json": json.dumps({"LP_HORIZON_HOURS": 24, "BATTERY_CAPACITY_KWH": 10.0}),
         "price_quantize_p": 1.0,
         "peak_threshold_p": 25.0,
@@ -249,6 +251,7 @@ def test_save_lp_snapshots_round_trip():
     # JSON fields survive the round-trip intact
     assert json.loads(inputs["config_snapshot_json"])["LP_HORIZON_HOURS"] == 24
     assert len(json.loads(inputs["base_load_json"])) == 48
+    assert json.loads(inputs["exogenous_snapshot_json"])["base_load_components"]["appliance_profile_kwh"][0] == 0.0
 
     slots = db.get_lp_solution_slots(run_id)
     assert len(slots) == 4

--- a/tests/test_db_snapshots.py
+++ b/tests/test_db_snapshots.py
@@ -13,10 +13,14 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import sqlite3
 
 import pytest
 
 from src import db
+from src.config import config as app_config
 
 
 @pytest.fixture(autouse=True)
@@ -166,6 +170,46 @@ def test_init_db_is_idempotent():
     # Second init must not raise — migrations use CREATE TABLE IF NOT EXISTS.
     db.init_db()
     db.init_db()
+
+
+def test_init_db_migrates_old_lp_inputs_snapshot_before_creating_forecast_index(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """CREATE TABLE lp_inputs_snapshot (
+                run_id INTEGER PRIMARY KEY,
+                run_at_utc TEXT NOT NULL,
+                plan_date TEXT,
+                horizon_hours INTEGER,
+                soc_initial_kwh REAL,
+                tank_initial_c REAL,
+                indoor_initial_c REAL,
+                soc_source TEXT,
+                tank_source TEXT,
+                indoor_source TEXT,
+                base_load_json TEXT,
+                micro_climate_offset_c REAL,
+                config_snapshot_json TEXT,
+                price_quantize_p REAL,
+                peak_threshold_p REAL,
+                cheap_threshold_p REAL,
+                daikin_control_mode TEXT,
+                optimization_preset TEXT,
+                energy_strategy_mode TEXT
+            )"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(app_config, "DB_PATH", str(db_path), raising=False)
+    db.init_db()
+    cols = _columns("lp_inputs_snapshot")
+    assert "forecast_fetch_at_utc" in cols
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heuristic_fallback.py
+++ b/tests/test_heuristic_fallback.py
@@ -1,6 +1,6 @@
 """Smoke test for OPTIMIZER_BACKEND=heuristic — catches silent rot in the fallback path.
 
-The heuristic backend is the safety net when PuLP/HiGHS fails to solve. No prod
+The heuristic backend is the safety net when PuLP/CBC fails to solve. No prod
 config sets it, so it can rot without anyone noticing — until the day PuLP fails
 and the rot bites. This test seeds a realistic 48-slot day, runs the heuristic,
 and asserts a non-empty plan comes back.

--- a/tests/test_lp_price_quantization.py
+++ b/tests/test_lp_price_quantization.py
@@ -80,6 +80,7 @@ def test_lp_solve_uses_conservative_quantization(
     from src.scheduler.lp_optimizer import LpInitialState, solve_lp
     from src.weather import WeatherLpSeries
 
+    monkeypatch.setattr(app_config, "LP_CBC_TIME_LIMIT_SECONDS", 15)
     monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
     monkeypatch.setattr(app_config, "LP_HP_MIN_ON_SLOTS", 1)
     monkeypatch.setattr(app_config, "LP_SOC_TERMINAL_VALUE_PENCE_PER_KWH", 0.0)

--- a/tests/test_lp_replay.py
+++ b/tests/test_lp_replay.py
@@ -123,7 +123,7 @@ def _persist_plan_as_run(
     plan_date: str,
     config_snapshot: dict | None = None,
 ) -> int:
-    """Insert optimizer_log + lp_inputs_snapshot + lp_solution_snapshot + meteo_forecast_history rows."""
+    """Insert optimizer_log + LP snapshots + canonical forecast rows."""
     run_id = db.log_optimizer_run({
         "run_at": run_at_utc.isoformat(),
         "rates_count": len(slots),
@@ -139,6 +139,7 @@ def _persist_plan_as_run(
         "daikin_actions_count": 0,
     })
 
+    fetch_at = (run_at_utc - timedelta(seconds=1)).isoformat()
     inputs_row = {
         "run_at_utc": run_at_utc.isoformat(),
         "plan_date": plan_date,
@@ -151,6 +152,7 @@ def _persist_plan_as_run(
         "indoor_source": initial.indoor_source,
         "base_load_json": json.dumps(base_load),
         "micro_climate_offset_c": 0.0,
+        "forecast_fetch_at_utc": fetch_at,
         "config_snapshot_json": json.dumps(config_snapshot or {}),
         "price_quantize_p": 1.0,
         "peak_threshold_p": float(plan.peak_threshold_pence),
@@ -183,10 +185,9 @@ def _persist_plan_as_run(
 
     db.save_lp_snapshots(run_id, inputs_row, solution_rows)
 
-    # Weather snapshot — fetched a second BEFORE run_at_utc so
-    # get_meteo_forecast_history_latest_before(run_at_utc) finds it. Round-trip
-    # the test's hourly forecast list so replay reconstructs an identical series.
-    fetch_at = (run_at_utc - timedelta(seconds=1)).isoformat()
+    # Weather snapshot — fetched a second BEFORE run_at_utc so the legacy
+    # fallback lookup still finds it. Snapshot reference is persisted on the
+    # LP inputs row for exact replay-by-reference.
     forecast_rows = [
         {
             "slot_time": f.time_utc.isoformat(),
@@ -290,7 +291,7 @@ def test_replay_run_falls_back_to_approx_when_cloud_cover_null():
     conn = db.get_connection()
     try:
         conn.execute(
-            "UPDATE meteo_forecast_history SET cloud_cover_pct = NULL "
+            "UPDATE meteo_forecast_value SET cloud_cover_pct = NULL "
             "WHERE forecast_fetch_at_utc < ?",
             (base.isoformat(),),
         )
@@ -304,7 +305,7 @@ def test_replay_run_falls_back_to_approx_when_cloud_cover_null():
 
 
 def test_replay_run_missing_weather_returns_clean_error():
-    """A run with no meteo_forecast_history snapshot should fail-fast cleanly."""
+    """A run with no persisted forecast snapshot should fail-fast cleanly."""
     base = datetime(2026, 7, 1, 0, 0, tzinfo=UTC)
     plan, slots, prices, base_load, initial, _forecast = _solve_baseline(8, base)
 

--- a/tests/test_mpc_event_triggers.py
+++ b/tests/test_mpc_event_triggers.py
@@ -309,26 +309,21 @@ def test_forecast_refresh_job_persists_even_when_disabled(monkeypatch):
     base = datetime.now(UTC)
     fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.0, shortwave_radiation_wm2=100.0) for i in range(6)]
 
-    saved_history: list[tuple[str, list]] = []
-    saved_latest: list[tuple[list, str]] = []
+    saved_snapshots: list[tuple[str, list, bool]] = []
 
-    def _save_hist(fetch_at, rows):
-        saved_history.append((fetch_at, rows))
-
-    def _save_latest(rows, day):
-        saved_latest.append((rows, day))
+    def _save_snapshot(fetch_at, rows, mark_latest=True, **_kwargs):
+        saved_snapshots.append((fetch_at, rows, bool(mark_latest)))
 
     triggered = MagicMock(side_effect=AssertionError("MPC must not be triggered when kill switch is off"))
 
     with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=[{"slot_time": (base + timedelta(hours=0)).isoformat(), "solar_w_m2": 50.0, "temp_c": 10.0}]), \
-         patch("src.db.save_meteo_forecast_history", side_effect=_save_hist), \
-         patch("src.db.save_meteo_forecast", side_effect=_save_latest), \
+         patch("src.db.save_meteo_forecast_snapshot", side_effect=_save_snapshot), \
          patch.object(runner, "bulletproof_mpc_job", triggered):
         runner.bulletproof_forecast_refresh_job()
 
-    assert len(saved_history) == 1
-    assert len(saved_latest) == 1
+    assert len(saved_snapshots) == 1
+    assert saved_snapshots[0][2] is True
     triggered.assert_not_called()
 
 
@@ -342,8 +337,7 @@ def test_forecast_refresh_job_no_trigger_without_previous_fetch(monkeypatch):
 
     with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=[]), \
-         patch("src.db.save_meteo_forecast_history"), \
-         patch("src.db.save_meteo_forecast"), \
+         patch("src.db.save_meteo_forecast_snapshot"), \
          patch.object(runner, "bulletproof_mpc_job", triggered):
         runner.bulletproof_forecast_refresh_job()
 
@@ -367,8 +361,7 @@ def test_forecast_refresh_job_triggers_when_solar_delta_exceeds_threshold(monkey
 
     with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=prev_rows), \
-         patch("src.db.save_meteo_forecast_history"), \
-         patch("src.db.save_meteo_forecast"), \
+         patch("src.db.save_meteo_forecast_snapshot"), \
          patch.object(runner, "bulletproof_mpc_job", _capture):
         runner.bulletproof_forecast_refresh_job()
 
@@ -387,8 +380,7 @@ def test_forecast_refresh_job_no_trigger_when_within_thresholds(monkeypatch):
     triggered = MagicMock(side_effect=AssertionError("must not trigger when delta is within thresholds"))
     with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=prev_rows), \
-         patch("src.db.save_meteo_forecast_history"), \
-         patch("src.db.save_meteo_forecast"), \
+         patch("src.db.save_meteo_forecast_snapshot"), \
          patch.object(runner, "bulletproof_mpc_job", triggered):
         runner.bulletproof_forecast_refresh_job()
     triggered.assert_not_called()


### PR DESCRIPTION
## Summary

Slice 2/5 of the PR #245 split. Foundation for PR-B (skill log /
per-hour microclimate), PR-C (Quartz), PR-D (margin guard), and PR-E
(live deviation triggers). Stacked on PR-A1 (#255).

### What ships

- **Canonical forecast schema** (#246): three tables replace the
  dual-write to ``meteo_forecast`` + ``meteo_forecast_history``:
  - ``meteo_forecast_snapshot`` — one row per fetch, carries
    ``source``, ``model_name``, ``model_version``,
    ``raw_payload_json`` for provider provenance + audit
  - ``meteo_forecast_value`` — normalized slot rows referencing a
    fetch, with ``cloud_cover_pct`` + ``direct_pv_kw``
  - ``meteo_forecast_latest_state`` — pointer to the most recent
    fetch so heartbeat + replay agree on "latest"
- ``lp_inputs_snapshot`` gains four nullable replay-aid columns:
  - ``forecast_fetch_at_utc`` — the *exact* fetch the LP used (no
    more "infer-by-timestamp")
  - ``exogenous_snapshot_json`` — base-load decomposition (residual
    profile, appliance overlay, flat fallback), weather-adjustment
    diagnostics (today_factor + diag, calibration table cells), and
    per-slot tariff line
  - ``dhw_draw_prior_json`` / ``occupancy_prior_json`` reserved for
    PR-B/V11-C/V11-D — left NULL until those land
- **Replay-by-fetch** (``src/scheduler/lp_replay.py``): when a run's
  ``forecast_fetch_at_utc`` is known, replay reads that exact fetch
  from the canonical store rather than the closest fetch before
  ``run_at_utc``. Closes the "what did the solver actually see"
  fidelity gap that #246 called out.
- **History UI exogenous + Why-This-Slot explainer**: the cockpit-at
  endpoint now exposes ``lp_exogenous`` and a server-rendered
  per-slot explanation (charge/import, discharge, DHW, space,
  forecast-fetch context, export-price line). Frozen on the
  snapshot, so the replay path doesn't re-derive in the browser.
- **LP regression gate tightening** (#191 / 77e1468):
  ``scripts/check_lp_regression.py`` now refuses to pass
  silently when forward + honest baseline windows are missing or
  replay coverage is incomplete.
- **CI fix — Bug A**: ``/api/v1/optimization/inputs`` previously
  inlined a raw ``SELECT`` against legacy ``meteo_forecast``; on a
  fresh DB / fresh fetch every slot returned None even though the
  LP was solving against a fully-populated forecast. Now reads
  from ``meteo_forecast_value`` keyed by the latest fetch, falling
  back to legacy for pre-migration rows.

### What is intentionally **not** in this PR

- Forecast skill log (table + nightly rebuild + load actuals) → PR-B
- Per-hour microclimate offset readers (``get_micro_climate_offset_by_hour_c``) → PR-B
- Quartz adapter / ``FORECAST_SOURCE`` switch → PR-C
- Peak-export economic margin guard + ``dispatch_decisions`` audit cols → PR-D
- Live PV/load deviation MPC triggers + ``forecast_pv_kw_from_row`` helper → PR-E
- Daikin calibration windows → PR-B

These slices stack on top of this canonical store; isolating them keeps
each slice cheap to review and lets the regression gate stay honest
between them.

### Approval gates (acknowledged still red)

The author's existing approval blockers from PR #245 still apply and
should be cleared before merging the *combined* effect into prod:

- ``scripts/check_lp_regression.py --mode=both --days 14`` — needs
  rebaseline once PR-A1's microclimate sign fix has 14 days of
  paired data.
- ``scripts/check_pv_forecast_accuracy.py`` — INCONCLUSIVE until
  ≥84 paired PV samples are available.

PR-A2 alone shouldn't move either of these (no solver math change,
no PV-source change), so the gates can stay red while we layer on
PR-B/C without blocking review of this slice.

## Testing

- ``pytest tests/`` on this branch: 877 passed before adding the
  CI-fix-A commit; targeted re-runs after the fix all green
  (``test_inputs_interpolation``, ``test_db_snapshots``,
  ``test_db_retention``, ``test_lp_replay``, ``test_mpc_event_triggers``).
- The full-suite re-run that includes CI-fix-A is running on the
  branch CI now.

## Issue context

- Implements #246 (canonical exogenous-input + actual audit trail).
- Unblocks #195 (V11-B quantile scenarios), #247 (Quartz),
  #185 (battery wear margin guard), and the live-deviation triggers.

## Test plan

- [x] Targeted DB / replay / MPC-trigger / inputs-endpoint suites
      green locally.
- [ ] Full ``pytest tests/`` green on CI for this PR.
- [ ] PR-A1 (#255) merges first; rebase this branch onto main.
- [ ] After merge, regenerate the LP regression baseline as part of
      PR-B with a deliberate rebaseline justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)