### PR TITLE
feat(diag): regression wins/losses + per-day inspection + PV bias report

### DIFF
--- a/scripts/check_lp_regression.py
+++ b/scripts/check_lp_regression.py
@@ -296,6 +296,147 @@ def run_check(
 # CLI
 # --------------------------------------------------------------------------
 
+def _build_wins_losses(
+    report: RegressionReport,
+    baseline_per_date: dict[str, dict[str, float]] | None,
+) -> list[dict[str, float | str]]:
+    """Per-day deltas of (current − baseline) replayed cost in pence.
+
+    Returns a list of ``{date, baseline_p, current_p, delta_p, classification}``
+    rows sorted by ``|delta_p|`` desc. ``classification`` is ``win`` when the
+    new code beats baseline (delta < 0), ``loss`` when worse, ``flat`` when
+    within 1 p, and ``no-baseline`` when the day isn't in the baseline.
+    """
+    rows: list[dict[str, float | str]] = []
+    by_date_current = {d.date: d for d in report.days if d.ok}
+    bd = baseline_per_date or {}
+    seen: set[str] = set()
+    for date_str, day in by_date_current.items():
+        seen.add(date_str)
+        bl = bd.get(date_str) or {}
+        try:
+            baseline_p = float(bl.get("total_replayed_cost_p", 0.0)) if bl else None
+        except (TypeError, ValueError):
+            baseline_p = None
+        if baseline_p is None:
+            classification = "no-baseline"
+            delta_p = 0.0
+            baseline_p_out = 0.0
+        else:
+            delta_p = day.total_replayed_cost_p - baseline_p
+            if delta_p < -1.0:
+                classification = "win"
+            elif delta_p > 1.0:
+                classification = "loss"
+            else:
+                classification = "flat"
+            baseline_p_out = baseline_p
+        rows.append({
+            "date": date_str,
+            "baseline_p": baseline_p_out,
+            "current_p": day.total_replayed_cost_p,
+            "delta_p": delta_p,
+            "classification": classification,
+        })
+    # Surface baseline-only days (regressed enough to fail to replay) too.
+    for date_str, bl in bd.items():
+        if date_str in seen:
+            continue
+        try:
+            baseline_p = float(bl.get("total_replayed_cost_p", 0.0))
+        except (TypeError, ValueError):
+            baseline_p = 0.0
+        rows.append({
+            "date": date_str,
+            "baseline_p": baseline_p,
+            "current_p": 0.0,
+            "delta_p": 0.0,
+            "classification": "missing-current",
+        })
+    rows.sort(key=lambda r: abs(float(r["delta_p"])), reverse=True)
+    return rows
+
+
+def _print_wins_losses(rows: list[dict[str, float | str]], top_k: int) -> None:
+    print()
+    print("=" * 80)
+    print(f"WINS / LOSSES vs baseline (top {top_k} by |Δ|)")
+    print("=" * 80)
+    print(f"{'date':>12}  {'baseline £':>11}  {'current £':>10}  {'Δ £':>9}  class")
+    for r in rows[: max(0, int(top_k))]:
+        print(
+            f"{str(r['date']):>12}  "
+            f"{float(r['baseline_p']) / 100:>+10.2f}  "
+            f"{float(r['current_p']) / 100:>+9.2f}  "
+            f"{float(r['delta_p']) / 100:>+8.2f}  "
+            f"{r['classification']}"
+        )
+    wins = [r for r in rows if r["classification"] == "win"]
+    losses = [r for r in rows if r["classification"] == "loss"]
+    flats = [r for r in rows if r["classification"] == "flat"]
+    win_total_p = sum(float(r["delta_p"]) for r in wins)
+    loss_total_p = sum(float(r["delta_p"]) for r in losses)
+    print("-" * 80)
+    print(
+        f"  Wins  : {len(wins):>3}  total Δ {win_total_p / 100:>+8.2f} £   "
+        f"Losses: {len(losses):>3}  total Δ {loss_total_p / 100:>+8.2f} £   "
+        f"Flat: {len(flats):>3}"
+    )
+    print()
+
+
+def _inspect_day(target: str, *, mode: str = "forward") -> int:
+    """Replay one day and dump per-slot LP outputs.
+
+    Reuses the existing ``replay_day`` machinery; surfaces ``slot_diffs`` for
+    the LAST run of the day (fully-resolved horizon) so the user can see the
+    plan that would have shipped if the day's recalc chain ran on current code.
+    """
+    from src.scheduler.lp_replay import replay_day
+
+    try:
+        r = replay_day(target, cadence="original", mode=mode)
+    except Exception as e:
+        print(f"[inspect-day] replay raised: {e}", file=sys.stderr)
+        return 1
+    if not r.ok:
+        print(f"[inspect-day] replay failed: {r.error}", file=sys.stderr)
+        return 1
+    runs = list(r.runs or [])
+    if not runs:
+        print(f"[inspect-day] no LP runs on {target}", file=sys.stderr)
+        return 1
+    last = runs[-1]
+    slots = last.slot_diffs or []
+    print()
+    print("=" * 100)
+    print(f"INSPECT-DAY {target} — last run (mode={mode}, run_id={last.run_id})")
+    print(f"  replayed cost (full day)  : {r.total_replayed_cost_p / 100:>+8.2f} £")
+    print(f"  original  cost (full day) : {r.total_original_cost_p / 100:>+8.2f} £")
+    print(f"  Δ                         : {r.total_delta_cost_p / 100:>+8.2f} £")
+    print("=" * 100)
+    print(
+        f"{'slot_utc':>20}  {'p':>6}  "
+        f"{'imp':>5}  {'exp':>5}  {'chg':>5}  {'dis':>5}  "
+        f"{'dhw':>5}  {'spc':>5}  {'soc':>6}  {'tank':>5}"
+    )
+    for s in slots:
+        print(
+            f"{str(s.get('slot_time_utc', ''))[-20:]:>20}  "
+            f"{float(s.get('price_p', 0.0)):>6.2f}  "
+            f"{float(s.get('new_import_kwh', 0.0)):>5.2f}  "
+            f"{float(s.get('new_export_kwh', 0.0)):>5.2f}  "
+            f"{float(s.get('new_charge_kwh', 0.0)):>5.2f}  "
+            f"{float(s.get('new_discharge_kwh', 0.0)):>5.2f}  "
+            f"{float(s.get('new_dhw_kwh', 0.0)):>5.2f}  "
+            f"{float(s.get('new_space_kwh', 0.0)):>5.2f}  "
+            f"{float(s.get('new_soc_kwh', 0.0)):>6.2f}  "
+            f"{float(s.get('new_tank_temp_c', 0.0)):>5.1f}"
+        )
+    print()
+    return 0
+
+
 def _print_report(report: RegressionReport) -> None:
     print()
     print("=" * 80)
@@ -386,6 +527,27 @@ def main(argv: list[str]) -> int:
         "--quiet", action="store_true",
         help="Suppress the human-readable table; useful in CI when --json is set.",
     )
