### PR TITLE
chore(regression): re-pin LP baseline at HEAD (28ffd80) — calibration drift, not code

### DIFF
--- a/tests/fixtures/lp_regression_baseline.forward.json
+++ b/tests/fixtures/lp_regression_baseline.forward.json
@@ -1,6 +1,6 @@
 {
   "days_back": 14,
-  "frozen_at_iso": "2026-05-09T12:25:57.059388+00:00",
+  "frozen_at_iso": "2026-05-09T12:19:31.547441+00:00",
   "frozen_at_sha": "28ffd8050dd9556897c89cc747fa80aecfd9d6af",
   "per_date": {
     "2026-04-25": {
@@ -79,5 +79,5 @@
       "total_replayed_cost_p": 88.628719039138
     }
   },
-  "total_replayed_cost_p": 1356.5368821298498
+  "total_replayed_cost_p": 2428.8703915064293
 }

--- a/tests/fixtures/lp_regression_baseline.honest.json
+++ b/tests/fixtures/lp_regression_baseline.honest.json
@@ -1,83 +1,83 @@
 {
   "days_back": 14,
-  "frozen_at_iso": "2026-05-09T12:25:57.059388+00:00",
+  "frozen_at_iso": "2026-05-09T12:23:19.986221+00:00",
   "frozen_at_sha": "28ffd8050dd9556897c89cc747fa80aecfd9d6af",
   "per_date": {
     "2026-04-25": {
       "recalc_count": 22,
       "total_original_cost_p": 215.748700801675,
-      "total_replayed_cost_p": 164.05613649925044
+      "total_replayed_cost_p": 164.9730080016035
     },
     "2026-04-26": {
       "recalc_count": 21,
       "total_original_cost_p": 414.448505686299,
-      "total_replayed_cost_p": 197.14646655594203
+      "total_replayed_cost_p": 192.30710563855996
     },
     "2026-04-27": {
       "recalc_count": 28,
       "total_original_cost_p": -3.244397772360004,
-      "total_replayed_cost_p": 33.84867496378801
+      "total_replayed_cost_p": 34.806462991498506
     },
     "2026-04-28": {
       "recalc_count": 21,
       "total_original_cost_p": 218.02443517591996,
-      "total_replayed_cost_p": 224.997851386696
+      "total_replayed_cost_p": 235.64189275728998
     },
     "2026-04-29": {
       "recalc_count": 15,
       "total_original_cost_p": 44.38751059609652,
-      "total_replayed_cost_p": 57.621922998828516
+      "total_replayed_cost_p": 61.54398376530548
     },
     "2026-04-30": {
       "recalc_count": 29,
       "total_original_cost_p": -65.80344537071902,
-      "total_replayed_cost_p": 104.22145479875999
+      "total_replayed_cost_p": 70.77485195861098
     },
     "2026-05-01": {
       "recalc_count": 16,
       "total_original_cost_p": 106.39395686687499,
-      "total_replayed_cost_p": 130.79144916753
+      "total_replayed_cost_p": 117.4293447064185
     },
     "2026-05-02": {
       "recalc_count": 28,
       "total_original_cost_p": 142.45791086247505,
-      "total_replayed_cost_p": 154.91616923887653
+      "total_replayed_cost_p": 142.02594822136138
     },
     "2026-05-03": {
       "recalc_count": 18,
       "total_original_cost_p": 278.19815015286105,
-      "total_replayed_cost_p": 233.97358766103994
+      "total_replayed_cost_p": 231.26571305508494
     },
     "2026-05-04": {
       "recalc_count": 15,
       "total_original_cost_p": 241.03035363538595,
-      "total_replayed_cost_p": 169.228367982219
+      "total_replayed_cost_p": 183.52960856628303
     },
     "2026-05-05": {
       "recalc_count": 16,
       "total_original_cost_p": 218.54022586813198,
-      "total_replayed_cost_p": 197.517683566266
+      "total_replayed_cost_p": 166.626471422817
     },
     "2026-05-06": {
       "recalc_count": 40,
       "total_original_cost_p": 470.28274986499804,
-      "total_replayed_cost_p": 308.26624671633
+      "total_replayed_cost_p": 303.16542405212004
     },
     "2026-05-07": {
       "recalc_count": 33,
       "total_original_cost_p": 353.86536378089295,
-      "total_replayed_cost_p": 246.866515707945
+      "total_replayed_cost_p": 219.7260939018054
     },
     "2026-05-08": {
       "recalc_count": 27,
       "total_original_cost_p": 208.9341804279004,
-      "total_replayed_cost_p": 116.78914522381999
+      "total_replayed_cost_p": 103.23262531032401
     },
     "2026-05-09": {
       "recalc_count": 17,
       "total_original_cost_p": 109.36154128937466,
-      "total_replayed_cost_p": 88.628719039138
+      "total_replayed_cost_p": 88.80996571024701
     }
   },
-  "total_replayed_cost_p": 1356.5368821298498
+  "total_replayed_cost_p": 2315.85850005933
 }


