### PR TITLE
fix(quartz): skip radiation-trained calibration on direct-PV path

### DIFF
--- a/src/weather.py
+++ b/src/weather.py
@@ -278,24 +278,26 @@ def forecast_pv_kw_from_row(
     """Apply the same PV forecast transform used by the LP and skill logger.
 
     When the provider supplies direct PV (Quartz), use that as the base signal
-    but still apply the same site calibration chain so Quartz can be corrected
-    for local shading / orientation bias. Otherwise cloud attenuation is
-    applied before the irradiance-to-kW conversion and the calibration lookup
-    follows the same cloud → hour → flat fallback chain as
-    ``forecast_to_lp_inputs``.
+    and skip the radiation-trained calibration tables. Quartz's blend model
+    already accounts for cloud cover via ECMWF inputs and self-calibrates
+    against actuals; applying our cloud-bucket factor (which was learned as
+    ``actual / estimate_pv_kw(open_meteo_radiation)``) on top of Quartz's
+    already-calibrated PV output double-corrects and biases mornings/dusk
+    too low (2026-05-08 audit caught morning over-prediction → grid charge,
+    afternoon under-prediction → battery filled too late). Quartz only gets
+    the ``flat * today_factor`` chain — site-level shading/orientation bias
+    can be captured by a future Quartz-trained calibration table without
+    breaking compatibility with the radiation path.
+
+    Otherwise cloud attenuation is applied before the irradiance-to-kW
+    conversion and the calibration lookup follows the same cloud → hour →
+    flat fallback chain as ``forecast_to_lp_inputs``.
     """
     scale_f = max(0.0, float(scale))
     if direct_pv_kw is not None:
         try:
             base_kw = max(0.0, float(direct_pv_kw))
-            cal = get_pv_calibration_factor_for(
-                int(hour_utc),
-                cloud_cover_pct,
-                cloud_table=cloud_table,
-                hourly_table=hourly_table,
-                flat=flat,
-            )
-            return base_kw * cal * scale_f
+            return base_kw * float(flat) * scale_f
         except (TypeError, ValueError):
             pass
     cloud_pct_f = float(cloud_cover_pct) if cloud_cover_pct is not None else 50.0

--- a/tests/test_pv_cloud_aware_calibration.py
+++ b/tests/test_pv_cloud_aware_calibration.py
@@ -121,8 +121,19 @@ def test_forecast_to_lp_inputs_callable_zero_factor_zeros_pv() -> None:
     assert out.pv_kwh_per_slot[0] == 0.0
 
 
-def test_direct_pv_path_still_uses_calibration_tables() -> None:
-    """Quartz direct PV should still be corrected by the site calibration tables."""
+def test_direct_pv_path_skips_radiation_trained_tables() -> None:
+    """Quartz direct PV must NOT be multiplied by the radiation-trained
+    cloud_table or hourly_table — those factors are
+    ``actual / estimate_pv_kw(open_meteo_radiation)`` ratios, so applying
+    them on top of Quartz output (which already self-calibrates against
+    its blend model's actuals) double-corrects.
+
+    Caught in the 2026-05-08 prod audit: morning cloud-table factors of
+    0.43-0.56× combined with the today_factor scalar pushed Quartz's
+    morning predictions to ~25 % of actuals, causing aggressive grid
+    charging in the cheap morning window followed by surplus-PV exports
+    in the afternoon at sub-peak Outgoing Agile rates.
+    """
     from src.weather import forecast_pv_kw_from_row
 
     cloud = {(12, 1): 0.50}
@@ -136,7 +147,12 @@ def test_direct_pv_path_still_uses_calibration_tables() -> None:
         hourly_table=hourly,
         flat=1.0,
     )
-    assert pv == pytest.approx(1.0)
+    # 2.0 kW × flat(1.0) × scale(1.0) = 2.0; tables are deliberately ignored.
+    # If they were applied the result would be 2.0 × 0.50 = 1.0.
+    assert pv == pytest.approx(2.0), (
+        f"Quartz path must skip radiation-trained tables; got {pv} "
+        "(1.0 indicates double-correction via cloud_table)"
+    )
 
 
 def test_forecast_to_lp_inputs_callable_exception_falls_back_safely() -> None:

