### PR TITLE
feat(lp): cap PV-abundance tank lift at 55°C separately from negative-price 65°C

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -584,6 +584,15 @@ class Config:
     LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH: float = float(
         os.getenv("LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", "0.5")
     )
+    # Tank target ceiling on PV-abundance slots, distinct from
+    # ``DHW_TEMP_MAX_C`` (65 °C) used on negative-price slots. The user's
+    # empirical manual schedule lifts to 45 °C on solar afternoons; this
+    # default 55 °C gives margin for guests + minor forecast error while
+    # avoiding the heavy standing losses of holding 65 °C through the day.
+    # Lower this toward 45 °C if standing-loss bleed-back becomes a concern.
+    DHW_TEMP_PV_ABUNDANCE_TARGET_C: float = float(
+        os.getenv("DHW_TEMP_PV_ABUNDANCE_TARGET_C", "55.0")
+    )
     # Slack penalty on the soft DHW ceiling (#225 item 1, was hardcoded 0.01).
     # Operators who want stricter comfort vs cost can tune this. Default 0.01
     # p/°C-slot preserves prior behaviour.

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -303,11 +303,24 @@ def daikin_dispatch_preview(
             "lp_optimizer": True,
         }
         # Only set tank_temp when the tank will be on — Daikin rejects temperatureControl on a powered-off tank.
-        # Floor at DHW_TEMP_COMFORT_C (48 °C); ceiling DHW_TEMP_MAX_C (65 °C).
-        # The LP already clamps tt ≤ 48 for positive-price slots and ≤ 65 for negative.
+        # Floor at DHW_TEMP_COMFORT_C (48 °C). Ceiling depends on slot kind:
+        #   negative      → DHW_TEMP_MAX_C (65 °C). Grid pays us; load all the kWh.
+        #   solar_charge  → DHW_TEMP_PV_ABUNDANCE_TARGET_C (55 °C). PV is free but
+        #                   holding 65 °C through afternoon bleeds standing losses
+        #                   before evening showers. Cap at 55 °C captures with
+        #                   margin without that bleed-back. Hard clamp here even
+        #                   though LP only soft-prefers it — Onecta write must
+        #                   reflect operator intent regardless of solver slack.
+        #   else (cheap)  → DHW_TEMP_MAX_C (65 °C). Cheap-grid imports may be
+        #                   marginal but the LP only emits cheap kind when it's
+        #                   chosen to charge → ride the LP plan.
         if tank_pow:
