### PR TITLE
fix(pnl+octopus): real-money PnL from measured grid import + revive V13 backfill (#306)

### DIFF
--- a/scripts/check_lp_regression.py
+++ b/scripts/check_lp_regression.py
@@ -37,6 +37,13 @@ domain.
 **Read-only.** No Fox / Daikin / network touches. Safe to run against a prod DB
 copy. Each day's replay takes ~1-3 s (one to ~five LP solves per day depending
 on how many MPC re-runs the day had); expect 1–3 min for 14 days.
+
+**Cost source — independent of PnL bug #306.** The replayed cost is
+``plan.import_kwh × agile_p − plan.export_kwh × export_p`` where ``import_kwh``
+and ``export_kwh`` come from the LP's own energy-balance decision variables
+(``src/scheduler/lp_replay.py``). It does NOT call ``compute_daily_pnl`` /
+``compute_period_pnl`` — so the load-vs-import bug in those analytics functions
+never affected the baseline. The frozen JSON pre-#306 values remain valid.
 """
 from __future__ import annotations
 

--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -195,17 +195,31 @@ def _format_pnl_block(pnl: dict[str, Any], *, day: date, tz: ZoneInfo) -> list[s
     delta is genuine "money saved" not "energy-cost-only saved".
     """
     out: list[str] = []
-    net = pnl["realised_cost_gbp"]
-    imp = pnl["realised_import_gbp"]
+    # Real-money view (preferred for user-facing £)
+    net_real = pnl.get("realised_net_cost_gbp")
+    imp_kwh = pnl.get("import_kwh")
+    imp_real = pnl.get("import_cost_gbp")
     std = pnl.get("standing_charge_gbp", 0.0)
     exp_gbp = pnl["export_revenue_gbp"]
     exp_kwh = pnl["export_kwh"]
+    # Legacy load-billed view (counterfactual: if no solar/battery)
+    net_load = pnl["realised_cost_gbp"]
+    imp_load = pnl["realised_import_gbp"]
     used_kwh = pnl["kwh"]
 
-    out.append(
-        f"- Net cost: £{net:+.2f}  (import £{imp:.2f} + standing £{std:.2f} − export £{exp_gbp:.2f})"
-    )
-    out.append(f"- Energy used: {used_kwh:.1f} kWh  |  exported: {exp_kwh:.1f} kWh")
+    if net_real is not None and imp_real is not None and imp_kwh is not None:
+        out.append(
+            f"- Net cost: **£{net_real:+.2f}** (real, metered) "
+            f"— import £{imp_real:.2f} ({imp_kwh:.1f} kWh) + standing £{std:.2f} − export £{exp_gbp:.2f}"
+        )
+        out.append(
+            f"- Energy used: {used_kwh:.1f} kWh  |  imported: {imp_kwh:.1f} kWh  |  exported: {exp_kwh:.1f} kWh"
+        )
+    else:
+        out.append(
+            f"- Net cost: £{net_load:+.2f}  (import £{imp_load:.2f} + standing £{std:.2f} − export £{exp_gbp:.2f})"
+        )
+        out.append(f"- Energy used: {used_kwh:.1f} kWh  |  exported: {exp_kwh:.1f} kWh")
 
     # Forecasted-export fallback: telemetry sometimes drops grid_export_kw
     # samples, leaving export_kwh=0 even on days where the LP committed
@@ -220,26 +234,44 @@ def _format_pnl_block(pnl: dict[str, Any], *, day: date, tz: ZoneInfo) -> list[s
                 f"(from {f_slots} committed peak_export slot{'s' if f_slots != 1 else ''})"
             )
 
-    if "delta_vs_fixed_tariff_gbp" in pnl:
+    # Prefer real-money deltas when available, fall back to load-billed
+    have_real = "delta_vs_svt_real_gbp" in pnl
+
+    if "delta_vs_fixed_tariff_real_gbp" in pnl or "delta_vs_fixed_tariff_gbp" in pnl:
         label = pnl.get("fixed_tariff_label") or "fixed tariff"
-        shadow = pnl["fixed_tariff_shadow_gbp"]
-        delta = pnl["delta_vs_fixed_tariff_gbp"]
+        if have_real and "fixed_tariff_shadow_real_gbp" in pnl:
+            shadow = pnl["fixed_tariff_shadow_real_gbp"]
+            delta = pnl["delta_vs_fixed_tariff_real_gbp"]
+        else:
+            shadow = pnl["fixed_tariff_shadow_gbp"]
+            delta = pnl["delta_vs_fixed_tariff_gbp"]
         out.append(
             f"- vs {label} (would have cost £{shadow:.2f}): "
             f"£{delta:+.2f} {'saved' if delta >= 0 else 'extra'}"
         )
