### PR TITLE
fix(db): migrate dispatch_decisions audit columns on existing DBs

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -878,6 +878,20 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_forecast_fetch ON lp_inputs_snapshot(forecast_fetch_at_utc)"
     )
+
+    # Older DBs predate the dispatch_decisions audit columns. The CREATE TABLE
+    # at SCHEMA-load time declares them for fresh installs, but a long-lived
+    # prod DB needs explicit ALTER TABLE migrations. ``persist_dispatch_decisions``
+    # writes None into these columns until the margin-guard slice ships, so the
+    # migration is a pure compatibility fix — no behavior change.
+    cur = conn.execute("PRAGMA table_info(dispatch_decisions)")
+    dd_cols = {str(r[1]) for r in cur.fetchall()}
+    if "export_price_p_kwh" not in dd_cols:
+        conn.execute("ALTER TABLE dispatch_decisions ADD COLUMN export_price_p_kwh REAL")
+    if "refill_price_p_kwh" not in dd_cols:
+        conn.execute("ALTER TABLE dispatch_decisions ADD COLUMN refill_price_p_kwh REAL")
+    if "economic_margin_p_kwh" not in dd_cols:
+        conn.execute("ALTER TABLE dispatch_decisions ADD COLUMN economic_margin_p_kwh REAL")
     # Older DBs predate the cloud-aware PV table (PR #232). Idempotent — when
     # the table is already created at SCHEMA-load time this block is a no-op.
     conn.execute(


### PR DESCRIPTION
## Summary

Hotfix discovered during the PR-A1+A2+B prod deploy.

PR #257 added ``export_price_p_kwh`` / ``refill_price_p_kwh`` /
``economic_margin_p_kwh`` to the ``dispatch_decisions`` ``CREATE TABLE
IF NOT EXISTS`` declaration (a leftover from the PR-D / margin-guard
slice that should not have been brought through), but no ``ALTER
TABLE`` migration was added. Fresh installs created the columns;
long-lived prod databases did not have them, so every LP solve logs:

    WARNING dispatch_decisions persistence failed (non-fatal):
    table dispatch_decisions has no column named export_price_p_kwh

The warning is wrapped in try/except, so the LP / dispatch / Fox
upload paths are unaffected — but the dispatch_decisions audit trail
stops accumulating rows until the schema is fixed.

This PR adds three idempotent ``ALTER TABLE`` statements to
``_migrate_schema()``. ``persist_dispatch_decisions`` already accepts
the columns as ``None`` defaults, so this is a pure compatibility
fix — no behaviour change. The columns become meaningful only when
the margin-guard slice (PR-D) actually starts populating them.

## Verification on prod after merge

After this image rebuilds and ``systemctl restart hem`` runs:

```
docker exec hem python - <<'PY'
import sqlite3
conn = sqlite3.connect("/app/data/energy_state.db")
cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatch_decisions)")}
for c in ("export_price_p_kwh", "refill_price_p_kwh", "economic_margin_p_kwh"):
    assert c in cols, f"missing {c}"
print("OK")
PY
```

The next ``filter_robust_peak_export`` call should write a row to
``dispatch_decisions`` without warnings.

## Testing

- ``pytest tests/test_db_snapshots.py tests/test_db_retention.py`` —
  28 passed locally.

## Test plan

- [x] Schema/retention tests green locally.
- [ ] CI green on this PR.
- [ ] After merge + image rebuild, prod warning ``table
  dispatch_decisions has no column named export_price_p_kwh``
  disappears from the next ``MPC re-optimise`` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)