### PR TITLE
fix(dispatch): peak idle target = NORMAL_C (45) not MIN_FLOOR_C (30)

### DIFF
--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -355,13 +355,16 @@ def daikin_dispatch_preview(
                 params["tank_power"] = False
                 # No tank_temp — tank off, target is meaningless.
             else:
-                # IDLE strategy: keep tank on at a low target so firmware
-                # doesn't reheat. Tank stays warm from prior heating; standing
-                # losses over peak window are minimal vs cycle overhead of a
-                # full power-off / power-on transition.
+                # IDLE strategy: keep tank on at the NORMAL target. If tank
+                # was inherited above target (e.g. from prior solar_preheat),
+                # firmware just stops reheating — no grid draw, tank cools
+                # naturally. If tank is at-or-below target, firmware maintains
+                # at the setpoint (small reheats only when needed). User's
+                # validated approach for well-insulated tanks: don't shut off,
+                # just lower the target back to "normal" and let physics work.
                 params["tank_power"] = True
                 params["tank_temp"] = round(
-                    float(getattr(config, "DHW_TEMP_MIN_FLOOR_C", 30.0)),
+                    float(getattr(config, "DHW_TEMP_NORMAL_C", 45.0)),
                     1,
                 )
         elif tank_pow:

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -215,19 +215,22 @@ def _build_peak_plan(base: datetime, n: int = 4) -> "LpPlan":
     return plan
 
 
-def test_dispatch_peak_idle_default_keeps_tank_on_low_target(
+def test_dispatch_peak_idle_default_keeps_tank_on_normal_target(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Default peak strategy ("idle") keeps tank ON at a low target during
-    peak. Firmware won't reheat (tank stays well above 30°C from prior
-    heating). Avoids turn-off/on cycle overhead. Climate still goes off."""
+    """Default peak strategy ("idle") keeps tank ON at the NORMAL target
+    during peak. If tank is inherited above target (from prior solar_preheat),
+    firmware sees current > setpoint and won't reheat — tank cools naturally.
+    If tank is at or below target, firmware maintains setpoint with small
+    reheats only when needed. Best for well-insulated tanks per user's
+    validated approach. Climate still goes off (saves grid)."""
     from src.config import config as app_config
     from src.scheduler.lp_dispatch import daikin_dispatch_preview
 
     monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
     monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
     monkeypatch.setattr(app_config, "DHW_PEAK_TANK_STRATEGY", "idle", raising=False)
-    monkeypatch.setattr(app_config, "DHW_TEMP_MIN_FLOOR_C", 30.0, raising=False)
+    monkeypatch.setattr(app_config, "DHW_TEMP_NORMAL_C", 45.0, raising=False)
     monkeypatch.setattr(
         "src.scheduler.lp_dispatch._optimization_preset_away_like",
         lambda: False,
@@ -240,15 +243,17 @@ def test_dispatch_peak_idle_default_keeps_tank_on_low_target(
     assert peak_pairs, "expected a shutdown action"
     for _restore, action in peak_pairs:
         params = action["params"]
-        # IDLE: tank stays ON, target is the low floor (30°C).
+        # IDLE: tank stays ON at NORMAL target (45°C, not the 30°C floor).
         assert params.get("tank_power") is True, (
             f"idle strategy must keep tank_power=True; params={params}"
         )
-        assert params.get("tank_temp") == pytest.approx(30.0), (
-            f"idle strategy must set tank_temp to DHW_TEMP_MIN_FLOOR_C (30°C); "
-            f"got {params.get('tank_temp')}"
+        assert params.get("tank_temp") == pytest.approx(45.0), (
+            f"idle strategy must set tank_temp to DHW_TEMP_NORMAL_C (45°C), "
+            f"NOT the absolute floor (30°C); got {params.get('tank_temp')}"
         )
-        # Climate STILL goes off during peak — that's a separate decision.
+        # Climate STILL goes off during peak — that's a separate decision
+        # the user explicitly said is "not discussing this yet" so default
+        # behaviour (climate off during peak) is preserved.
         assert params.get("climate_on") is False, (
             f"peak should still turn climate off; params={params}"
         )


### PR DESCRIPTION
## Summary

Quick fix-up on top of PR #296. After deploying PR #296, the user observed:

> tank is over than 50 now. more than necessary for our showers. we don't need to turn off, just set the temperature back to lower like 45.
> climate shouldn't change anytime, we are not discussing this yet.

PR #296's idle strategy used \`DHW_TEMP_MIN_FLOOR_C\` (30 °C) as the peak idle target. That's too low — it signals "deep idle, firmware basically never reheats." User wants the target to track the NORMAL value (45 °C): firmware sees current (50+) > setpoint (45) → no reheat. Tank cools naturally to 45 over time. Then firmware maintains at 45 with tiny reheats only when needed.

Matches the user's validated manual approach — set target to "normal," let physics + firmware handle the rest.

## What changed

\`src/scheduler/lp_dispatch.py\` peak idle: \`tank_temp = DHW_TEMP_NORMAL_C\` (45) instead of \`DHW_TEMP_MIN_FLOOR_C\` (30).

Climate still off during peak — user explicitly excluded climate from this discussion (\"we are not discussing this yet\").

## Test plan

- [x] 11 tests in \`tests/test_lp_pv_abundance.py\`:
  - Renamed \`test_dispatch_peak_idle_default_keeps_tank_on_normal_target\` (was \`...low_target\`), asserts target=45 not 30.
  - All others unchanged.

## What's still NOT addressed (separate work)

User also wants:
> after the showers the temp might be bellow the 45 set and we would be trying to keep it heat during early mornings but we only will use it again next day evening. […] we can heat it again during abundance of PV of the next day. until that it can remain off or not draining energy from batteries

That's a new feature — overnight tank-off between last shower and next-day PV abundance. Will design in a follow-up after this lands.

## Cross-links

- Stacks on: PR #296 (peak idle strategy).
- Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` Phase 1 attempt #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)