### PR TITLE
fix(dispatch): strip climate_on + lwt_offset from restore template

### DIFF
--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -478,12 +478,12 @@ def daikin_dispatch_preview(
         restore_end = (
             end_utc + timedelta(minutes=restore_window)
         ).isoformat().replace("+00:00", "Z")
+        # Restore params: tank-only (per user 2026-05-09 — climate hands-off).
+        # No climate_on, no lwt_offset; firmware autonomously manages climate.
         restore_params = {
-            "lwt_offset": 0.0,
             "tank_powerful": False,
             "tank_temp": float(config.DHW_TEMP_NORMAL_C),
             "tank_power": True,
-            "climate_on": True,
         }
         restore_row = {
             "device": "daikin",


### PR DESCRIPTION
Follow-up to #300. Action params were stripped of climate_on/lwt_offset, but the paired RESTORE template still emitted them — every end-of-window restore was touching climate state, contradicting the user's hands-off-climate directive.

Restore is now tank-only:
- tank_power: True
- tank_temp: DHW_TEMP_NORMAL_C (45°C)
- tank_powerful: False

14 tests pass. Pre-existing pending restores in prod still have old template (idempotent vs current state, so harmless tonight; self-cleans tomorrow when quota resets and LP re-plans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)