+    parser.add_argument(
+        "--wins-losses", action="store_true",
+        help=(
+            "After the standard report, print a per-day wins/losses table "
+            "sorted by |Δ| vs baseline. Useful to localise WHICH days the "
+            "new code helps or hurts before refreshing the baseline."
+        ),
+    )
+    parser.add_argument(
+        "--wins-losses-top-k", type=int, default=14,
+        help="When --wins-losses is set, print up to this many rows (default 14).",
+    )
+    parser.add_argument(
+        "--inspect-day", type=str, default=None,
+        help=(
+            "Replay ONE local date (YYYY-MM-DD) under --mode and dump per-slot "
+            "LP outputs (price, kWh per pillar, SoC, tank temp) for the last "
+            "run of the day. Mutually exclusive with the regression-gate flow; "
+            "exits 0/1 based on whether the replay succeeded."
+        ),
+    )
     args = parser.parse_args(argv[1:])
 
     logging.basicConfig(
@@ -393,6 +555,12 @@ def main(argv: list[str]) -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
         stream=sys.stderr,
     )
+
+    if args.inspect_day:
+        # Single-day inspection short-circuits the regression-gate flow —
+        # the gate only makes sense as an aggregate over the window.
+        single_mode = "forward" if args.mode == "both" else args.mode
+        return _inspect_day(args.inspect_day, mode=single_mode)
 
     if args.mode == "both":
         # Run forward + honest sequentially, fail on EITHER regressing.
