### PR TITLE
feat(daikin): 2h-aligned heartbeat refresh window (#267 S1)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -985,6 +985,16 @@ class Config:
     DAIKIN_CALIBRATION_WINDOWS_LOCAL: str = (
         os.getenv("DAIKIN_CALIBRATION_WINDOWS_LOCAL", "06:00-08:00,14:30-16:30")
     )
+    # 2 h-aligned Daikin refresh window. Onecta caches consumption data in
+    # 2-hour buckets that rotate at fixed UTC times (00, 02, …, 22). When
+    # enabled, the heartbeat fires one refresh in the first few minutes
+    # past each even hour UTC, capturing the freshest 2 h bucket as soon
+    # as it lands. 12 calls/day (well under the 200/day Daikin budget).
+    # See issue #267 (Daikin observation strategy epic).
+    DAIKIN_2H_REFRESH_ENABLED: bool = (
+        os.getenv("DAIKIN_2H_REFRESH_ENABLED", "true").strip().lower()
+        in ("1", "true", "yes")
+    )
     # Phase 4.1 — per-caller cache staleness ceilings (seconds) so non-heartbeat paths reuse the cache.
     DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS: int = int(
         os.getenv("DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS", "600")

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -409,6 +409,34 @@ def _parse_hhmm_to_seconds(value: str) -> int:
     return hour * 3600 + minute * 60
 
 
+def _in_daikin_2h_refresh_window(
+    now_utc: datetime | None = None,
+    *,
+    fire_minute_start: int = 2,
+    fire_minute_end: int = 7,
+) -> bool:
+    """Return True for the first few minutes after each even-hour UTC tick.
+
+    Onecta buffers operational + consumption data in **2-hour buckets** that
+    rotate at fixed UTC times (00, 02, 04, …, 22). A refresh fired right
+    after rotation captures the fresh bucket data; firing earlier just gets
+    the previous bucket repeated. Default window = ``[02, 07)`` minutes
+    past each even hour, so 12 refreshes/day land deterministically right
+    after each Onecta cache rotation.
+
+    Cost: 12 calls/day vs the 200/day Daikin quota — leaves 188/day for
+    Octopus pre-slot + cold-start + manual fetches.
+
+    See issue #267 (Daikin observation strategy epic), story S1.
+    """
+    if now_utc is None:
+        now_utc = datetime.now(UTC)
+    # Even-hour rotation: 0, 2, 4, ..., 22 UTC
+    if now_utc.hour % 2 != 0:
+        return False
+    return fire_minute_start <= now_utc.minute < fire_minute_end
+
+
 def _in_daikin_calibration_window(
     now_local: datetime | None = None,
     windows: str | None = None,
@@ -1254,10 +1282,16 @@ def bulletproof_heartbeat_tick() -> None:
         try:
             # Heartbeat reads from cache only — no auto-refresh to protect 200/day quota.
             # allow_refresh=True fires only when we are in a high-value window:
-            # either the Octopus pre-slot boundary or a local Daikin calibration slot.
+            #   - Octopus pre-slot boundary (5 min before tariff slot transition)
+            #   - 2 h Onecta cache rotation (deterministic, 12/day, even-hour UTC)
+            #   - local Daikin calibration window (heuristic, complements 2h-aligned)
             in_pre_slot = _in_octopus_pre_slot_window(now_utc)
+            in_2h = (
+                getattr(config, "DAIKIN_2H_REFRESH_ENABLED", True)
+                and _in_daikin_2h_refresh_window(now_utc)
+            )
             in_calibration = _in_daikin_calibration_window(now_local)
-            allow_refresh = in_pre_slot or in_calibration
+            allow_refresh = in_pre_slot or in_2h or in_calibration
             daikin_result = daikin_service.get_cached_devices(
                 allow_refresh=allow_refresh,
                 actor="heartbeat",
@@ -1265,9 +1299,10 @@ def bulletproof_heartbeat_tick() -> None:
             devices = daikin_result.devices
             if allow_refresh and daikin_result.source == "fresh":
                 logger.info(
-                    "Daikin refresh: fetched %d device(s) (pre-slot=%s calibration=%s)",
+                    "Daikin refresh: fetched %d device(s) (pre-slot=%s 2h=%s calibration=%s)",
                     len(devices),
                     in_pre_slot,
+                    in_2h,
                     in_calibration,
                 )
         except Exception as e:

--- a/tests/test_daikin_service.py
+++ b/tests/test_daikin_service.py
@@ -181,3 +181,48 @@ def test_daikin_calibration_window_at_boundaries():
     assert _in_daikin_calibration_window(datetime(2026, 4, 18, 14, 30, 0, tzinfo=tz))
     # Afternoon window end boundary is excluded.
     assert not _in_daikin_calibration_window(datetime(2026, 4, 18, 16, 30, 0, tzinfo=tz))
+
+
+def test_daikin_2h_refresh_window_fires_on_even_hour_first_minutes():
+    """The 2h-aligned window fires for [02, 07) min past each even UTC hour.
+
+    Onecta caches in 2-hour buckets; firing right after the rotation gives us
+    the freshest data. 12 fires/day = 12 calls/day, well under 200/day quota.
+    See #267 (S1).
+    """
+    from src.scheduler.runner import _in_daikin_2h_refresh_window
+
+    # 00:02 UTC — start of window after 00:00 rotation → True.
+    assert _in_daikin_2h_refresh_window(datetime(2026, 5, 6, 0, 2, 0, tzinfo=UTC))
+    # 00:06 UTC — still in [02, 07) → True.
+    assert _in_daikin_2h_refresh_window(datetime(2026, 5, 6, 0, 6, 59, tzinfo=UTC))
+    # 00:07 UTC — exclusive end → False.
+    assert not _in_daikin_2h_refresh_window(datetime(2026, 5, 6, 0, 7, 0, tzinfo=UTC))
+    # 00:01 UTC — before window start → False.
+    assert not _in_daikin_2h_refresh_window(datetime(2026, 5, 6, 0, 1, 59, tzinfo=UTC))
+
+
+def test_daikin_2h_refresh_window_skips_odd_hours():
+    """Odd-hour UTC ticks never fire — Onecta rotates on even hours only."""
+    from src.scheduler.runner import _in_daikin_2h_refresh_window
+
+    # 01:02, 03:04, 05:06 — all odd-hour, all False even within minute window.
+    assert not _in_daikin_2h_refresh_window(datetime(2026, 5, 6, 1, 2, 0, tzinfo=UTC))
+    assert not _in_daikin_2h_refresh_window(datetime(2026, 5, 6, 3, 4, 0, tzinfo=UTC))
+    assert not _in_daikin_2h_refresh_window(datetime(2026, 5, 6, 5, 6, 0, tzinfo=UTC))
+
+
+def test_daikin_2h_refresh_window_fires_12x_per_day():
+    """Sanity: enumerating every minute of a day, the window fires for exactly
+    12 distinct 5-minute blocks (one per even UTC hour)."""
+    from src.scheduler.runner import _in_daikin_2h_refresh_window
+
+    fires_per_hour: dict[int, int] = {}
+    for hour in range(24):
+        for minute in range(60):
+            t = datetime(2026, 5, 6, hour, minute, 0, tzinfo=UTC)
+            if _in_daikin_2h_refresh_window(t):
+                fires_per_hour[hour] = fires_per_hour.get(hour, 0) + 1
+
+    assert sorted(fires_per_hour.keys()) == list(range(0, 24, 2))  # 12 even hours
+    assert all(n == 5 for n in fires_per_hour.values())  # 5 minutes each


### PR DESCRIPTION
First story of the Daikin observation strategy epic (#267).

## Why

Onecta buffers operational + consumption data in **2-hour buckets**
that rotate at fixed UTC times (00, 02, 04, …, 22). Today's
heartbeat refreshes fire on a heuristic local-time window
(``DAIKIN_CALIBRATION_WINDOWS_LOCAL=06:00-08:00,14:30-16:30``) that
doesn't always coincide with cache rotation. When the local window
opens *between* rotations, we ask Onecta for "fresh" data and get
the previous bucket — a quota call for stale data.

## What ships

- New ``_in_daikin_2h_refresh_window(now_utc)`` helper. Pure
  function: returns ``True`` for ``[02, 07)`` minutes past each
  even UTC hour, else ``False``. 12 fires/day, deterministic,
  zero dependencies.
- Heartbeat ``allow_refresh`` now ORs three windows: Octopus
  pre-slot + 2 h-aligned UTC + local calibration. Each refresh log
  line is tagged with which window(s) fired.
- New env ``DAIKIN_2H_REFRESH_ENABLED=true|false`` (default
  ``true``) — kill switch for operators that want to opt out.

## Quota math

| Source | Calls/day |
|---|---:|
| Octopus pre-slot | ~6 |
| 2 h-aligned UTC (**this PR**) | 12 |
| Local calibration window | 2-4 |
| Cold-start + manual | ~5 |
| **Total ceiling** | **~25 vs 200/day budget** |

Plenty of headroom for follow-up stories in #267 (S2 richer payload
extraction, S3 per-bucket COP derivation).

## Tests

- 3 new ``tests/test_daikin_service.py`` cases:
  - boundary minutes around the 02-07 window
  - odd-hour skip (02:01 fires, 03:01 doesn't)
  - exhaustive 12-fires-per-day enumeration
- All 10 daikin-service tests pass.

## What this does **not** do

- S2: extract richer payload from each ``gateway-devices`` call
  (capture ``indoor_temp_c``, lwt setpoints, all sensoryData) —
  separate PR.
- S3: per-2h-bucket outdoor temp + COP derivation — depends on S2.
- S5: active control prerequisites — depends on ≥14 days of
  measured COP-per-bucket data from S3.

## Test plan

- [x] Boundary + enumeration tests green locally.
- [ ] Full ``pytest tests/`` green on CI for this PR.
- [ ] After merge + image rebuild, prod heartbeat fires one Daikin
  refresh in the first 5 min of each even UTC hour. Confirm via the
  ``Daikin refresh: ... 2h=True ...`` log line.
- [ ] Daily quota stays comfortably below 200 (target: ~25-30 calls/day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)