### PR TITLE
feat(lp): PV-abundance tank ceiling lift + reward + LP_TANK_HI_SLACK config (#225 item 1)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -569,6 +569,27 @@ class Config:
     LP_PEAK_EXPORT_TOP_QUARTILE_PERCENT: float = float(
         os.getenv("LP_PEAK_EXPORT_TOP_QUARTILE_PERCENT", "25")
     )
+    # PV-abundance DHW preheat (PR 3 of plan; tank ceiling lift). When per-slot
+    # (pv_avail − base_load − battery-charge headroom) exceeds this threshold,
+    # the LP lifts the tank ceiling to ``DHW_TEMP_MAX_C`` (same surface as the
+    # negative-price lift) and adds a small reward to e_dhw[i] so otherwise-
+    # curtailed PV gets stored as hot water for evening showers. Default 0.5
+    # kWh/slot — matches the user's empirical "afternoon set-point lift" pattern.
+    DHW_PV_ABUNDANCE_THRESHOLD_KWH: float = float(
+        os.getenv("DHW_PV_ABUNDANCE_THRESHOLD_KWH", "0.5")
+    )
+    # Reward magnitude for PV-abundance DHW heating. Must be smaller than
+    # ``EXPORT_RATE_PENCE × cop_dhw[i]`` so genuinely-profitable export still
+    # wins. Default 0.5 p/kWh.
+    LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH: float = float(
+        os.getenv("LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", "0.5")
+    )
+    # Slack penalty on the soft DHW ceiling (#225 item 1, was hardcoded 0.01).
+    # Operators who want stricter comfort vs cost can tune this. Default 0.01
+    # p/°C-slot preserves prior behaviour.
+    LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT: float = float(
+        os.getenv("LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT", "0.01")
+    )
     # Comma-separated trigger reasons for which scenario LP runs. Other
     # triggers (drift, forecast_revision, hourly cron not in this list)
     # use only the nominal solve to keep latency low.

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -264,6 +264,13 @@ def daikin_dispatch_preview(
             "cheap": "pre_heat",
             "peak": "shutdown",
             "peak_export": "shutdown",
+            # PR 3 of plan: solar_charge → solar_preheat. The LP's PV-abundance
+            # ceiling lift means tank_temp_c[i+1] is already raised toward
+            # DHW_TEMP_MAX_C on these slots; dispatch translates that into a
+            # tank-target write + powerful boost. Restore row at end-of-window
+            # drops back to DHW_TEMP_NORMAL_C — same safety scaffolding as
+            # negative/cheap kinds.
+            "solar_charge": "solar_preheat",
         }.get(kind, "normal")
 
         mid = start_utc + timedelta(minutes=15)
@@ -283,11 +290,16 @@ def daikin_dispatch_preview(
             lwt = max(-2.0, float(config.OPTIMIZATION_LWT_OFFSET_MIN))
         tank_pow = ed > EPS
         tank_powful = ed >= max_b - 1e-3
+        # Powerful boost is enabled on negative *and* solar_preheat slots —
+        # both want to dump as much energy into the tank as possible while
+        # the slot lasts (negative: paid to import; solar: free PV otherwise
+        # exported / curtailed). All other kinds keep powerful off.
+        powerful_kinds = ("negative", "solar_charge")
         params: dict[str, Any] = {
             "lwt_offset": round(lwt, 1),  # Daikin rejects sub-0.1 precision; rounds float epsilon to 0.0
-            "tank_powerful": tank_powful if kind == "negative" else False,
+            "tank_powerful": tank_powful if kind in powerful_kinds else False,
             "tank_power": tank_pow,
-            "climate_on": es > EPS or ed > EPS or kind in ("negative", "cheap"),
+            "climate_on": es > EPS or ed > EPS or kind in ("negative", "cheap", "solar_charge"),
             "lp_optimizer": True,
         }
         # Only set tank_temp when the tank will be on — Daikin rejects temperatureControl on a powered-off tank.

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -559,12 +559,21 @@ def solve_lp(
             if wm[i] or we[i]:
                 prob += tank[i + 1] >= t_min_dhw
 
-    # Per-slot DHW ceiling: 48 °C unless price < 0 (then 65 °C).
-    # Soft constraint — heavy penalty on breach — so an initial tank already above 48 °C
-    # (inherited from a prior negative window) stays feasible and is allowed to cool
-    # naturally instead of forcing an infeasible instantaneous drop.
+    # Per-slot DHW ceiling: 48 °C unless price < 0 OR PV is abundant (then DHW_TEMP_MAX_C, default 65 °C).
+    # PV abundance per slot = (pv_avail − base_load − max battery charge headroom) > threshold.
+    # When true, free PV would otherwise be exported / curtailed; lifting the tank ceiling lets
+    # the LP store that energy as hot water for evening showers instead. Composes naturally with
+    # the negative-price lift — same mechanism, different trigger. Soft constraint: heavy penalty
+    # on breach so an initial tank already above 48 °C (inherited from a prior lift) stays feasible.
+    pv_abundance_threshold = float(getattr(config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5))
+    pv_abundance: list[bool] = [
+        (pv_avail[i] - base_load_kwh[i] - max_batt_kwh) > pv_abundance_threshold
+        for i in range(n)
+    ]
     tank_hi_slot = [
-        float(config.DHW_TEMP_MAX_C) if price_line[i] < 0 else float(config.DHW_TEMP_COMFORT_C)
+        float(config.DHW_TEMP_MAX_C)
+        if (price_line[i] < 0 or pv_abundance[i])
+        else float(config.DHW_TEMP_COMFORT_C)
         for i in range(n)
     ]
     s_tank_hi = pulp.LpVariable.dicts("tank_hi_slack", range(n), lowBound=0)
@@ -679,11 +688,26 @@ def solve_lp(
     obj_comfort = comfort_pen * pulp.lpSum(s_lo[i] + s_hi[i] for i in range(n))
     # DHW overshoot above the comfort ceiling is not a comfort issue — it's just stored
     # hot water that will drift back naturally via tank losses. A *tiny* penalty
-    # (0.01 p/°C-slot) breaks ties toward the lower tank target without blocking the LP
+    # (default 0.01 p/°C-slot, configurable via ``LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT``;
+    # closes #225 item 1) breaks ties toward the lower tank target without blocking the LP
     # from filling the tank to 65 °C during negative-price windows (the whole point of
     # #50). Positive-price DHW heating is already discouraged by obj_grid, so no extra
     # penalty is needed to prevent gratuitous overshoot.
-    obj_tank_hi = 0.01 * pulp.lpSum(s_tank_hi[i] for i in range(n))
+    tank_hi_slack_p = float(getattr(config, "LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT", 0.01))
+    obj_tank_hi = tank_hi_slack_p * pulp.lpSum(s_tank_hi[i] for i in range(n))
+    # PV-abundance DHW reward: when PV exceeds self-use + battery headroom, every kWh
+    # the LP routes into the tank instead of curtailing earns a small reward. Tied to
+    # the same per-slot bool used for the ceiling lift above. Reward must stay below
+    # ``EXPORT_RATE_PENCE × cop_dhw[i]`` so export still wins when more profitable —
+    # the unit test ``test_pv_abundance_reward_does_not_dominate_export`` enforces this.
+    pv_abundance_reward_p = float(getattr(config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 0.0))
+    obj_pv_abundance_dhw: Any = 0
+    if pv_abundance_reward_p > 0:
+        abundant_indices = [i for i in range(n) if pv_abundance[i]]
+        if abundant_indices:
+            obj_pv_abundance_dhw = -pv_abundance_reward_p * pulp.lpSum(
+                e_dhw[i] for i in abundant_indices
+            )
     # PV curtailment penalty: prevents the LP from "happily curtailing" solar during
     # ForceCharge slots when the chg cap binds. Without this, pv_curt has zero objective
     # coefficient and the LP picks max-imp + curtail because grid imp at -7p ties or
@@ -696,7 +720,7 @@ def solve_lp(
     obj_pv_curt = (
         pv_curt_pen * pulp.lpSum(pv_curt[i] for i in range(n)) if pv_curt_pen > 0 else 0
     )
-    objective = obj_grid + obj_cycle + obj_comfort + obj_tank_hi + obj_pv_curt
+    objective = obj_grid + obj_cycle + obj_comfort + obj_tank_hi + obj_pv_curt + obj_pv_abundance_dhw
 
     if use_stress and stress_aux:
         # Stress cost is suppressed during negative-price slots: every kWh of

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -1,0 +1,229 @@
+"""PR 3 of plan: PV-abundance tank ceiling lift + reward + #225 item 1.
+
+Tests:
+1. **LP**: PV-abundance lifts ``tank_hi_slot`` to ``DHW_TEMP_MAX_C`` (composes
+   with the negative-price lift; same surface).
+2. **LP**: ``LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH > 0`` shifts e_dhw
+   toward abundant slots when the LP would otherwise route surplus PV elsewhere.
+3. **LP**: reward must NOT dominate export when the export rate is genuinely
+   profitable — guards the "near-zero grid cost first, profit second" policy.
+4. **LP**: ``LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT`` is honoured (closes #225 item 1).
+5. **Dispatch SAFETY**: every emitted ``solar_preheat`` action has a paired
+   ``restore`` row that drops the tank back to ``DHW_TEMP_NORMAL_C`` — this is
+   the user-stated hard constraint ("forgetting to switch back is the cost
+   problem"), so it gets a focused regression test.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+def _make_weather(slots, pv_kwh):
+    from src.weather import WeatherLpSeries
+    n = len(slots)
+    return WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[18.0] * n,
+        shortwave_radiation_wm2=[600.0] * n,
+        cloud_cover_pct=[20.0] * n,
+        pv_kwh_per_slot=pv_kwh,
+        cop_space=[3.5] * n,
+        cop_dhw=[3.0] * n,
+    )
+
+
+def _solve(slots, prices, pv, base_load, init_soc=8.0, init_tank=40.0,
+           export_prices=None, **monkeyed_config):
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+    init = LpInitialState(soc_kwh=init_soc, tank_temp_c=init_tank, indoor_temp_c=21.0)
+    return solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=_make_weather(slots, pv),
+        initial=init,
+        tz=ZoneInfo("Europe/London"),
+        export_price_pence=export_prices,
+    )
+
+
+# --------------------------------------------------------------------------
+# 1. PV-abundance lifts the tank ceiling
+# --------------------------------------------------------------------------
+
+def test_pv_abundance_lifts_tank_ceiling_above_comfort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When PV >> self-use + battery headroom, the LP can heat the tank
+    above DHW_TEMP_COMFORT_C (48 °C) without paying the soft-ceiling slack.
+    """
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5, raising=False)
+    monkeypatch.setattr(app_config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 5.0, raising=False)
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 8
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    # Healthy PV (4 kWh/slot — above battery + load + DHW capacity). No export
+    # rate provided → fall back to flat EXPORT_RATE_PENCE; reward is the only
+    # incentive to push PV into DHW.
+    plan = _solve(
+        slots=slots,
+        prices=[20.0] * n,
+        pv=[4.0] * n,
+        base_load=[0.3] * n,
+        init_soc=4.0,
+        init_tank=40.0,
+    )
+    assert plan.ok, plan.status
+    # With reward + lifted ceiling, tank should rise materially above comfort 48 °C.
+    max_tank = max(plan.tank_temp_c[1:])
+    assert max_tank > float(app_config.DHW_TEMP_COMFORT_C) + 2.0, (
+        f"PV-abundance lift should raise tank above comfort; got max={max_tank:.1f}"
+    )
+
+
+# --------------------------------------------------------------------------
+# 2. Reward must NOT dominate export when export is profitable
+# --------------------------------------------------------------------------
+
+def test_pv_abundance_reward_does_not_dominate_profitable_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When export rate × COP > tank reward, the LP should still export
+    rather than dump everything into the tank. Guards the 'profit second'
+    side of the user's near-zero-grid-cost policy."""
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5, raising=False)
+    monkeypatch.setattr(app_config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 0.5, raising=False)
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 4
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    # Plenty of PV; very high export rate (50p/kWh) → exporting is way more
+    # profitable than (reward 0.5p × cop_dhw 3.0 ≈ 1.5p of stored value).
+    plan = _solve(
+        slots=slots,
+        prices=[20.0] * n,
+        pv=[3.0] * n,
+        base_load=[0.3] * n,
+        init_soc=4.0,
+        init_tank=40.0,
+        export_prices=[50.0] * n,
+    )
+    assert plan.ok, plan.status
+    total_export = sum(plan.export_kwh)
+    total_dhw = sum(plan.dhw_electric_kwh)
+    # Most of the surplus PV must still go to export (dwarfs DHW heating).
+    assert total_export > total_dhw * 3.0, (
+        f"Reward must not dominate profitable export; "
+        f"export={total_export:.2f} kWh, dhw={total_dhw:.2f} kWh"
+    )
+
+
+# --------------------------------------------------------------------------
+# 3. LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT is honoured (closes #225 item 1)
+# --------------------------------------------------------------------------
+
+def test_tank_hi_slack_penalty_is_read_from_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify ``LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT`` is read from config
+    (closes #225 item 1: was hardcoded 0.01). Behavior-change tests against
+    this knob are brittle because under most realistic price profiles the LP
+    either (a) doesn't breach comfort at all (slack=0) or (b) is dominated
+    by negative-price revenue (slack overshadowed). The wiring + non-crash
+    is the verification that matters; observable tuning lands once an
+    operator pushes the value to non-default in production."""
+    from src.config import config as app_config
+
+    monkeypatch.setattr(app_config, "LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT", 0.5, raising=False)
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 8
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan = _solve(
+        slots=slots,
+        prices=[-5.0] + [10.0] * (n - 1),
+        pv=[0.0] * n,
+        base_load=[0.3] * n,
+        init_soc=8.0,
+        init_tank=40.0,
+    )
+    assert plan.ok, plan.status
+    # All tank temps finite + non-negative (tank can't go below 20 °C lower bound).
+    for t in plan.tank_temp_c:
+        assert t >= 19.0, t
+        assert t == t  # NaN check
+
+
+# --------------------------------------------------------------------------
+# 4. SAFETY: every solar_preheat action has a paired restore (user's hard constraint)
+# --------------------------------------------------------------------------
+
+def test_every_solar_preheat_action_has_paired_restore_to_normal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """User's hard constraint: forgetting to switch back is the cost problem.
+    Verify that every ``solar_preheat`` action emitted by the dispatch preview
+    is paired with a ``restore`` row that drops tank to DHW_TEMP_NORMAL_C."""
+    from src.config import config as app_config
+    from src.scheduler.lp_dispatch import daikin_dispatch_preview
+    from src.scheduler.lp_optimizer import LpPlan
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    # Build a minimal plan with two contiguous solar_charge slots followed by standard.
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 4
+    plan = LpPlan(ok=True, status="Optimal", objective_pence=0.0,
+                  peak_threshold_pence=25.0, cheap_threshold_pence=10.0)
+    plan.slot_starts_utc = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan.price_pence = [15.0] * n
+    plan.import_kwh = [0.0] * n
+    plan.export_kwh = [0.0] * n
+    # solar_charge: chg > EPS AND grid_import < EPS (PV-only charging).
+    plan.battery_charge_kwh = [1.0, 1.0, 0.0, 0.0]
+    plan.battery_discharge_kwh = [0.0] * n
+    plan.dhw_electric_kwh = [0.6, 0.6, 0.0, 0.0]
+    plan.space_electric_kwh = [0.0] * n
+    plan.soc_kwh = [5.0, 6.0, 7.0, 7.0, 7.0]
+    plan.tank_temp_c = [40.0, 50.0, 60.0, 60.0, 60.0]  # LP raised tank
+    plan.indoor_temp_c = [21.0] * (n + 1)
+    plan.pv_curt_kwh = [0.0] * n
+    plan.lwt_offset_c = [0.0] * n
+    plan.temp_outdoor_c = [18.0] * n
+
+    # Bypass the away-like preset gate
+    monkeypatch.setattr(
+        "src.scheduler.lp_dispatch._optimization_preset_away_like",
+        lambda: False,
+        raising=True,
+    )
+    # min_window_slots=1 so 2-slot solar window survives
+    monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
+
+    pairs = daikin_dispatch_preview(plan, forecast=[])
+    assert pairs, "expected at least one (restore, action) pair"
+
+    solar_pairs = [
+        (rest, act) for rest, act in pairs
+        if act.get("action_type") == "solar_preheat"
+    ]
+    assert solar_pairs, f"expected a solar_preheat action; got action_types={[a.get('action_type') for _, a in pairs]}"
+
+    for restore_row, action_row in solar_pairs:
+        # 1. action_type matches.
+        assert action_row["action_type"] == "solar_preheat"
+        # 2. Paired restore exists with restore action_type.
+        assert restore_row.get("action_type") == "restore", restore_row
+        # 3. Restore drops tank back to DHW_TEMP_NORMAL_C — the safety target.
+        assert restore_row["params"]["tank_temp"] == pytest.approx(
+            float(app_config.DHW_TEMP_NORMAL_C)
+        )
+        # 4. Restore turns powerful OFF — no "stuck powerful boost" overnight.
+        assert restore_row["params"]["tank_powerful"] is False
+        # 5. Restore window starts WHERE the action ends (no gap that could
+        #    let a missed-restore-window incident leave a hot tank).
+        assert restore_row["start_time"] == action_row["end_time"]


### PR DESCRIPTION
## Summary

LP-side preparation for active Daikin control: when forecast PV exceeds self-use + battery-charge headroom, the LP can now route otherwise-curtailed solar into the hot-water tank. Inert under \`DAIKIN_CONTROL_MODE=passive\` (today's prod state) — activates when #267 S5 flips active.

Closes #225 item 1 (\`LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT\` configurable).

## Why now

User's empirical schedule (saved to memory):

| Time (local) | Action | Tank target |
|---|---|---|
| ~14:00–15:00 | Manual set tank → 45 °C | Captures solar; ~1.4 kWh |
| Evening showers | (no action) | 45 → 41 °C |
| ~22:00 | Manual set tank → 37 °C | Avoids overnight reheat |
| Morning | (no action) | 37–38 °C; no morning shower |

This PR is the LP-side automation of the 14:00 step. PR 4 will add the time-of-day shower-schedule floor (off-peak floor 30 °C, the user OK'd the more aggressive number); PR 5 will add the Daikin write-budget guard. Together they replace the manual flow.

User's hard constraint: **"forgetting to switch back is the cost problem"** — the existing \`restore_action_id\` mechanism already handles this; **a focused safety test** in this PR asserts every \`solar_preheat\` action emits a paired \`restore\` row to \`DHW_TEMP_NORMAL_C\` with \`tank_powerful=False\` and a contiguous start_time = action end_time.

## What changed

### LP solver (\`src/scheduler/lp_optimizer.py\`)

- Compute per-slot \`pv_abundance[i] = (pv_avail[i] - base_load_kwh[i] - max_batt_kwh) > DHW_PV_ABUNDANCE_THRESHOLD_KWH\` (default 0.5 kWh).
- Lift \`tank_hi_slot[i]\` to \`DHW_TEMP_MAX_C\` (65 °C) when \`(price < 0 OR pv_abundance[i])\`. Same surface as the existing negative-price lift; composes naturally.
- Add objective term: \`-LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH × Σ e_dhw[i]\` over abundant slots. **Default 0.5 p/kWh** — small enough that profitable export still wins (test asserts a 50 p/kWh export rate beats the 0.5 p reward).
- \`LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT\` now read from config (was hardcoded 0.01). Default preserves prior behaviour. **Closes #225 item 1.**

### Dispatch (\`src/scheduler/lp_dispatch.py\`)

- \`daikin_dispatch_preview\` action_type map: \`solar_charge → solar_preheat\`.
- \`tank_powerful\` enabled on \`solar_charge\` (matches negative-slot pattern — both want to dump as much energy into the tank as possible while the window lasts).
- \`climate_on\` enabled on \`solar_charge\` so the heat-pump compressor can run.
- Restore-row logic untouched — every \`solar_preheat\` pair gets the paired \`restore\` to \`DHW_TEMP_NORMAL_C\` with \`tank_powerful=False\`.

### Config (\`src/config.py\`)

- \`DHW_PV_ABUNDANCE_THRESHOLD_KWH\` (default 0.5) — kWh/slot threshold.
- \`LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH\` (default 0.5).
- \`LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT\` (default 0.01).

All runtime-mutable.

## Test plan

- [x] 4 new tests in \`tests/test_lp_pv_abundance.py\`:
  - \`test_pv_abundance_lifts_tank_ceiling_above_comfort\`
  - \`test_pv_abundance_reward_does_not_dominate_profitable_export\` (50 p/kWh export × 3.0 cop_dhw ≈ 150 p of stored value vs 0.5 p reward → export wins)
  - \`test_tank_hi_slack_penalty_is_read_from_config\` (smoke test for #225 item 1)
  - **\`test_every_solar_preheat_action_has_paired_restore_to_normal\`** — the safety test. Builds a synthetic plan with \`solar_charge\` slots, runs \`daikin_dispatch_preview\`, asserts every emitted \`solar_preheat\` action has a paired restore row with \`tank_temp=DHW_TEMP_NORMAL_C\`, \`tank_powerful=False\`, and \`restore.start_time == action.end_time\` (no gap window that could leave a hot tank).
- [x] Full unit-test suite: **794 passed in 137 s**, no regressions.
- [x] Schema unchanged (no migration in PR 3).
- [x] Replay \`--days 7\` against prod snapshot: aggregate cost identical to PR #285/#286 baseline (+£0.46 vs frozen). Confirms PR 3 is correctly **inert under DAIKIN_CONTROL_MODE=passive** — the LP clamps \`e_dhw\` to firmware-predicted values via \`passive_e_dhw\`, so the reward and ceiling lift have no objective influence. They activate when the active flip ships per #267 S5.

## Cross-links

- Closes #225 item 1.
- Bridges to: #196 (DHW draw learning will replace the static abundance threshold), #197 (occupancy inference auto-detects guests).
- Activates when: #267 S5 flips \`DAIKIN_CONTROL_MODE=active\`. The LP plan output (\`tank_temp_c[i+1]\` raised on abundant slots) is already consumed by the dispatch layer; this PR just makes sure the plan asks for it.
- Stacks on: #285 (PR 1), #286 (PR 2).
- Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` PR 3 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)