### PR TITLE
fix(pv): exclude clamped observations + statistical median in today-factor

### DIFF
--- a/src/weather.py
+++ b/src/weather.py
@@ -1050,9 +1050,14 @@ def compute_today_pv_correction_factor(
             "min_hours_required": min_hours,
         }
 
-    # 4. Median ratio (robust to one bad hour) + safety clamp
+    # 4. Statistical median (mean of two middle values for even-length lists,
+    # not ``sorted[len//2]`` which is the *upper* of the two middles).
     sorted_r = sorted(r for _, r in ratios)
-    median = sorted_r[len(sorted_r) // 2]
+    n_r = len(sorted_r)
+    if n_r % 2 == 1:
+        median = sorted_r[n_r // 2]
+    else:
+        median = (sorted_r[n_r // 2 - 1] + sorted_r[n_r // 2]) / 2.0
     lo, hi = safety_clamp
     factor = max(lo, min(hi, median))
 
@@ -1190,8 +1195,28 @@ def compute_today_pv_correction_factor_by_hour(
             "min_hours_required": min_hours,
         }
 
-    sorted_obs = sorted(observed.values())
-    median = sorted_obs[len(sorted_obs) // 2]
+    # Compute median for the unobserved-hour fallback. Two corrections vs the
+    # original implementation:
+    #   1. Exclude hours that were *clamped* — by construction they're at the
+    #      ``[lo, hi]`` boundary because either actual or forecast was tiny;
+    #      the ratio is unreliable as a representative value for the rest of
+    #      the day. Including them pulls the median toward the clamp bounds
+    #      and biases the projection wrongly. Concrete repro on 2026-05-06:
+    #      observed = {5: 2.0(clamp), 6: 0.67, 7: 1.10, 9: 0.30(clamp)} →
+    #      old median = 1.10, true unclamped median = 0.89. The 1.10 made
+    #      the LP scale UP an already-too-optimistic forecast on a heavy-
+    #      cloud day.
+    #   2. ``sorted[len//2]`` is the *upper* of two middle values for even-
+    #      length lists, not the statistical median. Use the mean of the
+    #      two middle values for proper even-length median.
+    unclamped = [r for h, r in observed.items() if h not in clamped_hours]
+    median_source = unclamped if len(unclamped) >= max(2, min_hours) else list(observed.values())
+    sorted_obs = sorted(median_source)
+    n_obs = len(sorted_obs)
+    if n_obs % 2 == 1:
+        median = sorted_obs[n_obs // 2]
+    else:
+        median = (sorted_obs[n_obs // 2 - 1] + sorted_obs[n_obs // 2]) / 2.0
 
     factor_by_hour: dict[int, float] = {h: 1.0 for h in range(24)}
     imputed_hours: list[int] = []
@@ -1206,6 +1231,7 @@ def compute_today_pv_correction_factor_by_hour(
         "n_observed": len(observed),
         "n_imputed": len(imputed_hours),
         "median_ratio": round(median, 4),
+        "median_source": "unclamped_only" if median_source is unclamped else "all_observed",
         "ratios_per_hour": {h: round(v, 4) for h, v in observed.items()},
         "imputed_hours": imputed_hours,
         "clamped_hours": clamped_hours,

--- a/tests/test_pv_today_aware_calibration.py
+++ b/tests/test_pv_today_aware_calibration.py
@@ -203,3 +203,97 @@ def test_per_hour_returns_empty_when_only_one_hour_observed():
     by_hour, diag = compute_today_pv_correction_factor_by_hour()
     assert by_hour == {}, "single observation should not produce a per-hour map"
     assert "min_hours_required" in diag
+
+
+# ---------------------------------------------------------------------------
+# PR-J: median computation fixes
+# Bug 1: clamped values were anchoring the median at clamp bounds.
+# Bug 2: ``sorted[len//2]`` is upper of two middles for even-length lists.
+# ---------------------------------------------------------------------------
+
+
+def test_per_hour_median_excludes_clamped_observations():
+    """Two valid + two clamped observations → median computed only from valid pair.
+
+    Repro of the 2026-05-06 prod state: observations at hours 5/6/7/9 produced
+    ratios [2.0(clamp), 0.67, 1.10, 0.30(clamp)]. The old code returned 1.10
+    (sorted[2] of all 4); after this fix it should return (0.67+1.10)/2 = 0.885
+    by excluding the two clamped values.
+    """
+    from src.weather import compute_today_pv_correction_factor_by_hour
+
+    # Hour 5: dawn, tiny forecast → ratio explodes → clamped to 2.0 (upper).
+    _seed_realtime(hour_utc=5, kw=0.10)
+    _seed_forecast(hour_utc=5, irradiance_wm2=2.0)
+    # Hour 6: ratio ~0.67 (within clamp range).
+    _seed_realtime(hour_utc=6, kw=1.0)
+    _seed_forecast(hour_utc=6, irradiance_wm2=440.0)  # cal ~1.495 kW; ratio ~0.67
+    # Hour 7: ratio ~1.10.
+    _seed_realtime(hour_utc=7, kw=2.0)
+    _seed_forecast(hour_utc=7, irradiance_wm2=475.0)  # cal ~1.815 kW; ratio ~1.10
+    # Hour 9: heavy cloud morning, ratio at lower clamp.
+    _seed_realtime(hour_utc=9, kw=0.10)
+    _seed_forecast(hour_utc=9, irradiance_wm2=350.0)  # cal ~1.34 kW; ratio ~0.075 → clamp 0.30
+
+    by_hour, diag = compute_today_pv_correction_factor_by_hour()
+    assert by_hour, f"expected non-empty map; diag={diag}"
+    # Two of four observations were clamped (hours 5 and 9).
+    assert set(diag["clamped_hours"]) == {5, 9}, f"clamped_hours: {diag['clamped_hours']}"
+    # Median should reflect ONLY the unclamped {6, 7} → mean(0.67, 1.10) ≈ 0.885.
+    assert diag["median_source"] == "unclamped_only"
+    assert 0.80 <= diag["median_ratio"] <= 0.95, f"expected ~0.89; got {diag['median_ratio']}"
+
+
+def test_per_hour_median_falls_back_when_too_few_unclamped():
+    """If excluding clamped leaves <min_hours observations, fall back to all-observed.
+
+    Otherwise we'd return an empty map when most of the day's data was at clamp
+    boundaries — losing the signal entirely.
+    """
+    from src.weather import compute_today_pv_correction_factor_by_hour
+
+    # Two clamped observations, no unclamped → unclamped subset has 0 entries.
+    _seed_realtime(hour_utc=5, kw=0.10)
+    _seed_forecast(hour_utc=5, irradiance_wm2=2.0)  # tiny forecast → clamp upper
+    _seed_realtime(hour_utc=18, kw=0.10)
+    _seed_forecast(hour_utc=18, irradiance_wm2=2.0)  # tiny forecast → clamp upper
+
+    by_hour, diag = compute_today_pv_correction_factor_by_hour()
+    assert by_hour, f"expected non-empty map (fallback to all-observed); diag={diag}"
+    assert diag["median_source"] == "all_observed", f"diag: {diag}"
+
+
+def test_scalar_uses_statistical_median_for_even_length():
+    """Scalar adjuster: 4 observations [0.4, 0.6, 1.4, 1.6] → median = 1.0,
+    not ``sorted[2] = 1.4``."""
+    from src.weather import compute_today_pv_correction_factor
+
+    # Calibrated forecast for hours 6/7/8/9 with ratios 0.4 / 0.6 / 1.4 / 1.6
+    # against measured kW.
+    seeds = [
+        (6,  0.4, 1.0),  # actual / forecast = 0.4 → ratio 0.4 (clamped if outside range)
+        (7,  0.6, 1.0),
+        (8,  1.4, 1.0),
+        (9,  1.6, 1.0),
+    ]
+    # We want to produce ratios [0.4, 0.6, 1.4, 1.6] so the calibrated forecast
+    # for each hour must be ~1.0 kW. estimate_pv_kw(rad) × cloud_attenuation
+    # × calibration ≈ 1.0 kW. Easiest: seed irradiance + a flat hourly cal of 1.0.
+    db.upsert_pv_calibration_hourly(
+        {h: 1.0 for h in range(6, 19)},
+        {h: 50 for h in range(6, 19)},
+        window_days=14,
+    )
+    for h, actual_kw, _ in seeds:
+        _seed_realtime(hour_utc=h, kw=actual_kw)
+    # Need irradiance such that estimate_pv_kw(att·rad) ≈ 1.0 → 4.5 × (rad/1000) × 0.85 = 1.0
+    # → rad ≈ 261. With cloud=0% (passed via _seed_forecast helper), att=1.0.
+    for h, _, _ in seeds:
+        _seed_forecast(hour_utc=h, irradiance_wm2=261.0)
+
+    factor, diag = compute_today_pv_correction_factor()
+    # True median of [0.4, 0.6, 1.4, 1.6] = (0.6 + 1.4) / 2 = 1.0
+    # Old (buggy) code returned sorted[2] = 1.4
+    assert diag["median_ratio"] == pytest.approx(1.0, abs=0.05), (
+        f"expected statistical median 1.0; got {diag['median_ratio']}"
+    )


### PR DESCRIPTION
## Summary

Two bugs in the today-aware PV adjuster surfaced on 2026-05-06 prod data:

**Bug 1: Clamped observations included in median.** The per-hour
``compute_today_pv_correction_factor_by_hour`` was computing the median
over all observed ratios — including ones clamped at the safety bounds.
Clamped values carry no signal (they're at ``[0.30, 2.0]`` by
construction when actual ≪ or ≫ forecast) but pulled the median.
Concrete reproduction from today's prod:

```
observed = {5: 2.0(clamp), 6: 0.67, 7: 1.10, 9: 0.30(clamp)}
old median   = 1.10  (sorted[len//2] of all four)
fixed median = 0.89  (mean of 0.67 + 1.10 — unclamped only)
```

On today's heavy-cloud day (reality ~0.60× calibrated forecast), the
old 1.10 factor scaled the LP's PV expectation **UP**, making the
over-forecast worse. The 0.89 nudges it down toward reality.

Falls back to all-observed when too few unclamped exist (LP still gets
a signal). Diag exposes ``median_source`` so we audit which path took.

**Bug 2: Even-length median off-by-one.** ``sorted[len//2]`` returns
the upper of the two middle values for even-length lists, not the
statistical median. For [0.4, 0.6, 1.4, 1.6] it returned 1.4 instead
of 1.0. Fixed to use the mean of the two middle values. Applies to
both the scalar and per-hour variants.

## Why it matters today

Today's plan was force-charging from grid because the LP saw forecast
PV at 1.310 kW for slot 10:00 UTC and only got 0.274 kW measured.
With factor 1.105 the LP saw 1.45 kW expected — even further from
reality. With the fix, factor would be 0.89 → LP sees 1.17 kW, still
high but closer; combined with the live-deviation MPC trigger
(already firing on prod) the dispatch reacts faster.

## Tests

- 3 new ``tests/test_pv_today_aware_calibration.py`` cases:
  - ``median_excludes_clamped_observations`` — pins the unclamped-only path
  - ``median_falls_back_when_too_few_unclamped`` — pins the all-observed fallback
  - ``scalar_uses_statistical_median_for_even_length`` — pins the off-by-one fix
- All 13 tests in the file pass.

## Test plan

- [x] Per-hour adjuster + scalar adjuster tests green locally.
- [ ] Full ``pytest tests/`` green on CI for this PR.
- [ ] After merge + image rebuild, observe the
      ``PV calibration: per-hour today-aware adjuster active`` log line
      with ``median_source=unclamped_only`` (when applicable).
- [ ] On the next post-deploy LP run, ``today_factor_by_hour`` should
      reflect the unclamped median for today's observed hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)