### PR TITLE
feat(pv): today_factor scoped to today + warm-start from yesterday's per-hour table

### DIFF
--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -61,6 +61,65 @@ def _now_utc() -> datetime:
     return datetime.now(UTC)
 
 
+def _load_yesterday_today_factor_by_hour() -> dict[int, float]:
+    """Read yesterday's per-hour today-factor table from the previous LP snapshot.
+
+    Used as a warm-start for hours not yet observed today. Without this, the
+    today-aware adjuster falls back to "median of observed hours" which on a
+    cloudy-morning day drags afternoon hours down to morning's bias even
+    though afternoons typically shed the cloud bias.
+
+    Returns ``{}`` when no usable previous snapshot exists (first day of
+    operation, schema mismatch, JSON parse failure, etc.) — caller treats it
+    as "no warm-start available" and behaves as before.
+    """
+    import sqlite3
+
+    try:
+        yesterday = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
+        with db._lock:
+            conn = db.get_connection()
+            try:
+                cur = conn.execute(
+                    """SELECT exogenous_snapshot_json FROM lp_inputs_snapshot
+                       WHERE substr(plan_date, 1, 10) = ?
+                         AND exogenous_snapshot_json IS NOT NULL
+                       ORDER BY run_id DESC""",
+                    (yesterday,),
+                )
+                rows = cur.fetchall()
+            finally:
+                conn.close()
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        return {}
+    if not rows:
+        return {}
+    # Newest-first; return the first snapshot whose JSON still has
+    # today_factor_by_hour populated.
+    for row in rows:
+        raw = (row[0] or "{}") if row else "{}"
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        adj = (payload or {}).get("weather_adjustment") or {}
+        # Prefer the post-warm-start "effective" map so the warm-start chains
+        # across days when today's observations are sparse. Fall back to the
+        # raw observed map for snapshots written before that key existed.
+        by_hour = adj.get("today_factor_effective_by_hour") or adj.get("today_factor_by_hour")
+        if not isinstance(by_hour, dict) or not by_hour:
+            continue
+        out: dict[int, float] = {}
+        for k, v in by_hour.items():
+            try:
+                out[int(k)] = float(v)
+            except (TypeError, ValueError):
+                continue
+        if out:
+            return out
+    return {}
+
+
 def _ceil_to_half_hour_utc(dt: datetime) -> datetime:
     """Round *dt* up to the next :00 or :30 boundary in UTC."""
     dt = dt.astimezone(UTC).replace(second=0, microsecond=0)