--- a/tests/test_quartz_forecast.py
+++ b/tests/test_quartz_forecast.py
@@ -83,9 +83,18 @@ def test_quartz_fetch_merges_direct_pv_with_open_meteo_weather(monkeypatch: pyte
     assert result.raw_payload_json
 
 
-def test_direct_pv_uses_site_calibration_scale() -> None:
+def test_direct_pv_skips_radiation_trained_calibration_tables() -> None:
+    """Quartz's direct PV output must NOT be multiplied by the radiation-trained
+    cloud / hourly calibration tables. Those factors were learned against
+    Open-Meteo's shortwave_radiation_instant via
+    ``actual / estimate_pv_kw(rad)`` ratios, so applying them on top of
+    Quartz (which already does ECMWF-driven cloud blending and self-
+    calibrates against actuals) double-corrects and biases the LP's PV
+    expectation strongly toward zero — the 2026-05-08 prod incident.
+    """
     from src.weather import HourlyForecast, forecast_to_lp_inputs
 
+    # Stash a deliberately aggressive 0.5x hourly factor for hour 12.
     db.upsert_pv_calibration_hourly({12: 0.5}, {12: 8}, window_days=30)
 
     slot = datetime(2026, 5, 5, 12, 0, tzinfo=UTC)
@@ -97,13 +106,18 @@ def test_direct_pv_uses_site_calibration_scale() -> None:
             shortwave_radiation_wm2=0.0,
             estimated_pv_kw=2.0,
             heating_demand_factor=0.0,
-            pv_direct=True,
+            pv_direct=True,  # Quartz path
         )
     ]
 
     series = forecast_to_lp_inputs(forecast, [slot], pv_scale=1.0)
 
-    assert series.pv_kwh_per_slot == pytest.approx([0.5])
+    # Half-hour slot kWh = 2.0 kW × 0.5 h × flat(1.0) = 1.0 kWh.
+    # If the radiation-trained 0.5x factor were applied, we'd get 0.5.
+    assert series.pv_kwh_per_slot == pytest.approx([1.0]), (
+        "Quartz direct PV must skip the radiation-trained calibration; got "
+        f"{series.pv_kwh_per_slot} (expected [1.0], 0.5 indicates double-correction)"
+    )
 
 
 def test_quartz_national_metadata_capacity_can_downscale_site_kw(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- `forecast_pv_kw_from_row` was multiplying Quartz's `direct_pv_kw` by the radiation-trained `cloud_table` and `hourly_table`. Those tables were learned as `actual / estimate_pv_kw(open_meteo_radiation)`, so they double-correct when applied to Quartz output (which already does cloud-aware blending internally).
- Skip both tables on the Quartz path; keep only `flat × scale` (and the LP's separate `today_factor` is unaffected — it's applied later).
- Update existing test to lock in the new (correct) behavior.

## Why

2026-05-08 prod audit caught the asymmetric morning over-prediction / afternoon under-prediction pattern persisting into the Quartz era:

| date | morning ratio | afternoon ratio |
|------|---------------|-----------------|
| 2026-05-06 | 0.87 | 1.81 |
| 2026-05-07 | 0.97 | 1.09 |
| 2026-05-08 | 0.64 | 1.55 |

The cloud_table values were severe at the day's edges — hour 8 = 0.43, hour 18 = 0.29. Quartz at hour 8 today predicted 0.72 kWh (already credible). After cloud_table → 0.31. After today_factor (0.45) → 0.14. Actual was 0.64 — under-predicted **4.6×**. The LP responded by charging hard from grid in the morning; the under-predicted afternoon then overshot expectations, battery filled too late at 16:00, 2.13 kWh exported.

Conceptually: the cloud factors compensate Open-Meteo's known bias on cloudy mornings. Quartz uses ECMWF cloud forecasts as input to its blend model and continuously self-calibrates — the additional cloud factor is double-correction.

## Test plan

- [x] `pytest tests/test_quartz_forecast.py tests/test_pv_forecast_accuracy.py tests/test_weather_cop_preprocess.py tests/test_forecast_skill_log.py tests/test_fox_lp_dispatch_soc.py` (26 pass)
- [x] Updated test `test_direct_pv_skips_radiation_trained_calibration_tables` (was `_uses_site_calibration_scale`) — locks in the corrected behavior with explicit failure message
- [ ] After deploy: monitor next-day forecast vs actual ratio for the symmetric pattern (target morning ≈ afternoon ≈ 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)