### PR TITLE
fix(lp): relax PV-abundance threshold — drop max_batt_kwh term

### DIFF
--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -654,12 +654,26 @@ def solve_lp(
     #                   (b) holding 65 °C through the day bleeds back via standing losses
     #                   before the evening shower window arrives.
     #   else          → DHW_TEMP_COMFORT_C (default 48 °C).
-    # PV abundance per slot = (pv_avail − base_load − max battery charge headroom) > threshold.
-    # Soft constraint: heavy penalty on breach so an initial tank already above the ceiling
-    # (inherited from a prior lift) stays feasible.
+    # PV abundance per slot = (pv_avail − base_load) > threshold.
+    # The original formula in PR #287 also subtracted ``max_batt_kwh`` (the
+    # inverter's per-slot charge cap, ~2.5 kWh). That made abundance only
+    # trigger when PV > base_load + 2.5 + threshold ≈ 3.3 kWh/slot — basically
+    # peak-summer-noon territory only. The intent was "PV that would otherwise
+    # be exported / curtailed", but ``max_batt_kwh`` is a constant cap, not
+    # remaining battery capacity, so a full battery looked the same as an
+    # empty one.
+    #
+    # Dropping the battery term lets abundance trigger on more realistic
+    # sunny days. The LP's natural preference (cycle penalty + battery
+    # objective) still picks battery-charge over tank-heat when both are
+    # profitable; the threshold change just gives the LP the *option* to
+    # heat the tank when battery is full or cycle-penalty makes it the
+    # cheaper marginal sink. Soft constraint: heavy penalty on breach so an
+    # initial tank already above the ceiling (inherited from a prior lift)
+    # stays feasible.
     pv_abundance_threshold = float(getattr(config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5))
     pv_abundance: list[bool] = [
-        (pv_avail[i] - base_load_kwh[i] - max_batt_kwh) > pv_abundance_threshold
+        (pv_avail[i] - base_load_kwh[i]) > pv_abundance_threshold
         for i in range(n)
     ]
     pv_abundance_target = float(getattr(config, "DHW_TEMP_PV_ABUNDANCE_TARGET_C", 55.0))

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -86,6 +86,51 @@ def test_pv_abundance_lifts_tank_ceiling_above_comfort(
     )
 
 
+def test_pv_abundance_threshold_relaxed_for_realistic_sunny_day(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The relaxed abundance formula triggers on realistic sunny-day PV
+    (~1.5 kWh/slot), not only peak-summer-noon (>3 kWh/slot).
+
+    The original PR #287 formula was ``(pv_avail − base_load − max_batt_kwh)``
+    which subtracted the inverter cap (~2.5 kWh/slot) — too restrictive for
+    a 4.5 kWp install whose typical sunny-day peak is 2-3 kWh/slot. The fix
+    drops the battery term: ``(pv_avail − base_load) > threshold``.
+
+    This test isolates the *threshold mechanics* (does the abundance flag
+    fire?) from the *economic competition* with export revenue. We zero the
+    export rate so the only LP incentive is the tank-storage reward.
+    Active mode used because passive clamps e_dhw."""
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5, raising=False)
+    monkeypatch.setattr(app_config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 5.0, raising=False)
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 4
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan = _solve(
+        slots=slots,
+        prices=[20.0] * n,
+        pv=[1.5] * n,        # Realistic sunny-day mid-day PV
+        base_load=[0.3] * n,
+        init_soc=8.5,
+        init_tank=40.0,
+        export_prices=[0.0] * n,  # Zero export revenue — isolate from export
+                                   # trade-off; pure threshold test.
+    )
+    assert plan.ok, plan.status
+    # Old formula: (1.5 − 0.3 − 2.5) = −1.3 < 0.5 → would NOT trigger.
+    # New formula: (1.5 − 0.3)        =  1.2 > 0.5 → triggers. With tank
+    # storage rewarded and export rate 0, LP must heat the tank to capture
+    # the only available value.
+    max_tank = max(plan.tank_temp_c[1:])
+    assert max_tank > float(app_config.DHW_TEMP_COMFORT_C) + 1.0, (
+        f"Relaxed PV-abundance threshold should fire on 1.5 kWh/slot PV "
+        f"(would not trigger under old formula); max_tank={max_tank:.1f}"
+    )
+
+
 def test_dispatch_clamps_solar_preheat_at_pv_abundance_target_55c(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

PR #287's abundance formula required \`(pv_avail − base_load − max_batt_kwh) > threshold\` where \`max_batt_kwh\` is the inverter's per-slot charge cap (~2.5 kWh/slot, a **constant**). For the 4.5 kWp install, abundance only triggered when **PV > 3.3 kWh/slot** — basically peak-summer-noon territory only.

This fix drops the battery term: \`(pv_avail − base_load) > threshold\`.

## Why now

Investigation of tomorrow's prod plan after the active-flip prep work revealed the LP's solar_charge slots had \`dhw_kwh ≈ 0.009\` and tank temp flat at 37–38 °C. Two reasons:

1. \`DAIKIN_CONTROL_MODE=passive\` clamps \`e_dhw\` (expected — flips to active later).
2. **Even in active mode, the abundance threshold wouldn't have fired**: tomorrow's max PV slot is 0.80 kWh, well below the 3.3 kWh/slot bar.

The intent in #287 was "PV that would otherwise be exported / curtailed" — but \`max_batt_kwh\` is a static inverter cap, not remaining battery capacity. A full battery looked the same as an empty one.

## What changed

\`src/scheduler/lp_optimizer.py\`:

\`\`\`python
# Before (PR #287)
pv_abundance = (pv_avail[i] - base_load_kwh[i] - max_batt_kwh) > threshold

# After (this PR)
pv_abundance = (pv_avail[i] - base_load_kwh[i]) > threshold
\`\`\`

The LP's natural preference (cycle penalty + battery objective) still picks battery-charge over tank-heat when both are profitable; the threshold change just **gives the LP the option** to heat the tank when battery is full or cycle-penalty makes it the cheaper marginal sink.

## Numerical impact

| Scenario | Old formula | New formula |
|---|---|---|
| 0.5 kWh/slot PV, base 0.3 | NO (-2.3 < 0.5) | NO (0.2 < 0.5) ✓ |
| 1.5 kWh/slot PV, base 0.3 | NO (-1.3 < 0.5) | YES (1.2 > 0.5) ✓ |
| 3.0 kWh/slot PV, base 0.3 | NO (0.2 < 0.5) | YES (2.7 > 0.5) ✓ |
| 4.0 kWh/slot PV, base 0.3 | YES (1.2 > 0.5) | YES (3.7 > 0.5) ✓ |

The LP correctly identifies low-PV days as not abundant; the fix expands what counts as "abundant" to include realistic sunny days.

## Test plan

- [x] 7 tests in \`tests/test_lp_pv_abundance.py\` — all pass.
- [x] **NEW**: \`test_pv_abundance_threshold_relaxed_for_realistic_sunny_day\` — 1.5 kWh/slot PV, zero export rate (isolates threshold from export trade-off), active mode → tank must lift above comfort. Old formula would not fire; new formula does.
- [ ] Full unit suite (pending CI).

## Cross-links

- Fix-up to: PR #287 (PV-abundance ceiling lift).
- Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` Phase 0 follow-up.
- Activates with: #267 S5 (active control flip — once \`DAIKIN_CONTROL_MODE=active\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)