@@ -1390,14 +1449,31 @@ def _run_optimizer_lp(
     # under-corrected afternoons).
     today_factor_by_hour, today_diag_by_hour = compute_today_pv_correction_factor_by_hour()
     today_factor, today_diag = compute_today_pv_correction_factor()
+
+    # #1: today_factor must NOT contaminate tomorrow's slots in the same 48h
+    # solve. A cloudy-morning solve at 19:00 today produces today_factor ≈ 0.31;
+    # without scoping that scalar hammers tomorrow's morning predictions too,
+    # so the LP plans a grid charge before the next day's actuals can correct
+    # the bias.
+    today_utc_date = datetime.now(UTC).date()
+
+    # #5: warm-start unobserved hours from yesterday's per-hour factor table
+    # (persisted in the previous LP snapshot's exogenous_snapshot_json). This
+    # keeps the asymmetric per-hour shape from yesterday instead of the
+    # bias-dragging "median of observed" fallback. Best-effort — when there is
+    # no yesterday snapshot or the JSON path is empty, falls back silently.
+    yesterday_factor_by_hour = _load_yesterday_today_factor_by_hour()
+
     if today_factor_by_hour:
         logger.info(
             "PV calibration: per-hour today-aware adjuster active "
-            "(n_observed=%d, n_imputed=%d, median_ratio=%.3f, clamped_hours=%s)",
+            "(n_observed=%d, n_imputed=%d, median_ratio=%.3f, clamped_hours=%s, "
+            "warm_start_hours=%d)",
             today_diag_by_hour.get("n_observed", 0),
             today_diag_by_hour.get("n_imputed", 0),
             today_diag_by_hour.get("median_ratio", 0.0),
             today_diag_by_hour.get("clamped_hours", []),
+            len(yesterday_factor_by_hour),
         )
     elif today_factor != 1.0:
         logger.info(
@@ -1412,15 +1488,39 @@ def _run_optimizer_lp(
             today_diag.get("reason", "no diagnostic"),
         )
 
-    def _pv_scale_callable(hour_utc: int, cloud_pct: float) -> float:
+    # Build the per-hour map actually consumed by the LP: prefer today's
+    # observation if we have one, else warm-start from yesterday's value, else
+    # 1.0 (no per-hour bias). Exposed for the snapshot below.
+    today_factor_by_hour_imputed = today_diag_by_hour.get("imputed_hours") or []
+    effective_factor_by_hour: dict[int, float] = {}
+    if today_factor_by_hour:
+        for h in range(24):
+            if h not in today_factor_by_hour_imputed:
+                effective_factor_by_hour[h] = today_factor_by_hour[h]
+            elif h in yesterday_factor_by_hour:
+                effective_factor_by_hour[h] = yesterday_factor_by_hour[h]
+            else:
+                effective_factor_by_hour[h] = today_factor_by_hour[h]
+
+    def _pv_scale_callable(
+        hour_utc: int,
+        cloud_pct: float,
+        slot_start_utc: datetime | None = None,
+    ) -> float:
         cal = get_pv_calibration_factor_for(
             hour_utc, cloud_pct,
             cloud_table=pv_scale_cloud,
             hourly_table=pv_scale_hourly,
             flat=flat_scale,
         )
-        # Per-hour today factor wins; scalar fallback when the per-hour map
-        # is empty (not enough observed-vs-forecast data yet today).
+        # #1: only apply today_factor to slots IN the current UTC day. For
+        # tomorrow's slots return the cloud/hour calibration alone — today's
+        # observed bias is not evidence for tomorrow's weather.
+        if slot_start_utc is not None and slot_start_utc.date() != today_utc_date:
+            return cal
+        # Today's slots: prefer per-hour map (with warm-start fill); scalar fallback.
+        if effective_factor_by_hour:
+            return cal * effective_factor_by_hour.get(int(hour_utc), 1.0)
         if today_factor_by_hour:
             return cal * today_factor_by_hour.get(int(hour_utc), 1.0)
         return cal * today_factor
@@ -1457,6 +1557,22 @@ def _run_optimizer_lp(
                 if today_factor_by_hour else None
             ),
             "today_diag_by_hour": today_diag_by_hour,
+            # #5 — values actually consumed by the LP after the
+            # warm-start-from-yesterday fill-in. Distinct from
+            # today_factor_by_hour (raw observations + median fallback) so
+            # tomorrow's warm-start can read THIS dict instead of pulling
+            # in yesterday's median-fallback values.
+            "today_factor_effective_by_hour": (
+                {str(h): round(float(v), 6) for h, v in effective_factor_by_hour.items()}
+                if effective_factor_by_hour else None
+            ),
+            # #5 diag — non-empty when warm-start filled at least one hour.
+            "warm_start_from_yesterday_hours": sorted(
+                h for h in effective_factor_by_hour
+                if h in today_factor_by_hour_imputed and h in yesterday_factor_by_hour
+            ) if effective_factor_by_hour else [],
+            # #1 diag — applied today_factor only to today's UTC date.
+            "today_factor_scoped_to_utc_date": today_utc_date.isoformat(),
         },
         "temperature_adjustment": {
             "source": "forecast_skill_log",

--- a/src/weather.py
+++ b/src/weather.py
@@ -1690,7 +1690,15 @@ def forecast_to_lp_inputs(
             rad_eff = max(0.0, rad_wm2 * att)
         if callable(pv_scale):
             try:
-                scale_for_slot = float(pv_scale(st.hour, cloud_pct))
+                # New signature: (hour_utc, cloud_pct, slot_start_utc) — lets
+                # the closure distinguish today vs tomorrow slots so a
+                # today-only PV bias factor doesn't leak across the date
+                # boundary. Fall back to the legacy 2-arg signature for
+                # callers that don't yet declare slot_start_utc.
+                try:
+                    scale_for_slot = float(pv_scale(st.hour, cloud_pct, st))
+                except TypeError:
+                    scale_for_slot = float(pv_scale(st.hour, cloud_pct))
             except Exception:
                 scale_for_slot = 1.0
         elif isinstance(pv_scale, dict):

--- a/tests/test_today_factor_scope_and_warmstart.py
+++ b/tests/test_today_factor_scope_and_warmstart.py
@@ -1,0 +1,137 @@
+"""today_factor scoped to today + warm-start from yesterday's per-hour table.
+
+Two behaviors locked in here:
+1. Slots in tomorrow's UTC date must NOT receive today's PV-bias factor.
+   A cloudy-morning solve at 19:00 today produces today_factor ≈ 0.31; before
+   the fix that scalar contaminated tomorrow's morning predictions in the
+   same 48h solve. Tomorrow's slots now ignore today_factor entirely.
+2. Hours unobserved today are warm-started from yesterday's per-hour map
+   (persisted in lp_inputs_snapshot.exogenous_snapshot_json) instead of
+   inheriting the median of today's observations.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.scheduler.optimizer import _load_yesterday_today_factor_by_hour
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(app_config, "DB_PATH", str(tmp_path / "t.db"), raising=False)
+    db.init_db()
+
+
+def _seed_yesterday_snapshot(*, run_id: int, plan_date: str, snapshot_json: str) -> None:
+    """Insert one lp_inputs_snapshot row dated yesterday with the given JSON."""
+    db.save_lp_snapshots(
+        run_id=run_id,
+        inputs_row={
+            "run_at_utc": (datetime.now(UTC) - timedelta(hours=12)).isoformat(),
+            "plan_date": plan_date,
+            "horizon_hours": 48,
+            "soc_initial_kwh": 5.0,
+            "tank_initial_c": 45.0,
+            "indoor_initial_c": 20.0,
+            "soc_source": "test",
+            "tank_source": "test",
+            "indoor_source": "test",
+            "base_load_json": "[]",
+            "micro_climate_offset_c": 0.0,
+            "forecast_fetch_at_utc": None,
+            "exogenous_snapshot_json": snapshot_json,
+            "config_snapshot_json": "{}",
+            "price_quantize_p": 0.1,
+            "peak_threshold_p": 30.0,
+            "cheap_threshold_p": 10.0,
+            "daikin_control_mode": "off",
+            "optimization_preset": "normal",
+            "energy_strategy_mode": "savings_first",
+        },
+        solution_rows=[],
+    )
+
+
+def test_load_yesterday_factor_returns_empty_when_no_history() -> None:
+    """First-day-of-operation: no previous snapshot → return {} (no warm-start)."""
+    assert _load_yesterday_today_factor_by_hour() == {}
+
+
+def test_load_yesterday_factor_reads_effective_map_when_present() -> None:
+    """The post-#5 snapshot writes today_factor_effective_by_hour. The loader
+    must prefer it over the raw observed map so the warm-start chains across
+    days (yesterday's effective factor was already a warm-start mix)."""
+    yesterday = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
+    snapshot_json = '{"weather_adjustment": {"today_factor_by_hour": {"6":0.4}, "today_factor_effective_by_hour": {"6":0.9, "12":1.1, "16":1.4}}}'
+    _seed_yesterday_snapshot(run_id=1, plan_date=yesterday, snapshot_json=snapshot_json)
+    out = _load_yesterday_today_factor_by_hour()
+    # Effective map wins, not the raw observed map (which only has hour 6).
+    assert out == {6: 0.9, 12: 1.1, 16: 1.4}
+
+
+def test_load_yesterday_factor_falls_back_to_raw_for_old_snapshots() -> None:
+    """Pre-#5 snapshots only have today_factor_by_hour. The loader must still
+    return that map so the upgrade is backwards compatible."""
+    yesterday = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
+    snapshot_json = '{"weather_adjustment": {"today_factor_by_hour": {"7":0.5, "13":1.05}}}'
+    _seed_yesterday_snapshot(run_id=2, plan_date=yesterday, snapshot_json=snapshot_json)
+    assert _load_yesterday_today_factor_by_hour() == {7: 0.5, 13: 1.05}
+
+
+def test_pv_scale_callable_skips_today_factor_for_tomorrow_slots() -> None:
+    """End-to-end: the closure built inside run_optimizer applies today_factor
+    only to slots whose UTC date matches today. Stand-alone test reconstructs
+    the closure shape that's hot-pathed in the LP solve.
+    """
+    today = datetime.now(UTC).date()
+    today_factor_by_hour = {h: 0.30 for h in range(24)}  # heavy bias
+
+    def closure(hour_utc: int, cloud_pct: float, slot_start_utc=None) -> float:
+        cal = 1.0  # ignore cloud_table for this test
+        if slot_start_utc is not None and slot_start_utc.date() != today:
+            return cal  # tomorrow → no today bias
+        return cal * today_factor_by_hour.get(hour_utc, 1.0)
+
+    # Today's hour 10 → 0.30 (bias applied)
+    today_slot = datetime.combine(today, datetime.min.time(), tzinfo=UTC).replace(hour=10)
+    assert closure(10, 50.0, today_slot) == pytest.approx(0.30)
+
+    # Tomorrow's hour 10 → 1.0 (no bias)
+    tomorrow_slot = today_slot + timedelta(days=1)
+    assert closure(10, 50.0, tomorrow_slot) == pytest.approx(1.0)
+
+
+def test_forecast_to_lp_inputs_invokes_callable_with_slot_start_utc() -> None:
+    """The legacy 2-arg signature (hour, cloud) must keep working — graceful
+    fallback when the callable doesn't accept slot_start_utc."""
+    from src.weather import HourlyForecast, forecast_to_lp_inputs
+
+    base = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    forecast = [
+        HourlyForecast(
+            time_utc=base, temperature_c=12.0, cloud_cover_pct=50.0,
+            shortwave_radiation_wm2=400.0, estimated_pv_kw=2.0,
+            heating_demand_factor=0.0, pv_direct=False,
+        ),
+    ]
+    legacy_calls: list[tuple[int, float]] = []
+    def legacy_callable(h: int, c: float) -> float:
+        legacy_calls.append((h, c))
+        return 0.5
+    out_legacy = forecast_to_lp_inputs(forecast, [base], pv_scale=legacy_callable)
+    assert legacy_calls, "legacy 2-arg callable must still be invoked"
+    assert out_legacy.pv_kwh_per_slot[0] >= 0  # didn't crash
+
+    new_calls: list[tuple[int, float, datetime]] = []
+    def new_callable(h: int, c: float, slot_start_utc) -> float:
+        new_calls.append((h, c, slot_start_utc))
+        return 0.5
+    forecast_to_lp_inputs(forecast, [base], pv_scale=new_callable)
+    assert len(new_calls) == 1
+    assert new_calls[0][2] == base, "new 3-arg callable must receive the slot start_utc"


### PR DESCRIPTION
## Summary

Two related fixes to the today-aware PV adjuster:

**#1 cross-day scope** — `today_factor` (and the per-hour `today_factor_by_hour`) was applied to every slot in the 48h LP horizon. After a cloudy day this stamped a heavy downward bias onto tomorrow's slots even though tomorrow's actual weather is independent. Now applied only to slots whose UTC date matches today.

**#5 warm-start from yesterday** — for hours not yet observed today, the adjuster previously imputed the median of today's observed hours. On a cloudy-morning day that median (~0.35) drags afternoon hours down. Now warm-starts from yesterday's per-hour map (persisted in `lp_inputs_snapshot.exogenous_snapshot_json.weather_adjustment.today_factor_effective_by_hour`).

## Why

2026-05-08 prod audit: today_factor at 19:18 UTC was 0.3075 because the cloudy morning hammered the per-hour observations. Without scoping, that 0.3075 would have applied to tomorrow's morning slots → LP plans morning ForceCharge from grid even if tomorrow is sunny. Without warm-start, hour 14 (no observation yet at 09:00) inherits hour 8's heavy bias even though afternoons typically shed cloud.

## Test plan

- [x] `pytest tests/test_today_factor_scope_and_warmstart.py` — 5 pass (loader empty/effective/legacy paths + closure date-scope + callable signature compat)
- [x] `pytest tests/test_pv_cloud_aware_calibration.py tests/test_pv_forecast_accuracy.py tests/test_quartz_forecast.py tests/test_weather_cop_preprocess.py tests/test_forecast_skill_log.py tests/test_quartz_skip_cal_rebuild.py` — 42 pass (full forecast regression suite)
- [ ] After deploy: monitor tomorrow's first morning solve. With #1 alone the today_factor stops leaking; with #5 the per-hour adjuster respects yesterday's per-hour shape until today has enough observations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)