### PR TITLE
fix(dispatch): hands-off climate; prefer tank > export at home

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -578,11 +578,14 @@ class Config:
     DHW_PV_ABUNDANCE_THRESHOLD_KWH: float = float(
         os.getenv("DHW_PV_ABUNDANCE_THRESHOLD_KWH", "0.5")
     )
-    # Reward magnitude for PV-abundance DHW heating. Must be smaller than
-    # ``EXPORT_RATE_PENCE × cop_dhw[i]`` so genuinely-profitable export still
-    # wins. Default 0.5 p/kWh.
+    # Reward magnitude for PV-abundance DHW heating. Per user (2026-05-09):
+    # prefer tank-store over export when at home — household will use the
+    # stored hot water. Default 10 p/kWh × cop_dhw 3 ≈ 30 p/kWh equivalent
+    # stored value, well above 15 p export rate → tank wins. Zeroed at solve
+    # time when OPTIMIZATION_PRESET in (travel, away) — household isn't
+    # there to use stored hot water; revert to export-priority economics.
     LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH: float = float(
-        os.getenv("LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", "0.5")
+        os.getenv("LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", "10.0")
     )
     # Tank target ceiling on PV-abundance slots, distinct from
     # ``DHW_TEMP_MAX_C`` (65 °C) used on negative-price slots. The user's

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -403,10 +403,14 @@ def daikin_dispatch_preview(
         #     firmware/prior-action left it. Setting tank_power=False here would
         #     ACTIVELY DISABLE the tank, which is wrong intent.
         is_shutdown = kind in ("peak", "peak_export")
+        # CLIMATE HANDS-OFF: per user (2026-05-09), HEM does not touch the
+        # climate (space-heating) side. We do NOT emit climate_on or
+        # lwt_offset — Daikin firmware's own zone scheduling and weather
+        # curve handle space heating. The LP plans `e_space` as a forecast
+        # of likely consumption but doesn't direct it. All actions below are
+        # tank-only.
         params: dict[str, Any] = {
-            "lwt_offset": round(lwt, 1),  # Daikin rejects sub-0.1 precision; rounds float epsilon to 0.0
             "tank_powerful": tank_powful if kind in powerful_kinds else False,
-            "climate_on": es > EPS or ed > EPS or kind in ("negative", "cheap", "solar_charge"),
             "lp_optimizer": True,
         }
         if kind == "tank_idle_overnight":
@@ -414,18 +418,12 @@ def daikin_dispatch_preview(
             # target (default 38 °C). Firmware won't reheat from 50+ down to
             # 38 (current > setpoint, no action). If tank cools to 38 over
             # the long overnight, firmware maintains at 38 — backup buffer
-            # for unexpected morning shower. We also strip the climate-side
-            # params: user said "climate shouldn't change anytime, we are not
-            # discussing this yet" — leave Daikin's own zone scheduling alone.
-            params = {
-                "tank_powerful": False,
-                "tank_power": True,
-                "tank_temp": round(
-                    float(getattr(config, "DHW_TANK_OVERNIGHT_TARGET_C", 38.0)),
-                    1,
-                ),
-                "lp_optimizer": True,
-            }
+            # for unexpected morning shower.
+            params["tank_power"] = True
+            params["tank_temp"] = round(
+                float(getattr(config, "DHW_TANK_OVERNIGHT_TARGET_C", 38.0)),
+                1,
+            )
         elif is_shutdown:
             peak_strategy = (getattr(config, "DHW_PEAK_TANK_STRATEGY", "idle") or "idle").strip().lower()
             if peak_strategy == "shutdown":

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -856,10 +856,21 @@ def solve_lp(
     obj_tank_hi = tank_hi_slack_p * pulp.lpSum(s_tank_hi[i] for i in range(n))
     # PV-abundance DHW reward: when PV exceeds self-use + battery headroom, every kWh
     # the LP routes into the tank instead of curtailing earns a small reward. Tied to
-    # the same per-slot bool used for the ceiling lift above. Reward must stay below
-    # ``EXPORT_RATE_PENCE × cop_dhw[i]`` so export still wins when more profitable —
-    # the unit test ``test_pv_abundance_reward_does_not_dominate_export`` enforces this.
+    # the same per-slot bool used for the ceiling lift above.
+    #
+    # Per user 2026-05-09: prefer tank-store over export when at home (household
+    # will use the stored hot water). Default 10 p/kWh × cop ≈ 30 p stored
+    # value, well above 15 p export → tank wins. ZEROED here when preset is
+    # travel/away — household isn't there to use stored hot water, revert to
+    # export-priority economics.
     pv_abundance_reward_p = float(getattr(config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 0.0))
+    try:
+        from ..presets import OperationPreset
+        _preset_value = OperationPreset(config.OPTIMIZATION_PRESET)
+        if _preset_value in (OperationPreset.TRAVEL, OperationPreset.AWAY):
+            pv_abundance_reward_p = 0.0
+    except (ValueError, AttributeError):
+        pass
     obj_pv_abundance_dhw: Any = 0
     if pv_abundance_reward_p > 0:
         abundant_indices = [i for i in range(n) if pv_abundance[i]]

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -398,11 +398,14 @@ def test_dispatch_peak_idle_default_keeps_tank_on_normal_target(
             f"idle strategy must set tank_temp to DHW_TEMP_NORMAL_C (45°C), "
             f"NOT the absolute floor (30°C); got {params.get('tank_temp')}"
         )
-        # Climate STILL goes off during peak — that's a separate decision
-        # the user explicitly said is "not discussing this yet" so default
-        # behaviour (climate off during peak) is preserved.
-        assert params.get("climate_on") is False, (
-            f"peak should still turn climate off; params={params}"
+        # CLIMATE HANDS-OFF: HEM does not emit climate_on at all (per user
+        # 2026-05-09 — "we are not discussing climate yet"). Firmware
+        # autonomously manages the climate zone via its own schedule.
+        assert "climate_on" not in params, (
+            f"HEM must not touch climate_on; params={params}"
+        )
+        assert "lwt_offset" not in params, (
+            f"HEM must not touch lwt_offset (climate-side); params={params}"
         )
 
 
@@ -645,21 +648,25 @@ def test_dispatch_negative_price_action_uses_full_65c_cap(
 # 2. Reward must NOT dominate export when export is profitable
 # --------------------------------------------------------------------------
 
-def test_pv_abundance_reward_does_not_dominate_profitable_export(
+def test_pv_abundance_reward_zeroed_when_travel_or_away(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When export rate × COP > tank reward, the LP should still export
-    rather than dump everything into the tank. Guards the 'profit second'
-    side of the user's near-zero-grid-cost policy."""
+    """Per user 2026-05-09: prefer tank > export when AT HOME, but revert to
+    export-priority when travel/away (household isn't there to use stored hot
+    water). Test asserts the reward is zeroed under those presets — LP keeps
+    the standard export trade-off."""
     from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
     monkeypatch.setattr(app_config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5, raising=False)
-    monkeypatch.setattr(app_config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 0.5, raising=False)
+    monkeypatch.setattr(app_config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 10.0, raising=False)
+    # KEY: travel preset zeroes the reward at solve time.
+    monkeypatch.setattr(app_config, "OPTIMIZATION_PRESET", "travel", raising=False)
 
     base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
     n = 4
     slots = [base + timedelta(minutes=30 * i) for i in range(n)]
-    # Plenty of PV; very high export rate (50p/kWh) → exporting is way more
-    # profitable than (reward 0.5p × cop_dhw 3.0 ≈ 1.5p of stored value).
+    # Healthy PV, profitable export rate (50p) → without the at-home reward,
+    # LP picks export (high revenue) over tank (lower deferred-heating value).
     plan = _solve(
         slots=slots,
         prices=[20.0] * n,
@@ -672,10 +679,43 @@ def test_pv_abundance_reward_does_not_dominate_profitable_export(
     assert plan.ok, plan.status
     total_export = sum(plan.export_kwh)
     total_dhw = sum(plan.dhw_electric_kwh)
-    # Most of the surplus PV must still go to export (dwarfs DHW heating).
     assert total_export > total_dhw * 3.0, (
-        f"Reward must not dominate profitable export; "
+        f"Travel/away preset should zero the reward → export wins. "
         f"export={total_export:.2f} kWh, dhw={total_dhw:.2f} kWh"
+    )
+
+
+def test_pv_abundance_reward_dominates_export_when_at_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default behaviour at home (preset=normal): user wants tank > export.
+    With 10 p/kWh reward × cop 3 ≈ 30 p stored value, well above 15 p export,
+    LP should prefer tank-storage."""
+    from src.config import config as app_config
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(app_config, "DHW_PV_ABUNDANCE_THRESHOLD_KWH", 0.5, raising=False)
+    monkeypatch.setattr(app_config, "LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH", 10.0, raising=False)
+    monkeypatch.setattr(app_config, "OPTIMIZATION_PRESET", "normal", raising=False)
+
+    base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    n = 4
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan = _solve(
+        slots=slots,
+        prices=[20.0] * n,
+        pv=[3.0] * n,
+        base_load=[0.3] * n,
+        init_soc=4.0,
+        init_tank=40.0,
+        export_prices=[15.0] * n,  # typical Outgoing rate
+    )
+    assert plan.ok, plan.status
+    total_dhw = sum(plan.dhw_electric_kwh)
+    # Reward 10p × cop 3 = 30p stored value vs 15p export → tank wins. LP
+    # should plan substantial DHW heating.
+    assert total_dhw > 0.5, (
+        f"At home with reward=10, LP should prefer tank-storage over export; "
+        f"got dhw={total_dhw:.2f} kWh"
     )
 
 


### PR DESCRIPTION
## Summary

Two user directives bundled:

1. **Stop HEM from touching climate** — user was explicit ("we are not discussing this yet") but HEM was emitting \`climate_on=False\` during peak slots. Stripped \`climate_on\` AND \`lwt_offset\` from action params for ALL kinds.
2. **Prefer tank > export at home** — bumped \`LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH\` default 0.5 → **10**. Reward × COP 3 = 30 p stored value, well above 15 p export → tank wins. Zeroed when \`OPTIMIZATION_PRESET in (travel, away)\` — household isn't there.

## What changed

\`src/scheduler/lp_dispatch.py\`: stripped \`climate_on\` + \`lwt_offset\` from all action params. HEM emits tank-only writes (\`tank_power\`, \`tank_temp\`, \`tank_powerful\`). Daikin firmware autonomously manages the climate zone via its own schedule/thermostat.

\`src/scheduler/lp_optimizer.py\`: pv_abundance_reward zeroed when preset is travel/away.

\`src/config.py\`: \`LP_PV_ABUNDANCE_TANK_REWARD_PENCE_PER_KWH\` default raised 0.5 → 10.0.

## Tests (14 in test_lp_pv_abundance.py)

- Updated \`test_dispatch_peak_idle_default_keeps_tank_on_normal_target\`: asserts \`climate_on\`/\`lwt_offset\` **not in** params (was: climate_on=False).
- **NEW** \`test_pv_abundance_reward_zeroed_when_travel_or_away\`: preset=travel zeroes reward, export wins under high export rates.
- **NEW** \`test_pv_abundance_reward_dominates_export_when_at_home\`: preset=normal + reward=10 → LP plans DHW heating instead of export.
- All others unchanged.

## Operational note

Earlier today's flips left climate=False on Daikin. User reported seeing climate reactivate before this fix landed — Daikin firmware turned it back on autonomously. Going forward HEM will never write climate_on; firmware fully manages it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)