-    out.append(
-        f"- vs SVT (would have cost £{pnl['svt_shadow_gbp']:.2f}): "
-        f"£{pnl['delta_vs_svt_gbp']:+.2f} {'saved' if pnl['delta_vs_svt_gbp'] >= 0 else 'extra'}"
-    )
-    # "fixed shadow" is the legacy MANUAL_TARIFF_IMPORT_PENCE comparison —
-    # it falls back to SVT when not configured, so suppress the line in
-    # that case to avoid showing the same number twice.
-    if pnl["fixed_shadow_gbp"] != pnl["svt_shadow_gbp"]:
+
+    if have_real:
         out.append(
-            f"- vs fixed shadow (£{pnl['fixed_shadow_gbp']:.2f}): "
-            f"£{pnl['delta_vs_fixed_gbp']:+.2f} {'saved' if pnl['delta_vs_fixed_gbp'] >= 0 else 'extra'}"
+            f"- vs SVT (would have cost £{pnl['svt_shadow_real_gbp']:.2f}): "
+            f"£{pnl['delta_vs_svt_real_gbp']:+.2f} "
+            f"{'saved' if pnl['delta_vs_svt_real_gbp'] >= 0 else 'extra'}"
         )
+        if pnl["fixed_shadow_real_gbp"] != pnl["svt_shadow_real_gbp"]:
+            out.append(
+                f"- vs fixed shadow (£{pnl['fixed_shadow_real_gbp']:.2f}): "
+                f"£{pnl['delta_vs_fixed_real_gbp']:+.2f} "
+                f"{'saved' if pnl['delta_vs_fixed_real_gbp'] >= 0 else 'extra'}"
+            )
+    else:
+        out.append(
+            f"- vs SVT (would have cost £{pnl['svt_shadow_gbp']:.2f}): "
+            f"£{pnl['delta_vs_svt_gbp']:+.2f} {'saved' if pnl['delta_vs_svt_gbp'] >= 0 else 'extra'}"
+        )
+        if pnl["fixed_shadow_gbp"] != pnl["svt_shadow_gbp"]:
+            out.append(
+                f"- vs fixed shadow (£{pnl['fixed_shadow_gbp']:.2f}): "
+                f"£{pnl['delta_vs_fixed_gbp']:+.2f} {'saved' if pnl['delta_vs_fixed_gbp'] >= 0 else 'extra'}"
+            )
     return out
 
 
@@ -357,17 +389,21 @@ def build_brief_48h_summary(now_utc: datetime | None = None) -> str:
     today_line = _compact_tier(today)
     tomorrow_line = _compact_tier(tomorrow)
 
-    # Line 3 — running PnL today (best-effort)
+    # Line 3 — running PnL today (best-effort). Prefer real-money fields.
     pnl_line = "n/a"
     try:
         pnl = compute_daily_pnl(today)
-        if pnl and "realised_cost_gbp" in pnl:
-            net = pnl["realised_cost_gbp"]
-            svt = pnl.get("svt_shadow_gbp")
-            if svt is not None:
-                pnl_line = f"net £{net:+.2f} (SVT shadow £{svt:+.2f})"
-            else:
-                pnl_line = f"net £{net:+.2f}"
+        if pnl:
+            net = pnl.get("realised_net_cost_gbp")
+            svt = pnl.get("svt_shadow_real_gbp")
+            if net is None:
+                net = pnl.get("realised_cost_gbp")
+                svt = pnl.get("svt_shadow_gbp")
+            if net is not None:
+                if svt is not None:
+                    pnl_line = f"net £{net:+.2f} (SVT shadow £{svt:+.2f})"
+                else:
+                    pnl_line = f"net £{net:+.2f}"
     except Exception:
         pass
 

--- a/src/analytics/pnl.py
+++ b/src/analytics/pnl.py
@@ -67,24 +67,92 @@ def _realised_export_pence(day: date) -> tuple[float, float]:
     return revenue, total_kwh
 
 
