### PR TITLE
feat(dispatch): post-shower overnight tank idle (LP-driven, default 38°C)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -603,6 +603,22 @@ class Config:
     #     overhead. Pick this for poorly-insulated tanks where firmware
     #     would attempt mid-peak reheats from standing losses alone.
     DHW_PEAK_TANK_STRATEGY: str = os.getenv("DHW_PEAK_TANK_STRATEGY", "idle").strip().lower()
+    # Post-shower overnight tank idle (LP-driven). After the LAST shower window
+    # of the day, the LP has no DHW need until next-day's PV abundance — the
+    # tank is set to a low BACKUP target so firmware doesn't reheat overnight,
+    # but stays slightly above cold for unexpected morning showers. Reset to
+    # NORMAL when LP plans the next productive slot (cheap / negative /
+    # solar_charge — i.e. "next day's economics are better").
+    #   38 °C default — backup buffer for unplanned morning shower.
+    #   30 °C for full overnight cooling (no morning backup).
+    #   45 °C effectively disables the override.
+    DHW_TANK_OVERNIGHT_TARGET_C: float = float(
+        os.getenv("DHW_TANK_OVERNIGHT_TARGET_C", "38.0")
+    )
+    # Toggle the post-shower overnight override. Default true. Set to false
+    # to let overnight slots fall back to plain "standard" (no Daikin write,
+    # firmware does whatever it wants based on its own schedule).
+    DHW_TANK_OVERNIGHT_IDLE_ENABLED: str = os.getenv("DHW_TANK_OVERNIGHT_IDLE_ENABLED", "true")
     # Slack penalty on the soft DHW ceiling (#225 item 1, was hardcoded 0.01).
     # Operators who want stricter comfort vs cost can tune this. Default 0.01
     # p/°C-slot preserves prior behaviour.

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -155,7 +155,62 @@ def lp_plan_to_slots(plan: LpPlan) -> list[HalfHourSlot]:
                 target_soc_pct=target_soc_pct,
             )
         )
+
+    # Second pass: mark "tank_idle_overnight" slots.
+    #
+    # Once we pass a shower-window slot, subsequent "standard" slots represent
+    # the post-shower-overnight period where the user doesn't need hot water
+    # until next-day's PV abundance. Tank should idle at a low backup target
+    # (default 38 °C — backup if someone showers unexpectedly in the morning,
+    # but firmware won't reheat to maintain higher temps overnight).
+    #
+    # Reset when we hit a productive slot (cheap/negative/solar_charge) — that
+    # signals "next day's economics are better, tank can heat now."
+    if _overnight_tank_idle_enabled():
+        try:
+            from .lp_optimizer import _resolve_active_shower_windows, _window_set_slot_mask
+            from ..presets import OperationPreset
+            try:
+                _is_guests = OperationPreset(config.OPTIMIZATION_PRESET) == OperationPreset.GUESTS
+            except (ValueError, AttributeError):
+                _is_guests = False
+            shower_windows = _resolve_active_shower_windows(_is_guests)
+            shower_mask = _window_set_slot_mask(plan.slot_starts_utc, TZ(), windows=shower_windows)
+        except Exception:  # pragma: no cover — never let the override break dispatch
+            shower_mask = [False] * n
+
+        seen_shower_in_window = False
+        productive_kinds = {"cheap", "negative", "solar_charge"}
+        for i in range(n):
+            if shower_mask[i]:
+                seen_shower_in_window = True
+                continue
+            if out[i].kind in productive_kinds:
+                # Productive slot resets the overnight tracker — next day's
+                # showers reset the cycle.
+                seen_shower_in_window = False
+                continue
+            if seen_shower_in_window and out[i].kind == "standard":
+                out[i] = HalfHourSlot(
+                    start_utc=out[i].start_utc,
+                    end_utc=out[i].end_utc,
+                    price_pence=out[i].price_pence,
+                    kind="tank_idle_overnight",
+                    lp_grid_import_w=out[i].lp_grid_import_w,
+                    target_soc_pct=out[i].target_soc_pct,
+                )
     return out
