### PR TITLE
feat(telemetry): bump PV_TELEMETRY_INTERVAL_MINUTES default 30→5 min

### DIFF
--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -188,7 +188,13 @@ SCHEMA: dict[str, SettingSpec] = {
     "PV_TELEMETRY_INTERVAL_MINUTES": SettingSpec(
         key="PV_TELEMETRY_INTERVAL_MINUTES",
         type_name="int",
-        env_default=_int_env("PV_TELEMETRY_INTERVAL_MINUTES", "30"),
+        # 5 min default — gives 6 samples per LP slot (30 min) so the
+        # half-hour aggregations used by ``forecast_skill_log`` rebuild,
+        # the today-aware adjuster, and the bias diagnostics are based on
+        # a proper slot mean rather than a single point. Zero Fox quota
+        # cost since this reads the heartbeat-cached realtime, not the
+        # paid /raw API.
+        env_default=_int_env("PV_TELEMETRY_INTERVAL_MINUTES", "5"),
         min_value=5,
         max_value=120,
         cron_reload=True,
@@ -196,7 +202,8 @@ SCHEMA: dict[str, SettingSpec] = {
             "Interval (minutes) for the PV-realtime telemetry job. Each tick reads the "
             "Fox cached realtime (SoC%, solar/load/grid/battery kW) and persists in "
             "pv_realtime_history for offline calibration analysis. Zero Fox quota cost "
-            "(reads heartbeat-cached values)."
+            "(reads heartbeat-cached values). 5 min = 6 samples/slot for proper "
+            "slot-mean aggregations."
         ),
     ),
     "PV_CALIBRATION_WINDOW_DAYS": SettingSpec(


### PR DESCRIPTION
## Summary

Currently the PV-realtime telemetry job persists one
``pv_realtime_history`` row every 30 minutes. With LP slots also at
30 minutes, that gives exactly **one sample per slot** — every
half-hour aggregation downstream (``forecast_skill_log`` rebuild,
today-aware adjuster, prod bias diagnostics) ends up comparing a
single noisy point to the LP's slot mean.

Drop the default to **5 min** (6 samples/slot).

## Cost

| Resource | Today | After |
|---|---|---|
| Fox API quota | 0/day (uses heartbeat cache) | unchanged |
| SQLite writes | 48 rows/day | 288 rows/day |
| Disk | trivial | trivial |

## Why now

Came up in the 2026-05-06 review thread investigating today's
"force charge while PV available" complaint. We needed to compare
half-hour-mean actuals vs the LP's half-hour plan — but with one
sample per slot, the comparison is dominated by intra-slot cloud
variability. Bumping cadence here gives the bias diagnostics a
fair denominator and also tightens any future live-deviation
trigger on the PV axis.

## Test plan

- [x] Setting still validates within ``min_value=5, max_value=120``.
- [ ] Full ``pytest tests/`` green on CI for this PR.
- [ ] After merge + image rebuild, ``pv_realtime_history`` row count
      grows ~6× faster. Confirm via ``SELECT COUNT(*) FROM
      pv_realtime_history WHERE captured_at > datetime('now', '-1 hour')``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)