+def _realised_import_pence(day: date) -> tuple[float, float]:
+    """Per-slot ``import_kwh × Agile_slot_rate`` from MEASURED grid telemetry.
+
+    Returns ``(import_cost_pence, import_kwh_total)``. Per-slot import kWh comes
+    from :func:`db.half_hourly_grid_import_kwh_for_day` (trapezoidal integration
+    of ``pv_realtime_history.grid_import_kw``). Per-slot import rates come from
+    ``agile_rates`` matched on ``valid_from``.
+
+    Issue #306: replaces the load-based pre-image used by the legacy
+    ``realised_import_gbp`` field, which billed *household load* (not net grid
+    import) at Agile rates and inflated absolute £ figures ~3-4×.
+    """
+    bucket_kwh = db.half_hourly_grid_import_kwh_for_day(day)
+    if not bucket_kwh:
+        return 0.0, 0.0
+    a, b = _day_bounds(day)
+    # Pull every Agile import row touching the day (no tariff_code filter —
+    # we want whatever rate row the LP would have priced against).
+    rate_rows = db.get_execution_logs(from_ts=a, to_ts=b, limit=5000)
+    # The execution_log already aligns one row per slot with agile_price_pence
+    # at heartbeat write time, which is the same source the LP uses. Match
+    # buckets by slot ISO.
+    rate_by_start: dict[str, float] = {}
+    for r in rate_rows:
+        ts = r.get("timestamp")
+        p = r.get("agile_price_pence")
+        if ts is None or p is None:
+            continue
+        # Normalise heartbeat ts (microsecond precision) to half-hour slot key
+        try:
+            t = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+        slot_min = (t.minute // 30) * 30
+        slot = t.replace(minute=slot_min, second=0, microsecond=0)
+        slot_iso = slot.astimezone(UTC).isoformat().replace("+00:00", "Z")
+        rate_by_start.setdefault(slot_iso, float(p))
+    cost = 0.0
+    total_kwh = 0.0
+    matched = 0
+    unmatched_kwh = 0.0
+    for slot_iso, kwh in bucket_kwh.items():
+        rate = rate_by_start.get(slot_iso)
+        total_kwh += kwh
+        if rate is not None:
+            cost += kwh * rate
+            matched += 1
+        else:
+            unmatched_kwh += kwh
+    if unmatched_kwh > 0:
+        logger.info(
+            "Realised import %s: %d/%d slots matched Agile rates; %.3f kWh unmatched (priced at 0)",
+            day.isoformat(), matched, len(bucket_kwh), unmatched_kwh,
+        )
+    return cost, total_kwh
+
+
 def compute_daily_pnl(day: date) -> dict[str, Any]:
     """Daily PnL with apples-to-apples standing-charge accounting.
 
-    All shadow costs (SVT, Fixed, configured legacy fixed tariff) include the
-    standing charge so the deltas reflect what the household would actually
-    pay on each tariff. Realised cost on Agile likewise embeds the Agile
-    standing charge (``MANUAL_STANDING_CHARGE_PENCE_PER_DAY``) so the user-facing
-    "you saved £X vs SVT" figure isn't off by ~62p/day.
+    Two parallel views, both included in every result:
+
+    1. **Real-money fields** (``realised_net_cost_gbp``, ``*_shadow_real_gbp``,
+       ``delta_vs_*_real_gbp``, ``import_kwh``): computed from MEASURED grid
+       traffic in ``pv_realtime_history`` × per-slot tariff rates. This is
+       what actually moved through the meter.
+
+    2. **Load-billed counterfactual fields** (``realised_cost_gbp``,
+       ``*_shadow_gbp``, ``delta_vs_*_gbp``, ``kwh``): the legacy formulation
+       that bills the *whole household load* at Agile/SVT/Fixed rates. Useful
+       for "what would I pay if I had no solar/battery" framing but NOT what
+       the household actually paid. Inflates absolute £ ~3-4× on a typical
+       solar-rich day. Kept for backward compatibility (#306) — the brief
+       markdown labels these fields explicitly so callers can't confuse them.
+
+    All shadow costs include the standing charge so deltas reflect what the
+    household would actually pay on each tariff.
     """
     a, b = _day_bounds(day)
     rows = db.get_execution_logs(from_ts=a, to_ts=b, limit=5000)
     svt = svt_rate_pence()
     fixed = fixed_shadow_rate_pence()
-    realised_import = 0.0
+    realised_import_load = 0.0      # legacy: load × Agile (counterfactual)
     svt_energy_cost = 0.0
     fixed_energy_cost = 0.0
-    kwh_sum = 0.0
-    import_kwh = 0.0
+    kwh_sum = 0.0                   # household LOAD total (legacy)
     cheap_kwh = 0.0
     peak_kwh = 0.0
     for r in rows:
@@ -93,7 +161,7 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
         if p is None:
             continue
         kwh_sum += kwh
-        realised_import += kwh * float(p)
+        realised_import_load += kwh * float(p)
         svt_energy_cost += kwh * svt
         fixed_energy_cost += kwh * fixed
         sk = (r.get("slot_kind") or "").lower()
@@ -101,30 +169,43 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
             peak_kwh += kwh
         if sk in ("negative", "cheap"):
             cheap_kwh += kwh
-        if float(p) > 0 and kwh > 0:
-            import_kwh += kwh
 
     export_revenue, export_kwh = _realised_export_pence(day)
+    real_import_cost, import_kwh = _realised_import_pence(day)
     standing_p = float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0)
 
-    # Net daily cost = (energy import + standing) − export earnings.
-    # Standing is a fixed daily fee on Agile too, so it MUST be in here for
-    # comparisons to be meaningful.
-    realised = realised_import + standing_p - export_revenue
+    # === Legacy "load-billed" view (counterfactual: if no solar/battery) ===
+    realised = realised_import_load + standing_p - export_revenue
     svt_cost = svt_energy_cost + standing_p
     fixed_cost = fixed_energy_cost + standing_p
-
     alpha_svt = (svt_cost - realised) / 100.0
     alpha_fixed = (fixed_cost - realised) / 100.0
 