+
+
+def _overnight_tank_idle_enabled() -> bool:
+    """Toggle for the post-shower overnight tank idle override (default on).
+
+    Set ``DHW_TANK_OVERNIGHT_IDLE_ENABLED=false`` to disable — overnight slots
+    fall back to plain "standard" (no Daikin write, firmware does whatever it
+    wants based on its own schedule).
+    """
+    val = (getattr(config, "DHW_TANK_OVERNIGHT_IDLE_ENABLED", "true") or "true").strip().lower()
+    return val not in ("false", "0", "no", "off")
 
 
 def _lwt_offset_from_plan(i: int, plan: LpPlan) -> float:
@@ -271,6 +326,11 @@ def daikin_dispatch_preview(
             # drops back to DHW_TEMP_NORMAL_C — same safety scaffolding as
             # negative/cheap kinds.
             "solar_charge": "solar_preheat",
+            # tank_idle_overnight: post-shower-until-next-PV-abundance window.
+            # Tank target dropped to DHW_TANK_OVERNIGHT_TARGET_C (default 38°C)
+            # so firmware doesn't reheat overnight — but stays slightly above
+            # cold so an unexpected morning shower has some warm water.
+            "tank_idle_overnight": "tank_idle_overnight",
         }.get(kind, "normal")
 
         mid = start_utc + timedelta(minutes=15)
@@ -349,7 +409,24 @@ def daikin_dispatch_preview(
             "climate_on": es > EPS or ed > EPS or kind in ("negative", "cheap", "solar_charge"),
             "lp_optimizer": True,
         }
-        if is_shutdown:
+        if kind == "tank_idle_overnight":
+            # Post-shower-until-next-PV-abundance: tank ON at low backup
+            # target (default 38 °C). Firmware won't reheat from 50+ down to
+            # 38 (current > setpoint, no action). If tank cools to 38 over
+            # the long overnight, firmware maintains at 38 — backup buffer
+            # for unexpected morning shower. We also strip the climate-side
+            # params: user said "climate shouldn't change anytime, we are not
+            # discussing this yet" — leave Daikin's own zone scheduling alone.
+            params = {
+                "tank_powerful": False,
+                "tank_power": True,
+                "tank_temp": round(
+                    float(getattr(config, "DHW_TANK_OVERNIGHT_TARGET_C", 38.0)),
+                    1,
+                ),
+                "lp_optimizer": True,
+            }
+        elif is_shutdown:
             peak_strategy = (getattr(config, "DHW_PEAK_TANK_STRATEGY", "idle") or "idle").strip().lower()
             if peak_strategy == "shutdown":
                 params["tank_power"] = False

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -193,6 +193,153 @@ def test_dispatch_omits_tank_power_when_no_heat_planned_and_not_shutdown(
         )
 
 
