### PR TITLE
ops: serialise docker-publish builds per ref to prevent :main tag race

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,21 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+# Serialise builds per ref. Without this, two ``main`` commits landing
+# back-to-back kick off two parallel builds; whichever finishes second
+# wins the mutable ``:main`` tag, regardless of git commit order. We
+# observed this on 2026-05-06 (issue #268): the older commit's build
+# completed slightly later and overwrote the ``:main`` tag, sending
+# stale code to prod on the next ``docker compose pull``.
+#
+# ``cancel-in-progress: false`` keeps the older build running so we
+# still get a ``:<sha>`` tag for it (useful for rollback / audit);
+# the newer build queues up and pushes its tag last → ``:main``
+# always reflects the latest commit.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
Closes #268.

## Summary

Adds a ``concurrency`` group on ``docker-publish.yml`` so only one
build runs per ref at a time. Without this, two ``main`` commits
landing back-to-back kick off parallel builds; whichever finishes
**last** wins the mutable ``:main`` tag, regardless of git commit
order.

## Repro of the bug (today)

PR #265 (cadence change) and PR #266 (per-hour adjuster) merged ~30 s
apart on 2026-05-06. The build for PR #265 (older commit) finished
slightly later than PR #266, and overwrote the ``:main`` tag pointing
it at the older SHA. Prod's next ``docker compose pull`` got the
stale code; the per-hour adjuster from PR #266 was NOT live until I
manually triggered a fresh build via ``gh workflow run``.

## Fix

One-block YAML change:

```yaml
concurrency:
  group: docker-publish-${{ github.ref }}
  cancel-in-progress: false
```

- ``group: docker-publish-${{ github.ref }}`` — serialise per ref.
  ``main`` commits queue; tag builds (``v*``) and other branches
  are independent.
- ``cancel-in-progress: false`` — keep the in-flight build running
  so its ``:<sha>`` tag still gets pushed (useful for rollback +
  audit). The next build queues until it's done, so the ``:main``
  push order always matches commit order.

Trade-off: back-to-back merges now serialise (~1-2 min added
latency on the second deploy). Fair price for "the latest commit
always wins the mutable tag".

## Test plan

- [x] YAML lint (in-editor).
- [ ] Merge two trivial commits to main back-to-back; observe the
      second build queues until the first finishes and ``:main``
      ends up pointing at the second commit.
- [ ] No CI test changes — this is workflow-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)