### PR TITLE
feat(weather): Quartz forecast source + provider switch + token-lifecycle hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,12 +21,15 @@ OCTOPUS_MPAN_2=
 OCTOPUS_METER_SN_2=
 OCTOPUS_GSP=
 
-# Forecast source
+# Forecast source — leave default (open_meteo) until Quartz creds + client_id
+# are configured below. Switching ``FORECAST_SOURCE=quartz`` flips the LP /
+# heartbeat / replay path to Quartz direct PV (Open-Meteo still supplies
+# temperature + cloud context). API docs: https://api.quartz.solar/docs
 # FORECAST_SOURCE=open_meteo|quartz
-# Quartz Auth0 + Solar API (see README and docs/RUNBOOK)
 # QUARTZ_AUTH_URL=https://nowcasting-pro.eu.auth0.com/oauth/token
 # QUARTZ_API_BASE_URL=https://api.quartz.solar
-# QUARTZ_CLIENT_ID=tuJKOXmMGbN27iX4ZXzgZsNIoxDTPO88
+# Vendor-issued OAuth client_id; supply via .env (NOT committed):
+# QUARTZ_CLIENT_ID=
 # QUARTZ_AUDIENCE=https://api.nowcasting.io/
 # QUARTZ_USERNAME=
 # QUARTZ_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,24 @@ OCTOPUS_MPAN_2=
 OCTOPUS_METER_SN_2=
 OCTOPUS_GSP=
 
+# Forecast source
+# FORECAST_SOURCE=open_meteo|quartz
+# Quartz Auth0 + Solar API (see README and docs/RUNBOOK)
+# QUARTZ_AUTH_URL=https://nowcasting-pro.eu.auth0.com/oauth/token
+# QUARTZ_API_BASE_URL=https://api.quartz.solar
+# QUARTZ_CLIENT_ID=tuJKOXmMGbN27iX4ZXzgZsNIoxDTPO88
+# QUARTZ_AUDIENCE=https://api.nowcasting.io/
+# QUARTZ_USERNAME=
+# QUARTZ_PASSWORD=
+# Legacy aliases also accepted by the code:
+# QUARTZ_USER=
+# QUARTZ_PASS=
+# Optional Quartz site/GSP context:
+# QUARTZ_GSP_ID=
+# QUARTZ_MODEL_NAME=blend
+# QUARTZ_TREND_ADJUSTER_ON=true
+# QUARTZ_INSTALLED_CAPACITY_MW=0
+
 # Manual tariff (p/kWh) — Agile example: E-1R-AGILE-24-10-01-<GSP>
 MANUAL_TARIFF_IMPORT_PENCE=0
 MANUAL_TARIFF_EXPORT_PENCE=0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Every solve is snapshotted to SQLite so any past day's plan can be re-run under 
 ```
                 ┌─────────────────────────────┐
   Octopus Agile ──→  half-hourly tariff       │
-  Open-Meteo    ──→  temp + cloud + radiation │
+  Quartz / Open-Meteo ─→ PV nowcast + weather │
   Fox ESS       ──→  load, PV, SoC, schedule  │
   Daikin Onecta ──→  tank, indoor, outdoor    │     PuLP MILP
   SmartThings   ──→  appliance state          │ ──→ 24–48h plan ──→  Fox V3 schedule
@@ -52,8 +52,9 @@ Everything is parameterised via `.env`. Adapting it to a different setup is feas
 ## What it does
 
 - **Octopus Agile fetch** every 30 min. Stores import + Outgoing Agile rates in SQLite for the next ~36 h.
-- **Open-Meteo forecast** every LP solve — temperature, shortwave radiation, cloud cover. Snapshotted per fetch for replay.
-- **PV forecast calibration** — three-tier resolver: cloud-aware `(hour, cloud bucket)` table → per-hour-of-day table → flat factor. Today-aware OCF Quartz-style adjuster on top.
+- **Quartz forecast source** — preferred PV nowcast for the UK site. Auth via env, direct PV is snapshotted per fetch, and Open-Meteo remains the weather fallback/context source.
+- **Open-Meteo forecast** — temperature, cloud cover, irradiance. Snapshotted per fetch for replay and used as fallback when Quartz is unavailable.
+- **PV forecast calibration** — three-tier resolver: cloud-aware `(hour, cloud bucket)` table → per-hour-of-day table → flat factor. Quartz direct PV and irradiance-based PV both pass through the same site calibration chain. Today-aware OCF Quartz-style adjuster on top.
 - **Load forecast accuracy evaluator** — per-slot MAE/RMSE/bias broken down by local hour, plus a daily Daikin physics check against Onecta-measured kWh. Captures the biases the LP hasn't yet learned.
 - **MILP solver (PuLP)** — 96-slot horizon, soft penalties for cycling/comfort/inverter stress, scenario LP for peak-export robustness, twice-daily and tier-boundary MPC.
 - **Fox ESS Scheduler V3** — single daily upload of the optimised charge/discharge windows. Heuristic fallback if the LP fails.
@@ -90,6 +91,7 @@ pip install -r requirements.txt -r requirements-dev.txt
 
 cp .env.example .env
 # Edit .env — at minimum set OPENCLAW_READ_ONLY=true so nothing dials out.
+# To switch PV nowcasting, set FORECAST_SOURCE=quartz and fill the Quartz auth vars.
 
 pytest                                    # 837+ tests, ~3 min on a laptop
 python -m src.cli serve                   # FastAPI on :8000, MCP at /mcp
@@ -121,7 +123,8 @@ OAuth bootstrap (Daikin + SmartThings) uses one-shot containers documented in [`
 | Vendor | What we use | Auth |
 |---|---|---|
 | Octopus Energy | Agile import + Outgoing Agile export rates, optional consumption backfill | API key (read-only) |
-| Open-Meteo | Hourly forecast (temp, radiation, cloud cover) | None — public |
+| Quartz Solar | PV nowcast source for the LP; direct site PV when configured | Auth0 bearer token via env |
+| Open-Meteo | Hourly weather forecast and fallback PV context (temp, radiation, cloud cover) | None — public |
 | Fox ESS | SoC, PV, load, grid, Scheduler V3 upload | Open API key + signature |
 | Daikin Altherma | Status read + LWT/tank writes via Onecta | OAuth2 (auto-refresh) |
 | Samsung SmartThings | Washer/dryer/dishwasher schedule | OAuth2 (auto-refresh) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,8 @@ Home Energy Manager is designed as the **single planning brain** for the site: i
 | Source | Role |
 |--------|------|
 | **Octopus Agile** (half-hourly unit rates) | Stored in SQLite (`agile_rates`); drives cheap / peak / negative classification and cost math. |
-| **Open-Meteo forecast** (`src/weather.py`) | Per-slot temperature, irradiance → **estimated PV (kW)** and **heating demand factor**; steers “skip forced cheap when solar will cover” and Daikin pre-heat / peak frost logic. |
+| **Quartz PV nowcast** (`src/weather.py`) | Preferred PV source for the site when configured; direct PV is calibrated to local shading/orientation before the LP consumes it. |
+| **Open-Meteo forecast** (`src/weather.py`) | Per-slot temperature, irradiance, cloud cover → weather fallback/context and derived PV / heating demand inputs. |
 | **Rolling load proxy** (`execution_log` → mean kWh per half-hour) | Estimates typical import power needs; **battery margin** logic can extend pre-peak charge windows when peak load might exceed usable battery. |
 | **Fox realtime (cached)** | Battery **SoC**, work mode — guards and heartbeat context (not a polling loop; ~30s cache, sparse scheduler checks). |
 | **Daikin live telemetry** | Room/outdoor temps, LWT offset, tank — **heartbeat** applies SQLite actions, **frost cap** on peak setback when outdoor is cold. |
@@ -46,7 +47,7 @@ The older consent-driven **solver + dispatcher** (`src/optimization/`) was remov
 flowchart LR
   subgraph ingest [Ingest]
     O[Octopus Agile]
-    W[Open-Meteo]
+  Q[Quartz / Open-Meteo]
   end
   subgraph store [State]
     DB[(SQLite)]
@@ -58,7 +59,7 @@ flowchart LR
     H[Heartbeat]
   end
   O --> DB
-  W --> R
+  Q --> R
   DB --> R
   R --> DB
   R --> F[Fox V3]
@@ -74,7 +75,7 @@ Production path when `OPTIMIZER_BACKEND=lp` (default). Implementation: `src/sche
 
 - **Objective:** Minimize \(\sum_i (\text{import}_i \cdot \text{price}_i - \text{export}_i \cdot \text{EXPORT_RATE_PENCE})\) plus tiny battery-cycle penalty and comfort-band slack penalty.
 - **Constraints:** Half-hour energy balance; battery SoC with round-trip efficiency; mutex grid import vs export and charge vs discharge binaries; SEG-style **export ≤ PV use + discharge**; discrete heat-pump power buckets; DHW tank dynamics (UA loss to room); single-zone building / radiators (UA to outdoor, solar gain fraction, radiator thermal cap); shower windows and Legionella; terminal SoC/tank/indoor stitches.
-- **Inputs:** Octopus rates for the horizon, Open-Meteo → `WeatherLpSeries`, initial SoC (Fox cache), tank + room temps (Daikin / execution log fallbacks).
+- **Inputs:** Octopus rates for the horizon, Quartz/Open-Meteo → `WeatherLpSeries`, initial SoC (Fox cache), tank + room temps (Daikin / execution log fallbacks).
 - **Rollback:** Set `OPTIMIZER_BACKEND=heuristic` or POST `/api/v1/optimization/backend` with `{"backend":"heuristic"}` to use the legacy classifier in the same `run_optimizer()` entrypoint.
 
 ### Slot classification (`lp_dispatch.py`)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -73,6 +73,13 @@ The script: backs up DB → git pull → pip install → DB migration → restar
 | `FOX_DAILY_BUDGET` | `1200` | Conservative cap below Fox's 1440/day |
 | `LP_MPC_HOURS` | `6,9,12,15` | Intra-day MPC re-plan hours (BST/local). See MPC schedule below. |
 | `LP_MPC_WRITE_DEVICES` | `true` | MPC and Octopus-fetch re-plans push updated Fox/Daikin schedule to hardware |
+| `FORECAST_SOURCE` | `open_meteo` | Set to `quartz` to use Quartz PV nowcasts; Open-Meteo remains weather fallback/context |
+| `QUARTZ_USERNAME` / `QUARTZ_PASSWORD` | required for Quartz | Auth0 login used to fetch the Quartz bearer token |
+| `QUARTZ_CLIENT_ID` / `QUARTZ_AUDIENCE` | defaults in code | Quartz Auth0 client settings |
+| `QUARTZ_GSP_ID` | optional | Hosted Quartz GSP mapping; omit for national default |
+| `QUARTZ_MODEL_NAME` | `blend` | Quartz model selector for hosted API |
+| `QUARTZ_TREND_ADJUSTER_ON` | `true` | Quartz trend-adjuster toggle |
+| `QUARTZ_INSTALLED_CAPACITY_MW` | `0` | Optional downscale hint when Quartz returns capacity metadata |
 | `FOX_SOLAR_CHARGE_MIN_SOC_PERCENT` | `100` | `minSocOnGrid` for `solar_charge` SelfUse windows (blocks discharge, lets PV fill) |
 | `OPENCLAW_HOOKS_URL` | required if notifications on | Full URL, e.g. `http://127.0.0.1:18789/hooks/agent` |
 | `OPENCLAW_HOOKS_TOKEN` | required if notifications on | Same secret as Gateway `hooks.token` |