+def test_lp_plan_to_slots_marks_post_shower_slots_as_idle_overnight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the LAST shower window of the day, "standard" slots should be
+    re-classified as ``tank_idle_overnight`` until the next productive slot
+    (cheap/negative/solar_charge) — meaning tank target drops to backup
+    overnight target (38°C default) instead of leaving it at NORMAL.
+    """
+    from src.config import config as app_config
+    from src.scheduler.lp_dispatch import lp_plan_to_slots
+    from src.scheduler.lp_optimizer import LpPlan
+
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(app_config, "DHW_TANK_OVERNIGHT_IDLE_ENABLED", "true", raising=False)
+    monkeypatch.setattr(app_config, "OPTIMIZATION_PRESET", "normal", raising=False)
+    # Disable strict_savings so the export path doesn't override slot kinds.
+    monkeypatch.setattr(app_config, "ENERGY_STRATEGY_MODE", "savings_first", raising=False)
+
+    # Build a slot sequence covering 18:00 today through 11:00 tomorrow.
+    # Some slots are shower-window (19:00-22:00); after that, all "standard";
+    # next morning we'll add a cheap slot to confirm the reset.
+    base = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)  # 18:00 BST
+    n = 36  # 18 hours of half-hour slots
+    plan = LpPlan(ok=True, status="Optimal", objective_pence=0.0,
+                  peak_threshold_pence=25.0, cheap_threshold_pence=10.0)
+    plan.slot_starts_utc = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan.price_pence = [20.0] * n
+    # Make slot 28+ (11:00 BST next day onward) "cheap" so the reset triggers.
+    # Slot 28 = 18:00 + 14h = 08:00 UTC = 09:00 BST. Hmm not quite morning
+    # but close. Set those to negative price + grid charge to force "cheap".
+    plan.battery_charge_kwh = [0.0] * n
+    plan.import_kwh = [0.0] * n
+    plan.export_kwh = [0.0] * n
+    plan.battery_discharge_kwh = [0.0] * n
+    plan.dhw_electric_kwh = [0.0] * n
+    plan.space_electric_kwh = [0.0] * n
+    plan.soc_kwh = [5.0] * (n + 1)
+    plan.tank_temp_c = [45.0] * (n + 1)
+    plan.indoor_temp_c = [21.0] * (n + 1)
+    plan.pv_curt_kwh = [0.0] * n
+    plan.lwt_offset_c = [0.0] * n
+    plan.temp_outdoor_c = [18.0] * n
+
+    # Force last slot to "cheap" by making chg > EPS at price > 0.
+    plan.battery_charge_kwh[-1] = 0.5
+    plan.import_kwh[-1] = 0.5
+    plan.price_pence[-1] = 5.0  # below cheap_threshold
+
+    slots = lp_plan_to_slots(plan)
+
+    # Walk and verify state transitions.
+    seen_shower = False
+    seen_idle_overnight = False
+    seen_reset = False
+    for i, s in enumerate(slots):
+        local = s.start_utc.astimezone(ZoneInfo("Europe/London"))
+        h = local.hour + local.minute / 60
+        # 19-22 BST: shower window (mask True). Kind stays "standard" because
+        # LP planned no heat (e_dhw=0).
+        if 19 <= h < 22:
+            seen_shower = True
+        # 22-09 BST next morning: should be tank_idle_overnight (after shower,
+        # before any productive slot).
+        if seen_shower and not seen_reset and s.kind == "tank_idle_overnight":
+            seen_idle_overnight = True
+        # The last slot is "cheap" → resets the overnight tracker.
+        if s.kind == "cheap":
+            seen_reset = True
+            # After reset, no further idle_overnight should appear (we're at
+            # end of horizon anyway).
+
+    assert seen_idle_overnight, (
+        f"expected at least one tank_idle_overnight slot after the shower window; "
+        f"slot kinds: {[s.kind for s in slots]}"
+    )
+
+
+def test_dispatch_emits_overnight_idle_action_at_38c(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The overnight-idle action emits tank_temp=DHW_TANK_OVERNIGHT_TARGET_C
+    (default 38°C) with tank_power=True. Climate-side params are NOT emitted
+    (per user: 'climate shouldn't change anytime, we are not discussing this
+    yet')."""
+    from src.config import config as app_config
+    from src.scheduler.lp_dispatch import daikin_dispatch_preview
+    from src.scheduler.lp_optimizer import LpPlan
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(app_config, "DHW_TANK_OVERNIGHT_IDLE_ENABLED", "true", raising=False)
+    monkeypatch.setattr(app_config, "DHW_TANK_OVERNIGHT_TARGET_C", 38.0, raising=False)
+    monkeypatch.setattr(app_config, "OPTIMIZATION_PRESET", "normal", raising=False)
+    monkeypatch.setattr(app_config, "ENERGY_STRATEGY_MODE", "savings_first", raising=False)
+    monkeypatch.setattr(
+        "src.scheduler.lp_dispatch._optimization_preset_away_like",
+        lambda: False,
+        raising=True,
+    )
+
+    # 18:00 BST → 06:00 BST next day (12 hours). Includes shower window and
+    # plenty of overnight slots to mark.
+    base = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    n = 24
+    plan = LpPlan(ok=True, status="Optimal", objective_pence=0.0,
+                  peak_threshold_pence=25.0, cheap_threshold_pence=10.0)
+    plan.slot_starts_utc = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan.price_pence = [20.0] * n
+    plan.import_kwh = [0.0] * n
+    plan.export_kwh = [0.0] * n
+    plan.battery_charge_kwh = [0.0] * n
+    plan.battery_discharge_kwh = [0.0] * n
+    plan.dhw_electric_kwh = [0.0] * n
+    plan.space_electric_kwh = [0.0] * n
+    plan.soc_kwh = [5.0] * (n + 1)
+    plan.tank_temp_c = [50.0] * (n + 1)
+    plan.indoor_temp_c = [21.0] * (n + 1)
+    plan.pv_curt_kwh = [0.0] * n
+    plan.lwt_offset_c = [0.0] * n
+    plan.temp_outdoor_c = [18.0] * n
+
+    pairs = daikin_dispatch_preview(plan, forecast=[])
+    overnight_pairs = [(r, a) for r, a in pairs if a.get("action_type") == "tank_idle_overnight"]
+    assert overnight_pairs, (
+        f"expected a tank_idle_overnight action; got action_types: "
+        f"{[a.get('action_type') for _, a in pairs]}"
+    )
+    for _restore, action in overnight_pairs:
+        params = action["params"]
+        assert params.get("tank_power") is True, (
+            f"overnight idle keeps tank_power=True (NOT off — backup for "
+            f"unexpected morning shower); params={params}"
+        )
+        assert params.get("tank_temp") == pytest.approx(38.0), (
+            f"overnight idle target = DHW_TANK_OVERNIGHT_TARGET_C (38°C); "
+            f"got {params.get('tank_temp')}"
+        )
+        # Climate-side keys NOT emitted — user excluded climate from this work.
+        assert "climate_on" not in params, (
+            f"overnight idle should NOT touch climate_on; params={params}"
+        )
+        assert "lwt_offset" not in params, (
+            f"overnight idle should NOT touch lwt_offset; params={params}"
+        )
+
+
 def _build_peak_plan(base: datetime, n: int = 4) -> "LpPlan":
     """Helper: synthetic plan with all slots at peak prices (no PV, no charge)."""
     from src.scheduler.lp_optimizer import LpPlan


