### PR TITLE
fix(dispatch): scan merged window for max e_dhw — solar_preheat tank_power bug

### DIFF
--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -278,10 +278,40 @@ def daikin_dispatch_preview(
         outdoor = fc.temperature_c if fc else (plan.temp_outdoor_c[i0] if i0 < len(plan.temp_outdoor_c) else 0.0)
         peak_frost = kind == "peak" and outdoor < float(config.WEATHER_FROST_THRESHOLD_C)
 
-        j = min(i0, len(plan.dhw_electric_kwh) - 1)
-        ed = plan.dhw_electric_kwh[j] if plan.dhw_electric_kwh else 0.0
-        es = plan.space_electric_kwh[j] if plan.space_electric_kwh else 0.0
-        tt = plan.tank_temp_c[min(j + 1, len(plan.tank_temp_c) - 1)] if plan.tank_temp_c else float(config.DHW_TEMP_NORMAL_C)
+        # The merge in _merge_half_hour_slots_for_daikin groups slots by KIND
+        # (battery state), not by heat-pump activity. For solar_charge, the LP
+        # can plan e_dhw > 0 in just one slot inside a long merged window
+        # (e.g. one 30-min heat across a 3.5h window). Reading params from
+        # only the first slot would lose that — emitting tank_power=False
+        # for the whole window when the LP wanted heat in the middle.
+        #
+        # Scan the merged window for the MAX e_dhw and MAX tank_temp target.
+        # If any slot wants heat → tank_pow=True with the peak target. This
+        # is safe because Daikin's tolerance check skips the write when target
+        # is already met, so non-heating slots within the window become
+        # natural no-ops.
+        n_slots_in_window = max(1, round((end_utc - start_utc).total_seconds() / 1800))
+        i_end = min(i0 + n_slots_in_window, len(plan.dhw_electric_kwh)) if plan.dhw_electric_kwh else i0 + 1
+        j = min(i0, len(plan.dhw_electric_kwh) - 1) if plan.dhw_electric_kwh else 0
+        ed_max = max(
+            (plan.dhw_electric_kwh[k] for k in range(i0, i_end)),
+            default=0.0,
+        ) if plan.dhw_electric_kwh else 0.0
+        es_max = max(
+            (plan.space_electric_kwh[k] for k in range(i0, i_end)),
+            default=0.0,
+        ) if plan.space_electric_kwh else 0.0
+        # tank_temp_c is len N+1 (state at end of slot k is index k+1).
+        tt_max = max(
+            (plan.tank_temp_c[min(k + 1, len(plan.tank_temp_c) - 1)]
+             for k in range(i0, i_end)),
+            default=float(config.DHW_TEMP_NORMAL_C),
+        ) if plan.tank_temp_c else float(config.DHW_TEMP_NORMAL_C)
+        # Use first-slot params for the LWT offset (climate-curve adjustments
+        # don't accumulate the same way as DHW heat).
+        ed = ed_max
+        es = es_max
+        tt = tt_max
         # LP-derived LWT offset: continuous value back-computed from e_space[j] via the
         # inverse climate curve.  This replaces the old fixed-tier overrides so the solver's
         # energy decision directly controls the radiator temperature rather than a lookup table.

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -131,6 +131,89 @@ def test_pv_abundance_threshold_relaxed_for_realistic_sunny_day(
     )
 
 
+def test_dispatch_solar_preheat_picks_max_dhw_across_merged_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the LP plans e_dhw > 0 in just ONE slot inside a long merged
+    solar_charge window (because one 30-min heat satisfies the evening shower
+    constraint), dispatch must scan the whole window for max e_dhw — not
+    just read the first slot. Otherwise the action emits tank_power=False
+    across the whole window, deactivating the tank when the LP wanted heat
+    mid-window.
+
+    Regression test for the prod-active-flip bug found 2026-05-09: dispatch
+    sent tank_power=False for a Sun 10:00-13:30 solar_preheat window where
+    the LP had planned heating at slot 11:00 only."""
+    from src.config import config as app_config
+    from src.scheduler.lp_dispatch import daikin_dispatch_preview
+    from src.scheduler.lp_optimizer import LpPlan
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
+    monkeypatch.setattr(
+        "src.scheduler.lp_dispatch._optimization_preset_away_like",
+        lambda: False,
+        raising=True,
+    )
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 7  # 3.5h window, all solar_charge
+    plan = LpPlan(ok=True, status="Optimal", objective_pence=0.0,
+                  peak_threshold_pence=25.0, cheap_threshold_pence=10.0)
+    plan.slot_starts_utc = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan.price_pence = [15.0] * n
+    plan.import_kwh = [0.0] * n  # No grid import → solar_charge kind
+    plan.export_kwh = [0.0] * n
+    plan.battery_charge_kwh = [0.5] * n  # PV→battery in EVERY slot → kind=solar_charge for every slot
+    plan.battery_discharge_kwh = [0.0] * n
+    # LP planned heat in slot 1 ONLY (not slot 0). This mimics the prod bug:
+    # the merge-first-slot read e_dhw=~0 and emitted tank_power=False.
+    plan.dhw_electric_kwh = [0.009, 0.164, 0.005, 0.005, 0.005, 0.005, 0.005]
+    plan.space_electric_kwh = [0.0] * n
+    plan.soc_kwh = [5.0] + [5.0 + 0.5 * i for i in range(1, n + 1)]
+    # Tank rises sharply at slot 1 (the heat slot), then cools.
+    plan.tank_temp_c = [38.0, 38.2, 47.9, 47.6, 47.4, 47.2, 47.0, 46.8]
+    plan.indoor_temp_c = [21.0] * (n + 1)
+    plan.pv_curt_kwh = [0.0] * n
+    plan.lwt_offset_c = [0.0] * n
+    plan.temp_outdoor_c = [18.0] * n
+
+    pairs = daikin_dispatch_preview(plan, forecast=[])
+    solar = [(r, a) for r, a in pairs if a.get("action_type") == "solar_preheat"]
+    assert solar, f"expected a solar_preheat action; got {[a.get('action_type') for _, a in pairs]}"
+
+    # Multiple solar_charge slots may be merged. The merged action MUST
+    # cover the heat slot (slot 1, 12:30-13:00 UTC) AND set tank_power=True
+    # with a non-trivial tank_temp.
+    found_heat_action = False
+    for _restore, action in solar:
+        params = action["params"]
+        # If this action's window includes the heat slot:
+        s = datetime.fromisoformat(action["start_time"].replace("Z","+00:00"))
+        e = datetime.fromisoformat(action["end_time"].replace("Z","+00:00"))
+        heat_slot_start = base + timedelta(minutes=30 * 1)
+        if s <= heat_slot_start < e:
+            assert params.get("tank_power") is True, (
+                f"merged window covering the heat slot must have tank_power=True; "
+                f"params={params}"
+            )
+            assert "tank_temp" in params, (
+                f"tank_temp must be set when tank_power=True; params={params}"
+            )
+            assert params["tank_temp"] >= 47.0, (
+                f"tank_temp must reflect the peak target across the window "
+                f"(LP plan peaks at 47.9 in slot 1); got {params['tank_temp']}"
+            )
+            # 55°C cap from PR #292 still applies.
+            assert params["tank_temp"] <= float(app_config.DHW_TEMP_PV_ABUNDANCE_TARGET_C) + 0.001, (
+                f"tank_temp must respect PV-abundance cap (55°C); got {params['tank_temp']}"
+            )
+            found_heat_action = True
+    assert found_heat_action, (
+        "expected at least one solar_preheat action covering the LP heat slot"
+    )
+
+
 def test_dispatch_clamps_solar_preheat_at_pv_abundance_target_55c(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

**Critical bug found during the 2026-05-09 active-mode prod test.**

The dispatch emitted \`tank_power=False\` for a Sun 10:00–13:30 \`solar_preheat\` window where the LP had planned heating at slot 11:00 only. Result would have been **turning OFF the tank for 3.5 hours** — opposite of intended. Caught immediately during smoke-inspect of \`action_schedule\` rows; reverted to passive before any heartbeat tick fired.

## Root cause

\`_merge_half_hour_slots_for_daikin\` groups slots by **kind** (which depends on battery state via \`chg > EPS\`), not by heat-pump activity. For \`solar_charge\`, the LP can plan \`e_dhw > 0\` in **just one slot inside a long merged window** — one 30-min heat is enough to satisfy the evening shower constraint via tank thermodynamics.

Earlier kinds didn't trip this because they're uniform within their windows:

| Kind | LP plans \`e_dhw > 0\`? |
|---|---|
| \`cheap\` | Almost always — cheap windows are when LP does everything |
| \`negative\` | Same, even more aggressive |
| \`peak\` | Always 0 — that's the whole point |
| **\`solar_charge\`** | **Variable** — LP charges battery whole window, heats tank only when it's the cheapest option |

The dispatch read params from only the first slot:

\`\`\`python
j = min(i0, len(plan.dhw_electric_kwh) - 1)
ed = plan.dhw_electric_kwh[j]   # only slot 10:00
\`\`\`

For prod's actual run: \`e_dhw=0.009\` at 10:00, \`e_dhw=0.164\` at 11:00. \`ed = 0.009 < EPS\` → \`tank_pow=False\` → emit \`tank_power=False\` for the whole 3.5 h window. **Wrong.**

## Fix

Scan the merged window for the **max** \`e_dhw\` and **max** \`tank_temp_c\` target. If any slot wants heat, set \`tank_pow=True\` with the peak target. Daikin's 0.6 °C tolerance check turns non-heating slots within the window into natural no-ops on the wire.

\`\`\`python
n_slots_in_window = max(1, round((end_utc - start_utc).total_seconds() / 1800))
i_end = min(i0 + n_slots_in_window, len(plan.dhw_electric_kwh))
ed_max = max(plan.dhw_electric_kwh[k] for k in range(i0, i_end))
tt_max = max(plan.tank_temp_c[k+1] for k in range(i0, i_end))
ed = ed_max
tt = tt_max
\`\`\`

## Test

\`tests/test_lp_pv_abundance.py::test_dispatch_solar_preheat_picks_max_dhw_across_merged_window\` — synthetic 7-slot \`solar_charge\` window with \`e_dhw=0.164\` only in slot 1. Pre-fix: action emits \`tank_power=False\`, no \`tank_temp\`. Post-fix: action emits \`tank_power=True\`, \`tank_temp=47.9\` (peak across window, capped at 55 °C per PR #292).

8 tests pass in \`test_lp_pv_abundance.py\`. Full unit suite green.

## Operational note

This bug was found **on first active-mode flip** in prod, immediately reverted (no heartbeat tick fired = no hardware writes happened = no Onecta calls wasted). System is back in passive mode pending this fix landing.

After this PR merges + redeploys, the active flip can retry. The simulated active-mode plan that motivated the original flip showed exactly the right pattern (one DHW heat at 11:00 capturing PV → tank at 47.9 °C → naturally cools to 45.6 °C by 19:00 shower window → no expensive evening reheat). The fix makes that intent reach the hardware correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)