@@ -139,7 +146,7 @@ print(json.dumps(json.loads(row[1]), indent=2))
 ## What the Bulletproof engine does on each optimizer run
 
 1. Reads Agile rates from `agile_rates` table
-2. Fetches weather forecast (Open-Meteo)
+2. Fetches weather / PV forecast (Quartz when configured, otherwise Open-Meteo)
 3. Runs PuLP MILP solver → produces per-slot Fox + Daikin actions
 4. **Uploads Fox Scheduler V3 immediately** (one call, `fox_schedule_uploaded=1` in optimizer_log)
 5. Writes Daikin `action_schedule` rows for today

--- a/scripts/check_pv_forecast_accuracy.py
+++ b/scripts/check_pv_forecast_accuracy.py
@@ -48,6 +48,13 @@ def main() -> int:
     n_b = baseline["overall"]["n"]
     n_c = current["overall"]["n"]
     print(f"\nSamples: baseline={n_b}, current={n_c}")
+    min_samples = max(1, int(n_b * 0.5))
+    if n_c < min_samples:
+        print(
+            "\n❌ INCONCLUSIVE — not enough paired forecast/actual samples "
+            f"({n_c} < required {min_samples})."
+        )
+        return 1
 
     # Verdict
     mae_b = baseline["overall"]["mae_kw"]

--- a/src/config.py
+++ b/src/config.py
@@ -427,6 +427,32 @@ class Config:
     # Set e.g. 0.65 to permanently cap the forecast to 65% of Open-Meteo modelled output.
     # When 0 or unset, compute_pv_calibration_factor() derives it automatically from Fox history.
     PV_FORECAST_SCALE_FACTOR: float = float(os.getenv("PV_FORECAST_SCALE_FACTOR", "0"))
+    FORECAST_SOURCE: str = (os.getenv("FORECAST_SOURCE") or "open_meteo").strip().lower()
+    QUARTZ_AUTH_URL: str = (
+        os.getenv("QUARTZ_AUTH_URL") or "https://nowcasting-pro.eu.auth0.com/oauth/token"
+    ).strip()
+    QUARTZ_API_BASE_URL: str = (
+        os.getenv("QUARTZ_API_BASE_URL")
+        or "http://uk-production-uk-national-quartz-api.eu-west-1.elasticbeanstalk.com"
+    ).strip().rstrip("/")
+    QUARTZ_CLIENT_ID: str = (
+        os.getenv("QUARTZ_CLIENT_ID") or "tuJKOXmMGbN27iX4ZXzgZsNIoxDTPO88"
+    ).strip()
+    QUARTZ_AUDIENCE: str = (
+        os.getenv("QUARTZ_AUDIENCE") or "https://api.nowcasting.io/"
+    ).strip()
+    QUARTZ_USERNAME: str = (
+        os.getenv("QUARTZ_USERNAME") or os.getenv("QUARTZ_USER") or ""
+    ).strip()
+    QUARTZ_PASSWORD: str = os.getenv("QUARTZ_PASSWORD") or os.getenv("QUARTZ_PASS") or ""
+    QUARTZ_GSP_ID: str = (os.getenv("QUARTZ_GSP_ID") or "").strip()
+    QUARTZ_MODEL_NAME: str = (os.getenv("QUARTZ_MODEL_NAME") or "blend").strip()
+    QUARTZ_TREND_ADJUSTER_ON: bool = (
+        os.getenv("QUARTZ_TREND_ADJUSTER_ON", "true").lower() in ("1", "true", "yes")
+    )
+    QUARTZ_INSTALLED_CAPACITY_MW: float = float(
+        os.getenv("QUARTZ_INSTALLED_CAPACITY_MW", "0") or "0"
+    )
 
     # Agile scheduler (Daikin ASHP by price)
     SCHEDULER_ENABLED: bool = os.getenv("SCHEDULER_ENABLED", "false").lower() in ("true", "1", "yes")

--- a/src/config.py
+++ b/src/config.py
@@ -431,13 +431,17 @@ class Config:
     QUARTZ_AUTH_URL: str = (
         os.getenv("QUARTZ_AUTH_URL") or "https://nowcasting-pro.eu.auth0.com/oauth/token"
     ).strip()
+    # Default to the documented HTTPS endpoint at api.quartz.solar. Some
+    # development networks see a Cloudflare 1010 from that hostname; in that
+    # case set ``QUARTZ_API_BASE_URL`` explicitly in your local ``.env`` to
+    # the upstream Elastic Beanstalk URL. Production must use HTTPS so the
+    # Authorization bearer token is not sent over plaintext.
     QUARTZ_API_BASE_URL: str = (
-        os.getenv("QUARTZ_API_BASE_URL")
-        or "http://uk-production-uk-national-quartz-api.eu-west-1.elasticbeanstalk.com"
+        os.getenv("QUARTZ_API_BASE_URL") or "https://api.quartz.solar"
     ).strip().rstrip("/")
-    QUARTZ_CLIENT_ID: str = (
-        os.getenv("QUARTZ_CLIENT_ID") or "tuJKOXmMGbN27iX4ZXzgZsNIoxDTPO88"
-    ).strip()
+    # Vendor-issued OAuth client_id. Empty default — operators must supply it
+    # via ``.env`` so the value is not committed to OSS.
+    QUARTZ_CLIENT_ID: str = (os.getenv("QUARTZ_CLIENT_ID") or "").strip()
     QUARTZ_AUDIENCE: str = (
         os.getenv("QUARTZ_AUDIENCE") or "https://api.nowcasting.io/"
     ).strip()

--- a/src/db.py
+++ b/src/db.py
@@ -176,6 +176,7 @@ CREATE TABLE IF NOT EXISTS meteo_forecast_value (
     temp_c REAL,
     solar_w_m2 REAL,
     cloud_cover_pct REAL,
+    direct_pv_kw REAL,
     UNIQUE(forecast_fetch_at_utc, slot_time)
 );
 
@@ -624,9 +625,14 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             temp_c REAL,
             solar_w_m2 REAL,
             cloud_cover_pct REAL,
+            direct_pv_kw REAL,
             UNIQUE(forecast_fetch_at_utc, slot_time)
         )"""
     )
+    cur = conn.execute("PRAGMA table_info(meteo_forecast_value)")
+    mfv_cols = {str(r[1]) for r in cur.fetchall()}
+    if "direct_pv_kw" not in mfv_cols:
+        conn.execute("ALTER TABLE meteo_forecast_value ADD COLUMN direct_pv_kw REAL")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_meteo_forecast_value_slot ON meteo_forecast_value(slot_time)"
     )
@@ -2459,14 +2465,15 @@ def save_meteo_forecast_snapshot(
                     continue
                 conn.execute(
                     """INSERT OR IGNORE INTO meteo_forecast_value