+            if kind == "solar_charge":
+                ceiling = float(config.DHW_TEMP_PV_ABUNDANCE_TARGET_C)
+            else:
+                ceiling = float(config.DHW_TEMP_MAX_C)
             params["tank_temp"] = round(
-                min(float(config.DHW_TEMP_MAX_C), max(float(config.DHW_TEMP_COMFORT_C), tt)),
+                min(ceiling, max(float(config.DHW_TEMP_COMFORT_C), tt)),
                 1,
             )
         if kind == "peak" or kind == "peak_export":

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -647,21 +647,26 @@ def solve_lp(
             if shower_mask[i]:
                 prob += tank[i + 1] >= t_min_dhw
 
-    # Per-slot DHW ceiling: 48 °C unless price < 0 OR PV is abundant (then DHW_TEMP_MAX_C, default 65 °C).
+    # Per-slot DHW ceiling — three tiers:
+    #   negative-price → DHW_TEMP_MAX_C (default 65 °C). Grid pays us; load all the kWh in.
+    #   PV-abundant   → DHW_TEMP_PV_ABUNDANCE_TARGET_C (default 55 °C). Lower than negative
+    #                   because (a) the user's empirical manual schedule lifts to 45 °C and
+    #                   (b) holding 65 °C through the day bleeds back via standing losses
+    #                   before the evening shower window arrives.
+    #   else          → DHW_TEMP_COMFORT_C (default 48 °C).
     # PV abundance per slot = (pv_avail − base_load − max battery charge headroom) > threshold.
-    # When true, free PV would otherwise be exported / curtailed; lifting the tank ceiling lets
-    # the LP store that energy as hot water for evening showers instead. Composes naturally with
-    # the negative-price lift — same mechanism, different trigger. Soft constraint: heavy penalty
-    # on breach so an initial tank already above 48 °C (inherited from a prior lift) stays feasible.
+    # Soft constraint: heavy penalty on breach so an initial tank already above the ceiling
+    # (inherited from a prior lift) stays feasible.
     pv_abundance_threshold = float(getattr(config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5))
     pv_abundance: list[bool] = [
         (pv_avail[i] - base_load_kwh[i] - max_batt_kwh) > pv_abundance_threshold
         for i in range(n)
     ]
+    pv_abundance_target = float(getattr(config, "DHW_TEMP_PV_ABUNDANCE_TARGET_C", 55.0))
+    # Negative-price wins when both conditions are true (always more aggressive).
     tank_hi_slot = [
-        float(config.DHW_TEMP_MAX_C)
-        if (price_line[i] < 0 or pv_abundance[i])
-        else float(config.DHW_TEMP_COMFORT_C)
+        float(config.DHW_TEMP_MAX_C) if price_line[i] < 0
+        else (pv_abundance_target if pv_abundance[i] else float(config.DHW_TEMP_COMFORT_C))
         for i in range(n)
     ]
     s_tank_hi = pulp.LpVariable.dicts("tank_hi_slack", range(n), lowBound=0)

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -86,6 +86,126 @@ def test_pv_abundance_lifts_tank_ceiling_above_comfort(
     )
 
 
+def test_dispatch_clamps_solar_preheat_at_pv_abundance_target_55c(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatch layer hard-clamps the solar_preheat tank target at
+    ``DHW_TEMP_PV_ABUNDANCE_TARGET_C`` (55 °C), even when the LP plan
+    specified a higher value. Holding 65 °C through afternoon bleeds standing
+    losses before evening showers. The LP's soft preference is a hint;
+    dispatch enforces the operator-defined hard cap on the actual Onecta write.
+
+    Negative-price slots still use the full DHW_TEMP_MAX_C (65 °C) cap —
+    only solar_charge is dispatched at the tighter target."""
+    from src.config import config as app_config
+    from src.scheduler.lp_dispatch import daikin_dispatch_preview
+    from src.scheduler.lp_optimizer import LpPlan
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DHW_TEMP_PV_ABUNDANCE_TARGET_C", 55.0, raising=False)
+    monkeypatch.setattr(app_config, "DHW_TEMP_MAX_C", 65.0, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
+    monkeypatch.setattr(
+        "src.scheduler.lp_dispatch._optimization_preset_away_like",
+        lambda: False,
+        raising=True,
+    )
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 4
+    plan = LpPlan(ok=True, status="Optimal", objective_pence=0.0,
+                  peak_threshold_pence=25.0, cheap_threshold_pence=10.0)
+    plan.slot_starts_utc = [base + timedelta(minutes=30 * i) for i in range(n)]
+    # Two solar_charge slots (PV-only charging) followed by two with chg<EPS price>0 → standard.
+    plan.price_pence = [15.0] * n
+    plan.import_kwh = [0.0] * n
+    plan.export_kwh = [0.0] * n
+    plan.battery_charge_kwh = [1.0, 1.0, 0.0, 0.0]
+    plan.battery_discharge_kwh = [0.0] * n
+    plan.dhw_electric_kwh = [0.6, 0.6, 0.0, 0.0]
+    plan.space_electric_kwh = [0.0] * n
+    plan.soc_kwh = [5.0, 6.0, 7.0, 7.0, 7.0]
+    # LP plan WANTS tank at 65°C — emulates a runaway-reward scenario where
+    # the soft cap was overridden. Dispatch must still clamp at 55.
+    plan.tank_temp_c = [40.0, 65.0, 65.0, 65.0, 65.0]
+    plan.indoor_temp_c = [21.0] * (n + 1)
+    plan.pv_curt_kwh = [0.0] * n
+    plan.lwt_offset_c = [0.0] * n
+    plan.temp_outdoor_c = [18.0] * n
+
+    pairs = daikin_dispatch_preview(plan, forecast=[])
+    solar_pairs = [
+        (rest, act) for rest, act in pairs
+        if act.get("action_type") == "solar_preheat"
+    ]
+    assert solar_pairs, "expected a solar_preheat action"
+    for _restore, action in solar_pairs:
+        # Every solar_preheat write must clamp at 55, NOT the LP plan's 65.
+        tank_temp = action["params"].get("tank_temp")
+        assert tank_temp is not None, action
+        assert tank_temp <= 55.0 + 0.001, (
+            f"solar_preheat dispatch must clamp at DHW_TEMP_PV_ABUNDANCE_TARGET_C "
+            f"(55), not honour LP plan's 65; got tank_temp={tank_temp}"
+        )
+        # Also above comfort floor — proving the lift fired.
+        assert tank_temp >= float(app_config.DHW_TEMP_COMFORT_C) - 0.001, action
+
+
+def test_dispatch_negative_price_action_uses_full_65c_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The PV-abundance dispatch clamp at 55 °C must NOT apply to
+    negative-price (max_heat) actions — those still use DHW_TEMP_MAX_C (65 °C).
+    Belt-and-braces against accidentally clamping the negative-price benefit."""
+    from src.config import config as app_config
+    from src.scheduler.lp_dispatch import daikin_dispatch_preview
+    from src.scheduler.lp_optimizer import LpPlan
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DHW_TEMP_PV_ABUNDANCE_TARGET_C", 55.0, raising=False)
+    monkeypatch.setattr(app_config, "DHW_TEMP_MAX_C", 65.0, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
+    monkeypatch.setattr(
+        "src.scheduler.lp_dispatch._optimization_preset_away_like",
+        lambda: False,
+        raising=True,
+    )
+
+    base = datetime(2026, 1, 15, 1, 0, tzinfo=UTC)
+    n = 4
+    plan = LpPlan(ok=True, status="Optimal", objective_pence=0.0,
+                  peak_threshold_pence=25.0, cheap_threshold_pence=10.0)
+    plan.slot_starts_utc = [base + timedelta(minutes=30 * i) for i in range(n)]
+    # Negative price + grid charging → kind="negative" (not solar_charge)
+    plan.price_pence = [-5.0, -5.0, 10.0, 10.0]
+    plan.import_kwh = [2.0, 2.0, 0.0, 0.0]
+    plan.export_kwh = [0.0] * n
+    plan.battery_charge_kwh = [1.5, 1.5, 0.0, 0.0]
+    plan.battery_discharge_kwh = [0.0] * n
+    plan.dhw_electric_kwh = [0.6, 0.6, 0.0, 0.0]
+    plan.space_electric_kwh = [0.0] * n
+    plan.soc_kwh = [5.0, 6.0, 7.0, 7.0, 7.0]
+    plan.tank_temp_c = [40.0, 60.0, 65.0, 65.0, 65.0]
+    plan.indoor_temp_c = [21.0] * (n + 1)
+    plan.pv_curt_kwh = [0.0] * n
+    plan.lwt_offset_c = [0.0] * n
+    plan.temp_outdoor_c = [5.0] * n
+
+    pairs = daikin_dispatch_preview(plan, forecast=[])
+    neg_pairs = [
+        (rest, act) for rest, act in pairs
+        if act.get("action_type") == "max_heat"
+    ]
+    assert neg_pairs, "expected a max_heat action"
+    for _restore, action in neg_pairs:
+        tank_temp = action["params"].get("tank_temp")
+        assert tank_temp is not None, action
+        # negative slots may go up to 65 (not capped at 55).
+        assert tank_temp > 55.0, (
+            f"max_heat dispatch must allow tank_temp > 55; got {tank_temp}"
+        )
+
+
 # --------------------------------------------------------------------------
 # 2. Reward must NOT dominate export when export is profitable
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PRs #287 + #289 lifted the tank ceiling on both negative-price and PV-abundance slots to the same \`DHW_TEMP_MAX_C\` (65 °C). The user's empirical manual schedule lifts to 45 °C on solar afternoons — holding 65 °C through the day bleeds standing losses before the evening shower window arrives.

This PR splits the two ceilings: PV-abundance lifts cap at **55 °C** (with margin for guests + minor forecast error), negative-price lifts keep the full 65 °C.

## Why now

User asked specifically for \"acting Daikin tank now — heating during PV-abundant afternoons, low target overnight\" and chose the **55 °C** PV-abundance cap option. This PR lands that choice before the active-mode flip in Phase 1.

## What changed

### \`src/config.py\`

- \`DHW_TEMP_PV_ABUNDANCE_TARGET_C\` (default 55.0, runtime-mutable). Distinct from \`DHW_TEMP_MAX_C\` (65.0).

### \`src/scheduler/lp_optimizer.py\`

Three-tier \`tank_hi_slot\`:

| Condition | Ceiling |
|---|---|
| \`price_line[i] < 0\` | \`DHW_TEMP_MAX_C\` (65) |
| \`pv_abundance[i]\` | \`DHW_TEMP_PV_ABUNDANCE_TARGET_C\` (55) |
| else | \`DHW_TEMP_COMFORT_C\` (48) |

Negative-price wins when both conditions are true (always more aggressive).

### \`src/scheduler/lp_dispatch.py\`

\`daikin_dispatch_preview\` **hard-clamps** the \`tank_temp\` write at \`DHW_TEMP_PV_ABUNDANCE_TARGET_C\` when \`kind == \"solar_charge\"\`, regardless of what the LP plan said. This is belt-and-braces against LP soft-slack letting the tank temp drift above the cap under aggressive reward parameters — Onecta write must reflect operator intent.

## Test plan

- [x] 6 tests in \`tests/test_lp_pv_abundance.py\`:
  - 4 existing tests — all pass.
  - **NEW**: \`test_dispatch_clamps_solar_preheat_at_pv_abundance_target_55c\` — even when LP plan specifies 65 °C, dispatch clamps the Onecta write at 55.
  - **NEW**: \`test_dispatch_negative_price_action_uses_full_65c_cap\` — \`max_heat\` actions still allow tank > 55 (clamp is solar_charge-specific).
- [x] Verified rebased on freshly-merged main (post-#291).

## Cross-links

- Follow-up to: #287 (PV-abundance lift), #289 (write-budget guard).
- Stacks on: PR #291 (baseline refresh, just merged).
- Plan reference: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\`.
- Phase 0 of the active-mode prep — Phase 1 (\`DAIKIN_CONTROL_MODE=active\` flip) is the user's hand-off step after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)