+    # === Real-money view (measured grid traffic × rates) ===
+    realised_real = real_import_cost + standing_p - export_revenue
+    svt_real = (import_kwh * svt) + standing_p - export_revenue
+    fixed_real = (import_kwh * fixed) + standing_p - export_revenue
+    alpha_svt_real = (svt_real - realised_real) / 100.0
+    alpha_fixed_real = (fixed_real - realised_real) / 100.0
+
     out: dict[str, Any] = {
         "date": day.isoformat(),
-        "kwh": round(kwh_sum, 3),
-        "realised_cost_gbp": round(realised / 100.0, 4),
-        "realised_import_gbp": round(realised_import / 100.0, 4),
+        # === Real-money (preferred — use these for user-facing £ figures) ===
+        "realised_net_cost_gbp": round(realised_real / 100.0, 4),
+        "import_kwh": round(import_kwh, 3),
+        "import_cost_gbp": round(real_import_cost / 100.0, 4),
+        "svt_shadow_real_gbp": round(svt_real / 100.0, 4),
+        "fixed_shadow_real_gbp": round(fixed_real / 100.0, 4),
+        "delta_vs_svt_real_gbp": round(alpha_svt_real, 4),
+        "delta_vs_fixed_real_gbp": round(alpha_fixed_real, 4),
+        # === Shared (true regardless of view) ===
         "export_revenue_gbp": round(export_revenue / 100.0, 4),
         "export_kwh": round(export_kwh, 3),
         "standing_charge_gbp": round(standing_p / 100.0, 4),
+        # === Legacy "load-billed" counterfactual (DO NOT quote as real money) ===
+        "kwh": round(kwh_sum, 3),
+        "realised_cost_gbp": round(realised / 100.0, 4),
+        "realised_import_gbp": round(realised_import_load / 100.0, 4),
         "svt_shadow_gbp": round(svt_cost / 100.0, 4),
         "fixed_shadow_gbp": round(fixed_cost / 100.0, 4),
         "delta_vs_svt_gbp": round(alpha_svt, 4),
@@ -134,14 +215,17 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
     }
 
     # Optional: legacy fixed tariff comparison (e.g. previous British Gas plan).
-    # Skipped entirely when not configured so the brief stays clean.
+    # Both real and load-billed flavours emitted when configured.
     bg_rate = float(config.FIXED_TARIFF_RATE_PENCE or 0)
     bg_standing = float(config.FIXED_TARIFF_STANDING_PENCE_PER_DAY or 0)
     if bg_rate > 0 and bg_standing > 0:
-        bg_cost = (kwh_sum * bg_rate) + bg_standing
+        bg_cost_load = (kwh_sum * bg_rate) + bg_standing
+        bg_cost_real = (import_kwh * bg_rate) + bg_standing - export_revenue
         out["fixed_tariff_label"] = config.FIXED_TARIFF_LABEL or "fixed tariff"
-        out["fixed_tariff_shadow_gbp"] = round(bg_cost / 100.0, 4)
-        out["delta_vs_fixed_tariff_gbp"] = round((bg_cost - realised) / 100.0, 4)
+        out["fixed_tariff_shadow_real_gbp"] = round(bg_cost_real / 100.0, 4)
+        out["delta_vs_fixed_tariff_real_gbp"] = round((bg_cost_real - realised_real) / 100.0, 4)
+        out["fixed_tariff_shadow_gbp"] = round(bg_cost_load / 100.0, 4)
+        out["delta_vs_fixed_tariff_gbp"] = round((bg_cost_load - realised) / 100.0, 4)
 
     return out
 
@@ -260,6 +344,13 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
                     f"Entire range predates AGILE_TARIFF_START_DATE={agile_start.isoformat()}"
                 ),
                 "n_days": 0,
+                "realised_net_cost_gbp": 0.0,
+                "import_kwh": 0.0,
+                "import_cost_gbp": 0.0,
+                "svt_shadow_real_gbp": 0.0,
+                "fixed_shadow_real_gbp": 0.0,
+                "delta_vs_svt_real_gbp": 0.0,
+                "delta_vs_fixed_real_gbp": 0.0,
                 "kwh": 0.0,
                 "realised_cost_gbp": 0.0,
                 "realised_import_gbp": 0.0,
@@ -283,12 +374,22 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
     n = (end_day - start_day).days + 1
 
     totals = {
-        "kwh": 0.0,
-        "realised_cost_gbp": 0.0,
-        "realised_import_gbp": 0.0,
+        # Real-money axis
+        "realised_net_cost_gbp": 0.0,
+        "import_kwh": 0.0,
+        "import_cost_gbp": 0.0,
+        "svt_shadow_real_gbp": 0.0,
+        "fixed_shadow_real_gbp": 0.0,
+        "delta_vs_svt_real_gbp": 0.0,
+        "delta_vs_fixed_real_gbp": 0.0,
+        # Shared
         "export_revenue_gbp": 0.0,
         "export_kwh": 0.0,
         "standing_charge_gbp": 0.0,
+        # Legacy load-billed axis
+        "kwh": 0.0,
+        "realised_cost_gbp": 0.0,
+        "realised_import_gbp": 0.0,
         "svt_shadow_gbp": 0.0,
         "fixed_shadow_gbp": 0.0,
         "delta_vs_svt_gbp": 0.0,
@@ -298,6 +399,8 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
     }
     bg_shadow = 0.0
     bg_delta = 0.0
