### PR TITLE
chore(cal): skip cloud-table rebuild when FORECAST_SOURCE=quartz

### DIFF
--- a/src/scheduler/octopus_fetch.py
+++ b/src/scheduler/octopus_fetch.py
@@ -66,26 +66,37 @@ def fetch_and_store_rates(fox: FoxESSClient | None = None) -> dict[str, Any]:
         except Exception as e:
             logger.warning("Octopus export-rates fetch failed (non-fatal): %s", e)
 
-    # Refresh the per-hour-of-day PV calibration table (Fox actual vs Open-Meteo
-    # archive). Daily cadence is sufficient — bias drifts over weeks, not minutes.
-    # Failure is non-fatal; LP falls back to the flat factor.
-    try:
-        from ..weather import compute_pv_calibration_hourly_table
+    # Refresh the per-hour-of-day + cloud-aware PV calibration tables (Fox
+    # actual vs Open-Meteo archive). Skipped when FORECAST_SOURCE=quartz — the
+    # tables are radiation-trained (actual / estimate_pv_kw(open_meteo_rad))
+    # and ``forecast_pv_kw_from_row`` ignores them on the Quartz path (PR #279
+    # removed the double-correction). Recomputing them is wasted work + an
+    # avoidable Open-Meteo archive request. If the source ever flips back to
+    # open-meteo (manual fallback / Quartz outage) the tables get rebuilt
+    # again on the next octopus fetch.
+    forecast_source = (getattr(config, "FORECAST_SOURCE", "open-meteo") or "open-meteo").strip().lower()
+    if forecast_source in ("quartz", "quartz_solar"):
+        logger.info("PV calibration recompute skipped (FORECAST_SOURCE=%s; tables unused on Quartz path)", forecast_source)
+    else:
+        # Daily cadence is sufficient — bias drifts over weeks, not minutes.
+        # Failure is non-fatal; LP falls back to the flat factor.
+        try:
+            from ..weather import compute_pv_calibration_hourly_table
 
-        cal_status = compute_pv_calibration_hourly_table()
-        logger.info("PV per-hour calibration recompute: %s", cal_status)
-    except Exception as e:
-        logger.warning("PV per-hour calibration recompute failed (non-fatal): %s", e)
+            cal_status = compute_pv_calibration_hourly_table()
+            logger.info("PV per-hour calibration recompute: %s", cal_status)
+        except Exception as e:
+            logger.warning("PV per-hour calibration recompute failed (non-fatal): %s", e)
 
-    # PR #232: cloud-aware (hour × cloud-bucket) recompute. Same daily cadence,
-    # same failure mode (non-fatal — falls back to per-hour table or flat).
-    try:
-        from ..weather import compute_pv_calibration_hourly_cloud_table
+        # PR #232: cloud-aware (hour × cloud-bucket) recompute. Same daily cadence,
+        # same failure mode (non-fatal — falls back to per-hour table or flat).
+        try:
+            from ..weather import compute_pv_calibration_hourly_cloud_table
 
-        cloud_status = compute_pv_calibration_hourly_cloud_table()
-        logger.info("PV cloud-aware calibration recompute: %s", cloud_status)
-    except Exception as e:
-        logger.warning("PV cloud-aware calibration recompute failed (non-fatal): %s", e)
+            cloud_status = compute_pv_calibration_hourly_cloud_table()
+            logger.info("PV cloud-aware calibration recompute: %s", cloud_status)
+        except Exception as e:
+            logger.warning("PV cloud-aware calibration recompute failed (non-fatal): %s", e)
 
     summary: dict[str, Any] = {"ok": True, "rows": n, "export_rows": export_n}
     if config.USE_BULLETPROOF_ENGINE:

--- a/tests/test_quartz_skip_cal_rebuild.py
+++ b/tests/test_quartz_skip_cal_rebuild.py
@@ -1,0 +1,62 @@
+"""When FORECAST_SOURCE=quartz, the radiation-trained PV calibration tables
+(``pv_calibration_hourly`` + ``pv_calibration_hourly_cloud``) are unused at
+apply time (PR #279). The Octopus fetch job must skip the daily rebuild
+to avoid wasted Open-Meteo archive requests.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+
+
+_FAKE_RATES = [
+    # one minimal Agile rate row in the shape save_agile_rates expects
+    {"slot_time": "2026-05-09T00:00:00Z", "value_inc_vat": 5.0},
+]
+
+
+def test_cal_rebuild_skipped_on_quartz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
+    monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", "TEST-AGILE", raising=False)
+    monkeypatch.setattr(app_config, "USE_BULLETPROOF_ENGINE", False, raising=False)
+
+    from src.scheduler import octopus_fetch as of
+
+    with patch.object(of, "fetch_agile_rates", return_value=_FAKE_RATES), \
+         patch("src.db.save_agile_rates", return_value=len(_FAKE_RATES)), \
+         patch("src.weather.compute_pv_calibration_hourly_table") as cal_h, \
+         patch("src.weather.compute_pv_calibration_hourly_cloud_table") as cal_c:
+        of.fetch_and_store_rates()
+
+    assert not cal_h.called, "compute_pv_calibration_hourly_table called with FORECAST_SOURCE=quartz"
+    assert not cal_c.called, "compute_pv_calibration_hourly_cloud_table called with FORECAST_SOURCE=quartz"
+
+
+def test_cal_rebuild_runs_on_open_meteo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: when source is open-meteo, the rebuild still runs (no regression)."""
+    monkeypatch.setattr(app_config, "FORECAST_SOURCE", "open-meteo", raising=False)
+    monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", "TEST-AGILE", raising=False)
+    monkeypatch.setattr(app_config, "USE_BULLETPROOF_ENGINE", False, raising=False)
+
+    from src.scheduler import octopus_fetch as of
+
+    with patch.object(of, "fetch_agile_rates", return_value=_FAKE_RATES), \
+         patch("src.db.save_agile_rates", return_value=len(_FAKE_RATES)), \
+         patch("src.weather.compute_pv_calibration_hourly_table", return_value={"status": "ok"}) as cal_h, \
+         patch("src.weather.compute_pv_calibration_hourly_cloud_table", return_value={"status": "ok"}) as cal_c:
+        of.fetch_and_store_rates()
+
+    assert cal_h.called, "open-meteo path must still rebuild per-hour calibration"
+    assert cal_c.called, "open-meteo path must still rebuild cloud-aware calibration"


### PR DESCRIPTION
## Summary

Make the daily PV-calibration rebuild a no-op when `FORECAST_SOURCE=quartz`. Both tables are radiation-trained and PR #279 already makes them unused at apply time on the Quartz path — recomputing them is wasted work + an avoidable Open-Meteo archive request.

## Test plan

- [x] `pytest tests/test_quartz_skip_cal_rebuild.py` — 2 pass (skip-on-quartz, regression-on-open-meteo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)