-                       (forecast_fetch_at_utc, slot_time, temp_c, solar_w_m2, cloud_cover_pct)
-                       VALUES (?, ?, ?, ?, ?)""",
+                       (forecast_fetch_at_utc, slot_time, temp_c, solar_w_m2, cloud_cover_pct, direct_pv_kw)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
                     (
                         str(forecast_fetch_at_utc),
                         str(slot),
                         r.get("temp_c"),
                         r.get("solar_w_m2"),
                         r.get("cloud_cover_pct"),
+                        r.get("direct_pv_kw"),
                     ),
                 )
                 n += 1
@@ -2509,7 +2516,8 @@ def _get_latest_meteo_forecast_rows_for_slot_date(
     """
     cur = conn.execute(
         """SELECT substr(mv.slot_time, 1, 10) AS forecast_date,
-                  mv.slot_time, mv.temp_c, mv.solar_w_m2, mv.cloud_cover_pct
+                  mv.slot_time, mv.temp_c, mv.solar_w_m2, mv.cloud_cover_pct,
+                  mv.direct_pv_kw
              FROM meteo_forecast_value mv
              JOIN (
                  SELECT slot_time, MAX(forecast_fetch_at_utc) AS forecast_fetch_at_utc
@@ -2592,7 +2600,8 @@ def get_meteo_forecast_at_time(when_utc: str) -> dict[str, Any] | None:
             if latest_fetch_at:
                 cur = conn.execute(
                     """SELECT substr(slot_time, 1, 10) AS forecast_date,
-                              slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                              slot_time, temp_c, solar_w_m2, cloud_cover_pct,
+                              direct_pv_kw
                        FROM meteo_forecast_value
                        WHERE forecast_fetch_at_utc = ?
                          AND slot_time <= ?
@@ -2605,7 +2614,8 @@ def get_meteo_forecast_at_time(when_utc: str) -> dict[str, Any] | None:
                     return dict(row)
                 cur = conn.execute(
                     """SELECT substr(slot_time, 1, 10) AS forecast_date,
-                              slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                              slot_time, temp_c, solar_w_m2, cloud_cover_pct,
+                              direct_pv_kw
                        FROM meteo_forecast_value
                        WHERE forecast_fetch_at_utc = ?
                        ORDER BY slot_time ASC
@@ -3829,7 +3839,7 @@ def get_meteo_forecast_at(fetch_at_utc: str) -> list[dict[str, Any]]:
         conn = get_connection()
         try:
             cur = conn.execute(
-                """SELECT slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                """SELECT slot_time, temp_c, solar_w_m2, cloud_cover_pct, direct_pv_kw
                    FROM meteo_forecast_value
                    WHERE forecast_fetch_at_utc = ?
                    ORDER BY slot_time""",
@@ -4021,7 +4031,7 @@ def rebuild_forecast_skill_log_for_date(date_utc: str) -> int:
         try:
             cur = conn.execute(
                 """SELECT mv.forecast_fetch_at_utc, mv.slot_time, mv.temp_c, mv.solar_w_m2,
-                          mv.cloud_cover_pct
+                          mv.cloud_cover_pct, mv.direct_pv_kw
                    FROM meteo_forecast_value mv
                    JOIN meteo_forecast_snapshot ms
                      ON ms.forecast_fetch_at_utc = mv.forecast_fetch_at_utc
@@ -4113,6 +4123,7 @@ def rebuild_forecast_skill_log_for_date(date_utc: str) -> int:
                 hour_utc,
                 rad_wm2,
                 cloud_pct,
+                direct_pv_kw=row.get("direct_pv_kw"),
                 cloud_table=cal_cloud,
                 hourly_table=cal_hour,
                 flat=flat_cal,
@@ -4202,7 +4213,7 @@ def get_meteo_forecast_history_latest_before(when_utc: str) -> list[dict[str, An
             row = cur.fetchone()
             if row and row[0]:
                 cur = conn.execute(
-                    """SELECT slot_time, temp_c, solar_w_m2, cloud_cover_pct
+                    """SELECT slot_time, temp_c, solar_w_m2, cloud_cover_pct, direct_pv_kw
                        FROM meteo_forecast_value
                        WHERE forecast_fetch_at_utc = ?
                        ORDER BY slot_time""",

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -292,18 +292,21 @@ def _residual_pv_kwh_per_slot(
 
     # forecast is hourly; expand to half-hourly by halving the hourly kWh
     # estimate (good enough for this dispatch decision).
-    by_hour: dict[datetime, tuple[float, float | None]] = {
-        f.time_utc: (float(f.estimated_pv_kw), float(f.cloud_cover_pct))
+    by_hour: dict[datetime, tuple[float, float | None, bool]] = {
+        f.time_utc: (float(f.estimated_pv_kw), float(f.cloud_cover_pct), bool(getattr(f, "pv_direct", False)))
         for f in forecast
     }
     out: dict[datetime, float] = {}
     for slot_start in slot_starts_utc:
         hour_anchor = slot_start.replace(minute=0, second=0, microsecond=0)
-        pv_kw, cloud_pct = by_hour.get(hour_anchor, (0.0, None))
+        pv_kw, cloud_pct, pv_direct = by_hour.get(hour_anchor, (0.0, None, False))
         scale = get_pv_calibration_factor_for(
             hour_anchor.hour, cloud_pct,
             cloud_table=cal_cloud, hourly_table=cal_hourly, flat=flat_cal,
         )
+        if pv_direct:
+            scale = 1.0
+            today_factor = 1.0
         # Half-hour kWh = kW × 0.5h × calibration × today-aware factor
         out[slot_start] = pv_kw * 0.5 * scale * today_factor
     return out

--- a/src/scheduler/lp_replay.py
+++ b/src/scheduler/lp_replay.py
@@ -684,8 +684,13 @@ def _reconstruct_weather(
                 temperature_c=temp_c,
                 cloud_cover_pct=cloud,
                 shortwave_radiation_wm2=rad,
-                estimated_pv_kw=estimate_pv_kw(rad),
+                estimated_pv_kw=(
+                    float(r["direct_pv_kw"])
+                    if r.get("direct_pv_kw") is not None
+                    else estimate_pv_kw(rad)
+                ),
                 heating_demand_factor=compute_heating_demand_factor(temp_c),
+                pv_direct=r.get("direct_pv_kw") is not None,
             )
         )
 

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -21,6 +21,7 @@ from ..weather import (
     HourlyForecast,
     estimate_pv_kw,
     fetch_forecast,
+    fetch_forecast_snapshot,
     forecast_to_lp_inputs,
     get_forecast_for_slot,
 )
@@ -1304,7 +1305,8 @@ def _run_optimizer_lp(
     prices = [s.price_pence for s in slots]
     starts = [s.start_utc for s in slots]
 
-    forecast = fetch_forecast(hours=max(48, int(config.LP_HORIZON_HOURS) + 24))
+    forecast_fetch = fetch_forecast_snapshot(hours=max(48, int(config.LP_HORIZON_HOURS) + 24))
+    forecast = forecast_fetch.forecast
     forecast_fetch_at_utc = datetime.now(UTC).isoformat()
     # Persist the canonical forecast snapshot once so heartbeat + replay can
     # both reference the same fetch instead of duplicating latest/history rows.
@@ -1315,12 +1317,17 @@ def _run_optimizer_lp(
                 "temp_c": f.temperature_c,
                 "solar_w_m2": f.shortwave_radiation_wm2,
                 "cloud_cover_pct": f.cloud_cover_pct,
+                "direct_pv_kw": f.estimated_pv_kw if getattr(f, "pv_direct", False) else None,
             }
             for f in forecast
         ]
         db.save_meteo_forecast_snapshot(
             forecast_fetch_at_utc,
             forecast_rows,
+            source=forecast_fetch.source,
+            model_name=forecast_fetch.model_name,
+            model_version=forecast_fetch.model_version,
+            raw_payload_json=forecast_fetch.raw_payload_json,
             mark_latest=True,
         )
     # PV calibration — fallback chain (best to worst):

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -852,12 +852,13 @@ def bulletproof_forecast_refresh_job() -> None:
         return
     try:
         from .. import db as _db
-        from ..weather import _forecast_delta, fetch_forecast
+        from ..weather import _forecast_delta, fetch_forecast_snapshot
 
         lookahead_h = int(config.MPC_FORECAST_DRIFT_LOOKAHEAD_HOURS)
         # Pull a forecast at least as long as the lookahead window we'll compare on,
         # but cap reasonable: Open-Meteo gives 48h easily.
-        new_fcst = fetch_forecast(hours=max(lookahead_h, 24))
+        forecast_fetch = fetch_forecast_snapshot(hours=max(lookahead_h, 24))
+        new_fcst = forecast_fetch.forecast
         if not new_fcst:
             logger.debug("forecast refresh: empty fetch, skipping")
             return
@@ -868,6 +869,7 @@ def bulletproof_forecast_refresh_job() -> None:
                 "temp_c": f.temperature_c,
                 "solar_w_m2": f.shortwave_radiation_wm2,
                 "cloud_cover_pct": f.cloud_cover_pct,
+                "direct_pv_kw": f.estimated_pv_kw if getattr(f, "pv_direct", False) else None,
             }
             for f in new_fcst
         ]
@@ -876,6 +878,10 @@ def bulletproof_forecast_refresh_job() -> None:
         _db.save_meteo_forecast_snapshot(
             now_utc.isoformat(),
             new_rows,
+            source=forecast_fetch.source,
+            model_name=forecast_fetch.model_name,
+            model_version=forecast_fetch.model_version,
+            raw_payload_json=forecast_fetch.raw_payload_json,
             mark_latest=True,
         )
 

--- a/src/weather.py
+++ b/src/weather.py
@@ -423,21 +423,44 @@ def _fetch_open_meteo_forecast(
     return result
 
 
+# Cached Auth0 access token + epoch second when it expires. We fetch a fresh
+# token slightly before the upstream ``expires_in`` mark so the next forecast
+# request never races a 401 from the API.
 _QUARTZ_TOKEN: str | None = None
+_QUARTZ_TOKEN_EXPIRES_AT: float = 0.0
+_QUARTZ_TOKEN_REFRESH_LEEWAY_SECONDS = 60
 
 
-def _quartz_token() -> str | None:
-    """Return a Quartz bearer token using configured Auth0 credentials."""
-    global _QUARTZ_TOKEN
-    if _QUARTZ_TOKEN:
+def _quartz_token(*, force_refresh: bool = False) -> str | None:
+    """Return a cached Quartz bearer token, refreshing when expired or forced.
+
+    Auth0 access tokens issued for the password grant typically expire after
+    24 h. The original implementation cached the token for the lifetime of
+    the process and silently 401'd thereafter. This version tracks
+    ``expires_in`` and re-authenticates when the token is within the leeway
+    window or explicitly forced (e.g. on a 401 from the forecast endpoint).
+    """
+    global _QUARTZ_TOKEN, _QUARTZ_TOKEN_EXPIRES_AT
+    import time as _time
+
+    if (
+        not force_refresh
+        and _QUARTZ_TOKEN
+        and (_QUARTZ_TOKEN_EXPIRES_AT - _QUARTZ_TOKEN_REFRESH_LEEWAY_SECONDS) > _time.time()
+    ):
         return _QUARTZ_TOKEN
+
     username = (getattr(config, "QUARTZ_USERNAME", "") or "").strip()
     password = getattr(config, "QUARTZ_PASSWORD", "") or ""
-    if not username or not password:
-        logger.warning("Quartz credentials are not configured")
+    client_id = (getattr(config, "QUARTZ_CLIENT_ID", "") or "").strip()
+    if not username or not password or not client_id:
+        logger.warning(
+            "Quartz credentials are not configured (need QUARTZ_USERNAME, "
+            "QUARTZ_PASSWORD, QUARTZ_CLIENT_ID)"
+        )
         return None
     body = {
-        "client_id": getattr(config, "QUARTZ_CLIENT_ID", ""),
+        "client_id": client_id,
         "audience": getattr(config, "QUARTZ_AUDIENCE", "https://api.nowcasting.io/"),
         "grant_type": "password",
         "username": username,
@@ -456,7 +479,14 @@ def _quartz_token() -> str | None:
         if not token:
             logger.warning("Quartz auth response did not include access_token")
             return None
+        try:
+            expires_in = float(payload.get("expires_in") or 0.0)
+        except (TypeError, ValueError):
+            expires_in = 0.0
         _QUARTZ_TOKEN = token
+        # Default to a one-hour TTL when the upstream omits ``expires_in`` so
+        # we still re-authenticate periodically rather than caching forever.
+        _QUARTZ_TOKEN_EXPIRES_AT = _time.time() + (expires_in if expires_in > 0 else 3600.0)
         return token
     except (urllib.error.URLError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
         logger.warning("Quartz auth failed: %s", e)
@@ -529,13 +559,28 @@ def _fetch_quartz_forecast(
         }
         model_name = getattr(config, "QUARTZ_MODEL_NAME", "blend")
     url = f"{base_url}{path}?{urllib.parse.urlencode(params)}"
-    try:
+
+    def _do_fetch(bearer: str) -> dict[str, Any] | list[Any]:
         req = urllib.request.Request(
             url,
-            headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
+            headers={"Accept": "application/json", "Authorization": f"Bearer {bearer}"},
         )
         with urllib.request.urlopen(req, timeout=20) as resp:
-            payload = json.loads(resp.read().decode())
+            return json.loads(resp.read().decode())
+
+    try:
+        try:
+            payload = _do_fetch(token)
+        except urllib.error.HTTPError as http_err:
+            # 401 → cached token expired; force a fresh auth and retry once.
+            if http_err.code == 401:
+                logger.info("Quartz forecast 401; refreshing access token")
+                token = _quartz_token(force_refresh=True)
+                if not token:
+                    return ForecastFetchResult(forecast=[], source="quartz")
+                payload = _do_fetch(token)
+            else:
+                raise
     except (urllib.error.URLError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
         logger.warning("Quartz forecast fetch failed: %s", e)
         return ForecastFetchResult(forecast=[], source="quartz")

--- a/src/weather.py
+++ b/src/weather.py
@@ -10,7 +10,9 @@ Forecast is used by the optimization solver to:
   - Skip grid battery charging when solar is expected to fill the battery
 """
 import json
+import logging
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -19,6 +21,8 @@ from typing import Any
 
 from .config import config, cop_at_temperature
 from .physics import apply_cop_lift_multiplier, get_lwt_base_c
+
+logger = logging.getLogger(__name__)
 
 # --------------------------------------------------------------------------
 # Historical (analytics only)
@@ -229,6 +233,18 @@ class HourlyForecast:
     shortwave_radiation_wm2: float  # W/m² surface global tilted irradiance
     estimated_pv_kw: float        # estimated PV generation for 4.5kWp system
     heating_demand_factor: float  # 0-1: how much heating is needed relative to base temp
+    pv_direct: bool = False       # True when provider supplies site PV directly.
+
+
+@dataclass
+class ForecastFetchResult:
+    """Forecast plus provider metadata for canonical snapshot persistence."""
+
+    forecast: list[HourlyForecast]
+    source: str
+    model_name: str | None = None
+    model_version: str | None = None
+    raw_payload_json: str | None = None
 
 
 # System constants for PV estimate (London W4 system)
@@ -253,6 +269,7 @@ def forecast_pv_kw_from_row(
     shortwave_radiation_wm2: float,
     cloud_cover_pct: float | None,
     *,
+    direct_pv_kw: float | None = None,
     cloud_table: dict[tuple[int, int], float] | None = None,
     hourly_table: dict[int, float] | None = None,
     flat: float = 1.0,
@@ -260,10 +277,27 @@ def forecast_pv_kw_from_row(
 ) -> float:
     """Apply the same PV forecast transform used by the LP and skill logger.
 
-    Cloud attenuation is applied to the irradiance, the result is converted
-    to kW via :func:`estimate_pv_kw`, and the calibration lookup follows the
-    same cloud → hour → flat fallback chain as ``forecast_to_lp_inputs``.
+    When the provider supplies direct PV (Quartz), use that value as the
+    base signal but still run it through the site calibration chain so a
+    consistent shading / orientation correction is applied regardless of
+    source. Otherwise cloud attenuation is applied to the irradiance before
+    the irradiance-to-kW conversion. Calibration lookup follows the same
+    cloud → hour → flat fallback chain as ``forecast_to_lp_inputs``.
     """
+    scale_f = max(0.0, float(scale))
+    if direct_pv_kw is not None:
+        try:
+            base_kw = max(0.0, float(direct_pv_kw))
+            cal = get_pv_calibration_factor_for(
+                int(hour_utc),
+                cloud_cover_pct,
+                cloud_table=cloud_table,
+                hourly_table=hourly_table,
+                flat=flat,
+            )
+            return base_kw * cal * scale_f
+        except (TypeError, ValueError):
+            pass
     cloud_pct_f = float(cloud_cover_pct) if cloud_cover_pct is not None else 50.0
     att = max(0.0, min(1.0, 1.0 - 0.25 * (cloud_pct_f / 100.0)))
     rad_eff = max(0.0, float(shortwave_radiation_wm2) * att)
@@ -274,7 +308,7 @@ def forecast_pv_kw_from_row(
         hourly_table=hourly_table,
         flat=flat,
     )
-    return estimate_pv_kw(rad_eff) * cal * max(0.0, float(scale))
+    return estimate_pv_kw(rad_eff) * cal * scale_f
 
 
 def compute_heating_demand_factor(
@@ -294,6 +328,35 @@ def compute_heating_demand_factor(
 
 
 def fetch_forecast(
+    lat: str | None = None,
+    lon: str | None = None,
+    hours: int = 48,
+) -> list[HourlyForecast]:
+    """Fetch forecast rows from the configured provider."""
+    return fetch_forecast_snapshot(lat=lat, lon=lon, hours=hours).forecast
+
+
+def fetch_forecast_snapshot(
+    lat: str | None = None,
+    lon: str | None = None,
+    hours: int = 48,
+) -> ForecastFetchResult:
+    """Fetch forecast rows plus source metadata for canonical persistence."""
+    source = (getattr(config, "FORECAST_SOURCE", "open_meteo") or "open_meteo").strip().lower()
+    if source in ("quartz", "quartz_solar"):
+        base = _fetch_open_meteo_forecast(lat=lat, lon=lon, hours=hours)
+        quartz = _fetch_quartz_forecast(hours=hours, base_weather=base)
+        if quartz.forecast:
+            return quartz
+        logger.warning("Quartz forecast unavailable; falling back to Open-Meteo")
+        return ForecastFetchResult(forecast=base, source="open-meteo")
+    return ForecastFetchResult(
+        forecast=_fetch_open_meteo_forecast(lat=lat, lon=lon, hours=hours),
+        source="open-meteo",
+    )
+
+
+def _fetch_open_meteo_forecast(
     lat: str | None = None,
     lon: str | None = None,
     hours: int = 48,
@@ -360,6 +423,194 @@ def fetch_forecast(
     return result
 
 
+_QUARTZ_TOKEN: str | None = None
+
+
+def _quartz_token() -> str | None:
+    """Return a Quartz bearer token using configured Auth0 credentials."""
+    global _QUARTZ_TOKEN
+    if _QUARTZ_TOKEN:
+        return _QUARTZ_TOKEN
+    username = (getattr(config, "QUARTZ_USERNAME", "") or "").strip()
+    password = getattr(config, "QUARTZ_PASSWORD", "") or ""
+    if not username or not password:
+        logger.warning("Quartz credentials are not configured")
+        return None
+    body = {
+        "client_id": getattr(config, "QUARTZ_CLIENT_ID", ""),
+        "audience": getattr(config, "QUARTZ_AUDIENCE", "https://api.nowcasting.io/"),
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+    }
+    try:
+        req = urllib.request.Request(
+            getattr(config, "QUARTZ_AUTH_URL", "https://nowcasting-pro.eu.auth0.com/oauth/token"),
+            data=json.dumps(body).encode(),
+            headers={"content-type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            payload = json.loads(resp.read().decode())
+        token = str(payload.get("access_token") or "")
+        if not token:
+            logger.warning("Quartz auth response did not include access_token")
+            return None
+        _QUARTZ_TOKEN = token
+        return token
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+        logger.warning("Quartz auth failed: %s", e)
+        return None
+
+
+def _quartz_site_kw(
+    row: dict[str, Any],
+    *,
+    installed_capacity_mw: float | None = None,
+) -> float | None:
+    normalized = row.get("expectedPowerGenerationNormalized")
+    if normalized is not None:
+        try:
+            frac = float(normalized)
+        except (TypeError, ValueError):
+            frac = 0.0
+        if frac > 1.0:
+            frac /= 100.0
+        return max(0.0, frac * float(config.PV_CAPACITY_KWP))
+
+    capacity_mw = (
+        float(installed_capacity_mw)
+        if installed_capacity_mw is not None and installed_capacity_mw > 0
+        else float(getattr(config, "QUARTZ_INSTALLED_CAPACITY_MW", 0.0) or 0.0)
+    )
+    if capacity_mw <= 0:
+        return None
+    try:
+        mw = float(row.get("expectedPowerGenerationMegawatts") or 0.0)
+    except (TypeError, ValueError):
+        return None
+    frac = mw / capacity_mw
+    return max(0.0, frac * float(config.PV_CAPACITY_KWP))
+
+
+def _fetch_quartz_forecast(
+    *,
+    hours: int,
+    base_weather: list[HourlyForecast],
+) -> ForecastFetchResult:
+    """Fetch hosted Quartz PV nowcast and merge it with weather context.
+
+    Hosted Quartz supplies PV generation, not temperature. Until site-level
+    Quartz is available here, Open-Meteo remains the temperature/cloud source.
+    """
+    token = _quartz_token()
+    if not token:
+        return ForecastFetchResult(forecast=[], source="quartz")
+
+    start = datetime.now(UTC).replace(second=0, microsecond=0)
+    end = start + timedelta(hours=max(1, hours))
+    gsp_id = (getattr(config, "QUARTZ_GSP_ID", "") or "").strip()
+    base_url = getattr(config, "QUARTZ_API_BASE_URL", "https://api.quartz.solar").rstrip("/")
+    if gsp_id:
+        path = f"/v0/solar/GB/gsp/{urllib.parse.quote(gsp_id)}/forecast"
+        params = {
+            "start_datetime_utc": start.isoformat().replace("+00:00", "Z"),
+            "end_datetime_utc": end.isoformat().replace("+00:00", "Z"),
+        }
+        model_name = None
+    else:
+        path = "/v0/solar/GB/national/forecast"
+        params = {
+            "start_datetime_utc": start.isoformat().replace("+00:00", "Z"),
+            "end_datetime_utc": end.isoformat().replace("+00:00", "Z"),
+            "include_metadata": "true",
+            "model_name": getattr(config, "QUARTZ_MODEL_NAME", "blend"),
+            "trend_adjuster_on": str(bool(getattr(config, "QUARTZ_TREND_ADJUSTER_ON", True))).lower(),
+        }
+        model_name = getattr(config, "QUARTZ_MODEL_NAME", "blend")
+    url = f"{base_url}{path}?{urllib.parse.urlencode(params)}"
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={"Accept": "application/json", "Authorization": f"Bearer {token}"},
+        )
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            payload = json.loads(resp.read().decode())
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+        logger.warning("Quartz forecast fetch failed: %s", e)
+        return ForecastFetchResult(forecast=[], source="quartz")
+
+    values: list[dict[str, Any]]
+    model_version = None
+    installed_capacity_mw: float | None = None
+    if isinstance(payload, dict):
+        values = list(payload.get("forecastValues") or [])
+        model = payload.get("model") or {}
+        model_name = str(model.get("name") or model_name or "quartz")
+        model_version = str(model.get("version") or "") or None
+        location = payload.get("location") or {}
+        try:
+            installed_capacity_mw = float(location.get("installedCapacityMw"))
+        except (AttributeError, TypeError, ValueError):
+            installed_capacity_mw = None
+    elif isinstance(payload, list):
+        values = list(payload)
+    else:
+        values = []
+
+    quartz_rows: list[HourlyForecast] = []
+    for row in values:
+        if not isinstance(row, dict):
+            continue
+        site_kw = _quartz_site_kw(row, installed_capacity_mw=installed_capacity_mw)
+        if site_kw is None:
+            continue
+        try:
+            target = datetime.fromisoformat(str(row["targetTime"]).replace("Z", "+00:00"))
+        except (KeyError, TypeError, ValueError):
+            continue
+        if target.tzinfo is None:
+            target = target.replace(tzinfo=UTC)
+        # Quartz targetTime is the period end. Use the period start so it lines
+        # up with our half-hour slot starts.
+        slot_time = target - timedelta(minutes=30)
+        weather_row = get_forecast_for_slot(slot_time, base_weather)
+        temp_c = weather_row.temperature_c if weather_row else 10.0
+        cloud_pct = weather_row.cloud_cover_pct if weather_row else 50.0
+        equivalent_rad = site_kw / max(0.001, float(config.PV_CAPACITY_KWP) * float(config.PV_SYSTEM_EFFICIENCY)) * 1000.0
+        quartz_rows.append(
+            HourlyForecast(
+                time_utc=slot_time,
+                temperature_c=temp_c,
+                cloud_cover_pct=cloud_pct,
+                shortwave_radiation_wm2=max(0.0, equivalent_rad),
+                estimated_pv_kw=site_kw,
+                heating_demand_factor=compute_heating_demand_factor(temp_c),
+                pv_direct=True,
+            )
+        )
+
+    if not quartz_rows:
+        return ForecastFetchResult(forecast=[], source="quartz", raw_payload_json=json.dumps(payload))
+
+    quartz_by_time = {f.time_utc: f for f in quartz_rows}
+    first_q = min(quartz_by_time)
+    last_q = max(quartz_by_time)
+    merged = list(quartz_rows)
+    for f in base_weather:
+        if first_q <= f.time_utc <= last_q:
+            continue
+        merged.append(f)
+    merged.sort(key=lambda f: f.time_utc)
+    return ForecastFetchResult(
+        forecast=merged[: max(hours, len(quartz_rows))],
+        source="quartz",
+        model_name=model_name or ("quartz-gsp" if gsp_id else "quartz-national"),
+        model_version=model_version,
+        raw_payload_json=json.dumps(payload, separators=(",", ":")),
+    )
+
+
 def _forecast_delta(
     prev_rows: list[dict[str, Any]],
     new_rows: list[dict[str, Any]],
@@ -411,8 +662,18 @@ def _forecast_delta(
         p = prev_idx[slot]
         n = new_idx[slot]
         try:
-            prev_pv = estimate_pv_kw(float(p.get("solar_w_m2") or 0.0))
-            new_pv = estimate_pv_kw(float(n.get("solar_w_m2") or 0.0))
+            prev_pv = forecast_pv_kw_from_row(
+                slot.hour,
+                float(p.get("solar_w_m2") or 0.0),
+                p.get("cloud_cover_pct"),
+                direct_pv_kw=p.get("direct_pv_kw"),
+            )
+            new_pv = forecast_pv_kw_from_row(
+                slot.hour,
+                float(n.get("solar_w_m2") or 0.0),
+                n.get("cloud_cover_pct"),
+                direct_pv_kw=n.get("direct_pv_kw"),
+            )
             delta_pv_kwh_total += abs(new_pv - prev_pv)  # 1h slot → kW * 1h = kWh
         except (ValueError, TypeError):
             pass
@@ -704,6 +965,9 @@ def compute_today_pv_correction_factor(
         forecast_rows = _db.get_meteo_forecast(today)
     except Exception:  # noqa: BLE001
         forecast_rows = []
+    cal_cloud = _db.get_pv_calibration_hourly_cloud()
+    cal_hour = _db.get_pv_calibration_hourly()
+    flat_cal = compute_pv_calibration_factor() if not cal_cloud and not cal_hour else 1.0
     forecast_per_hour: dict[int, float] = {}
     for r in forecast_rows:
         try:
@@ -712,9 +976,15 @@ def compute_today_pv_correction_factor(
                 ts = ts.replace(tzinfo=UTC)
             if ts.date().isoformat() != today:
                 continue
-            rad = float(r.get("solar_w_m2") or 0.0)
-            # Forecast row is hour-anchored; estimate_pv_kw × 1h = kWh per hour
-            forecast_per_hour[ts.hour] = forecast_per_hour.get(ts.hour, 0.0) + estimate_pv_kw(rad)
+            forecast_per_hour[ts.hour] = forecast_per_hour.get(ts.hour, 0.0) + forecast_pv_kw_from_row(
+                ts.hour,
+                float(r.get("solar_w_m2") or 0.0),
+                r.get("cloud_cover_pct"),
+                direct_pv_kw=r.get("direct_pv_kw"),
+                cloud_table=cal_cloud,
+                hourly_table=cal_hour,
+                flat=flat_cal,
+            )
         except (ValueError, TypeError, KeyError):
             continue
 
@@ -1000,6 +1270,7 @@ def evaluate_pv_forecast_accuracy(
     actual_kw_samples: dict[tuple[str, int], list[float]] = defaultdict(list)
     forecast_radiation: dict[tuple[str, int], float] = {}
     forecast_cloud: dict[tuple[str, int], float | None] = {}
+    forecast_direct_pv: dict[tuple[str, int], float | None] = {}
 
     with _db._lock:
         conn = _db.get_connection()
@@ -1037,6 +1308,9 @@ def evaluate_pv_forecast_accuracy(
             key = (ts.date().isoformat(), ts.hour)
             forecast_radiation[key] = float(r.get("solar_w_m2") or 0.0)
             forecast_cloud[key] = float(r.get("cloud_cover_pct")) if r.get("cloud_cover_pct") is not None else None
+            forecast_direct_pv[key] = (
+                float(r.get("direct_pv_kw")) if r.get("direct_pv_kw") is not None else None
+            )
         current_day += _td(days=1)
 
     # Build paired (predicted_kw, actual_kw) tuples
@@ -1052,6 +1326,7 @@ def evaluate_pv_forecast_accuracy(
         cal = get_pv_calibration_factor_for(
             key[1],
             forecast_cloud.get(key),
+            direct_pv_kw=forecast_direct_pv.get(key),
             cloud_table=cal_cloud,
             hourly_table=cal_hourly,
             flat=flat_cal,
@@ -1145,20 +1420,27 @@ def forecast_to_lp_inputs(
         temp_c = _interp_hourly_scalar(forecast, st, "temperature_c", 10.0)
         rad_wm2 = _interp_hourly_scalar(forecast, st, "shortwave_radiation_wm2", 0.0)
         cloud_pct = _interp_hourly_scalar(forecast, st, "cloud_cover_pct", 50.0)
-        # Cloud attenuation on top of API irradiance
-        att = max(0.0, min(1.0, 1.0 - 0.25 * (cloud_pct / 100.0)))
-        rad_eff = max(0.0, rad_wm2 * att)
-        kw_ac = estimate_pv_kw(rad_eff, capacity_kwp=cap, efficiency=eff)
-        # Resolve the per-slot scale factor.
-        if callable(pv_scale):
-            try:
-                scale_for_slot = float(pv_scale(st.hour, cloud_pct))
-            except Exception:
-                scale_for_slot = 1.0
-        elif isinstance(pv_scale, dict):
-            scale_for_slot = pv_scale.get(st.hour, pv_scale_fallback)
+        nearest = get_forecast_for_slot(st, forecast)
+        direct_pv = bool(nearest and nearest.pv_direct)
+        if direct_pv:
+            rad_eff = max(0.0, rad_wm2)
+            kw_ac = max(0.0, _interp_hourly_scalar(forecast, st, "estimated_pv_kw", 0.0))
+            scale_for_slot = 1.0
         else:
-            scale_for_slot = float(pv_scale)
+            # Cloud attenuation on top of API irradiance.
+            att = max(0.0, min(1.0, 1.0 - 0.25 * (cloud_pct / 100.0)))
+            rad_eff = max(0.0, rad_wm2 * att)
+            kw_ac = estimate_pv_kw(rad_eff, capacity_kwp=cap, efficiency=eff)
+            # Resolve the per-slot scale factor.
+            if callable(pv_scale):
+                try:
+                    scale_for_slot = float(pv_scale(st.hour, cloud_pct))
+                except Exception:
+                    scale_for_slot = 1.0
+            elif isinstance(pv_scale, dict):
+                scale_for_slot = pv_scale.get(st.hour, pv_scale_fallback)
+            else:
+                scale_for_slot = float(pv_scale)
         # Apply calibration scale and enforce per-hour physical ceiling
         slot_ceil = hourly_ceil.get(st.hour, cap * eff * 0.5)
         pv_kwh = min(slot_ceil, max(0.0, kw_ac * 0.5 * scale_for_slot))

--- a/src/weather.py
+++ b/src/weather.py
@@ -1106,12 +1106,25 @@ def get_pv_calibration_factor_for(
 
     Pass pre-fetched tables to avoid hitting the DB inside per-slot loops.
     """
+    import sqlite3
+
     from . import db as _db
 
+    # Tolerate missing DB tables. ``forecast_pv_kw_from_row`` is called from
+    # pure-function unit tests that don't run ``init_db()``, and from a
+    # cold-start window in prod between schema-create and the first
+    # calibration recompute. Either way the right behaviour is to fall back
+    # to ``flat`` rather than crash.
     if cloud_table is None:
-        cloud_table = _db.get_pv_calibration_hourly_cloud()
+        try:
+            cloud_table = _db.get_pv_calibration_hourly_cloud()
+        except sqlite3.OperationalError:
+            cloud_table = {}
     if hourly_table is None:
-        hourly_table = _db.get_pv_calibration_hourly()
+        try:
+            hourly_table = _db.get_pv_calibration_hourly()
+        except sqlite3.OperationalError:
+            hourly_table = {}
 
     bucket = cloud_bucket(cloud_cover_pct)
     if cloud_table:
@@ -1368,15 +1381,15 @@ def evaluate_pv_forecast_accuracy(
         rad = forecast_radiation.get(key)
         if rad is None:
             continue
-        cal = get_pv_calibration_factor_for(
+        predicted_kw = forecast_pv_kw_from_row(
             key[1],
+            rad,
             forecast_cloud.get(key),
             direct_pv_kw=forecast_direct_pv.get(key),
             cloud_table=cal_cloud,
             hourly_table=cal_hourly,
             flat=flat_cal,
         )
-        predicted_kw = estimate_pv_kw(rad) * cal
         if predicted_kw < min_kw and actual_kw < min_kw:
             continue                      # both negligible — skip dawn/dusk
         pairs_per_hour[key[1]].append((predicted_kw, actual_kw))
@@ -1450,11 +1463,24 @@ def forecast_to_lp_inputs(
     dhw_pen = float(config.COP_DHW_PENALTY)
     cap = float(config.PV_CAPACITY_KWP)
     eff = float(config.PV_SYSTEM_EFFICIENCY)
+    import sqlite3
+
     from . import db as _db
 
-    cal_cloud = _db.get_pv_calibration_hourly_cloud()
-    cal_hourly = _db.get_pv_calibration_hourly()
-    flat_cal = compute_pv_calibration_factor() if not cal_cloud and not cal_hourly else 1.0
+    # Same DB-tolerance shape as ``get_pv_calibration_factor_for`` — pure
+    # callers may invoke this without ever running ``init_db()``.
+    try:
+        cal_cloud = _db.get_pv_calibration_hourly_cloud()
+    except sqlite3.OperationalError:
+        cal_cloud = {}
+    try:
+        cal_hourly = _db.get_pv_calibration_hourly()
+    except sqlite3.OperationalError:
+        cal_hourly = {}
+    try:
+        flat_cal = compute_pv_calibration_factor() if not cal_cloud and not cal_hourly else 1.0
+    except sqlite3.OperationalError:
+        flat_cal = 1.0
 
     # PV scale: explicit arg > config override > 1.0. Accept float OR per-hour dict.
     if pv_scale is None:

--- a/src/weather.py
+++ b/src/weather.py
@@ -277,12 +277,12 @@ def forecast_pv_kw_from_row(
 ) -> float:
     """Apply the same PV forecast transform used by the LP and skill logger.
 
-    When the provider supplies direct PV (Quartz), use that value as the
-    base signal but still run it through the site calibration chain so a
-    consistent shading / orientation correction is applied regardless of
-    source. Otherwise cloud attenuation is applied to the irradiance before
-    the irradiance-to-kW conversion. Calibration lookup follows the same
-    cloud → hour → flat fallback chain as ``forecast_to_lp_inputs``.
+    When the provider supplies direct PV (Quartz), use that as the base signal
+    but still apply the same site calibration chain so Quartz can be corrected
+    for local shading / orientation bias. Otherwise cloud attenuation is
+    applied before the irradiance-to-kW conversion and the calibration lookup
+    follows the same cloud → hour → flat fallback chain as
+    ``forecast_to_lp_inputs``.
     """
     scale_f = max(0.0, float(scale))
     if direct_pv_kw is not None:
@@ -1378,7 +1378,10 @@ def forecast_to_lp_inputs(
     """Build per-slot outdoor temperature, irradiance, PV kWh/slot, and COP arrays for the MILP.
 
     PV uses :func:`estimate_pv_kw` with ``PV_CAPACITY_KWP`` and ``PV_SYSTEM_EFFICIENCY``,
-    scaled by ``pv_scale``:
+    scaled by ``pv_scale`` and corrected through the site calibration tables.
+    Quartz direct PV follows the same calibration chain so the solver still
+    sees local shading/orientation bias instead of raw vendor output.
+    ``pv_scale`` can be:
       - ``float``: single multiplier applied to every slot (legacy behaviour).
       - ``dict[int, float]``: per-hour-of-day UTC factor (richer calibration that
         captures shading / sun-angle bias). Missing hours fall back to the median
@@ -1402,6 +1405,11 @@ def forecast_to_lp_inputs(
     dhw_pen = float(config.COP_DHW_PENALTY)
     cap = float(config.PV_CAPACITY_KWP)
     eff = float(config.PV_SYSTEM_EFFICIENCY)
+    from . import db as _db
+
+    cal_cloud = _db.get_pv_calibration_hourly_cloud()
+    cal_hourly = _db.get_pv_calibration_hourly()
+    flat_cal = compute_pv_calibration_factor() if not cal_cloud and not cal_hourly else 1.0
 
     # PV scale: explicit arg > config override > 1.0. Accept float OR per-hour dict.
     if pv_scale is None:
@@ -1424,26 +1432,35 @@ def forecast_to_lp_inputs(
         direct_pv = bool(nearest and nearest.pv_direct)
         if direct_pv:
             rad_eff = max(0.0, rad_wm2)
-            kw_ac = max(0.0, _interp_hourly_scalar(forecast, st, "estimated_pv_kw", 0.0))
-            scale_for_slot = 1.0
         else:
             # Cloud attenuation on top of API irradiance.
             att = max(0.0, min(1.0, 1.0 - 0.25 * (cloud_pct / 100.0)))
             rad_eff = max(0.0, rad_wm2 * att)
-            kw_ac = estimate_pv_kw(rad_eff, capacity_kwp=cap, efficiency=eff)
-            # Resolve the per-slot scale factor.
-            if callable(pv_scale):
-                try:
-                    scale_for_slot = float(pv_scale(st.hour, cloud_pct))
-                except Exception:
-                    scale_for_slot = 1.0
-            elif isinstance(pv_scale, dict):
-                scale_for_slot = pv_scale.get(st.hour, pv_scale_fallback)
-            else:
-                scale_for_slot = float(pv_scale)
+        if callable(pv_scale):
+            try:
+                scale_for_slot = float(pv_scale(st.hour, cloud_pct))
+            except Exception:
+                scale_for_slot = 1.0
+        elif isinstance(pv_scale, dict):
+            scale_for_slot = pv_scale.get(st.hour, pv_scale_fallback)
+        else:
+            scale_for_slot = float(pv_scale)
+        # The provider-specific PV signal can still be locally corrected: Quartz
+        # direct PV is site-level, but it still benefits from the same calibration
+        # chain that the irradiance-based path uses.
+        kw_ac = forecast_pv_kw_from_row(
+            st.hour,
+            rad_wm2,
+            cloud_pct,
+            direct_pv_kw=_interp_hourly_scalar(forecast, st, "estimated_pv_kw", 0.0) if direct_pv else None,
+            cloud_table=cal_cloud,
+            hourly_table=cal_hourly,
+            flat=flat_cal,
+            scale=scale_for_slot,
+        )
         # Apply calibration scale and enforce per-hour physical ceiling
         slot_ceil = hourly_ceil.get(st.hour, cap * eff * 0.5)
-        pv_kwh = min(slot_ceil, max(0.0, kw_ac * 0.5 * scale_for_slot))
+        pv_kwh = min(slot_ceil, max(0.0, kw_ac * 0.5))
         base_cop = max(1.0, cop_at_temperature(curve, temp_c))
         cop_s = base_cop
         lift_pen = float(getattr(config, "LP_COP_LIFT_PENALTY_PER_KELVIN", 0.0))

--- a/tests/test_db_snapshots.py
+++ b/tests/test_db_snapshots.py
@@ -86,7 +86,8 @@ def test_meteo_forecast_snapshot_has_expected_columns():
 def test_meteo_forecast_value_has_expected_columns():
     cols = _columns("meteo_forecast_value")
     for expected in (
-        "id", "forecast_fetch_at_utc", "slot_time", "temp_c", "solar_w_m2", "cloud_cover_pct",
+        "id", "forecast_fetch_at_utc", "slot_time", "temp_c", "solar_w_m2",
+        "cloud_cover_pct", "direct_pv_kw",
     ):
         assert expected in cols, f"missing column {expected}"
 

--- a/tests/test_mpc_event_triggers.py
+++ b/tests/test_mpc_event_triggers.py
@@ -304,10 +304,12 @@ def test_forecast_delta_ignores_slots_outside_lookahead():
 def test_forecast_refresh_job_persists_even_when_disabled(monkeypatch):
     """Kill switch off: still saves to history (audit trail) but never triggers MPC."""
     from src.scheduler import runner
+    from src.weather import ForecastFetchResult
 
     monkeypatch.setattr(runner.config, "MPC_EVENT_DRIVEN_ENABLED", False)
     base = datetime.now(UTC)
     fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.0, shortwave_radiation_wm2=100.0) for i in range(6)]
+    fake_fetch = ForecastFetchResult(forecast=fake_fcst, source="open-meteo")
 
     saved_snapshots: list[tuple[str, list, bool]] = []
 
@@ -316,7 +318,7 @@ def test_forecast_refresh_job_persists_even_when_disabled(monkeypatch):
 
     triggered = MagicMock(side_effect=AssertionError("MPC must not be triggered when kill switch is off"))
 
-    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+    with patch("src.weather.fetch_forecast_snapshot", return_value=fake_fetch), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=[{"slot_time": (base + timedelta(hours=0)).isoformat(), "solar_w_m2": 50.0, "temp_c": 10.0}]), \
          patch("src.db.save_meteo_forecast_snapshot", side_effect=_save_snapshot), \
          patch.object(runner, "bulletproof_mpc_job", triggered):
@@ -330,12 +332,14 @@ def test_forecast_refresh_job_persists_even_when_disabled(monkeypatch):
 def test_forecast_refresh_job_no_trigger_without_previous_fetch(monkeypatch):
     """First-ever invocation has no prev — must persist but never trigger."""
     from src.scheduler import runner
+    from src.weather import ForecastFetchResult
 
     base = datetime.now(UTC)
     fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.0, shortwave_radiation_wm2=100.0) for i in range(6)]
+    fake_fetch = ForecastFetchResult(forecast=fake_fcst, source="open-meteo")
     triggered = MagicMock(side_effect=AssertionError("first-ever call must not trigger"))
 
-    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+    with patch("src.weather.fetch_forecast_snapshot", return_value=fake_fetch), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=[]), \
          patch("src.db.save_meteo_forecast_snapshot"), \
          patch.object(runner, "bulletproof_mpc_job", triggered):
@@ -346,12 +350,14 @@ def test_forecast_refresh_job_no_trigger_without_previous_fetch(monkeypatch):
 
 def test_forecast_refresh_job_triggers_when_solar_delta_exceeds_threshold(monkeypatch):
     from src.scheduler import runner
+    from src.weather import ForecastFetchResult
 
     monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_SOLAR_KWH_THRESHOLD", 0.5)
     monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_LOOKAHEAD_HOURS", 6)
     base = datetime.now(UTC)
     # New forecast: much sunnier than the previous fetch — should cross the 0.5 kWh threshold easily.
     fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.0, shortwave_radiation_wm2=600.0) for i in range(6)]
+    fake_fetch = ForecastFetchResult(forecast=fake_fcst, source="open-meteo")
     prev_rows = [{"slot_time": (base + timedelta(hours=i)).isoformat(), "solar_w_m2": 50.0, "temp_c": 10.0} for i in range(6)]
 
     captured: dict = {}
@@ -359,7 +365,7 @@ def test_forecast_refresh_job_triggers_when_solar_delta_exceeds_threshold(monkey
     def _capture(**kwargs):
         captured.update(kwargs)
 
-    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+    with patch("src.weather.fetch_forecast_snapshot", return_value=fake_fetch), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=prev_rows), \
          patch("src.db.save_meteo_forecast_snapshot"), \
          patch.object(runner, "bulletproof_mpc_job", _capture):
@@ -370,15 +376,17 @@ def test_forecast_refresh_job_triggers_when_solar_delta_exceeds_threshold(monkey
 
 def test_forecast_refresh_job_no_trigger_when_within_thresholds(monkeypatch):
     from src.scheduler import runner
+    from src.weather import ForecastFetchResult
 
     monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_SOLAR_KWH_THRESHOLD", 100.0)  # huge threshold
     monkeypatch.setattr(runner.config, "MPC_FORECAST_DRIFT_TEMP_C_THRESHOLD", 100.0)
     base = datetime.now(UTC)
     fake_fcst = [MagicMock(time_utc=base + timedelta(hours=i), temperature_c=10.5, shortwave_radiation_wm2=110.0) for i in range(6)]
+    fake_fetch = ForecastFetchResult(forecast=fake_fcst, source="open-meteo")
     prev_rows = [{"slot_time": (base + timedelta(hours=i)).isoformat(), "solar_w_m2": 100.0, "temp_c": 10.0} for i in range(6)]
 
     triggered = MagicMock(side_effect=AssertionError("must not trigger when delta is within thresholds"))
-    with patch("src.weather.fetch_forecast", return_value=fake_fcst), \
+    with patch("src.weather.fetch_forecast_snapshot", return_value=fake_fetch), \
          patch("src.db.get_meteo_forecast_history_latest_before", return_value=prev_rows), \
          patch("src.db.save_meteo_forecast_snapshot"), \
          patch.object(runner, "bulletproof_mpc_job", triggered):

--- a/tests/test_mpc_event_triggers.py
+++ b/tests/test_mpc_event_triggers.py
@@ -250,6 +250,10 @@ def _make_forecast_rows(base_utc: datetime, *, count: int, solar_w_m2: float, te
             "slot_time": (base_utc + timedelta(hours=i)).isoformat(),
             "temp_c": temp_c,
             "solar_w_m2": solar_w_m2,
+            # Pin cloud cover to 0 so ``forecast_pv_kw_from_row`` does not
+            # apply its default 50% attenuation against the synthetic
+            # irradiance values these delta tests reason about.
+            "cloud_cover_pct": 0.0,
         }
         for i in range(count)
     ]

--- a/tests/test_pv_cloud_aware_calibration.py
+++ b/tests/test_pv_cloud_aware_calibration.py
@@ -121,6 +121,24 @@ def test_forecast_to_lp_inputs_callable_zero_factor_zeros_pv() -> None:
     assert out.pv_kwh_per_slot[0] == 0.0
 
 
+def test_direct_pv_path_still_uses_calibration_tables() -> None:
+    """Quartz direct PV should still be corrected by the site calibration tables."""
+    from src.weather import forecast_pv_kw_from_row
+
+    cloud = {(12, 1): 0.50}
+    hourly = {12: 0.75}
+    pv = forecast_pv_kw_from_row(
+        12,
+        0.0,
+        40.0,
+        direct_pv_kw=2.0,
+        cloud_table=cloud,
+        hourly_table=hourly,
+        flat=1.0,
+    )
+    assert pv == pytest.approx(1.0)
+
+
 def test_forecast_to_lp_inputs_callable_exception_falls_back_safely() -> None:
     """If callable raises, slot scale falls back to 1.0 (no crash)."""
     base = datetime(2026, 5, 2, 12, 0, tzinfo=UTC)

--- a/tests/test_pv_forecast_accuracy.py
+++ b/tests/test_pv_forecast_accuracy.py
@@ -38,7 +38,7 @@ def _seed_day_with_samples(d: date, hour_kw: dict[int, float],
     rows = []
     for h, irr in forecast_irr.items():
         ts = datetime.combine(d, datetime.min.time()).replace(hour=h, tzinfo=UTC)
-        rows.append({"slot_time": ts.isoformat(), "temp_c": 15.0, "solar_w_m2": irr})
+        rows.append({"slot_time": ts.isoformat(), "temp_c": 15.0, "solar_w_m2": irr, "cloud_cover_pct": 0.0})
     db.save_meteo_forecast(rows, d.isoformat())
 
 

--- a/tests/test_pv_today_aware_calibration.py
+++ b/tests/test_pv_today_aware_calibration.py
@@ -52,7 +52,16 @@ def _seed_forecast(hour_utc: int, irradiance_wm2: float) -> None:
         hour=hour_utc, tzinfo=UTC,
     )
     db.save_meteo_forecast(
-        [{"slot_time": ts.isoformat(), "temp_c": 15.0, "solar_w_m2": irradiance_wm2}],
+        [{
+            "slot_time": ts.isoformat(),
+            "temp_c": 15.0,
+            "solar_w_m2": irradiance_wm2,
+            # Pin cloud cover so ``forecast_pv_kw_from_row`` does not apply
+            # the default 50% attenuation the new transform uses when
+            # cloud_cover_pct is absent — these tests reason about the raw
+            # irradiance → kW conversion.
+            "cloud_cover_pct": 0.0,
+        }],
         today.isoformat(),
     )
 

--- a/tests/test_quartz_forecast.py
+++ b/tests/test_quartz_forecast.py
@@ -82,8 +82,10 @@ def test_quartz_fetch_merges_direct_pv_with_open_meteo_weather(monkeypatch: pyte
     assert result.raw_payload_json
 
 
-def test_direct_pv_skips_open_meteo_calibration_scale() -> None:
+def test_direct_pv_uses_site_calibration_scale() -> None:
     from src.weather import HourlyForecast, forecast_to_lp_inputs
+
+    db.upsert_pv_calibration_hourly({12: 0.5}, {12: 8}, window_days=30)
 
     slot = datetime(2026, 5, 5, 12, 0, tzinfo=UTC)
     forecast = [
@@ -98,9 +100,9 @@ def test_direct_pv_skips_open_meteo_calibration_scale() -> None:
         )
     ]
 
-    series = forecast_to_lp_inputs(forecast, [slot], pv_scale=0.0)
+    series = forecast_to_lp_inputs(forecast, [slot], pv_scale=1.0)
 
-    assert series.pv_kwh_per_slot == pytest.approx([1.0])
+    assert series.pv_kwh_per_slot == pytest.approx([0.5])
 
 
 def test_quartz_national_metadata_capacity_can_downscale_site_kw(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_quartz_forecast.py
+++ b/tests/test_quartz_forecast.py
@@ -66,6 +66,7 @@ def test_quartz_fetch_merges_direct_pv_with_open_meteo_weather(monkeypatch: pyte
     monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_CLIENT_ID", "test-client-id", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_GSP_ID", "42", raising=False)
     monkeypatch.setattr(weather, "_QUARTZ_TOKEN", None)
     monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
@@ -141,6 +142,7 @@ def test_quartz_national_metadata_capacity_can_downscale_site_kw(monkeypatch: py
     monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_CLIENT_ID", "test-client-id", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_GSP_ID", "", raising=False)
     monkeypatch.setattr(weather, "_QUARTZ_TOKEN", None)
     monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
@@ -173,3 +175,53 @@ def test_direct_pv_round_trips_through_canonical_snapshot() -> None:
     rows = db.get_meteo_forecast_at(fetched_at)
 
     assert rows[0]["direct_pv_kw"] == pytest.approx(1.7)
+
+
+def test_quartz_token_skips_when_client_id_empty(monkeypatch):
+    """Empty ``QUARTZ_CLIENT_ID`` ⇒ no auth attempt; falls back gracefully.
+
+    The vendor-issued client_id is sensitive and must not be hardcoded into
+    the repo, so the default is empty. Without it, the adapter must not
+    attempt the Auth0 round-trip — it should log and return ``None``.
+    """
+    from src import weather
+
+    monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_CLIENT_ID", "", raising=False)
+    monkeypatch.setattr(weather, "_QUARTZ_TOKEN", None)
+    monkeypatch.setattr(weather, "_QUARTZ_TOKEN_EXPIRES_AT", 0.0)
+
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError("urlopen called even though QUARTZ_CLIENT_ID is empty")
+
+    monkeypatch.setattr(weather.urllib.request, "urlopen", _should_not_be_called)
+    assert weather._quartz_token() is None
+
+
+def test_quartz_token_refreshes_after_expiry(monkeypatch):
+    """An expired cached token forces a fresh Auth0 round-trip on next call."""
+    from src import weather
+
+    monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_CLIENT_ID", "test-client-id", raising=False)
+    monkeypatch.setattr(weather, "_QUARTZ_TOKEN", "stale-token")
+    monkeypatch.setattr(weather, "_QUARTZ_TOKEN_EXPIRES_AT", 0.0)
+
+    calls = {"n": 0}
+
+    class _Resp:
+        def __init__(self, payload): self._payload = json.dumps(payload).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return self._payload
+
+    def _fake_urlopen(req, *_a, **_kw):
+        calls["n"] += 1
+        return _Resp({"access_token": "fresh-token", "expires_in": 3600})
+
+    monkeypatch.setattr(weather.urllib.request, "urlopen", _fake_urlopen)
+    token = weather._quartz_token()
+    assert token == "fresh-token"
+    assert calls["n"] == 1, "expected one auth round-trip when cache is stale"

--- a/tests/test_quartz_forecast.py
+++ b/tests/test_quartz_forecast.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+class _Resp:
+    def __init__(self, payload: dict[str, Any] | list[dict[str, Any]]):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+
+
+def test_quartz_fetch_merges_direct_pv_with_open_meteo_weather(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src import weather
+
+    base = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    open_meteo_payload = {
+        "hourly": {
+            "time": [(base + timedelta(hours=i)).isoformat().replace("+00:00", "") for i in range(4)],
+            "temperature_2m": [11.0, 12.0, 13.0, 14.0],
+            "cloud_cover": [80.0, 70.0, 60.0, 50.0],
+            "shortwave_radiation_instant": [100.0, 200.0, 300.0, 400.0],
+        }
+    }
+    quartz_target = base + timedelta(minutes=30)
+    quartz_payload = [
+        {
+            "targetTime": quartz_target.isoformat().replace("+00:00", "Z"),
+            "expectedPowerGenerationMegawatts": 10.0,
+            "expectedPowerGenerationNormalized": 0.5,
+        }
+    ]
+
+    def fake_urlopen(req, timeout=0):  # noqa: ANN001
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if "api.open-meteo.com" in url:
+            return _Resp(open_meteo_payload)
+        if "oauth/token" in url:
+            return _Resp({"access_token": "token"})
+        if "/v0/solar/GB/" in url:
+            return _Resp(quartz_payload)
+        raise AssertionError(f"unexpected url {url}")
+
+    monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_GSP_ID", "42", raising=False)
+    monkeypatch.setattr(weather, "_QUARTZ_TOKEN", None)
+    monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
+
+    result = weather.fetch_forecast_snapshot(hours=4)
+
+    direct = [f for f in result.forecast if f.pv_direct]
+    assert result.source == "quartz"
+    assert len(direct) == 1
+    assert direct[0].time_utc == base
+    assert direct[0].estimated_pv_kw == pytest.approx(2.25)
+    assert direct[0].temperature_c == pytest.approx(11.0)
+    assert direct[0].cloud_cover_pct == pytest.approx(80.0)
+    assert result.raw_payload_json
+
+
+def test_direct_pv_skips_open_meteo_calibration_scale() -> None:
+    from src.weather import HourlyForecast, forecast_to_lp_inputs
+
+    slot = datetime(2026, 5, 5, 12, 0, tzinfo=UTC)
+    forecast = [
+        HourlyForecast(
+            time_utc=slot,
+            temperature_c=12.0,
+            cloud_cover_pct=100.0,
+            shortwave_radiation_wm2=0.0,
+            estimated_pv_kw=2.0,
+            heating_demand_factor=0.0,
+            pv_direct=True,
+        )
+    ]
+
+    series = forecast_to_lp_inputs(forecast, [slot], pv_scale=0.0)
+
+    assert series.pv_kwh_per_slot == pytest.approx([1.0])
+
+
+def test_quartz_national_metadata_capacity_can_downscale_site_kw(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src import weather
+
+    base = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    open_meteo_payload = {
+        "hourly": {
+            "time": [base.isoformat().replace("+00:00", "")],
+            "temperature_2m": [11.0],
+            "cloud_cover": [50.0],
+            "shortwave_radiation_instant": [100.0],
+        }
+    }
+    quartz_payload = {
+        "location": {"label": "national", "installedCapacityMw": 1000.0},
+        "model": {"name": "blend_adjust", "version": "1.3.0"},
+        "forecastValues": [
+            {
+                "targetTime": (base + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+                "expectedPowerGenerationMegawatts": 500.0,
+            }
+        ],
+    }
+
+    def fake_urlopen(req, timeout=0):  # noqa: ANN001
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if "api.open-meteo.com" in url:
+            return _Resp(open_meteo_payload)
+        if "oauth/token" in url:
+            return _Resp({"access_token": "token"})
+        if "/v0/solar/GB/" in url:
+            return _Resp(quartz_payload)
+        raise AssertionError(f"unexpected url {url}")
+
+    monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_GSP_ID", "", raising=False)
+    monkeypatch.setattr(weather, "_QUARTZ_TOKEN", None)
+    monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
+
+    result = weather.fetch_forecast_snapshot(hours=2)
+
+    direct = [f for f in result.forecast if f.pv_direct]
+    assert result.model_name == "blend_adjust"
+    assert direct[0].estimated_pv_kw == pytest.approx(2.25)
+
+
+def test_direct_pv_round_trips_through_canonical_snapshot() -> None:
+    fetched_at = "2026-05-05T10:00:00+00:00"
+    db.save_meteo_forecast_snapshot(
+        fetched_at,
+        [
+            {
+                "slot_time": "2026-05-05T12:00:00+00:00",
+                "temp_c": 12.0,
+                "solar_w_m2": 0.0,
+                "cloud_cover_pct": 90.0,
+                "direct_pv_kw": 1.7,
+            }
+        ],
+        source="quartz",
+        model_name="quartz-gsp",
+        raw_payload_json='{"ok":true}',
+    )
+
+    rows = db.get_meteo_forecast_at(fetched_at)
+
+    assert rows[0]["direct_pv_kw"] == pytest.approx(1.7)


### PR DESCRIPTION
## Summary

Slice 4/5 of the PR #245 split. Adds Quartz Solar (Open Climate Fix)
as a first-class forecast source for PV. The temperature/cloud signal
still comes from Open-Meteo because the hosted Quartz endpoint
provides PV directly, not the full weather state.

API docs: https://api.quartz.solar/docs

### What ships

- **Provider switch**: `FORECAST_SOURCE=open_meteo|quartz` (default
  `open_meteo`). When set to `quartz` the LP, heartbeat refresh, and
  replay layers route through the new adapter; Open-Meteo continues
  to supply temperature + cloud context for the same horizon.
- **`_fetch_quartz_forecast`**: GSP-level when `QUARTZ_GSP_ID` is set,
  otherwise national. National responses use either
  `expectedPowerGenerationNormalized` (treated as a fraction of
  installed capacity) or `expectedPowerGenerationMegawatts` divided
  by `location.installedCapacityMw` to scale to site kW.
- **Direct-PV runs through site calibration**: rather than bypassing
  the cloud-aware / per-hour calibration tables on Quartz rows, the
  adapter applies them via `forecast_pv_kw_from_row` so a consistent
  shading / orientation correction is applied regardless of source.
- **Canonical persistence**: every fetch lands in
  `meteo_forecast_snapshot` with `source` / `model_name` /
  `model_version` / `raw_payload_json`, and per-slot rows in
  `meteo_forecast_value` carry `direct_pv_kw`. Replay by fetch_at_utc
  reconstructs Quartz rows identically.
- **Documentation**: `.env.example`, `README.md`, `docs/ARCHITECTURE.md`,
  `docs/RUNBOOK.md` updated with the env-key list + provider-switch
  guidance.

### Security + lifecycle hardening (extra commit on top of cherry-picks)

The original Quartz commits had three issues I fixed before opening
this PR:

1. **HTTPS default**: `QUARTZ_API_BASE_URL` was defaulting to a plain
   HTTP Elastic Beanstalk hostname, which would have leaked the
   bearer token in cleartext from prod. Default is now
   `https://api.quartz.solar`. Operators needing the EB URL set it
   explicitly (CLAUDE.md notes which dev networks see Cloudflare
   1010 from the .solar host).
2. **`QUARTZ_CLIENT_ID` defaults empty**: vendor-issued client_id was
   hardcoded into the OSS repo. `_quartz_token` now refuses to round-
   trip Auth0 when `client_id` is empty (logs and returns `None`).
   Operators must supply via `.env`.
3. **Token expiry tracking**: `_quartz_token` now tracks `expires_in`
   and re-authenticates ~60 s before the bearer expires.
   `_fetch_quartz_forecast` retries once on a 401 with
   `force_refresh=True`. Long-lived containers no longer silently
   degrade to Open-Meteo when the typical 24 h Auth0 token expires.

### What is intentionally **not** in this PR

- Peak-export economic margin guard + dispatch_decisions audit cols
  → PR-D
- Live PV/load deviation MPC triggers → PR-E

### How to roll out

1. Merge this PR + image rebuild + `systemctl restart hem`. Default
   stays `FORECAST_SOURCE=open_meteo` — no behaviour change yet.
2. After 3+ days of `forecast_skill_log` data accumulates on Open-
   Meteo (started by PR-B), set `FORECAST_SOURCE=quartz` in prod
   `.env` and restart. Heartbeat will fetch a Quartz snapshot on next
   tick. The skill log keeps the same shape, so we get a clean
   forecast-vs-actual comparison between sources.
3. If Quartz proves materially better (lower MAE on
   `predicted_pv_kwh`), keep it. If not, flip back to
   `FORECAST_SOURCE=open_meteo`.

## Testing

- `pytest tests/test_quartz_forecast.py` — 6 passed (4 cherry-picked
  + 2 new for the security work).
- Full suite running on the branch CI.

## Issue context

- Implements #247 (Quartz forecast source migration).
- Stacks on PR-A2 (#258 — canonical schema) and PR-B (#257 — skill log).

## Test plan

- [x] Quartz adapter tests pass locally (cherry-picked + new
  security tests).
- [ ] Full `pytest tests/` green on CI for this PR.
- [ ] After merge + image rebuild, prod stays on Open-Meteo
  (`FORECAST_SOURCE` unset). Confirm via `meteo_forecast_snapshot.source`
  on next fetch.
- [ ] After 3+ days of skill-log data, flip
  `FORECAST_SOURCE=quartz` in `/srv/hem/.env`, `systemctl restart hem`,
  and confirm `meteo_forecast_snapshot.source = "quartz"` on the next
  fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)