+    bg_shadow_real = 0.0
+    bg_delta_real = 0.0
     bg_label: str | None = None
     bg_seen = False
 
@@ -310,6 +413,8 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
             bg_seen = True
             bg_shadow += float(p["fixed_tariff_shadow_gbp"])
             bg_delta += float(p["delta_vs_fixed_tariff_gbp"])
+            bg_shadow_real += float(p.get("fixed_tariff_shadow_real_gbp") or 0.0)
+            bg_delta_real += float(p.get("delta_vs_fixed_tariff_real_gbp") or 0.0)
             bg_label = bg_label or p.get("fixed_tariff_label")
 
     base_label = label or f"{start_day.isoformat()}..{end_day.isoformat()}"
@@ -329,6 +434,8 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
     out.update({k: round(v, 4 if not k.endswith("_kwh") else 3) for k, v in totals.items()})
     if bg_seen:
         out["fixed_tariff_label"] = bg_label or "fixed tariff"
+        out["fixed_tariff_shadow_real_gbp"] = round(bg_shadow_real, 4)
+        out["delta_vs_fixed_tariff_real_gbp"] = round(bg_delta_real, 4)
         out["fixed_tariff_shadow_gbp"] = round(bg_shadow, 4)
         out["delta_vs_fixed_tariff_gbp"] = round(bg_delta, 4)
     return out