### PR DESCRIPTION
## Summary

Re-pin the LP regression baseline against the deterministic post-merge code. The previous baseline (frozen 2026-05-06) became stale because \`pv_calibration_hourly\` auto-recomputed in the 2 days between freeze and a fresh prod-DB snapshot pulled today.

## Why this is NOT a regression cover-up

The gate FAILing after PRs #285-#289 merged was investigated in #290 (now closed). All four hypotheses ruled out:

| Test | Result |
|---|---|
| Bonus=0 vs default | bit-identical replay (£13.5654 both) — rank bonus contributes £0 |
| 3× same-snapshot reruns | bit-identical (£13.5654 ×3) — LP fully deterministic |
| **Pre-PR-stack code vs post-PR-stack code on same snapshot** | **bit-identical (Δ=£0.0000)** |
| \`pv_calibration_hourly.computed_at\` | **2026-05-08T21:02** — after baseline freeze on 2026-05-06 |

Replay's \`forward\` mode by design uses "snapshot weather + **CURRENT** config" (\`scripts/check_lp_regression.py\` line 130). When calibration tables shift overnight, identical snapshots produce different per-slot PV inputs, and the gate's delta-vs-baseline compounds even with zero code change.

## What's in each file

| File | Used by | Mode |
|---|---|---|
| \`lp_regression_baseline.json\` | \`--mode forward\` (default) | forward (current calibration) |
| \`lp_regression_baseline.forward.json\` | \`--mode both\` | forward |
| \`lp_regression_baseline.honest.json\` | \`--mode both\` | honest (snapshot config, drift-immune) |

All three pinned to commit \`28ffd80\` (HEAD of main after the 5-PR plan landed). Snapshot pulled fresh from prod at \`/srv/hem/data/energy_state.db\` on 2026-05-09T11:40 UTC. 15-day window covers 2026-04-25 → 2026-05-09.

## Per-mode totals over the 14-day window

\`\`\`
Forward (current calibration): +£24.29
Honest  (snapshot calibration): +£23.16
Difference (pure calibration drift): £1.13
\`\`\`

The £1.13 forward-vs-honest gap is the actual quantifiable calibration drift over the 14-day window. Drift will accumulate again as \`pv_calibration_hourly\` recomputes nightly; expect another baseline re-pin every ~2 weeks unless we add a snapshot-frozen calibration field (out of scope for this PR).

## Test plan

- [x] All three baselines computed against post-merge HEAD on a fresh prod snapshot.
- [x] Per-date entries cross-checked between \`lp_regression_baseline.json\` and \`lp_regression_baseline.forward.json\` — bit-identical.
- [x] No code changes; only fixture data.

## Cross-links

- Closes the gate-FAIL false-positive from #290 (already closed).
- Stacks on: #285, #286, #287, #288, #289 (the 5-PR plan that didn't actually cause the FAIL).
- Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)