@@ -422,6 +590,11 @@ def main(argv: list[str]) -> int:
             if not args.quiet:
                 print(f"\n### MODE = {m.upper()} ###")
                 _print_report(r)
+                if args.wins_losses:
+                    bl = _load_baseline(mode_baseline_path) or {}
+                    per_date = bl.get("per_date") if isinstance(bl, dict) else None
+                    rows = _build_wins_losses(r, per_date if isinstance(per_date, dict) else None)
+                    _print_wins_losses(rows, args.wins_losses_top_k)
 
         if args.json:
             args.json.parent.mkdir(parents=True, exist_ok=True)
@@ -463,6 +636,11 @@ def main(argv: list[str]) -> int:
 
     if not args.quiet:
         _print_report(report)
+        if args.wins_losses:
+            bl = _load_baseline(args.baseline) or {}
+            per_date = bl.get("per_date") if isinstance(bl, dict) else None
+            rows = _build_wins_losses(report, per_date if isinstance(per_date, dict) else None)
+            _print_wins_losses(rows, args.wins_losses_top_k)
 
     return 0 if report.passed else 1
 

--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -81,7 +81,29 @@ def build_morning_payload() -> str:
 
     lines.append(f"**Yesterday ({yesterday}) — financial summary**")
     lines.extend(_format_pnl_block(pnl, day=yesterday, tz=tz))
+
+    bias_line = _pv_bias_line()
+    if bias_line:
+        lines.extend(["", bias_line])
+
     return "\n".join(lines)
+
+
+def _pv_bias_line() -> str | None:
+    """One-line PV forecast bias (am/pm) for the morning brief.
+
+    Returns ``None`` when no paired samples exist yet — callers should skip
+    rather than render an empty line. Surfaces the same headline that the
+    ``get_pv_forecast_bias`` MCP tool returns, so OpenClaw + the brief agree.
+    """
+    try:
+        from .pv_bias_report import summarise_pv_bias
+        report = summarise_pv_bias(window_days=int(config.PV_BIAS_REPORT_WINDOW_DAYS))
+    except Exception:  # pragma: no cover — diagnostic line must never break the brief
+        return None
+    if int(report.get("n_paired", 0)) <= 0:
+        return None
+    return report.get("headline")
 
 
 # --------------------------------------------------------------------------