--- a/src/db.py
+++ b/src/db.py
@@ -2875,24 +2875,26 @@ def compute_fox_energy_daily_from_realtime(
     return out
 
 
-def half_hourly_grid_export_kwh_for_day(
+def _half_hourly_grid_kwh_for_day(
     day: date,
+    column: str,
     *,
     max_gap_seconds: int = 1800,
 ) -> dict[str, float]:
-    """Per-slot grid-export kWh for ``day``, keyed by ISO half-hour slot start (UTC).
+    """Shared trapezoidal-integration over ``pv_realtime_history.<column>`` for
+    ``day``, keyed by ISO half-hour slot start (UTC). ``column`` must be one of
+    ``grid_export_kw`` / ``grid_import_kw`` (caller-vetted).
 
-    Trapezoidal-integrates ``pv_realtime_history.grid_export_kw`` and assigns each
-    sample-pair's energy to the bucket containing the EARLIER sample (matching
-    :func:`compute_fox_energy_daily_from_realtime`). Slots with no telemetry get no
-    key — caller decides whether to treat missing as zero or fall back to a daily
-    total.
-
-    Used by :mod:`src.analytics.pnl` to value realised exports against per-slot
-    Octopus Outgoing rates (issue #207).
+    Each sample-pair's energy is assigned to the bucket containing the EARLIER
+    sample (matching :func:`compute_fox_energy_daily_from_realtime`). Slots with
+    no telemetry get no key — caller decides whether to treat missing as zero
+    or fall back to a daily total.
     """
     from collections import defaultdict
     from datetime import datetime as _dt
+
+    if column not in ("grid_export_kw", "grid_import_kw"):
+        raise ValueError(f"unsupported column: {column}")
 
     day_iso = day.isoformat()
     # Pull samples for the day plus one before/after for boundary integration.
@@ -2900,7 +2902,7 @@ def half_hourly_grid_export_kwh_for_day(
         conn = get_connection()
         try:
             cur = conn.execute(
-                """SELECT captured_at, grid_export_kw
+                f"""SELECT captured_at, {column}
                    FROM pv_realtime_history
                    WHERE substr(captured_at, 1, 10) BETWEEN ? AND ?
                    ORDER BY captured_at""",
@@ -2931,24 +2933,61 @@ def half_hourly_grid_export_kwh_for_day(
 
     buckets: dict[str, float] = defaultdict(float)
     prev_ts: _dt | None = None
-    prev_export: float = 0.0
+    prev_val: float = 0.0
     for row in rows_raw:
         ts = _parse(row[0])
         if ts is None:
             continue
-        cur_export = float(row[1]) if row[1] is not None else 0.0
+        cur_val = float(row[1]) if row[1] is not None else 0.0
         if prev_ts is not None:
             dt_s = min((ts - prev_ts).total_seconds(), max_gap_seconds)
             if dt_s > 0:
                 hours = dt_s / 3600.0
-                avg_kw = (prev_export + cur_export) / 2.0
+                avg_kw = (prev_val + cur_val) / 2.0
                 # Only count pairs whose earlier sample falls on `day`.
                 if prev_ts.date().isoformat() == day_iso:
                     buckets[_slot_key(prev_ts)] += avg_kw * hours
         prev_ts = ts
-        prev_export = cur_export
+        prev_val = cur_val
 
     return dict(buckets)
+
+
+def half_hourly_grid_export_kwh_for_day(
+    day: date,
+    *,
+    max_gap_seconds: int = 1800,
+) -> dict[str, float]:
+    """Per-slot grid-export kWh for ``day``, keyed by ISO half-hour slot start (UTC).
+
+    Trapezoidal integration of ``pv_realtime_history.grid_export_kw``. See
+    :func:`_half_hourly_grid_kwh_for_day` for mechanics.
+
+    Used by :mod:`src.analytics.pnl` to value realised exports against per-slot
+    Octopus Outgoing rates (issue #207).
+    """
+    return _half_hourly_grid_kwh_for_day(day, "grid_export_kw", max_gap_seconds=max_gap_seconds)
+
+
+def half_hourly_grid_import_kwh_for_day(
+    day: date,
+    *,
+    max_gap_seconds: int = 1800,
+) -> dict[str, float]:
+    """Per-slot grid-import kWh for ``day``, keyed by ISO half-hour slot start (UTC).
+
+    Trapezoidal integration of ``pv_realtime_history.grid_import_kw``. Used by
+    :mod:`src.analytics.pnl` to compute the *real* net cost — billing
+    measured grid import (not household load) at per-slot Agile rates.
+
+    Issue #306: prior to this helper, ``compute_daily_pnl`` multiplied
+    ``execution_log.consumption_kwh`` (= load × Agile) which inflated absolute
+    £ figures ~3-4× because PV + battery self-supply was treated as if grid-
+    bought. The V13 nightly Octopus backfill was supposed to overwrite the
+    estimated rows with metered import but had been failing silently for
+    weeks (Octopus deprecated ``order_by=asc``).
+    """
+    return _half_hourly_grid_kwh_for_day(day, "grid_import_kw", max_gap_seconds=max_gap_seconds)
 
 
 def upsert_fox_energy_daily(rows: list[dict[str, Any]]) -> int:

--- a/src/energy/octopus_client.py
+++ b/src/energy/octopus_client.py
@@ -177,10 +177,14 @@ def fetch_consumption(
         period_from: Start of period (UTC). Defaults to 30 days ago.
         period_to: End of period (UTC). Defaults to now.
         group_by: Aggregation — None (half-hourly), "day", "week", "month"
-        order: "asc" (oldest first) or "desc"
+        order: "asc" (oldest first) or "desc". Mapped to Octopus's current
+            ``order_by`` values (``period`` / ``-period``); the legacy
+            ``asc``/``desc`` literals were rejected with HTTP 400 starting
+            ~2026-04, breaking the V13 nightly backfill silently.
 
     Returns:
-        List of ConsumptionSlot ordered by interval_start.
+        List of ConsumptionSlot sorted by interval_start ascending
+        (defensive sort, independent of the API's ordering).
     """
     if period_from is None:
         period_from = datetime.now(UTC) - timedelta(days=30)
@@ -191,10 +195,11 @@ def fetch_consumption(
         f"{OCTOPUS_BASE}/electricity-meter-points/{mpan}"
         f"/meters/{serial}/consumption/"
     )
+    order_by_param = "-period" if order == "desc" else "period"
     params: dict[str, str] = {
         "period_from": period_from.isoformat(),
         "period_to": period_to.isoformat(),
-        "order_by": order,
+        "order_by": order_by_param,
     }
     if group_by:
         params["group_by"] = group_by
@@ -213,6 +218,7 @@ def fetch_consumption(
                 interval_end=end,
                 consumption_kwh=float(kwh),
             ))
+    slots.sort(key=lambda s: s.interval_start)
     return slots
 
 

--- a/tests/test_pnl_real_money.py
+++ b/tests/test_pnl_real_money.py
@@ -1,0 +1,172 @@
+"""Real-money PnL fields use measured grid import — issue #306.
+
+The legacy ``realised_cost_gbp`` field bills HOUSEHOLD LOAD at Agile rates.
+On a solar-rich day where load is 22 kWh but only 6 kWh comes from the grid,
+that inflates the absolute £ figure ~3-4× because PV + battery self-supply
+gets billed as if grid-bought.
+
+The new ``realised_net_cost_gbp`` (and matching ``*_real_gbp`` shadows) bill
+the *measured* grid import (from ``pv_realtime_history.grid_import_kw``) at
+per-slot Agile rates. This is what actually moved through the meter.
+"""
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.analytics import pnl
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+def _save_pv(ts: datetime, *, import_kw: float = 0.0, export_kw: float = 0.0,
+             load_kw: float = 0.0) -> None:
+    db.save_pv_realtime_sample(
+        captured_at=ts.isoformat().replace("+00:00", "Z"),
+        solar_power_kw=0.0,
+        soc_pct=50.0,
+        load_power_kw=load_kw,
+        grid_import_kw=import_kw,
+        grid_export_kw=export_kw,
+        battery_charge_kw=0.0,
+        battery_discharge_kw=0.0,
+        source="test",
+    )
+
+
+def _save_execution(ts: datetime, kwh: float, agile_p: float) -> None:
+    db.log_execution(
+        {
+            "timestamp": ts.isoformat().replace("+00:00", "Z"),
+            "consumption_kwh": kwh,
+            "agile_price_pence": agile_p,
+            "slot_kind": "standard",
+        }
+    )
+
+
+def test_half_hourly_grid_import_helper_returns_kwh_per_slot() -> None:
+    """Two samples 30 min apart with constant 2 kW import → 1 kWh in
+    the bucket containing the earlier sample."""
+    day = date(2026, 5, 1)
+    t0 = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    _save_pv(t0, import_kw=2.0)
+    _save_pv(t0 + timedelta(minutes=30), import_kw=2.0)
+
+    out = db.half_hourly_grid_import_kwh_for_day(day)
+    key = "2026-05-01T12:00:00Z"
+    assert key in out
+    assert out[key] == pytest.approx(1.0, abs=1e-3)
+
+
+def test_realised_net_cost_uses_grid_import_not_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The headline #306 fix: load and grid_import diverge on a solar day,
+    and ``realised_net_cost_gbp`` must bill grid_import (not load) at Agile.
+
+    Setup: heartbeat row says load=4 kWh consumed at 20p (legacy field
+    sees this as £0.80 of import). PV telemetry says only 1 kWh was
+    grid-imported in the same slot. New field should bill 1 kWh × 20p =
+    £0.20, not £0.80.
+    """
+    monkeypatch.setattr(app_config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 0.0)
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+
+    # Heartbeat says household consumed 4 kWh at 20p (load × Agile = £0.80)
+    _save_execution(slot, kwh=4.0, agile_p=20.0)
+
+    # Real PV telemetry: only 1 kWh of that came from the grid (rest from PV/battery)
+    _save_pv(slot, import_kw=2.0, load_kw=8.0)
+    _save_pv(slot + timedelta(minutes=30), import_kw=2.0, load_kw=8.0)
+    # 0.5h × 2 kW = 1 kWh imported
+
+    p = pnl.compute_daily_pnl(day)
+
+    # Real-money: 1 kWh × 20p = £0.20
+    assert p["import_kwh"] == pytest.approx(1.0, abs=1e-2)
+    assert p["import_cost_gbp"] == pytest.approx(0.20, abs=1e-3)
+    assert p["realised_net_cost_gbp"] == pytest.approx(0.20, abs=1e-3)
+
+    # Legacy load-billed (what the bug used to surface): 4 kWh × 20p = £0.80
+    assert p["realised_import_gbp"] == pytest.approx(0.80, abs=1e-3)
+    assert p["realised_cost_gbp"] == pytest.approx(0.80, abs=1e-3)
+
+
+def test_real_shadow_deltas_use_real_import_axis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``svt_shadow_real_gbp`` and ``fixed_shadow_real_gbp`` bill the same
+    *real* grid_import × shadow rate, so the delta-vs-Agile reflects what
+    the household would actually have paid on each tariff."""
+    monkeypatch.setattr(app_config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 0.0)
+    monkeypatch.setattr(app_config, "SVT_RATE_PENCE", 30.0)
+    monkeypatch.setattr(app_config, "MANUAL_TARIFF_IMPORT_PENCE", 30.0)
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 13, 0, tzinfo=UTC)
+
+    _save_execution(slot, kwh=4.0, agile_p=20.0)
+    _save_pv(slot, import_kw=2.0)
+    _save_pv(slot + timedelta(minutes=30), import_kw=2.0)
+    # → 1 kWh imported × 20p = £0.20 on Agile
+    # → 1 kWh × 30p = £0.30 on SVT/Fixed
+    # → real delta = +£0.10 saved
+
+    p = pnl.compute_daily_pnl(day)
+
+    assert p["realised_net_cost_gbp"] == pytest.approx(0.20, abs=1e-3)
+    assert p["svt_shadow_real_gbp"] == pytest.approx(0.30, abs=1e-3)
+    assert p["delta_vs_svt_real_gbp"] == pytest.approx(0.10, abs=1e-3)
+    # Legacy delta is inflated (4× too high)
+    assert p["delta_vs_svt_gbp"] == pytest.approx(0.40, abs=1e-3)
+
+
+def test_fixed_tariff_real_shadow_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured BG-style fixed tariff produces both real and load deltas."""
+    monkeypatch.setattr(app_config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 0.0)
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_LABEL", "British Gas Fixed v58")
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_RATE_PENCE", 25.0)
+    monkeypatch.setattr(app_config, "FIXED_TARIFF_STANDING_PENCE_PER_DAY", 40.0)
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 13, 0, tzinfo=UTC)
+
+    _save_execution(slot, kwh=4.0, agile_p=20.0)
+    _save_pv(slot, import_kw=2.0)
+    _save_pv(slot + timedelta(minutes=30), import_kw=2.0)
+
+    p = pnl.compute_daily_pnl(day)
+
+    # Real: 1 kWh × 25p + 40p standing = 65p = £0.65
+    assert p["fixed_tariff_shadow_real_gbp"] == pytest.approx(0.65, abs=1e-3)
+    # Real Agile: 1 × 20p = 20p
+    # Delta: BG would cost £0.65, Agile cost £0.20 → +£0.45 saved
+    assert p["delta_vs_fixed_tariff_real_gbp"] == pytest.approx(0.45, abs=1e-3)
+
+    # Legacy: 4 kWh × 25p + 40p = 140p = £1.40
+    assert p["fixed_tariff_shadow_gbp"] == pytest.approx(1.40, abs=1e-3)
+
+
+def test_no_pv_telemetry_returns_zero_real_cost() -> None:
+    """When ``pv_realtime_history`` has nothing for the day, real-money
+    fields safely report zero (no inflation from missing data)."""
+    day = date(2026, 5, 1)
+    slot = datetime(2026, 5, 1, 13, 0, tzinfo=UTC)
+    _save_execution(slot, kwh=4.0, agile_p=20.0)
+    # No PV samples
+
+    p = pnl.compute_daily_pnl(day)
+
+    assert p["import_kwh"] == 0.0
+    assert p["import_cost_gbp"] == 0.0
+    # Net = 0 import + standing - 0 export
+    standing = p["standing_charge_gbp"]
+    assert p["realised_net_cost_gbp"] == pytest.approx(standing, abs=1e-3)


### PR DESCRIPTION
Closes #306.

User caught this on 2026-05-09 by cross-checking the Fox app vs HEM brief.

| | Reported | Reality | Inflation |
|---|---|---|---|
| Today net cost | £4.41 | **£1.05** | ~4× |
| Today vs BG Fixed | +£0.72 | **+£0.06** | ~12× |
| Today grid import | (kwh:22.8 = LOAD) | **6.6 kWh** | — |

## Two bugs

### A. `compute_daily_pnl` billed LOAD not IMPORT
`src/analytics/pnl.py` summed `execution_log.consumption_kwh` (= Fox `load_power_kw × 0.5h` when `source='estimated'`) × Agile rates as if all that energy came from the grid. PV + battery self-supply got billed.

### B. V13 nightly backfill silently broken since ~late April
Octopus deprecated `order_by=asc` → HTTP 400. The 04:00 cron registered fine but every fire crashed in `fetch_consumption`. `source='estimated'` for **every** `execution_log` row for 10+ days. Without B fixed, A's inflation would stay forever.

## LP impact: zero

LP solver uses `pv_realtime_history.load_power_kw` directly (already moved off `execution_log` in #176). Grid imp/exp are LP decision variables from the energy balance. Regression baseline (`check_lp_regression.py`) uses LP's own `plan.import_kwh × agile_p` — independent of the bug. Frozen baseline values remain valid; doc comment added.

## Fixes

1. **`src/energy/octopus_client.py`** — map legacy `asc`/`desc` to current `period`/`-period` + defensive sort. **Revives the V13 backfill.**
2. **`src/db.py`** — new `half_hourly_grid_import_kwh_for_day` (mirror of the export helper).
3. **`src/analytics/pnl.py`** — added `realised_net_cost_gbp`, `import_kwh`, `import_cost_gbp`, plus `*_real_gbp` shadow variants and `delta_vs_*_real_gbp` deltas. Sourced from `pv_realtime_history.grid_import_kw × 0.5h × Agile slot rate`. Legacy fields kept as documented "load-billed counterfactual" for back-compat.
4. **`src/analytics/daily_brief.py`** — morning/night briefs surface real-money figures with `(real, metered)` qualifier. Compact running-PnL line prefers real fields with fallback.
5. **`scripts/check_lp_regression.py`** — doc comment confirming independence from bug.

## Validation against prod-DB snapshot

| Metric | Legacy | Real | Notes |
|---|---|---|---|
| Today (5/9) import_kwh | n/a | **6.60 kWh** | matches Fox app exactly |
| Today realised_net_cost_gbp | £3.65 | **£0.30** | (no standing locally; ~£0.92 on prod) |
| Last week (5/2-5/8) realised | £35.10 | **£14.70** | |
| Last week delta vs Fixed v58 | +£4.61 | **+£6.81 saved** | real story is BETTER |
| Last week kwh / import_kwh | 153 / — | — / **99** | gap = PV self-consumption |

## Tests

5 new in `tests/test_pnl_real_money.py`:
- Helper trapezoidal integration
- Load≠import on a solar day (the smoking gun)
- Real shadow deltas
- Configured fixed-tariff shadow
- Missing-PV-telemetry zero-safety

27/27 PnL + brief tests pass. Full suite green (after one assertion-text adjustment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)