### PR TITLE
feat(lp): static-physics DHW draw model — bridge to V11-C / #196

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -619,6 +619,25 @@ class Config:
     # to let overnight slots fall back to plain "standard" (no Daikin write,
     # firmware does whatever it wants based on its own schedule).
     DHW_TANK_OVERNIGHT_IDLE_ENABLED: str = os.getenv("DHW_TANK_OVERNIGHT_IDLE_ENABLED", "true")
+    # Static-physics DHW draw model (precursor to V11-C #196 learned prior).
+    # Total litres of hot water drawn per day, distributed evenly across
+    # configured shower-window slots. The LP subtracts the corresponding
+    # thermal energy from the tank balance so it sees realistic post-shower
+    # temperature drops instead of just standing-loss.
+    #
+    # Default 144 L = household of 4 (2 adults + 2 children sharing one
+    # shower together) × 8 min/shower × 6 L/min (low-flow eco showerhead).
+    # Adjust if your shower flow is higher (e.g. 8-10 L/min standard) — at
+    # 8 L/min the same usage = 192 L/day.
+    #
+    # Set to 0 to disable (LP reverts to previous behavior — only standing
+    # loss modeled).
+    DHW_DAILY_SHOWER_LITRES: float = float(os.getenv("DHW_DAILY_SHOWER_LITRES", "144"))
+    # Cold-mains inlet temp (°C). UK average ~10°C; varies seasonally.
+    DHW_COLD_INLET_TEMP_C: float = float(os.getenv("DHW_COLD_INLET_TEMP_C", "10.0"))
+    # Use temperature at the tap (°C) — typical mixer-tap shower temp.
+    # Used to compute hot-water litres drawn from tank: hot = mix × (use - cold) / (tank - cold).
+    DHW_USAGE_TEMP_C: float = float(os.getenv("DHW_USAGE_TEMP_C", "40.0"))
     # Slack penalty on the soft DHW ceiling (#225 item 1, was hardcoded 0.01).
     # Operators who want stricter comfort vs cost can tune this. Default 0.01
     # p/°C-slot preserves prior behaviour.

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -508,6 +508,44 @@ def solve_lp(
         else [flat_export_rate] * n
     )
 
+    # Resolve shower windows + DHW draw model EARLY (before the per-slot loop)
+    # so the tank thermo equation can subtract the realistic shower-time draw
+    # from each slot's energy balance. Without this, the LP only sees standing
+    # loss (~0.5°C/h) and misses the much bigger drop from someone showering
+    # (~6°C per shower for a 200L tank). Result without it: LP plans no
+    # heating during the day, evening tank is technically ≥ 45°C in the LP's
+    # math but reality has tank dropping below 45°C mid-shower → firmware
+    # reheats at unfavorable rates the LP didn't predict.
+    #
+    # Static-physics version (this PR; bridges to V11-C / #196's learned prior).
+    guests_preset = False
+    try:
+        from ..presets import OperationPreset
+        guests_preset = OperationPreset(config.OPTIMIZATION_PRESET) == OperationPreset.GUESTS
+    except (ValueError, AttributeError):
+        pass
+    shower_windows = _resolve_active_shower_windows(guests_preset)
+    shower_mask = _window_set_slot_mask(slot_starts_utc, tz, windows=shower_windows)
+    n_shower_slots = sum(1 for x in shower_mask if x)
+    daily_shower_litres = float(getattr(config, "DHW_DAILY_SHOWER_LITRES", 0.0))
+    cold_inlet_c = float(getattr(config, "DHW_COLD_INLET_TEMP_C", 10.0))
+    use_temp_c = float(getattr(config, "DHW_USAGE_TEMP_C", 40.0))
+    # Linearised hot-water draw per slot (kWh thermal). Hot litres drawn
+    # from tank = mix_litres × (use - cold) / (target - cold). At target temp
+    # (t_min_dhw) this gives a constant per slot.
+    if n_shower_slots > 0 and daily_shower_litres > 0 and t_min_dhw > cold_inlet_c:
+        litres_per_slot = daily_shower_litres / n_shower_slots
+        hot_litres = litres_per_slot * (use_temp_c - cold_inlet_c) / (t_min_dhw - cold_inlet_c)
+        # Energy in J = L × CP_J/L/K × ΔT
+        draw_j_per_slot = hot_litres * float(config.DHW_WATER_CP) * (t_min_dhw - cold_inlet_c)
+    else:
+        draw_j_per_slot = 0.0
+    # Per-slot draw vector — non-zero only on shower-window slots.
+    shower_draw_j: list[float] = [
+        draw_j_per_slot if shower_mask[i] else 0.0
+        for i in range(n)
+    ]
+
     for i in range(n):
         e_hp_i = e_dhw[i] + e_space[i]
 
