### PR TITLE
feat(forecast): drop refresh cadence to 30 min for Quartz nowcast parity

### DIFF
--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -166,15 +166,23 @@ SCHEMA: dict[str, SettingSpec] = {
     "MPC_FORECAST_REFRESH_INTERVAL_MINUTES": SettingSpec(
         key="MPC_FORECAST_REFRESH_INTERVAL_MINUTES",
         type_name="int",
-        env_default=_int_env("MPC_FORECAST_REFRESH_INTERVAL_MINUTES", "60"),
+        # Default 30 min — aligned with Quartz's ``blend`` model refresh
+        # cadence (the underlying ``pvnet_v2`` nowcast updates every
+        # ~30 min). Open-Meteo's hourly model rolls every 60 min so OM-only
+        # deployments could still set 60 in ``.env`` without losing signal,
+        # but 30 is cheap (24 free OM calls/day vs 12) and catches mid-hour
+        # nowcast adjustments when Quartz is active.
+        env_default=_int_env("MPC_FORECAST_REFRESH_INTERVAL_MINUTES", "30"),
         min_value=10,
         max_value=720,
         cron_reload=True,
         description=(
-            "Interval (minutes) for the Open-Meteo refresh + revision-trigger detector. "
-            "Each tick re-fetches the forecast and fires an MPC re-plan if the next 6h of "
-            "solar/temp diverged materially from the previous fetch. Lower = quicker reaction "
-            "to weather changes; higher = less Open-Meteo traffic."
+            "Interval (minutes) for the forecast refresh + revision-trigger detector. "
+            "Each tick re-fetches the active forecast source (Open-Meteo or Quartz per "
+            "FORECAST_SOURCE) and fires an MPC re-plan if the next 6 h of solar/temp "
+            "diverged materially from the previous fetch. Lower = quicker reaction to "
+            "intra-hour nowcast updates (especially relevant for Quartz which refreshes "
+            "every ~30 min); higher = less network traffic but missed nowcast cycles."
         ),
     ),
     "PV_TELEMETRY_INTERVAL_MINUTES": SettingSpec(


### PR DESCRIPTION
## Summary

The forecast refresh cron was running at 60-min intervals. With
Quartz live (PR #260) this misses every other ``blend`` model update
— Quartz's ``pvnet_v2`` nowcast refreshes every ~30 min and the
``blend`` aggregator follows that cadence.

This PR drops ``MPC_FORECAST_REFRESH_INTERVAL_MINUTES`` default from
**60 → 30**. The setting remains runtime-tunable
(``cron_reload=True``) so anyone wanting the old behaviour can set
``=60`` in ``.env`` without a restart.

### Cost analysis

| Source | Today | After this PR | Limit |
|---|---|---|---|
| Open-Meteo (free tier) | 24 calls/day | 48 calls/day | 10000/day |
| Quartz Auth0 token | 1 fetch/day (cached 24h) | unchanged | n/a |
| Quartz forecast GET | 24/day | 48/day | n/a (own infra) |

### Why this matters

In the historical analysis (14 days, post-deploy thread), the
afternoon slots showed **+17% systematic under-forecast bias** —
actual PV consistently beats the LP's calibrated prediction. Part of
that gap is the calibration table over-correcting (separate PR
queued); part is intra-hour adjuster signal we miss when refreshing
every 60 min instead of every 30. This PR closes the cadence gap;
the calibration adjuster comes next.

### Tests

- ``pytest tests/test_mpc_event_triggers.py tests/test_lp_replay.py`` —
  38 passed locally.
- The setting is already covered by existing runtime-settings tests.

## Test plan

- [x] Targeted suites green locally.
- [ ] Full ``pytest tests/`` green on CI for this PR.
- [ ] After merge + image rebuild, prod heartbeat fetches every
      30 min instead of 60. Confirm via the
      ``Forecast refresh cron scheduled every N min`` log line on
      next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)