### PR TITLE
feat(dispatch): Daikin write-budget guard + Sunday legionella skip

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1055,6 +1055,13 @@ class Config:
     # the first time the api_quota module sees DAIKIN_CONTROL_MODE=active.
     DAIKIN_ACTIVE_SOAK_DAILY_BUDGET: int = int(os.getenv("DAIKIN_ACTIVE_SOAK_DAILY_BUDGET", "100"))
     DAIKIN_ACTIVE_SOAK_DAYS: int = int(os.getenv("DAIKIN_ACTIVE_SOAK_DAYS", "3"))
+    # PR 5 of plan: write-budget reservation. Each LP plan push, the budget
+    # guard subtracts this from quota_remaining("daikin") before deciding how
+    # many action_schedule pairs to upsert. Reserves headroom for the
+    # heartbeat's safe-default reconciles + telemetry reads (~30 calls/day on
+    # current prod). Lower if Daikin call volume drops; raise if heartbeat
+    # reconciles are starving for headroom.
+    DAIKIN_RESERVE_FOR_HEARTBEAT: int = int(os.getenv("DAIKIN_RESERVE_FOR_HEARTBEAT", "30"))
     # Circuit breaker: pause Daikin writes after N consecutive failures within W minutes,
     # cooldown for C minutes, reset on next successful write. Defends against an Onecta
     # outage burning quota with retries. 0 fails = breaker disabled.

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -350,6 +350,121 @@ def daikin_dispatch_preview(
     return out
 
 
+def _drop_legionella_window_pairs(
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    """Drop any (restore, action) pair whose action falls inside Sunday
+    10:30–12:00 local — Daikin firmware owns the weekly thermal-shock cycle.
+
+    Keeping a manual setpoint write in that window risks fighting the firmware
+    (or, worse, racing it). The cycle runs autonomously per CLAUDE.md; we just
+    stay out of its way.
+    """
+    out: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    tz = TZ()
+    for rest, act in pairs:
+        try:
+            start_utc = datetime.fromisoformat(act["start_time"].replace("Z", "+00:00"))
+            local = start_utc.astimezone(tz)
+            local_min = local.hour * 60 + local.minute
+            if local.weekday() == 6 and 10 * 60 + 30 <= local_min < 12 * 60:
+                logger.info(
+                    "write_daikin_from_lp_plan: skipping pair start=%s — Sunday legionella window",
+                    act["start_time"],
+                )
+                continue
+        except (KeyError, ValueError, TypeError):
+            pass
+        out.append((rest, act))
+    return out
+
+
+def _coalesce_low_value_pairs(
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    """Merge adjacent pairs with the same low-value action_type by extending
+    the earlier window's end_time and dropping the later pair.
+
+    Low-value kinds: ``pre_heat`` (cheap-slot tank lift) and ``solar_preheat``.
+    High-value kinds (``max_heat`` for negative slots, ``shutdown`` for peak
+    and peak_export) are NEVER coalesced — they target distinct windows that
+    can't be substituted.
+    """
+    if not pairs:
+        return pairs
+    coalescible = {"pre_heat", "solar_preheat"}
+    out = [pairs[0]]
+    for rest, act in pairs[1:]:
+        prev_rest, prev_act = out[-1]
+        prev_type = prev_act.get("action_type")
+        cur_type = act.get("action_type")
+        if (
+            prev_type == cur_type
+            and cur_type in coalescible
+            and prev_act.get("end_time") == act.get("start_time")
+        ):
+            # Extend previous action + restore to swallow this pair.
+            prev_act["end_time"] = act["end_time"]
+            prev_rest["start_time"] = rest["start_time"]
+            prev_rest["end_time"] = rest["end_time"]
+            out[-1] = (prev_rest, prev_act)
+            continue
+        out.append((rest, act))
+    return out
+
+
+def _apply_write_budget(
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]],
+    headroom: int,
+) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], list[str]]:
+    """Bound the number of Daikin writes a plan will queue against quota headroom.
+
+    Algorithm (PR 5 of plan):
+    1. Each pair is 2 writes (action + restore). If 2*len(pairs) ≤ headroom,
+       pass through.
+    2. Coalesce adjacent same-kind low-value pairs (``pre_heat``,
+       ``solar_preheat``).
+    3. If still over budget, drop trailing low-value pairs until we fit.
+    4. NEVER drop or coalesce ``max_heat`` (negative-price) or ``shutdown``
+       (peak / peak_export) — these are the high-value pairs whose timing
+       can't be substituted.
+
+    Returns (filtered_pairs, dropped_action_descriptions). Caller surfaces the
+    dropped list via notification.
+    """
+    if headroom <= 0:
+        # Nothing to spend — drop every low-value pair, keep only high-value.
+        keep_kinds = {"max_heat", "shutdown"}
+        filtered = [(r, a) for r, a in pairs if a.get("action_type") in keep_kinds]
+        dropped = [
+            f"{a.get('action_type')}@{a.get('start_time')}"
+            for r, a in pairs if a.get("action_type") not in keep_kinds
+        ]
+        return filtered, dropped
+
+    if 2 * len(pairs) <= headroom:
+        return pairs, []
+
+    coalesced = _coalesce_low_value_pairs(pairs)
+    dropped: list[str] = []
+    if 2 * len(coalesced) <= headroom:
+        return coalesced, dropped
+
+    # Still over budget — drop trailing low-value pairs (preserve high-value
+    # earliest-first; each pair is 2 writes).
+    coalescible = {"pre_heat", "solar_preheat"}
+    # Walk from the END of the list and drop coalescible pairs first.
+    keep: list[tuple[dict[str, Any], dict[str, Any]]] = list(coalesced)
+    i = len(keep) - 1
+    while 2 * len(keep) > headroom and i >= 0:
+        _r, a = keep[i]
+        if a.get("action_type") in coalescible:
+            dropped.append(f"{a.get('action_type')}@{a.get('start_time')}")
+            keep.pop(i)
+        i -= 1
+    return keep, dropped
+
+
 def write_daikin_from_lp_plan(
     plan_date: str,
     plan: LpPlan,
@@ -366,6 +481,10 @@ def write_daikin_from_lp_plan(
     action_schedule row ids we've already pinged about; once the rows
     are cleared/replaced by this function, those ids are dead and the set
     would otherwise leak entries forever.
+
+    PR 5 of plan: applies the Daikin write-budget guard (coalesce low-value +
+    drop tail + notify) and skips any pair landing inside the Sunday legionella
+    window before the upsert loop.
     """
     try:
         from .. import state_machine as _sm
@@ -393,6 +512,30 @@ def write_daikin_from_lp_plan(
     else:
         db.clear_actions_for_date(plan_date, device="daikin")
     pairs = daikin_dispatch_preview(plan, forecast)
+    # PR 5: filter Sunday legionella window before budget guard so it doesn't
+    # eat into headroom counting against pairs that get dropped anyway.
+    pairs = _drop_legionella_window_pairs(pairs)
+    # PR 5: budget guard. quota_remaining returns full budget when api_call_log
+    # is empty; subtract a reservation so the heartbeat still has headroom for
+    # safe-default reconciles + telemetry reads.
+    try:
+        from ..api_quota import quota_remaining
+        reserve = int(getattr(config, "DAIKIN_RESERVE_FOR_HEARTBEAT", 30))
+        headroom = max(0, quota_remaining("daikin") - reserve)
+    except Exception:  # pragma: no cover — quota lookup must never break dispatch
+        headroom = 9999
+    pairs, dropped = _apply_write_budget(pairs, headroom)
+    if dropped:
+        try:
+            from ..notifier import notify_strategy_update
+            notify_strategy_update(
+                f"Daikin write-budget guard active: dropped {len(dropped)} low-value "
+                f"action(s) to fit headroom={headroom}. Consider raising "
+                f"DAIKIN_DAILY_BUDGET or lowering DAIKIN_RESERVE_FOR_HEARTBEAT.",
+                warnings=dropped,
+            )
+        except Exception:  # pragma: no cover — notification must never break dispatch
+            logger.exception("write-budget guard: notify_strategy_update failed")
     count = 0
     for restore_row, action_row in pairs:
         rid = db.upsert_action(

--- a/tests/test_daikin_write_budget_guard.py
+++ b/tests/test_daikin_write_budget_guard.py
@@ -1,0 +1,280 @@
+"""PR 5 of plan: Daikin write-budget guard + Sunday legionella skip.
+
+The dispatch layer must:
+1. Skip any (restore, action) pair whose action falls inside Sunday 10:30–12:00
+   local — Daikin firmware owns the weekly thermal-shock cycle.
+2. Coalesce adjacent same-kind low-value pairs (``pre_heat``, ``solar_preheat``)
+   when 2 × len(pairs) > headroom.
+3. Drop trailing low-value pairs if still over budget after coalescing.
+4. NEVER drop or coalesce ``max_heat`` (negative-price) or ``shutdown`` (peak)
+   — those time-critical pairs always survive.
+5. Notify the operator (via ``notify_strategy_update``) when actions were
+   dropped so the budget can be raised if the pattern persists.
+
+These tests exercise the helpers directly with synthetic pair lists so we
+don't have to round-trip through a full LP solve.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _pair(action_type: str, start_iso: str, end_iso: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build a (restore, action) pair shaped like ``daikin_dispatch_preview``."""
+    restore_end = (
+        datetime.fromisoformat(end_iso.replace("Z", "+00:00")) + timedelta(minutes=5)
+    ).isoformat().replace("+00:00", "Z")
+    return (
+        {
+            "device": "daikin",
+            "action_type": "restore",
+            "start_time": end_iso,
+            "end_time": restore_end,
+            "params": {"tank_temp": 45.0, "tank_powerful": False, "tank_power": True,
+                       "lwt_offset": 0.0, "climate_on": True},
+        },
+        {
+            "device": "daikin",
+            "action_type": action_type,
+            "start_time": start_iso,
+            "end_time": end_iso,
+            "params": {"tank_temp": 60.0, "tank_powerful": True, "tank_power": True,
+                       "lwt_offset": 0.0, "climate_on": True},
+            "lp_slot_kind": action_type,
+        },
+    )
+
+
+# --------------------------------------------------------------------------
+# Sunday legionella skip
+# --------------------------------------------------------------------------
+
+def test_drops_pair_inside_sunday_legionella_window() -> None:
+    """Sunday 11:00 BST = 10:00 UTC — inside 10:30–12:00 BST window when
+    BST is active. Test in winter (UTC=local) for unambiguous timing."""
+    from src.scheduler.lp_dispatch import _drop_legionella_window_pairs
+    # Sunday 2026-01-04 — UTC = local in winter.
+    inside = _pair("max_heat", "2026-01-04T11:00:00Z", "2026-01-04T11:30:00Z")
+    outside = _pair("max_heat", "2026-01-04T13:00:00Z", "2026-01-04T13:30:00Z")
+    out = _drop_legionella_window_pairs([inside, outside])
+    assert len(out) == 1
+    assert out[0][1]["start_time"] == "2026-01-04T13:00:00Z"
+
+
+def test_keeps_pair_outside_sunday_window() -> None:
+    """Same hour but a different weekday — pair must survive."""
+    from src.scheduler.lp_dispatch import _drop_legionella_window_pairs
+    # Saturday 2026-01-03 11:00 UTC — same time, wrong day.
+    pair = _pair("max_heat", "2026-01-03T11:00:00Z", "2026-01-03T11:30:00Z")
+    out = _drop_legionella_window_pairs([pair])
+    assert len(out) == 1
+
+
+def test_keeps_pair_at_sunday_window_edge() -> None:
+    """The 12:00 boundary is exclusive — a pair starting exactly at 12:00
+    local must survive."""
+    from src.scheduler.lp_dispatch import _drop_legionella_window_pairs
+    pair = _pair("max_heat", "2026-01-04T12:00:00Z", "2026-01-04T12:30:00Z")
+    assert len(_drop_legionella_window_pairs([pair])) == 1
+
+
+# --------------------------------------------------------------------------
+# Coalesce
+# --------------------------------------------------------------------------
+
+def test_coalesce_merges_adjacent_solar_preheat_pairs() -> None:
+    """Two adjacent ``solar_preheat`` windows → one extended pair, restore
+    pushed to end of merged window."""
+    from src.scheduler.lp_dispatch import _coalesce_low_value_pairs
+    p1 = _pair("solar_preheat", "2026-06-01T13:00:00Z", "2026-06-01T13:30:00Z")
+    p2 = _pair("solar_preheat", "2026-06-01T13:30:00Z", "2026-06-01T14:00:00Z")
+    out = _coalesce_low_value_pairs([p1, p2])
+    assert len(out) == 1
+    rest, act = out[0]
+    assert act["start_time"] == "2026-06-01T13:00:00Z"
+    assert act["end_time"] == "2026-06-01T14:00:00Z"
+    # Restore window now starts after the merged action.
+    assert rest["start_time"] == "2026-06-01T14:00:00Z"
+
+
+def test_coalesce_does_not_merge_high_value_kinds() -> None:
+    """Two adjacent ``max_heat`` windows must NOT coalesce — those are
+    high-value windows whose timing can't be substituted."""
+    from src.scheduler.lp_dispatch import _coalesce_low_value_pairs
+    p1 = _pair("max_heat", "2026-06-01T01:00:00Z", "2026-06-01T01:30:00Z")
+    p2 = _pair("max_heat", "2026-06-01T01:30:00Z", "2026-06-01T02:00:00Z")
+    out = _coalesce_low_value_pairs([p1, p2])
+    assert len(out) == 2
+
+
+def test_coalesce_does_not_merge_non_adjacent_pairs() -> None:
+    """Two solar_preheat windows separated by a gap must stay separate."""
+    from src.scheduler.lp_dispatch import _coalesce_low_value_pairs
+    p1 = _pair("solar_preheat", "2026-06-01T13:00:00Z", "2026-06-01T13:30:00Z")
+    p2 = _pair("solar_preheat", "2026-06-01T14:00:00Z", "2026-06-01T14:30:00Z")
+    out = _coalesce_low_value_pairs([p1, p2])
+    assert len(out) == 2
+
+
+# --------------------------------------------------------------------------
+# Budget guard end-to-end
+# --------------------------------------------------------------------------
+
+def test_budget_guard_passes_through_under_headroom() -> None:
+    """When 2 × len(pairs) ≤ headroom, no coalesce / drop / notify."""
+    from src.scheduler.lp_dispatch import _apply_write_budget
+    pairs = [
+        _pair("max_heat", "2026-06-01T01:00:00Z", "2026-06-01T01:30:00Z"),
+        _pair("solar_preheat", "2026-06-01T13:00:00Z", "2026-06-01T13:30:00Z"),
+    ]
+    out, dropped = _apply_write_budget(pairs, headroom=10)
+    assert len(out) == 2
+    assert dropped == []
+
+
+def test_budget_guard_drops_low_value_when_over_budget() -> None:
+    """14-pair plan with headroom=10 → coalesces solar_preheat but keeps all
+    high-value pairs. Result must fit within headroom."""
+    from src.scheduler.lp_dispatch import _apply_write_budget
+    # 4 max_heat (high value) + 10 solar_preheat (low value)
+    pairs = [
+        _pair("max_heat", f"2026-06-01T0{1+i}:00:00Z", f"2026-06-01T0{1+i}:30:00Z")
+        for i in range(4)
+    ] + [
+        _pair("solar_preheat", f"2026-06-01T{12+i:02d}:00:00Z", f"2026-06-01T{12+i:02d}:30:00Z")
+        for i in range(10)
+    ]
+    out, dropped = _apply_write_budget(pairs, headroom=10)
+    # Must fit (each pair = 2 writes).
+    assert 2 * len(out) <= 10
+    # All max_heat survive.
+    high_value_kept = [a.get("action_type") for _r, a in out if a.get("action_type") == "max_heat"]
+    assert len(high_value_kept) == 4
+    # Some solar_preheat got dropped.
+    assert len(dropped) > 0
+    assert all("solar_preheat" in d for d in dropped)
+
+
+def test_budget_guard_zero_headroom_drops_all_low_value() -> None:
+    """When headroom is 0, every low-value pair must be dropped but high-
+    value pairs survive (they fight for hardware-critical timing)."""
+    from src.scheduler.lp_dispatch import _apply_write_budget
+    pairs = [
+        _pair("max_heat", "2026-06-01T01:00:00Z", "2026-06-01T01:30:00Z"),
+        _pair("solar_preheat", "2026-06-01T13:00:00Z", "2026-06-01T13:30:00Z"),
+        _pair("shutdown", "2026-06-01T17:00:00Z", "2026-06-01T17:30:00Z"),
+    ]
+    out, dropped = _apply_write_budget(pairs, headroom=0)
+    kept_kinds = {a.get("action_type") for _r, a in out}
+    assert kept_kinds == {"max_heat", "shutdown"}
+    assert len(dropped) == 1
+    assert "solar_preheat" in dropped[0]
+
+
+def test_budget_guard_never_drops_max_heat_or_shutdown() -> None:
+    """Even with absurdly low headroom, max_heat and shutdown survive — they
+    target hardware-critical timing windows that other slots can't substitute."""
+    from src.scheduler.lp_dispatch import _apply_write_budget
+    pairs = [
+        _pair("max_heat", "2026-06-01T01:00:00Z", "2026-06-01T01:30:00Z"),
+        _pair("shutdown", "2026-06-01T17:00:00Z", "2026-06-01T17:30:00Z"),
+    ]
+    out, dropped = _apply_write_budget(pairs, headroom=0)
+    assert len(out) == 2  # both kept
+    assert dropped == []
+
+
+def test_budget_guard_coalesce_alone_can_fit_under_budget() -> None:
+    """When coalescing brings us under budget, no pair should be dropped."""
+    from src.scheduler.lp_dispatch import _apply_write_budget
+    # 8 adjacent solar_preheat slots × 2 writes = 16; coalesce → 1 pair × 2 = 2.
+    pairs = [
+        _pair(
+            "solar_preheat",
+            f"2026-06-01T{12 + i//2:02d}:{(i%2)*30:02d}:00Z",
+            f"2026-06-01T{12 + (i+1)//2:02d}:{((i+1)%2)*30:02d}:00Z",
+        )
+        for i in range(8)
+    ]
+    out, dropped = _apply_write_budget(pairs, headroom=2)
+    assert len(out) == 1
+    assert dropped == []
+
+
+# --------------------------------------------------------------------------
+# Notification side-effect
+# --------------------------------------------------------------------------
+
+def test_write_daikin_notifies_when_dropping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the budget guard drops actions, ``notify_strategy_update`` must
+    be called with the drop summary."""
+    from src.config import config as app_config
+    from src.scheduler import lp_dispatch
+    from src.scheduler.lp_optimizer import LpPlan
+
+    # Stub quota_remaining tiny to force drops.
+    def _fake_remaining(vendor: str) -> int:
+        return 4 if vendor == "daikin" else 9999
+    monkeypatch.setattr("src.api_quota.quota_remaining", _fake_remaining)
+    monkeypatch.setattr(app_config, "DAIKIN_RESERVE_FOR_HEARTBEAT", 0, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+
+    # Stub upsert + clear so we don't touch SQLite.
+    monkeypatch.setattr(lp_dispatch.db, "upsert_action", lambda **kw: 1)
+    monkeypatch.setattr(lp_dispatch.db, "clear_actions_in_range", lambda *a, **kw: 0)
+    monkeypatch.setattr(lp_dispatch.db, "clear_actions_for_date", lambda *a, **kw: 0)
+    monkeypatch.setattr(lp_dispatch.db, "update_action_restore_link", lambda *a, **kw: None)
+
+    # Build a minimal LpPlan
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    plan = LpPlan(ok=True, status="Optimal", objective_pence=0.0,
+                  peak_threshold_pence=25.0, cheap_threshold_pence=10.0)
+    plan.slot_starts_utc = [base + timedelta(minutes=30 * i) for i in range(2)]
+
+    # Adjacent solar_preheat pairs (each pair contiguous: 12:00-12:30,
+    # 12:30-13:00, …) → coalesce to 1 → 2 writes. Headroom 4. No drops, no notify.
+    def _fake_preview_adjacent(plan: LpPlan, forecast: list) -> list:
+        out = []
+        for i in range(8):
+            start_h = 12 + i // 2
+            start_m = (i % 2) * 30
+            end_h = 12 + (i + 1) // 2
+            end_m = ((i + 1) % 2) * 30
+            out.append(_pair(
+                "solar_preheat",
+                f"2026-06-01T{start_h:02d}:{start_m:02d}:00Z",
+                f"2026-06-01T{end_h:02d}:{end_m:02d}:00Z",
+            ))
+        return out
+    monkeypatch.setattr(lp_dispatch, "daikin_dispatch_preview", _fake_preview_adjacent)
+
+    with patch("src.notifier.notify_strategy_update") as mock_notify:
+        lp_dispatch.write_daikin_from_lp_plan("2026-06-01", plan, forecast=[])
+        # 8 solar_preheat pairs adjacent → coalesce → 1 pair = 2 writes ≤ 4. No drops.
+        assert mock_notify.call_count == 0, (
+            f"Coalesce alone should fit headroom; mock called with: {mock_notify.call_args}"
+        )
+
+    # Non-adjacent pairs (1h gap each) so coalesce can't help → forces drops.
+    def _fake_preview_non_adjacent(plan: LpPlan, forecast: list) -> list:
+        # 6 pairs at 12,14,16,18,20,22 → all in 24 h, no contiguity.
+        return [
+            _pair(
+                "solar_preheat",
+                f"2026-06-01T{12 + 2*i:02d}:00:00Z",
+                f"2026-06-01T{12 + 2*i:02d}:30:00Z",
+            )
+            for i in range(6)
+        ]
+    monkeypatch.setattr(lp_dispatch, "daikin_dispatch_preview", _fake_preview_non_adjacent)
+
+    with patch("src.notifier.notify_strategy_update") as mock_notify:
+        lp_dispatch.write_daikin_from_lp_plan("2026-06-01", plan, forecast=[])
+        assert mock_notify.call_count == 1
+        msg = mock_notify.call_args[0][0]
+        assert "Daikin write-budget guard" in msg
+        assert "dropped" in msg


### PR DESCRIPTION
## Summary

Plan-time guard inside \`write_daikin_from_lp_plan\` that bounds the number of action_schedule writes by the current Daikin quota headroom. Coalesces adjacent low-value pairs first, drops tail low-value pairs if still over budget, and notifies the operator. Skips any pair landing in the **Sunday 10:30–12:00 local legionella window** so we don't fight Onecta's autonomous thermal-shock cycle.

## Note on #267 S4

S4 ("populate \`api_call_log\` for Daikin") **is already done in main** — see [my comment on the epic](https://github.com/albinati/home-energy-manager/issues/267#issuecomment-4412369150). \`src/daikin/client.py:50-56,68,80,102,116\` already calls \`api_quota.record_call("daikin", kind, ok=...)\` on every HTTP outcome. Verified 67 daikin reads / 24h on prod. This PR consumes that signal via \`quota_remaining("daikin")\`.

## Why now

Per the user's hard constraint ("forgetting to switch back is the cost problem"), and the broader plan goal of preparing for active Daikin control flip (#267 S5):

- When the LP queues N action_schedule pairs but Onecta's daily quota only leaves headroom for M < N, the heartbeat would silently drop late writes after exhausting quota — leaving high-value windows un-honoured.
- A plan-time guard is more predictable: coalesce + drop tail-low-value + notify, so the operator sees what got dropped and can raise the budget if the pattern persists.
- Sunday legionella skip prevents racing Daikin firmware during the weekly thermal-shock cycle (CLAUDE.md line 122).

## What changed

### \`src/scheduler/lp_dispatch.py\`

- \`_drop_legionella_window_pairs(pairs)\` drops any pair whose action starts inside Sunday 10:30–12:00 local. zoneinfo handles DST.
- \`_coalesce_low_value_pairs(pairs)\` merges adjacent same-kind \`pre_heat\` / \`solar_preheat\` pairs. Never coalesces \`max_heat\` or \`shutdown\`.
- \`_apply_write_budget(pairs, headroom)\`:
  1. If 2 × len(pairs) ≤ headroom → pass through.
  2. Coalesce adjacent low-value pairs.
  3. If still over → drop trailing low-value pairs.
  4. NEVER drops \`max_heat\` or \`shutdown\`.
  5. Returns \`(filtered_pairs, dropped_action_descriptions)\`.
- \`write_daikin_from_lp_plan\` now applies legionella skip + budget guard before the upsert loop. \`quota_remaining("daikin")\` read once per plan; reservation = \`DAIKIN_RESERVE_FOR_HEARTBEAT\` (default 30) preserves headroom for heartbeat reconciles + telemetry reads.
- Drop summary notified via \`notifier.notify_strategy_update\`.

### \`src/config.py\`

- \`DAIKIN_RESERVE_FOR_HEARTBEAT\` (default 30, runtime-mutable).

## Test plan

- [x] 12 new tests in \`tests/test_daikin_write_budget_guard.py\`:
  - **Sunday skip:** drops pair inside window, keeps pair outside (Saturday same time), keeps pair at 12:00 boundary (exclusive).
  - **Coalesce:** merges adjacent \`solar_preheat\`, never merges \`max_heat\` / \`shutdown\`, doesn't merge non-adjacent pairs.
  - **Budget guard:** passes through under headroom, drops low-value when over budget (14-pair plan with headroom=10), zero-headroom drops all low-value but keeps high-value, never drops \`max_heat\` / \`shutdown\`, coalesce-alone can fit (8 adjacent → 1 pair).
  - **Integration:** end-to-end \`write_daikin_from_lp_plan\` with mocked quota and SQLite — drop summary surfaces via \`notify_strategy_update\`.
- [x] Full unit-test suite: **802 passed in 137 s**. No regressions.
- [x] Verified inert on current prod snapshot (passive mode + 67 reads / 0 writes per 24 h leaves quota_remaining well above headroom requirement).

## Cross-links

- Closes (already-done): **#267 S4** — api_call_log populated for Daikin (existing in main).
- Activates with: #267 S5 (active control flip).
- Stacks on: #285 (PR 1), #286 (PR 2), #287 (PR 3), #288 (PR 4).
- Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` PR 5 of 5 (final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)