@@ -562,7 +600,10 @@ def solve_lp(
         # DHW tank thermodynamics
         q_heat_dhw = e_dhw[i] * cop_dhw[i] * j_per_kwh
         loss_tank_j = ua_tank * (tank[i] - t_in[i]) * dt_s
-        prob += tank[i + 1] == tank[i] + (q_heat_dhw - loss_tank_j) / c_tank
+        # DHW draw on shower-window slots (static-physics model). Pre-computed
+        # in shower_draw_j[i]; zero outside shower windows.
+        draw_j_i = shower_draw_j[i]
+        prob += tank[i + 1] == tank[i] + (q_heat_dhw - loss_tank_j - draw_j_i) / c_tank
 
         # Building thermodynamics
         q_heat_space = e_space[i] * cop_space[i] * j_per_kwh

--- a/tests/test_lp_dhw_draw_model.py
+++ b/tests/test_lp_dhw_draw_model.py
@@ -1,0 +1,182 @@
+"""Static-physics DHW draw model — bridge to V11-C / #196.
+
+The LP's tank energy balance previously only modeled standing loss
+(``ua_tank × (tank − indoor)``) — missing the much larger energy removal
+from someone showering. Result: LP planned no heating during daytime,
+expecting tank to drift gradually from standing loss alone, but reality has
+tank dropping ~6 °C per shower as hot water exits the tank and is replaced
+by cold water.
+
+This module ships a static-physics DHW draw model: per-slot kWh thermal
+energy removed during shower-window slots, computed from configured daily
+mix-litres × use-temp delta. Replaces the missing ``q_draw`` term.
+
+The full V11-C work (#196) layers learned-from-history priors on top.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+def _make_weather(slots, pv_kwh=None, base_kwh=None):
+    from src.weather import WeatherLpSeries
+    n = len(slots)
+    return WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[15.0] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[50.0] * n,
+        pv_kwh_per_slot=pv_kwh or [0.0] * n,
+        cop_space=[3.5] * n,
+        cop_dhw=[3.0] * n,
+    )
+
+
+def test_dhw_draw_model_drops_tank_temp_during_shower_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When DHW_DAILY_SHOWER_LITRES > 0, the LP's planned tank trajectory
+    must drop materially during shower-window slots (real physics) instead
+    of staying nearly flat (standing loss only)."""
+    from src.config import config as app_config
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(app_config, "DHW_DAILY_SHOWER_LITRES", 144.0, raising=False)
+    monkeypatch.setattr(app_config, "DHW_USAGE_TEMP_C", 40.0, raising=False)
+    monkeypatch.setattr(app_config, "DHW_COLD_INLET_TEMP_C", 10.0, raising=False)
+
+    # 6 slots covering the 19:00-22:00 shower window. Constant 20p price, no PV,
+    # tank initial 50°C. LP should plan zero or minimal heating during shower
+    # slots (heating during showers is wasteful — wait until cheap window).
+    base = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)  # 19:00 BST
+    n = 6
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=[20.0] * n,
+        base_load_kwh=[0.3] * n,
+        weather=_make_weather(slots),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0, indoor_temp_c=21.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, plan.status
+
+    # Without draw model, tank would have dropped ~0.5°C over 3h (just standing
+    # loss). With draw model, even with LP's heating to maintain ≥ 45°C, the
+    # END temperature should be at the floor (close to 45°C) — meaning the LP
+    # had to plan substantial heating to OFFSET the draw. Without draw model
+    # the LP would just leave tank at 49+ all the way through.
+    end_tank = plan.tank_temp_c[-1]
+    # With 144L/day = 5 kWh thermal over 6 slots, draw alone (no heat) would
+    # drop tank by ~21°C in this window. LP must heat substantially. End-of-
+    # window tank should be close to the floor 45°C, not the starting 50°C.
+    assert end_tank < 49.0, (
+        f"With draw model, tank should NOT stay near starting temp 50°C "
+        f"through shower window — that would mean LP didn't see the draw. "
+        f"Got end_tank={end_tank:.1f}"
+    )
+    # Sanity: still above floor.
+    assert end_tank >= 44.5, (
+        f"LP must keep tank ≥ floor (45°C) at all shower slots; got end_tank={end_tank:.1f}"
+    )
+
+
+def test_dhw_draw_model_zero_litres_disables_draw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting DHW_DAILY_SHOWER_LITRES=0 reverts to previous behavior — LP
+    sees only standing loss, plans minimal heating."""
+    from src.config import config as app_config
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(app_config, "DHW_DAILY_SHOWER_LITRES", 0.0, raising=False)
+
+    base = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+    n = 6
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=[20.0] * n,
+        base_load_kwh=[0.3] * n,
+        weather=_make_weather(slots),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0, indoor_temp_c=21.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, plan.status
+    end_tank = plan.tank_temp_c[-1]
+    # No draw → tank stays close to starting temp (only standing loss applies).
+    # 3 h × ~0.2 °C/h = small drop; should still be > 49°C.
+    assert end_tank > 49.0, (
+        f"With DHW_DAILY_SHOWER_LITRES=0 (draw disabled), tank should barely "
+        f"drop over 3 h shower window; got end_tank={end_tank:.1f}"
+    )
+
+
+def test_dhw_draw_model_forces_pv_time_heating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point: with draw model active, LP plans heating during PV-
+    abundant or cheap morning slots to satisfy the evening shower constraint.
+    Without draw model, LP would leave the tank alone all day (wrong).
+
+    Test: 24h horizon (08:00 → 08:00 next day) with PV in middle, cheap
+    rates morning, shower window 19:00-22:00. With draw model, e_dhw must be
+    non-zero somewhere before the shower window.
+    """
+    from src.config import config as app_config
+    from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    monkeypatch.setattr(app_config, "DHW_DAILY_SHOWER_LITRES", 144.0, raising=False)
+
+    base = datetime(2026, 6, 1, 7, 0, tzinfo=UTC)  # 08:00 BST
+    n = 24  # 12 h
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    # Cheap rates in afternoon (PV-rich), expensive in morning/evening.
+    prices = []
+    for i in range(n):
+        local_h = (slots[i] + timedelta(minutes=15)).astimezone(ZoneInfo("Europe/London")).hour
+        if 12 <= local_h < 16:
+            prices.append(10.0)  # cheap PV-time
+        elif 16 <= local_h < 20:
+            prices.append(28.0)  # peak
+        else:
+            prices.append(20.0)
+    pv = [0.0 if h < 6 else (1.5 if 6 <= h < 16 else 0.0) for h in range(n)]
+    pv = []  # rebuild against actual times
+    for s in slots:
+        local_h = (s + timedelta(minutes=15)).astimezone(ZoneInfo("Europe/London")).hour
+        if 11 <= local_h <= 15:
+            pv.append(2.0)  # mid-day sunshine
+        else:
+            pv.append(0.0)
+
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=prices,
+        base_load_kwh=[0.3] * n,
+        weather=_make_weather(slots, pv_kwh=pv),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0, indoor_temp_c=21.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, plan.status
+
+    # Check that LP planned positive e_dhw somewhere BEFORE the shower window
+    # (i.e. on cheap or PV-time slots), not just during.
+    pre_shower_dhw = sum(
+        plan.dhw_electric_kwh[i] for i in range(n)
+        if (slots[i] + timedelta(minutes=15)).astimezone(ZoneInfo("Europe/London")).hour < 19
+    )
+    assert pre_shower_dhw > 0.5, (
+        f"With draw model, LP must plan substantial pre-shower DHW heating "
+        f"(during cheap PV slots) to maintain 45°C through evening. Got "
+        f"{pre_shower_dhw:.2f} kWh before 19:00."
+    )


