### PR TITLE
fix(fox): use duration-weighted avg for fdPwr when merging ForceCharge windows

### DIFF
--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -599,6 +599,16 @@ def _merge_adjacent_force_charge_rows(
     """Join consecutive ForceCharge segments even when fdSoc/fdPwr differ (e.g. negative vs cheap slot).
 
     Tuple convention: ``(work_mode, fd_soc, fd_pwr, min_soc_on_grid, max_soc)``.
+
+    fd_pwr (the W cap sent to Fox) is duration-weighted across the merged
+    windows rather than max-merged. Fox V3 treats fdPwr as a charging-rate
+    cap and pulls aggressively until fdSoc is reached, so a max-merge causes
+    a high-power slot to "set the rate" for the entire merged window — which
+    over-charges in the LP's tapered slots. Duration-weighted average means
+    total grid energy across the window matches the LP's planned total.
+
+    fd_soc still uses max so the merged block charges to the highest target
+    in the run, and min_soc_on_grid uses max for the same reason.
     """
     out: list[tuple[datetime, datetime, tuple]] = []
     for a, b, k in merged:
@@ -607,11 +617,20 @@ def _merge_adjacent_force_charge_rows(
             and out[-1][2][0] == "ForceCharge"
             and k[0] == "ForceCharge"
         ):
-            a0, _, k0 = out[-1]
+            a0, end0, k0 = out[-1]
+            dur0_s = max(0.0, (end0 - a0).total_seconds())
+            dur1_s = max(0.0, (b - a).total_seconds())
+            tot_s = dur0_s + dur1_s
+            pwr0 = float(k0[2] or 0)
+            pwr1 = float(k[2] or 0)
+            if tot_s > 0:
+                weighted_pwr = round((pwr0 * dur0_s + pwr1 * dur1_s) / tot_s)
+            else:
+                weighted_pwr = max(pwr0, pwr1)
             nk = (
                 "ForceCharge",
                 max(k0[1] or 0, k[1] or 0),
-                max(k0[2] or 0, k[2] or 0),
+                int(weighted_pwr),
                 max(k0[3], k[3]),
                 _max_optional(k0[4] if len(k0) > 4 else None, k[4] if len(k) > 4 else None),
             )

--- a/tests/test_fox_lp_dispatch_soc.py
+++ b/tests/test_fox_lp_dispatch_soc.py
@@ -72,7 +72,12 @@ def test_slot_fox_tuple_cheap_fallback_when_no_target() -> None:
     assert msg == _min_r()
 
 
-def test_merge_adjacent_force_charge_uses_max_fd_soc_and_min_soc() -> None:
+def test_merge_adjacent_force_charge_uses_duration_weighted_avg_pwr() -> None:
+    """Two equal-length slots → duration-weighted avg = arithmetic mean of pwr.
+
+    fd_soc and min_soc_on_grid still take MAX (charge to highest target,
+    enforce highest reserve). Only fd_pwr is averaged.
+    """
     t0 = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
     s1 = HalfHourSlot(
         start_utc=t0,
@@ -94,8 +99,45 @@ def test_merge_adjacent_force_charge_uses_max_fd_soc_and_min_soc() -> None:
     assert len(groups) == 1
     assert groups[0].work_mode == "ForceCharge"
     assert groups[0].fd_soc == 70
-    assert groups[0].fd_pwr == 1200
+    assert groups[0].fd_pwr == 1100  # weighted avg of 1000 & 1200 over equal durations
     assert groups[0].min_soc_on_grid == _min_r()
+
+
+def test_merge_adjacent_force_charge_weighted_avg_preserves_lp_total_energy() -> None:
+    """Front-loaded LP plan (high-pwr slot followed by low-pwr trickle) must
+    not get the entire merged block running at the high-pwr slot's rate.
+
+    Before this fix, max-merge meant the 09:30-13:30 ForceCharge today blew
+    through SoC 11→91% in 3 hours instead of taking the planned 4 hours
+    (over-imported by +36% / +2.7 kWh). Weighted-avg ensures the merged
+    fdPwr ≈ (LP planned total kWh) / window_hours × 1000.
+    """
+    t0 = datetime(2026, 6, 1, 9, 30, tzinfo=UTC)
+    # Mimic today's 09:30-13:30 LP plan (8 × 30-min slots, varying imports)
+    plan_imp_w = [1350, 4900, 2250, 2250, 750, 750, 750, 750]
+    slots = [
+        HalfHourSlot(
+            start_utc=t0 + timedelta(minutes=30 * i),
+            end_utc=t0 + timedelta(minutes=30 * (i + 1)),
+            price_pence=16.0,
+            kind="cheap",
+            lp_grid_import_w=p,
+            target_soc_pct=95,
+        )
+        for i, p in enumerate(plan_imp_w)
+    ]
+    groups = _merge_fox_groups(slots)
+    assert len(groups) == 1
+    assert groups[0].work_mode == "ForceCharge"
+    expected_avg = round(sum(plan_imp_w) / len(plan_imp_w))
+    assert groups[0].fd_pwr == expected_avg, (
+        f"expected weighted avg {expected_avg} W, got {groups[0].fd_pwr} W. "
+        "Max-merge would have returned 4900 W (the peak slot)."
+    )
+    # Sanity: weighted result is bounded by [min, max] of inputs
+    assert min(plan_imp_w) <= groups[0].fd_pwr <= max(plan_imp_w)
+    # Sanity: weighted result is far below the historical max-merge value
+    assert groups[0].fd_pwr < max(plan_imp_w) // 2
 
 
 def test_slot_fox_tuple_peak_export_uses_reserve_min_soc() -> None:


### PR DESCRIPTION
## Summary

- `_merge_adjacent_force_charge_rows` was max-merging fdPwr — a single high-power LP slot at the front of a multi-hour block set the rate for the entire merged window. Fox V3 then blew through SoC much faster than the LP planned.
- Switch to duration-weighted average so total grid energy across the merged window matches the LP's planned total.
- fdSoc and minSocOnGrid still use MAX (correct semantics — charge to highest target, enforce highest reserve).

## Why

2026-05-08 prod audit:

```
slot     plan_imp  act_imp   PV_act   SoC%
09:30      0.66    0.52     0.32     10%
10:00      2.44    1.75     0.60     17%
10:30      1.12    1.71     0.52     37%
12:00      0.37    1.41     0.30     55%   ← overshoot
12:30      0.37    1.69     0.59     72%   ← overshoot
13:00      0.37    1.79     0.46     91%   ← overshoot

plan total: 7.49 kWh   actual: 10.18 kWh   +36%
```

The LP wanted a front-loaded charge with a long taper (0.37 kWh/slot = 740 W in the trickle phase). After max-merge, fdPwr inherited the max — 4900 W from the 10:00 slot, clamped to FOX_FORCE_CHARGE_MAX_PWR ≈ 3500 W. Fox V3 ran the entire 4-hour window at ~3.4 kW. Battery filled 3 slots early, then surplus afternoon PV exported at sub-peak Outgoing Agile rates instead of being absorbed.

With this fix: weighted avg = 7.49 / 4 × 1000 ≈ 1875 W. Fox draws at constant 1.9 kW for 4 hours, hits 95% by window end, no premature export.

## Test plan

- [x] `pytest tests/test_fox_lp_dispatch_soc.py tests/test_heuristic_fallback.py tests/test_fox_groups_overflow.py` (25 pass)
- [x] Existing test updated: `test_merge_adjacent_force_charge_uses_duration_weighted_avg_pwr` (was `_uses_max_fd_soc_and_min_soc`) — equal-duration slots → arithmetic mean
- [x] New test: `test_merge_adjacent_force_charge_weighted_avg_preserves_lp_total_energy` — uses today's actual 8-slot plan profile to lock in the fix
- [ ] After deploy: monitor next ForceCharge block on prod for plan-vs-actual import alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)