### PR DESCRIPTION
## Summary

Implements the second half of the user's tank strategy: after the last shower window, tank target drops to a low backup setpoint (38 °C) so firmware doesn't reheat overnight. Resets when the next productive slot (cheap / negative / solar_charge) comes along — i.e. "next day's economics are better, tank can heat now."

User's exact words:
> after the showers the temp might be bellow the 45 set and we would be trying to keep it heat during early mornings but we only will use it again next day evening. so we can heat it again during abundance of PV of the next day.

## Per the user's choices

| Question | Answer |
|---|---|
| Trigger | LP-driven (after last shower → first PV abundance) |
| Action | tank_power=True, tank_temp=38 °C (backup buffer for unexpected morning shower) |
| Climate? | Untouched — user said "we are not discussing this yet" |

## How it works

\`lp_plan_to_slots\` adds a second pass: walks forward, tracks "we're past today's shower window," reclassifies subsequent \`standard\` slots as \`tank_idle_overnight\` UNTIL it sees a productive slot (cheap/negative/solar_charge — meaning "next day's economics are better").

\`daikin_dispatch_preview\` adds \`tank_idle_overnight\` to the action_type map. Special-cased params: only \`tank_power=True\` + \`tank_temp\` + \`tank_powerful=False\` + \`lp_optimizer=True\`. Climate-side keys (\`climate_on\`, \`lwt_offset\`) **omitted entirely** — user explicitly excluded climate from this work.

## Configurable

- \`DHW_TANK_OVERNIGHT_TARGET_C\` (default 38.0). 30 = no backup. 45 = effectively disables.
- \`DHW_TANK_OVERNIGHT_IDLE_ENABLED\` (default \`true\`). Set \`false\` to skip the override entirely.

## Tests (2 new + 11 existing)

- **NEW** \`test_lp_plan_to_slots_marks_post_shower_slots_as_idle_overnight\` — synthetic plan with shower window followed by standard slots; asserts second-pass reclassification fires.
- **NEW** \`test_dispatch_emits_overnight_idle_action_at_38c\` — action params: tank_power=True, tank_temp=38, climate_on absent.
- Full unit suite green locally.

## End-to-end behavior with this PR + #287 + #297

User's manual schedule:
- 14:00–15:00 → tank to 45 °C (capture solar)
- Evening showers
- 22:00 → tank to 37 °C (avoid morning reheat)

Active LP after this PR:
- Solar abundance window (e.g. 13:00–15:00) → \`solar_preheat\` to 55 °C
- Peak window (16:00–22:00) → idle: tank ON @ 45 °C target (PR #297)
- **Post-shower until next-day PV abundance → tank ON @ 38 °C (this PR)**
- Next-day solar window → cycle repeats

Cross-links: PR #287 (PV-abundance lift), PR #297 (peak idle = 45). Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` Phase 1 attempt #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)