### PR DESCRIPTION
## Summary

User identified a critical gap after watching the LP plan **zero DHW heating across the full day**, despite tank starting hot enough but dropping into shower-window territory naturally:

> we have all the values for forecasting it better: cop, thermal loss, target temp, number of showers number of people time for showers how much heating we would lose until there and outdoor temp. check it

Verified: the LP's tank energy balance only modeled standing loss (\`ua_tank × (tank − indoor)\`) — missing the much larger energy removal when someone showers (~6 °C drop per shower vs ~0.5 °C/h standing loss). LP's predicted tank trajectory diverged ~10°+ from reality by evening, causing firmware to reheat at unfavourable rates the LP hadn't planned for.

## Fix

Static-physics draw model added to the LP tank energy balance:

\`\`\`
tank[i+1] = tank[i] + (q_heat - loss - draw) / c_tank
                                    ^^^^ NEW
\`\`\`

\`draw\` is non-zero only on shower-window slots, computed from configured daily mix-litres × use-temp delta:

\`\`\`
litres_per_slot = DHW_DAILY_SHOWER_LITRES / num_shower_slots
hot_litres = litres_per_slot × (use_temp − cold) / (target − cold)
draw_J = hot_litres × DHW_WATER_CP × (target − cold)
\`\`\`

## Numerical impact (default 144 L/day)

- Hot litres drawn per shower-window slot: ~21 L → 0.84 kWh thermal/slot
- 6-slot shower window: 5 kWh thermal/day = ~1.67 kWh electrical/day at COP 3
- Equivalent to **21.6 °C drop on a 200 L tank** if no heating planned

The LP now plans heating during cheap / PV-abundant slots before the shower window to keep tank above 45 °C through evening — matching the user's manual intuition that the system should heat from solar.

## New config

- \`DHW_DAILY_SHOWER_LITRES\` (default 144 = 2 adults + 2 kids sharing 1 shower × 8 min × 6 L/min low-flow). Set to 0 to disable.
- \`DHW_COLD_INLET_TEMP_C\` (default 10).
- \`DHW_USAGE_TEMP_C\` (default 40).

## Tests

3 new in \`tests/test_lp_dhw_draw_model.py\`:
- \`test_dhw_draw_model_drops_tank_temp_during_shower_window\` — with draw on, LP can't keep tank near starting 50 °C through 3 h shower window; must drop close to 45 °C floor.
- \`test_dhw_draw_model_zero_litres_disables_draw\` — disabling reverts to standing-loss-only.
- \`test_dhw_draw_model_forces_pv_time_heating\` — 24 h horizon with cheap PV afternoon → LP plans non-trivial DHW kWh BEFORE evening shower window.

53 adjacent tests pass (LP optimizer, PV-abundance, shower-schedule, regression script).

## Bridges to

- **#196 (V11-C: DHW draw learning)** — same place in the LP, static physics here, learned-from-history later.
- Plan: \`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md\` Phase 1 attempt #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)