--- a/src/analytics/pv_bias_report.py
+++ b/src/analytics/pv_bias_report.py
@@ -1,0 +1,106 @@
+"""Morning vs afternoon PV forecast bias.
+
+Wraps :func:`src.weather.evaluate_pv_forecast_accuracy` and bins the per-hour
+``bias_kw`` series into ``morning`` (04–12 UTC) and ``afternoon`` (12–20 UTC)
+aggregates so the morning brief and the ``get_pv_forecast_bias`` MCP tool can
+say things like "PV bias 14 d: am +0.18 kW under-forecast, pm −0.05 kW over".
+
+Sign convention follows :func:`evaluate_pv_forecast_accuracy`:
+``bias_kw = mean(actual − predicted)``. Positive → forecast was too low
+(under-forecast); negative → forecast was too high (over-forecast).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .. import weather
+
+# Hour bins use UTC because the underlying tables key on UTC ``captured_at`` /
+# ``slot_time``. London ≡ UTC in winter and UTC+1 in summer; the bins
+# 04–12 / 12–20 UTC straddle that drift cleanly enough for a daily report.
+MORNING_HOURS: tuple[int, ...] = (4, 5, 6, 7, 8, 9, 10, 11)
+AFTERNOON_HOURS: tuple[int, ...] = (12, 13, 14, 15, 16, 17, 18, 19)
+
+
+def _aggregate_bin(per_hour: dict[int, dict[str, Any]], hours: tuple[int, ...]) -> dict[str, Any]:
+    rows = [per_hour[h] for h in hours if h in per_hour]
+    n = sum(int(r.get("n", 0)) for r in rows)
+    if n <= 0:
+        return {"bias_kw": None, "mae_kw": None, "rmse_kw": None, "n": 0, "hours": list(hours)}
+    weighted_bias = sum(float(r.get("bias_kw", 0.0)) * int(r.get("n", 0)) for r in rows) / n
+    weighted_mae = sum(float(r.get("mae_kw", 0.0)) * int(r.get("n", 0)) for r in rows) / n
+    sq = sum((float(r.get("rmse_kw", 0.0)) ** 2) * int(r.get("n", 0)) for r in rows) / n
+    return {
+        "bias_kw": round(weighted_bias, 3),
+        "mae_kw": round(weighted_mae, 3),
+        "rmse_kw": round(sq ** 0.5, 3),
+        "n": n,
+        "hours": list(hours),
+    }
+
+
+def summarise_pv_bias(window_days: int = 14) -> dict[str, Any]:
+    """Compute the morning/afternoon PV-forecast bias summary.
+
+    Returns a dict shaped for both the morning brief and the MCP tool::
+
+        {
+            "ok": True,
+            "window_days": 14,
+            "n_paired": 245,
+            "morning": {"bias_kw": 0.18, "mae_kw": 0.32, "rmse_kw": 0.45, "n": 88, "hours": [...]},
+            "afternoon": {"bias_kw": -0.05, ..., "n": 120, "hours": [...]},
+            "overall": {"bias_kw": ..., "mae_kw": ..., "rmse_kw": ..., "mape_pct": ...},
+            "headline": "am +0.18 kW under, pm −0.05 kW over (14 d, n=245)",
+        }
+
+    When the underlying paired sample is empty the function still returns
+    ``ok: True`` with ``n_paired: 0`` and ``headline: "no paired samples"`` —
+    callers can treat that as "skip the line in the brief".
+    """
+    raw = weather.evaluate_pv_forecast_accuracy(window_days=int(window_days))
+    per_hour = raw.get("per_hour") or {}
+    overall = raw.get("overall") or {}
+    n_paired = int(raw.get("n_paired", 0))
+
+    morning = _aggregate_bin(per_hour, MORNING_HOURS)
+    afternoon = _aggregate_bin(per_hour, AFTERNOON_HOURS)
+
+    headline = _format_headline(window_days, n_paired, morning, afternoon)
+
+    return {
+        "ok": True,
+        "window_days": int(window_days),
+        "n_paired": n_paired,
+        "morning": morning,
+        "afternoon": afternoon,
+        "overall": {
+            "bias_kw": overall.get("bias_kw"),
+            "mae_kw": overall.get("mae_kw"),
+            "rmse_kw": overall.get("rmse_kw"),
+            "mape_pct": overall.get("mape_pct"),
+            "mean_actual_kw": overall.get("mean_actual_kw"),
+            "mean_pred_kw": overall.get("mean_pred_kw"),
+        },
+        "headline": headline,
+    }
+
+
+def _format_bin(label: str, b: dict[str, Any]) -> str | None:
+    bias = b.get("bias_kw")
+    if bias is None:
+        return None
+    direction = "under" if bias > 0 else ("over" if bias < 0 else "neutral")
+    sign = "+" if bias > 0 else ("−" if bias < 0 else "")
+    # Use a real minus sign for over-forecast so screen-readers + Telegram
+    # render consistently. abs() avoids "−-0.05".
+    return f"{label} {sign}{abs(bias):.2f} kW {direction}"
+
+
+def _format_headline(window_days: int, n_paired: int, morning: dict, afternoon: dict) -> str:
+    if n_paired <= 0:
+        return f"PV bias {window_days} d: no paired samples yet"
+    parts = [p for p in (_format_bin("am", morning), _format_bin("pm", afternoon)) if p]
+    if not parts:
+        return f"PV bias {window_days} d: no paired samples in morning/afternoon bins"
+    return f"PV bias {window_days} d: {', '.join(parts)} (n={n_paired})"

--- a/src/config.py
+++ b/src/config.py
@@ -242,6 +242,12 @@ class Config:
         os.getenv("FIXED_TARIFF_STANDING_PENCE_PER_DAY", "0")
     )
 
+    # Window (in days) for the morning-vs-afternoon PV forecast bias report
+    # surfaced in the morning brief and via the ``get_pv_forecast_bias`` MCP
+    # tool. Reads ``pv_calibration_hourly`` and ``pv_realtime_history`` via
+    # ``weather.evaluate_pv_forecast_accuracy``.
+    PV_BIAS_REPORT_WINDOW_DAYS: int = int(os.getenv("PV_BIAS_REPORT_WINDOW_DAYS", "14"))
+
     # Effective start of the Octopus Agile tariff. Period aggregations
     # (weekly/monthly/MTD/YTD) clamp their start date upward to this value
     # so pre-switch days don't pollute the realised cost or shadow comparisons

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2199,6 +2199,26 @@ def build_mcp() -> FastMCP:
         return {"ok": True, "forecast_hourly": fc[:48], "daikin": daikin}
 
     @mcp.tool(
+        name="get_pv_forecast_bias",
+        description=(
+            "Morning vs afternoon PV forecast bias over a trailing window "
+            "(default PV_BIAS_REPORT_WINDOW_DAYS, 14 d). Returns weighted "
+            "bias_kw / mae_kw / rmse_kw for the morning (04–12 UTC) and "
+            "afternoon (12–20 UTC) bins plus an overall row and a one-line "
+            "headline. Sign convention: `bias_kw = mean(actual − predicted)` "
+            "— positive = forecast was too low (under-forecast), negative = "
+            "too high (over-forecast). Sibling to the live three-way "
+            "deviation tracker (#263); this is the static-prior view."
+        ),
+    )
+    def get_pv_forecast_bias(window_days: int | None = None) -> dict[str, Any]:
+        from .analytics.pv_bias_report import summarise_pv_bias
+        days = int(window_days) if window_days else int(config.PV_BIAS_REPORT_WINDOW_DAYS)
+        if days <= 0:
+            return {"ok": False, "error": "window_days must be > 0"}
+        return summarise_pv_bias(window_days=days)
+
+    @mcp.tool(
         name="get_action_log",
         description=(
             "Recent device-command rows from action_log: who triggered what, "

--- a/tests/test_pv_bias_report.py
+++ b/tests/test_pv_bias_report.py
@@ -1,0 +1,125 @@
+"""Tests for the morning vs afternoon PV forecast bias summariser.
+
+The underlying ``weather.evaluate_pv_forecast_accuracy`` is exercised by
+``test_pv_forecast_accuracy.py``; here we mock it to keep these tests fast
+and pinpoint the binning + headline logic.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _fake_eval(per_hour: dict[int, dict[str, float]] | None,
+               n_paired: int = 100,
+               overall: dict[str, float] | None = None) -> dict[str, Any]:
+    return {
+        "window_days": 14,
+        "n_paired": int(n_paired),
+        "overall": overall or {
+            "mae_kw": 0.40, "rmse_kw": 0.55, "bias_kw": 0.05,
+            "mean_actual_kw": 0.80, "mean_pred_kw": 0.75,
+            "mape_pct": 35.0, "n": int(n_paired),
+        },
+        "per_hour": per_hour or {},
+    }
+
+
+def test_under_forecast_morning_renders_positive_bias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mornings under-forecast (actual > predicted) → morning bias_kw > 0."""
+    from src.analytics import pv_bias_report
+    from src import weather as weather_mod
+
+    per_hour = {h: {"bias_kw": 0.20, "mae_kw": 0.30, "rmse_kw": 0.40, "n": 10}
+                for h in (4, 5, 6, 7, 8, 9, 10, 11)}
+    per_hour.update({h: {"bias_kw": -0.05, "mae_kw": 0.20, "rmse_kw": 0.25, "n": 10}
+                     for h in (12, 13, 14, 15, 16, 17, 18, 19)})
+    monkeypatch.setattr(weather_mod, "evaluate_pv_forecast_accuracy",
+                        lambda window_days: _fake_eval(per_hour, n_paired=160))
+
+    out = pv_bias_report.summarise_pv_bias(window_days=14)
+    assert out["ok"] is True
+    assert out["window_days"] == 14
+    assert out["n_paired"] == 160
+    assert out["morning"]["bias_kw"] == pytest.approx(0.20, abs=0.01)
+    assert out["morning"]["n"] == 80  # 8 hours × 10
+    assert out["afternoon"]["bias_kw"] == pytest.approx(-0.05, abs=0.01)
+    assert "am +0.20 kW under" in out["headline"]
+    assert "pm" in out["headline"] and "0.05" in out["headline"]
+
+
+def test_over_forecast_uses_minus_sign_in_headline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Afternoons over-forecast → headline labels them with 'over'."""
+    from src.analytics import pv_bias_report
+    from src import weather as weather_mod
+
+    per_hour = {h: {"bias_kw": -0.50, "mae_kw": 0.55, "rmse_kw": 0.70, "n": 12}
+                for h in (12, 13, 14, 15, 16, 17, 18, 19)}
+    monkeypatch.setattr(weather_mod, "evaluate_pv_forecast_accuracy",
+                        lambda window_days: _fake_eval(per_hour, n_paired=96))
+
+    out = pv_bias_report.summarise_pv_bias(window_days=14)
+    assert out["afternoon"]["bias_kw"] == pytest.approx(-0.50)
+    assert out["morning"]["bias_kw"] is None  # nothing in morning hours
+    assert "pm" in out["headline"] and "over" in out["headline"]
+
+
+def test_empty_data_returns_skip_signal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No paired samples → ``n_paired=0`` and a 'no paired samples' headline.
+    Callers (the morning brief) treat this as 'skip the line'."""
+    from src.analytics import pv_bias_report
+    from src import weather as weather_mod
+
+    monkeypatch.setattr(weather_mod, "evaluate_pv_forecast_accuracy",
+                        lambda window_days: _fake_eval({}, n_paired=0))
+
+    out = pv_bias_report.summarise_pv_bias(window_days=14)
+    assert out["ok"] is True
+    assert out["n_paired"] == 0
+    assert "no paired samples" in out["headline"]
+    assert out["morning"]["bias_kw"] is None
+    assert out["afternoon"]["bias_kw"] is None
+
+
+def test_weighted_aggregation_uses_sample_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hours with more samples should pull the weighted bias_kw toward them.
+
+    1 hour with bias +1.0 (n=100) and 7 hours with bias 0.0 (n=1 each)
+    → morning bias ≈ 100 / 107 ≈ 0.93, NOT the simple average 0.125.
+    """
+    from src.analytics import pv_bias_report
+    from src import weather as weather_mod
+
+    per_hour: dict[int, dict[str, float]] = {}
+    for h in (4, 5, 6, 7, 8, 9, 10):
+        per_hour[h] = {"bias_kw": 0.0, "mae_kw": 0.1, "rmse_kw": 0.1, "n": 1}
+    per_hour[11] = {"bias_kw": 1.0, "mae_kw": 1.0, "rmse_kw": 1.0, "n": 100}
+    monkeypatch.setattr(weather_mod, "evaluate_pv_forecast_accuracy",
+                        lambda window_days: _fake_eval(per_hour, n_paired=107))
+
+    out = pv_bias_report.summarise_pv_bias(window_days=14)
+    assert out["morning"]["n"] == 107
+    # weighted = (0×7 + 1.0×100) / 107 ≈ 0.935
+    assert out["morning"]["bias_kw"] == pytest.approx(0.935, abs=0.01)
+
+
+def test_morning_brief_skips_line_when_no_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The brief helper returns None when n_paired == 0 so the line drops out."""
+    from src.analytics import daily_brief
+    from src.analytics import pv_bias_report
+
+    monkeypatch.setattr(pv_bias_report, "summarise_pv_bias",
+                        lambda window_days: {"ok": True, "n_paired": 0,
+                                              "headline": "PV bias 14 d: no paired samples yet"})
+    assert daily_brief._pv_bias_line() is None
+
+
+def test_morning_brief_renders_headline_when_data_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.analytics import daily_brief
+    from src.analytics import pv_bias_report
+
+    headline = "PV bias 14 d: am +0.18 kW under, pm −0.05 kW over (n=160)"
+    monkeypatch.setattr(pv_bias_report, "summarise_pv_bias",
+                        lambda window_days: {"ok": True, "n_paired": 160, "headline": headline})
+    assert daily_brief._pv_bias_line() == headline


### PR DESCRIPTION
## Summary

Risk-free **diagnostics** PR — no LP behaviour change. Surfaces existing data so the LP-touching PRs that follow can be scored per-day before refreshing the regression baseline.

## Why now

Last week's audit (2026-05-02 → 2026-05-08) showed Agile lost £0.48 vs BG Fixed v58. Diagnosing *which* day caused *what* is currently hard: \`scripts/check_lp_regression.py\` emits aggregate cost only, and there is no morning-vs-afternoon PV-forecast bias surface even though the data exists. This PR closes both gaps without touching the LP.

## What changed

### \`scripts/check_lp_regression.py\`

- \`--wins-losses\` — after the standard report, prints a per-day \`current vs baseline\` table sorted by \`|Δ|\`, classified as \`win\` / \`loss\` / \`flat\` / \`no-baseline\` / \`missing-current\`. Surfaces totals: "Wins: 1, total Δ −£0.50; Losses: 4, total Δ +£0.96; Flat: 0".
- \`--inspect-day YYYY-MM-DD\` — replays one date under \`--mode\` and dumps per-slot LP outputs (price, import/export/charge/discharge kWh, dhw/space kWh, SoC, tank °C) for the last run of the day. Mutually exclusive with the regression-gate flow; useful when a wins-losses row is unexplained.

### \`src/analytics/pv_bias_report.py\` (new)

\`summarise_pv_bias(window_days)\` wraps \`weather.evaluate_pv_forecast_accuracy\` and bins the per-hour \`bias_kw\` series into:
- morning (04–12 UTC)
- afternoon (12–20 UTC)

Returns weighted \`bias_kw\` / \`mae_kw\` / \`rmse_kw\` per bin + an overall row + a one-line headline. Sign convention: \`bias_kw = mean(actual − predicted)\` — positive = forecast too low (under-forecast); negative = too high (over-forecast).

### \`src/mcp_server.py\`

New MCP tool \`get_pv_forecast_bias(window_days?)\`. Sibling to the live-deviation tracker work in #263 — this is the static-prior view OpenClaw can query at any time.

### \`src/analytics/daily_brief.py\`

\`build_morning_payload\` appends one line at the end:
> PV bias 14 d: am −0.08 kW over, pm +0.13 kW under (n=194)

Skips silently when no paired samples yet.

### \`src/config.py\`

\`PV_BIAS_REPORT_WINDOW_DAYS\` (default 14). Read by both the brief and the MCP tool.

## End-to-end verification on prod DB snapshot

Pulled \`/srv/hem/data/energy_state.db\` and ran:

\`\`\`
$ DB_PATH=/tmp/snap.db PYTHONPATH=. .venv/bin/python -c \\
  "from src.analytics.pv_bias_report import summarise_pv_bias as s; print(s(14)['headline'])"
PV bias 14 d: am −0.08 kW over, pm +0.13 kW under (n=194)
\`\`\`

That **confirms the user's hypothesis** — afternoons are under-forecast (we miss free PV) and mornings are over-forecast (we under-import expecting PV that doesn't fully arrive). This is exactly the data #248 (Quartz-calibrated buy-guard) needs to consume.

\`--wins-losses\` against the same snapshot localised the post-baseline drift to 4 specific days (5/3, 5/5, 5/2, 5/4 each lost £0.16–0.28 vs baseline frozen 2026-05-06).

## Test plan

- [x] \`pytest tests/test_pv_bias_report.py\` — 6 new tests (binning, weighting, empty data, brief integration).
- [x] \`pytest tests/test_check_lp_regression.py tests/test_brief_expanded.py tests/test_daily_brief_split.py\` — 32 existing tests still green.
- [x] \`scripts/check_lp_regression.py --help\` — both new flags documented.
- [x] \`--wins-losses\` end-to-end against prod snapshot.
- [x] \`--inspect-day 2026-05-06\` end-to-end against prod snapshot — per-slot table renders cleanly.
- [x] PV bias against prod snapshot returns sensible numbers (n=194, am over, pm under).

## Cross-links

- #263 — three-way live deviation tracker (live sibling of this static-prior bias view).
- #248 — Quartz-calibrated buy-guard (consumes the bias data this PR surfaces).
- #274 — export timing rank-based (next PR; will use \`--wins-losses\` for per-day validation).

## Plan

\`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` — PR 1 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)