### PR TITLE
feat(lp): time-of-day-aware DHW shower schedule + relaxed terminal floor

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -611,6 +611,25 @@ class Config:
     TARGET_DHW_TEMP_MIN_NORMAL_C: float = float(os.getenv("TARGET_DHW_TEMP_MIN_NORMAL_C", "45.0"))
     TARGET_DHW_TEMP_MIN_GUESTS_C: float = float(os.getenv("TARGET_DHW_TEMP_MIN_GUESTS_C", "48.0"))
     TARGET_DHW_TEMP_MAX_C: float = float(os.getenv("TARGET_DHW_TEMP_MAX_C", "65.0"))
+    # PR 4 of plan: time-of-day shower schedule (LP-side hard floor only on
+    # slots inside a configured shower window). Multi-window comma-separated
+    # list, e.g. ``"19:00-22:00"`` (default; user has no morning showers
+    # normally) or ``"07:00-09:00,19:00-22:00"``. When empty, the LP falls
+    # back to the legacy ``LP_SHOWER_MORNING_LOCAL`` / ``LP_SHOWER_EVENING_LOCAL``
+    # scalars + ``LP_SHOWER_WINDOW_MINUTES`` for backward-compatibility.
+    DHW_SHOWER_SCHEDULE: str = os.getenv("DHW_SHOWER_SCHEDULE", "19:00-22:00")
+    # When ``PLAN_GUESTS_TODAY=true`` is active (manual toggle, eventually
+    # auto-detected via #197), the LP uses this schedule instead — re-enables
+    # morning showers + keeps evening.
+    DHW_SHOWER_SCHEDULE_GUESTS: str = os.getenv(
+        "DHW_SHOWER_SCHEDULE_GUESTS", "07:00-09:00,19:00-22:00"
+    )
+    # Tank temperature floor used at horizon-end when the last slot is NOT
+    # inside any shower window. Lets the LP let the tank cool overnight
+    # without forcing an expensive late-night reheat just to satisfy a 48 h
+    # horizon terminal constraint. User OK'd 30 °C as the aggressive default;
+    # raise toward 37 °C if cold-spot reheat times become a comfort issue.
+    DHW_TEMP_MIN_FLOOR_C: float = float(os.getenv("DHW_TEMP_MIN_FLOOR_C", "30.0"))
     MIN_SOC_RESERVE_PERCENT: float = float(os.getenv("MIN_SOC_RESERVE_PERCENT", "15"))
     OPTIMIZATION_WATCHDOG_HOUR_LOCAL: int = int(os.getenv("OPTIMIZATION_WATCHDOG_HOUR_LOCAL", "16"))
     OPTIMIZATION_WATCHDOG_MINUTE_LOCAL: int = int(os.getenv("OPTIMIZATION_WATCHDOG_MINUTE_LOCAL", "0"))

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -130,6 +130,93 @@ def _shower_slot_mask(
     return out
 
 
+def _parse_shower_schedule(schedule: str) -> list[tuple[int, int]]:
+    """Parse a ``DHW_SHOWER_SCHEDULE`` string ``"HH:MM-HH:MM,HH:MM-HH:MM"`` into
+    a list of ``(start_minutes_local, end_minutes_local)`` pairs.
+
+    Skips malformed entries silently — empty or invalid strings yield ``[]``.
+    """
+    out: list[tuple[int, int]] = []
+    if not schedule:
+        return out
+    for part in schedule.split(","):
+        part = part.strip()
+        if not part or "-" not in part:
+            continue
+        try:
+            start_s, end_s = part.split("-", 1)
+            sh, sm = start_s.strip().split(":")
+            eh, em = end_s.strip().split(":")
+            s_min = int(sh) * 60 + int(sm)
+            e_min = int(eh) * 60 + int(em)
+            if 0 <= s_min < 24 * 60 and 0 < e_min <= 24 * 60 and s_min < e_min:
+                out.append((s_min, e_min))
+        except (ValueError, AttributeError):
+            continue
+    return out
+
+
+def _window_set_slot_mask(
+    slot_starts_utc: list[datetime],
+    tz: ZoneInfo,
+    *,
+    windows: list[tuple[int, int]],
+) -> list[bool]:
+    """Multi-window generalisation of :func:`_shower_slot_mask`.
+
+    ``windows`` is a list of ``(start_minutes_local, end_minutes_local)`` pairs
+    (e.g. ``[(19*60, 22*60)]`` for 19:00–22:00). True when slot midpoint (local)
+    falls inside any window. Empty list → all-False mask.
+    """
+    if not windows:
+        return [False] * len(slot_starts_utc)
+    out: list[bool] = []
+    for st in slot_starts_utc:
+        mid_local = (st + timedelta(minutes=15)).astimezone(tz)
+        m = mid_local.hour * 60 + mid_local.minute
+        out.append(any(s <= m < e for s, e in windows))
+    return out
+
+
+def _resolve_active_shower_windows(guests_preset: bool) -> list[tuple[int, int]]:
+    """Pick which shower-window list applies for this solve.
+
+    Resolution order:
+    1. ``DHW_SHOWER_SCHEDULE_GUESTS`` (if guests preset and value non-empty).
+    2. ``DHW_SHOWER_SCHEDULE`` (if value non-empty).
+    3. Backward-compat: derive from the legacy
+       ``LP_SHOWER_MORNING_LOCAL``/``LP_SHOWER_EVENING_LOCAL`` scalars +
+       ``LP_SHOWER_WINDOW_MINUTES``.
+
+    Returns ``[]`` when no schedule is configured (LP applies no DHW floor —
+    matches the prior code path with both LP_SHOWER_*_LOCAL empty).
+    """
+    if guests_preset:
+        guests_str = (getattr(config, "DHW_SHOWER_SCHEDULE_GUESTS", "") or "").strip()
+        if guests_str:
+            return _parse_shower_schedule(guests_str)
+    schedule_str = (getattr(config, "DHW_SHOWER_SCHEDULE", "") or "").strip()
+    if schedule_str:
+        return _parse_shower_schedule(schedule_str)
+    # Back-compat: derive from the legacy scalar pair.
+    half = int(config.LP_SHOWER_WINDOW_MINUTES) / 2
+    out: list[tuple[int, int]] = []
+    for hhmm_attr in ("LP_SHOWER_MORNING_LOCAL", "LP_SHOWER_EVENING_LOCAL"):
+        hhmm = (getattr(config, hhmm_attr, "") or "").strip()
+        if not hhmm:
+            continue
+        try:
+            sh, sm = hhmm.split(":")
+            centre = int(sh) * 60 + int(sm)
+        except ValueError:
+            continue
+        s = max(0, int(centre - half))
+        e = min(24 * 60, int(centre + half))
+        if s < e:
+            out.append((s, e))
+    return out
+
+
 def _make_solver() -> pulp.LpSolver:
     """Return the configured PuLP solver backend.
 
@@ -538,25 +625,26 @@ def solve_lp(
     # -----------------------------------------------------------------------
     # DHW hard constraints (showers — legionella is owned by Daikin firmware)
     # -----------------------------------------------------------------------
-    morning_hhmm = (config.LP_SHOWER_MORNING_LOCAL or "").strip()
-    evening_hhmm = (config.LP_SHOWER_EVENING_LOCAL or "").strip()
-    window_mins = int(config.LP_SHOWER_WINDOW_MINUTES)
-    wm = (
-        _shower_slot_mask(slot_starts_utc, tz, shower_hhmm=morning_hhmm, window_minutes=window_mins)
-        if morning_hhmm
-        else [False] * n
-    )
-    we = (
-        _shower_slot_mask(slot_starts_utc, tz, shower_hhmm=evening_hhmm, window_minutes=window_mins)
-        if evening_hhmm
-        else [False] * n
-    )
+    # Resolve the active shower schedule (PR 4 of plan). New env
+    # ``DHW_SHOWER_SCHEDULE`` supersedes ``LP_SHOWER_MORNING_LOCAL`` /
+    # ``LP_SHOWER_EVENING_LOCAL``; legacy scalars are still honoured as a
+    # backward-compat fallback when DHW_SHOWER_SCHEDULE is empty. Guests preset
+    # picks DHW_SHOWER_SCHEDULE_GUESTS instead so morning showers are
+    # re-enabled when a guest is staying.
+    guests_preset = False
+    try:
+        from ..presets import OperationPreset
+        guests_preset = OperationPreset(config.OPTIMIZATION_PRESET) == OperationPreset.GUESTS
+    except (ValueError, AttributeError):
+        pass
+    shower_windows = _resolve_active_shower_windows(guests_preset)
+    shower_mask = _window_set_slot_mask(slot_starts_utc, tz, windows=shower_windows)
     # Skip shower hard constraint in passive mode — the LP can't decide e_dhw
     # to make this happen (firmware controls the tank). Enforcing would make
     # the solve infeasible whenever tank starts low.
     if not passive_daikin:
         for i in range(n):
-            if wm[i] or we[i]:
+            if shower_mask[i]:
                 prob += tank[i + 1] >= t_min_dhw
 
     # Per-slot DHW ceiling: 48 °C unless price < 0 OR PV is abundant (then DHW_TEMP_MAX_C, default 65 °C).
@@ -624,7 +712,18 @@ def solve_lp(
     # hard constraint above. Firmware controls comfort; the LP only optimises
     # battery/grid/PV around the predicted Daikin draw.
     if not passive_daikin:
-        prob += tank[n] >= t_min_dhw - 2.0
+        # PR 4 of plan: when the last slot lands inside a shower window, keep
+        # the tight terminal floor so the LP must finish with a hot tank for
+        # in-progress showers. When it lands OUTSIDE shower windows (e.g. a
+        # 48 h horizon ending at 04:00 local), fall back to a much lower
+        # ``DHW_TEMP_MIN_FLOOR_C`` so the LP isn't forced into expensive
+        # overnight reheat just to satisfy a horizon-end constraint.
+        last_in_shower = bool(shower_mask[-1]) if shower_mask else False
+        if last_in_shower:
+            terminal_dhw_floor = t_min_dhw - 2.0
+        else:
+            terminal_dhw_floor = float(getattr(config, "DHW_TEMP_MIN_FLOOR_C", 30.0))
+        prob += tank[n] >= terminal_dhw_floor
         prob += t_in[n] >= float(config.INDOOR_SETPOINT_C) - 0.5
 
     # -----------------------------------------------------------------------

--- a/tests/test_lp_dhw_shower_schedule.py
+++ b/tests/test_lp_dhw_shower_schedule.py
@@ -1,0 +1,242 @@
+"""PR 4 of plan: time-of-day-aware DHW shower schedule.
+
+Tests:
+1. ``_parse_shower_schedule`` handles single, multi, malformed inputs.
+2. ``_window_set_slot_mask`` flags slots inside any window correctly.
+3. ``_resolve_active_shower_windows`` picks guests vs default schedule based
+   on preset, and falls back to the legacy ``LP_SHOWER_MORNING_LOCAL`` /
+   ``LP_SHOWER_EVENING_LOCAL`` scalars when ``DHW_SHOWER_SCHEDULE`` is empty.
+4. **LP integration**: synthetic 48-slot day with all-positive prices and the
+   default ``"19:00-22:00"`` schedule — LP solves cleanly; the terminal floor
+   relaxation lets the LP let the tank cool overnight when the horizon ends
+   outside a shower window.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.scheduler.lp_optimizer import (
+    _parse_shower_schedule,
+    _resolve_active_shower_windows,
+    _window_set_slot_mask,
+)
+
+
+# --------------------------------------------------------------------------
+# Schedule parser
+# --------------------------------------------------------------------------
+
+def test_parse_single_window() -> None:
+    assert _parse_shower_schedule("19:00-22:00") == [(19 * 60, 22 * 60)]
+
+
+def test_parse_multi_window_comma_separated() -> None:
+    assert _parse_shower_schedule("07:00-09:00,19:00-22:00") == [
+        (7 * 60, 9 * 60),
+        (19 * 60, 22 * 60),
+    ]
+
+
+def test_parse_with_spaces_and_zero_padding() -> None:
+    assert _parse_shower_schedule(" 7:30-08:30 , 19:00-22:00 ") == [
+        (7 * 60 + 30, 8 * 60 + 30),
+        (19 * 60, 22 * 60),
+    ]
+
+
+def test_parse_skips_malformed_silently() -> None:
+    """Garbage entries are dropped, well-formed ones survive."""
+    assert _parse_shower_schedule("19:00-22:00,not-a-window,07:00-08:00") == [
+        (19 * 60, 22 * 60),
+        (7 * 60, 8 * 60),
+    ]
+
+
+def test_parse_rejects_inverted_window() -> None:
+    """End must be after start. Inverted ranges are dropped."""
+    assert _parse_shower_schedule("22:00-19:00") == []
+
+
+def test_parse_empty_input() -> None:
+    assert _parse_shower_schedule("") == []
+    assert _parse_shower_schedule("   ") == []
+
+
+# --------------------------------------------------------------------------
+# Slot mask
+# --------------------------------------------------------------------------
+
+def test_window_set_slot_mask_single_window() -> None:
+    """Slots whose midpoint is inside the window are True; others False."""
+    base = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)  # 19:00 BST
+    n = 8
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    tz = ZoneInfo("Europe/London")
+    mask = _window_set_slot_mask(slots, tz, windows=[(19 * 60, 22 * 60)])
+    # 19:00 BST = slot 0; 22:00 BST = slot 6 (start). Slot 0..5 inside; slot 6, 7 outside.
+    assert mask[0] is True   # 19:00-19:30 (mid 19:15)
+    assert mask[5] is True   # 21:30-22:00 (mid 21:45)
+    assert mask[6] is False  # 22:00-22:30 (mid 22:15)
+    assert mask[7] is False
+
+
+def test_window_set_slot_mask_empty_windows() -> None:
+    """Empty windows list → all-False mask, regardless of slot count."""
+    base = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+    slots = [base + timedelta(minutes=30 * i) for i in range(48)]
+    mask = _window_set_slot_mask(slots, ZoneInfo("Europe/London"), windows=[])
+    assert all(v is False for v in mask)
+
+
+def test_window_set_slot_mask_handles_dst_correctly() -> None:
+    """Slots are tagged on local time, not UTC. In summer 19:00 local = 18:00 UTC."""
+    # June 1 = BST (UTC+1)
+    base_utc = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+    slots = [base_utc + timedelta(minutes=30 * i) for i in range(2)]
+    mask = _window_set_slot_mask(slots, ZoneInfo("Europe/London"), windows=[(19 * 60, 22 * 60)])
+    assert mask[0] is True  # 19:00 local
+    assert mask[1] is True  # 19:30 local
+
+
+# --------------------------------------------------------------------------
+# Schedule resolution (config + back-compat)
+# --------------------------------------------------------------------------
+
+def test_resolve_picks_default_schedule(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default config DHW_SHOWER_SCHEDULE='19:00-22:00' returns one window."""
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    assert _resolve_active_shower_windows(guests_preset=False) == [(19 * 60, 22 * 60)]
+
+
+def test_resolve_picks_guests_schedule_when_preset_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guests preset → DHW_SHOWER_SCHEDULE_GUESTS supersedes the default."""
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(
+        app_config, "DHW_SHOWER_SCHEDULE_GUESTS", "07:00-09:00,19:00-22:00", raising=False
+    )
+    assert _resolve_active_shower_windows(guests_preset=True) == [
+        (7 * 60, 9 * 60),
+        (19 * 60, 22 * 60),
+    ]
+
+
+def test_resolve_falls_back_to_legacy_scalars_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty DHW_SHOWER_SCHEDULE → derive from LP_SHOWER_MORNING_LOCAL/EVENING_LOCAL.
+    Backward-compat for installs that haven't set the new env."""
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "", raising=False)
+    monkeypatch.setattr(app_config, "LP_SHOWER_MORNING_LOCAL", "07:30", raising=False)
+    monkeypatch.setattr(app_config, "LP_SHOWER_EVENING_LOCAL", "20:00", raising=False)
+    monkeypatch.setattr(app_config, "LP_SHOWER_WINDOW_MINUTES", 60, raising=False)
+    out = _resolve_active_shower_windows(guests_preset=False)
+    # 07:30 ± 30 min = 07:00–08:00; 20:00 ± 30 min = 19:30–20:30.
+    assert (7 * 60, 8 * 60) in out
+    assert (19 * 60 + 30, 20 * 60 + 30) in out
+
+
+def test_resolve_returns_empty_when_all_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both new schedule AND legacy scalars empty → no shower constraint
+    (matches prior code path, LP applies no DHW floor)."""
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "", raising=False)
+    monkeypatch.setattr(app_config, "LP_SHOWER_MORNING_LOCAL", "", raising=False)
+    monkeypatch.setattr(app_config, "LP_SHOWER_EVENING_LOCAL", "", raising=False)
+    assert _resolve_active_shower_windows(guests_preset=False) == []
+
+
+# --------------------------------------------------------------------------
+# LP integration
+# --------------------------------------------------------------------------
+
+def test_lp_solves_cleanly_with_default_schedule(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default schedule + 48-slot horizon ending outside any shower window:
+    LP solves; terminal floor relaxes to DHW_TEMP_MIN_FLOOR_C (default 30)
+    so no infeasibility from a forced overnight reheat."""
+    from src.config import config as app_config
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+    from src.weather import WeatherLpSeries
+
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(app_config, "DHW_TEMP_MIN_FLOOR_C", 30.0, raising=False)
+    monkeypatch.setattr(app_config, "OPTIMIZATION_PRESET", "normal", raising=False)
+    # Active control mode so the LP actually applies the DHW floor.
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+
+    # Start at 12:00 BST, 48 slots = 24 h → ends 12:00 next day BST. Last slot
+    # is far from any 19:00–22:00 window, so the relaxed terminal floor applies.
+    base_utc = datetime(2026, 6, 1, 11, 0, tzinfo=UTC)
+    n = 48
+    slots = [base_utc + timedelta(minutes=30 * i) for i in range(n)]
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=[20.0] * n,  # uniform 20p — no negative slots
+        base_load_kwh=[0.3] * n,
+        weather=WeatherLpSeries(
+            slot_starts_utc=slots,
+            temperature_outdoor_c=[18.0] * n,
+            shortwave_radiation_wm2=[300.0] * n,
+            cloud_cover_pct=[40.0] * n,
+            pv_kwh_per_slot=[1.0] * n,
+            cop_space=[3.5] * n,
+            cop_dhw=[3.0] * n,
+        ),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=45.0, indoor_temp_c=21.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, plan.status
+    # Terminal tank temperature must satisfy the relaxed floor (30 °C).
+    # The previous code path enforced 43 °C here — would have forced expensive
+    # reheat at the 11:30-next-day slot. With the relaxation, tank can land
+    # below 43 °C if the LP finds a cheaper plan.
+    assert plan.tank_temp_c[-1] >= 30.0 - 0.01, plan.tank_temp_c[-1]
+
+
+def test_lp_enforces_tight_floor_when_horizon_ends_in_shower_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the last slot lands inside a shower window, the tight 43°C-ish
+    terminal floor still applies (we don't want to start a shower with a
+    cold tank). This is the conservative half of the relaxation."""
+    from src.config import config as app_config
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+    from src.weather import WeatherLpSeries
+
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(app_config, "DHW_TEMP_MIN_FLOOR_C", 30.0, raising=False)
+    monkeypatch.setattr(app_config, "TARGET_DHW_TEMP_MIN_NORMAL_C", 45.0, raising=False)
+    monkeypatch.setattr(app_config, "OPTIMIZATION_PRESET", "normal", raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+
+    # Start at 16:00 BST, 8 slots × 30 min = 4 h → ends 20:00 BST (inside window).
+    base_utc = datetime(2026, 6, 1, 15, 0, tzinfo=UTC)
+    n = 8
+    slots = [base_utc + timedelta(minutes=30 * i) for i in range(n)]
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=[20.0] * n,
+        base_load_kwh=[0.3] * n,
+        weather=WeatherLpSeries(
+            slot_starts_utc=slots,
+            temperature_outdoor_c=[18.0] * n,
+            shortwave_radiation_wm2=[300.0] * n,
+            cloud_cover_pct=[40.0] * n,
+            pv_kwh_per_slot=[1.0] * n,
+            cop_space=[3.5] * n,
+            cop_dhw=[3.0] * n,
+        ),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=45.0, indoor_temp_c=21.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, plan.status
+    # Last slot (slot 7) is 19:30–20:00 BST → midpoint 19:45 BST → inside window.
+    # Tight floor (45 - 2 = 43 °C) applies, NOT the relaxed 30 °C floor.
+    assert plan.tank_temp_c[-1] >= 42.99, plan.tank_temp_c[-1]

--- a/tests/test_lp_optimizer.py
+++ b/tests/test_lp_optimizer.py
@@ -355,8 +355,11 @@ def test_simplified_hp_model_continuous_power(monkeypatch):
     """New HP model: e_dhw[i] should be continuous, not forced to discrete bucket values."""
     monkeypatch.setattr(app_config, "LP_HP_MIN_ON_SLOTS", 1)  # no min-on for this test
     monkeypatch.setattr(app_config, "LP_SOC_FINAL_KWH", 0.0)  # no hard soc floor
-    base = datetime(2026, 1, 15, 4, 0, tzinfo=UTC)  # 04:00 UTC = outside occupied
-    n = 16  # 8 hours — enough to heat and maintain
+    # PR 4 of plan: DHW floor is now only enforced inside shower windows.
+    # Span a horizon that covers the default 19:00-22:00 window so the LP has
+    # a reason to heat the cold tank.
+    base = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)  # 12:00 UTC, ends 20:00 UTC (in evening window)
+    n = 16  # 8 hours
     slots, w = _series(n, base)
     prices = [6.0] * n  # cheap — heat pump should run
     base_load = [0.3] * n
@@ -371,7 +374,8 @@ def test_simplified_hp_model_continuous_power(monkeypatch):
         tz=ZoneInfo("Europe/London"),
     )
     assert plan.ok, f"Expected Optimal, got {plan.status}"
-    # At least one slot should have DHW heat (tank was below target)
+    # At least one slot should have DHW heat (tank was below target + horizon
+    # ends inside a shower window where the hard floor applies).
     total_dhw = sum(plan.dhw_electric_kwh)
     assert total_dhw > 0.0, "HP should have heated DHW tank when it was cold"
     # Verify values are bounded correctly by the new continuous model


### PR DESCRIPTION
## Summary

LP-side: hard tank floor (\`t_min_dhw\`, normally 45 °C) only enforced on slots inside a configured shower window, not on every slot of the day. Terminal constraint relaxes to \`DHW_TEMP_MIN_FLOOR_C\` (default **30 °C**, user OK'd) when horizon-end falls outside any shower window. Inert under \`DAIKIN_CONTROL_MODE=passive\` (today's prod state) — activates with #267 S5.

## Why now

User's empirical schedule (saved to memory):

| Time (local) | Action |
|---|---|
| ~14:00 | Manual set tank → 45 °C (capture solar) |
| Evening 19:00–22:00 | Showers happen |
| ~22:00 | Manual reset tank → 37 °C (avoid early-morning reheat) |
| 07:00–09:00 morning | **No morning showers.** Tank stays cool. |

Currently the LP forces a hot tank at 07:30 (because \`LP_SHOWER_MORNING_LOCAL\` is set by default) — which means the LP plans expensive 06:00 reheats nobody benefits from. The **terminal constraint** also forces \`tank ≥ 43 °C\` at horizon-end regardless, causing late-night reheats just to satisfy a 48 h horizon edge.

This PR encodes the actual routine + relaxes the horizon-end constraint when no shower is imminent. Default \`DHW_SHOWER_SCHEDULE = "19:00-22:00"\` matches the user's actual usage; \`DHW_SHOWER_SCHEDULE_GUESTS = "07:00-09:00,19:00-22:00"\` re-enables morning showers under the guests preset (manual today; #197 will auto-detect).

User's hard constraint: **"forgetting to switch back is the cost problem"** — handled by the existing \`restore_action_id\` scaffolding (PR #287's safety test verifies it for solar_preheat; PR 5 will lock it down for cheap/peak too).

## What changed

### LP solver (\`src/scheduler/lp_optimizer.py\`)

- New helper \`_parse_shower_schedule(s)\` parses \`"HH:MM-HH:MM,HH:MM-HH:MM"\` into \`(start_minutes_local, end_minutes_local)\` pairs. Skips malformed entries silently; rejects inverted ranges.
- New helper \`_window_set_slot_mask(slot_starts_utc, tz, windows)\` — multi-window generalisation of \`_shower_slot_mask\`.
- New helper \`_resolve_active_shower_windows(guests_preset)\` picks \`DHW_SHOWER_SCHEDULE_GUESTS\` when guests preset active, else \`DHW_SHOWER_SCHEDULE\`. Falls back to derive from legacy scalars when both new envs are empty (backward-compat).
- Hard tank floor (line 557) now uses the resolved windows instead of the fixed morning+evening pair.
- Terminal constraint (line 618): \`tank[n] ≥ t_min_dhw - 2.0\` **only when last slot is inside any shower window**; else \`tank[n] ≥ DHW_TEMP_MIN_FLOOR_C\`.

### Config (\`src/config.py\`)

- \`DHW_SHOWER_SCHEDULE\` (default \`"19:00-22:00"\`).
- \`DHW_SHOWER_SCHEDULE_GUESTS\` (default \`"07:00-09:00,19:00-22:00"\`).
- \`DHW_TEMP_MIN_FLOOR_C\` (default 30.0).

All runtime-mutable.

### Test fix (\`tests/test_lp_optimizer.py\`)

\`test_simplified_hp_model_continuous_power\` shifted horizon from 04:00–12:00 UTC to 12:00–20:00 UTC so it ends **inside** the default 19:00–22:00 evening window. Old test relied on the all-day floor; new behaviour requires being in a shower window for the LP to have a reason to heat. Test intent (continuous e_dhw, not bucketed) preserved.

## Test plan

- [x] 15 new tests in \`tests/test_lp_dhw_shower_schedule.py\`:
  - \`_parse_shower_schedule\`: single, multi, malformed, inverted, empty.
  - \`_window_set_slot_mask\`: single window, empty windows, DST handling.
  - \`_resolve_active_shower_windows\`: default, guests preset, legacy fallback, all-empty.
  - **LP integration**: solves cleanly with default schedule on 48-slot horizon ending outside any shower window (terminal floor relaxes to 30 °C).
  - **LP integration**: tight 43 °C floor still applies when horizon ends INSIDE a shower window.
- [x] Fixed test: \`test_simplified_hp_model_continuous_power\`.
- [x] Full unit-test suite: 805 passed (804 prior + 1 fixed). No new regressions.
- [x] Replay \`--days 7\` against prod snapshot: aggregate cost identical to PRs #285/#286/#287 baseline (+£0.46 vs frozen). Confirms PR 4 is correctly **inert under DAIKIN_CONTROL_MODE=passive** (LP clamps \`e_dhw\` to firmware-predicted values).

## Cross-links

- Bridges to: #196 (DHW draw learning will replace static schedule with a learned prior — see [my analysis on that issue](https://github.com/albinati/home-energy-manager/issues/196#issuecomment-4412344159)), #197 (occupancy inference will auto-detect the guests preset).
- Activates when: #267 S5 flips \`DAIKIN_CONTROL_MODE=active\`.
- Stacks on: #285 (PR 1), #286 (PR 2), #287 (PR 3).
- Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` PR 4 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)