### PR TITLE
feat(brief+heartbeat): Phase A data quality — Fox/meter audit, skill line, dedup, Daikin-quota-friendly heartbeat (#306)

### DIFF
--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -221,6 +221,16 @@ def _format_pnl_block(pnl: dict[str, Any], *, day: date, tz: ZoneInfo) -> list[s
         )
         out.append(f"- Energy used: {used_kwh:.1f} kWh  |  exported: {exp_kwh:.1f} kWh")
 
+    # Phase A audit line: Fox CT clamps vs Octopus smart-meter daily totals
+    # for divergence detection. Both sources should agree to ~5%; bigger
+    # gaps suggest heartbeat coverage problems or meter calibration drift.
+    audit_line = _fox_vs_meter_audit_line(day)
+    if audit_line:
+        out.append(audit_line)
+    skill_line = _forecast_skill_line(day)
+    if skill_line:
+        out.append(skill_line)
+
     # Forecasted-export fallback: telemetry sometimes drops grid_export_kw
     # samples, leaving export_kwh=0 even on days where the LP committed
     # peak_export and the inverter genuinely discharged. Estimate from
@@ -273,6 +283,72 @@ def _format_pnl_block(pnl: dict[str, Any], *, day: date, tz: ZoneInfo) -> list[s
                 f"£{pnl['delta_vs_fixed_gbp']:+.2f} {'saved' if pnl['delta_vs_fixed_gbp'] >= 0 else 'extra'}"
             )
     return out
+
+
+def _fox_vs_meter_audit_line(day: date) -> str | None:
+    """Format a one-line side-by-side comparison of Fox CT-clamp totals vs
+    Octopus smart-meter daily totals. Both sources should agree to ~5%; bigger
+    gaps surface heartbeat-coverage or calibration issues early.
+
+    Returns ``None`` when either source is missing for ``day`` (e.g. no
+    Octopus daily cache yet, no Fox API rollup).
+    """
+    fox = db.get_fox_energy_daily_by_date(day.isoformat())
+    meter = db.get_octopus_daily_meter(day.isoformat())
+    if not fox or not meter:
+        return None
+
+    def _fmt_pair(fox_v: float | None, meter_v: float | None) -> str | None:
+        if fox_v is None or meter_v is None:
+            return None
+        gap_pct = ((fox_v - meter_v) / meter_v * 100) if meter_v else 0.0
+        return f"{fox_v:.2f} / {meter_v:.2f} kWh ({gap_pct:+.1f}%)"
+
+    imp = _fmt_pair(fox.get("import_kwh"), meter.get("import_kwh"))
+    exp = _fmt_pair(fox.get("export_kwh"), meter.get("export_kwh"))
+    if not imp:
+        return None
+    parts = [f"import {imp}"]
+    if exp:
+        parts.append(f"export {exp}")
+    return f"- Audit (Fox vs meter): {' | '.join(parts)}"
+
+
+def _forecast_skill_line(day: date) -> str | None:
+    """Format a one-line forecast-vs-actual summary from forecast_skill_log.
+
+    Reads ``forecast_skill_log`` rows for ``day`` (UTC) populated by
+    ``rebuild_forecast_skill_log_for_date``. Returns mean outdoor-temp MAE
+    and PV bias (forecast − actual). Skipped when no rows.
+    """
+    try:
+        iso = day.isoformat()
+        rows = db.get_forecast_skill_rows(iso, iso)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    temp_errs: list[float] = []
+    pv_diffs: list[float] = []
+    for r in rows:
+        pt = r.get("predicted_temp_c")
+        at = r.get("actual_temp_c")
+        if pt is not None and at is not None:
+            temp_errs.append(abs(float(pt) - float(at)))
+        pp = r.get("predicted_pv_kwh")
+        ap = r.get("actual_pv_kwh")
+        if pp is not None and ap is not None:
+            pv_diffs.append(float(pp) - float(ap))
+
+    parts: list[str] = []
+    if temp_errs:
+        parts.append(f"outdoor MAE {sum(temp_errs)/len(temp_errs):.1f}°C")
+    if pv_diffs:
+        parts.append(f"PV bias {sum(pv_diffs)/len(pv_diffs):+.2f} kWh/h")
+    if not parts:
+        return None
+    return f"- Forecast skill ({len(rows)}h): {', '.join(parts)}"
 
 
 def _forecasted_export_for_day(day: date, tz: ZoneInfo) -> tuple[float, float, int]:

--- a/src/config.py
+++ b/src/config.py
@@ -279,7 +279,11 @@ class Config:
         "yes",
     )
     DB_PATH: str = (os.getenv("DB_PATH") or "energy_state.db").strip()
-    HEARTBEAT_INTERVAL_SECONDS: int = int(os.getenv("HEARTBEAT_INTERVAL_SECONDS", "120"))
+    # 300s default (#306 follow-up): heartbeat no longer calls Daikin API,
+    # so cadence is bounded by Fox cache freshness + MPC drift detection latency.
+    # 5-min latency on SoC drift / low-SoC alerts is well within battery safety
+    # margin. Override via env to tighten.
+    HEARTBEAT_INTERVAL_SECONDS: int = int(os.getenv("HEARTBEAT_INTERVAL_SECONDS", "300"))
     SVT_RATE_PENCE: float = float(os.getenv("SVT_RATE_PENCE", "24.50"))
     OPTIMIZATION_PEAK_THRESHOLD_PENCE: float = float(
         os.getenv("OPTIMIZATION_PEAK_THRESHOLD_PENCE", "25")

--- a/src/db.py
+++ b/src/db.py
@@ -369,6 +369,19 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         )"""
     )
 
+    # Phase A (#306 follow-up): cache Octopus's smart-meter daily totals
+    # alongside the Fox CT-clamp totals so the daily brief can surface a
+    # side-by-side audit line (Fox vs meter divergence). Populated by the
+    # nightly consumption backfill cron right after V13's half-hour backfill.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS octopus_daily_meter (
+            date TEXT PRIMARY KEY,
+            import_kwh REAL,
+            export_kwh REAL,
+            fetched_at TEXT NOT NULL
+        )"""
+    )
+
     # V10.2: daikin_consumption_daily — per-day heat-pump energy attribution.
     # Source: 'onecta' (preferred) when Onecta consumption endpoint returns
     # the day, 'telemetry_integral' when computed from daikin_telemetry rows
@@ -3207,6 +3220,55 @@ def get_fox_energy_daily_range(start_date: str, end_date: str) -> list[dict[str,
             conn.close()
 
 
+def upsert_octopus_daily_meter(
+    date_str: str,
+    *,
+    import_kwh: float | None,
+    export_kwh: float | None,
+) -> None:
+    """Cache Octopus smart-meter daily totals (one row per local date).
+
+    Both kWh args are nullable — export is None for households without an
+    Outgoing tariff. ``fetched_at`` is set to UTC now on every call so
+    callers can detect stale rows.
+    """
+    now = datetime.now(UTC).isoformat()
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT INTO octopus_daily_meter
+                   (date, import_kwh, export_kwh, fetched_at)
+                   VALUES (?, ?, ?, ?)
+                   ON CONFLICT(date) DO UPDATE SET
+                     import_kwh = excluded.import_kwh,
+                     export_kwh = excluded.export_kwh,
+                     fetched_at = excluded.fetched_at""",
+                (date_str, import_kwh, export_kwh, now),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def get_octopus_daily_meter(date_str: str) -> dict[str, Any] | None:
+    """Cached Octopus smart-meter daily totals for ``date_str`` or None.
+
+    Returns ``{"date", "import_kwh", "export_kwh", "fetched_at"}``. The brief
+    surfaces this side-by-side with ``fox_energy_daily`` for divergence audit.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM octopus_daily_meter WHERE date = ?", (date_str,)
+            )
+            r = cur.fetchone()
+            return dict(r) if r else None
+        finally:
+            conn.close()
+
+
 def get_fox_energy_dates_for_month(year: int, month: int) -> set[str]:
     """Set of ``YYYY-MM-DD`` already cached for the given calendar month.
 
@@ -4736,25 +4798,31 @@ def update_execution_log_metered(
     with _lock:
         conn = get_connection()
         try:
+            # Issue #306 follow-up: SELECT all rows in the slot window, not just
+            # the first. The legacy LIMIT 1 left straggler heartbeat rows (e.g.
+            # at 01:35:50 within a 01:30 slot) intact, double-counting in any
+            # SUM-over-execution_log path. Updating one + deleting the rest
+            # leaves exactly one canonical metered row per slot.
             cur = conn.execute(
                 """SELECT id, agile_price_pence, svt_shadow_price_pence,
                           fixed_shadow_price_pence, source
                    FROM execution_log
                    WHERE timestamp >= ? AND timestamp < ?
-                   ORDER BY timestamp ASC
-                   LIMIT 1""",
+                   ORDER BY timestamp ASC""",
                 (slot_start_iso, slot_end_iso),
             )
-            row = cur.fetchone()
-            if row:
-                agile = float(row["agile_price_pence"] or 0.0)
-                svt = float(row["svt_shadow_price_pence"] or 0.0)
-                fixed = float(row["fixed_shadow_price_pence"] or 0.0)
+            rows = cur.fetchall()
+            if rows:
+                primary = rows[0]
+                stragglers = rows[1:]
+                agile = float(primary["agile_price_pence"] or 0.0)
+                svt = float(primary["svt_shadow_price_pence"] or 0.0)
+                fixed = float(primary["fixed_shadow_price_pence"] or 0.0)
                 # Preserve 'metered_synthetic' lineage across idempotent re-runs;
                 # heartbeat-overlay rows otherwise become 'metered'.
                 next_source = (
                     "metered_synthetic"
-                    if row["source"] == "metered_synthetic"
+                    if primary["source"] == "metered_synthetic"
                     else "metered"
                 )
                 conn.execute(
@@ -4775,9 +4843,19 @@ def update_execution_log_metered(
                         kwh * (svt - agile),
                         kwh * (fixed - agile),
                         next_source,
-                        int(row["id"]),
+                        int(primary["id"]),
                     ),
                 )
+                if stragglers:
+                    placeholders = ",".join("?" for _ in stragglers)
+                    conn.execute(
+                        f"DELETE FROM execution_log WHERE id IN ({placeholders})",
+                        tuple(int(r["id"]) for r in stragglers),
+                    )
+                    logger.debug(
+                        "consumption_backfill: deduped %d straggler row(s) for slot %s",
+                        len(stragglers), slot_start_iso,
+                    )
                 conn.commit()
                 return True
 

--- a/src/scheduler/consumption_backfill.py
+++ b/src/scheduler/consumption_backfill.py
@@ -145,6 +145,30 @@ def backfill_for_date(target_local_date: date) -> BackfillResult:
         iso, len(slots), updated, missing, roles.import_mpan,
     )
 
+    # Phase A: cache the day's Octopus totals alongside Fox's so the brief can
+    # surface a side-by-side audit line without re-fetching every read. Sum
+    # the half-hourly slots we already have. Export side fetched separately
+    # if Outgoing is configured.
+    import_total = sum(s.consumption_kwh for s in slots) if slots else None
+    export_total: float | None = None
+    if roles.export_mpan and roles.export_serial:
+        try:
+            exp_slots = fetch_consumption(
+                mpan=str(roles.export_mpan),
+                serial=str(roles.export_serial),
+                period_from=period_from,
+                period_to=period_to,
+            )
+            export_total = sum(s.consumption_kwh for s in exp_slots) if exp_slots else 0.0
+        except Exception as e:
+            logger.debug("Octopus export fetch failed (non-fatal): %s", e)
+    try:
+        db.upsert_octopus_daily_meter(
+            iso, import_kwh=import_total, export_kwh=export_total
+        )
+    except Exception as e:
+        logger.warning("octopus_daily_meter upsert failed (non-fatal): %s", e)
+
     return BackfillResult(
         target_date=iso,
         slots_fetched=len(slots),

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -1315,16 +1315,15 @@ def bulletproof_heartbeat_tick() -> None:
     if get_scheduler_paused():
         return
 
-    if config.DAIKIN_CLIENT_ID and config.DAIKIN_CLIENT_SECRET and config.DAIKIN_TOKEN_FILE.exists():
-        try:
-            from ..daikin.auth import prefetch_daikin_access_token
-
-            prefetch_daikin_access_token()
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            logger.debug("Daikin OAuth prefetch (before device calls): %s", e)
-
+    # PR Phase A — heartbeat NEVER calls Daikin API (#306 follow-up).
+    # The Onecta 200-call/day quota is too tight to spend any of it on the
+    # heartbeat's monitoring path. Token prefetch removed (auth.py refreshes
+    # lazily on next 401). Device cache refresh forced off (allow_refresh=False).
+    # Cache stays warm via:
+    #   - Plan dispatch (LP → Daikin write events)
+    #   - Twice-daily briefs (08:00, 22:00 local — read Daikin state)
+    #   - Slot-boundary reconciliation below (cache-only diff check)
+    #   - Manual MCP calls
     tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
     now_local = datetime.now(tz)
     now_utc = datetime.now(UTC)
@@ -1337,33 +1336,13 @@ def bulletproof_heartbeat_tick() -> None:
     devices = []
     if config.DAIKIN_CLIENT_ID and config.DAIKIN_CLIENT_SECRET and config.DAIKIN_TOKEN_FILE.exists():
         try:
-            # Heartbeat reads from cache only — no auto-refresh to protect 200/day quota.
-            # allow_refresh=True fires only when we are in a high-value window:
-            #   - Octopus pre-slot boundary (5 min before tariff slot transition)
-            #   - 2 h Onecta cache rotation (deterministic, 12/day, even-hour UTC)
-            #   - local Daikin calibration window (heuristic, complements 2h-aligned)
-            in_pre_slot = _in_octopus_pre_slot_window(now_utc)
-            in_2h = (
-                getattr(config, "DAIKIN_2H_REFRESH_ENABLED", True)
-                and _in_daikin_2h_refresh_window(now_utc)
-            )
-            in_calibration = _in_daikin_calibration_window(now_local)
-            allow_refresh = in_pre_slot or in_2h or in_calibration
             daikin_result = daikin_service.get_cached_devices(
-                allow_refresh=allow_refresh,
+                allow_refresh=False,
                 actor="heartbeat",
             )
             devices = daikin_result.devices
-            if allow_refresh and daikin_result.source == "fresh":
-                logger.info(
-                    "Daikin refresh: fetched %d device(s) (pre-slot=%s 2h=%s calibration=%s)",
-                    len(devices),
-                    in_pre_slot,
-                    in_2h,
-                    in_calibration,
-                )
         except Exception as e:
-            logger.debug("Daikin heartbeat skip: %s", e)
+            logger.debug("Daikin heartbeat cache read skip: %s", e)
             devices = []
 
     soc = None

--- a/tests/test_pnl_real_money.py
+++ b/tests/test_pnl_real_money.py
@@ -155,6 +155,43 @@ def test_fixed_tariff_real_shadow_when_configured(
     assert p["fixed_tariff_shadow_gbp"] == pytest.approx(1.40, abs=1e-3)
 
 
+def test_backfill_dedupes_stragglers_in_slot_window() -> None:
+    """update_execution_log_metered must leave exactly one canonical row per
+    slot bucket. Pre-fix LIMIT 1 left straggler heartbeat rows intact, which
+    double-counted in the legacy realised_cost_gbp SUM path."""
+    slot_start = datetime(2026, 5, 1, 13, 0, tzinfo=UTC)
+    # Three estimated heartbeat rows landed within the same 30-min slot
+    # at different microsecond offsets — typical when the heartbeat fires
+    # multiple times before the half-hour deduper kicks in.
+    _save_execution(slot_start + timedelta(seconds=12), kwh=0.4, agile_p=20.0)
+    _save_execution(slot_start + timedelta(minutes=5, seconds=33), kwh=0.5, agile_p=20.0)
+    _save_execution(slot_start + timedelta(minutes=18, seconds=47), kwh=0.3, agile_p=20.0)
+
+    # Pre-backfill: 3 rows in the slot
+    pre = db.get_execution_logs(
+        from_ts=slot_start.isoformat(),
+        to_ts=(slot_start + timedelta(minutes=30)).isoformat(),
+        limit=10,
+    )
+    assert len(pre) == 3
+
+    ok = db.update_execution_log_metered(
+        slot_start.isoformat().replace("+00:00", "Z"),
+        consumption_kwh=1.234,
+    )
+    assert ok is True
+
+    # Post-backfill: exactly one canonical row remains, with the metered kWh
+    post = db.get_execution_logs(
+        from_ts=slot_start.isoformat(),
+        to_ts=(slot_start + timedelta(minutes=30)).isoformat(),
+        limit=10,
+    )
+    assert len(post) == 1
+    assert post[0]["consumption_kwh"] == pytest.approx(1.234, abs=1e-6)
+    assert post[0]["source"] == "metered"
+
+
 def test_no_pv_telemetry_returns_zero_real_cost() -> None:
     """When ``pv_realtime_history`` has nothing for the day, real-money
     fields safely report zero (no inflation from missing data)."""


### PR DESCRIPTION
Phase A of the data-quality plan from the 2026-05-10 audit. Five small, independently-revertable changes ship together so tomorrow morning's brief gives an honest accuracy picture from the first run.

Plan: `/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md`

## What changes per area

| # | Concern | Files | Net effect |
|---|---|---|---|
| **A1** | Octopus daily cache + Fox-vs-meter audit | `src/db.py` (new `octopus_daily_meter` table + helpers); `src/scheduler/consumption_backfill.py`; `src/analytics/daily_brief.py` | New brief line: `Audit (Fox vs meter): import X / Y kWh (Z%) ...` |
| **A2** | Forecast skill brief line | `src/analytics/daily_brief.py` | New brief line: `Forecast skill (24h): outdoor MAE X°C, PV bias Y kWh/h` |
| **A3** | Quartz vs Fox PV skill log | none — investigation showed it already works | Verified 24 hourly rows on prod for 2026-05-09 with Quartz predictions vs Fox actuals |
| **A4** | Heartbeat: drop Daikin API + slow to 300s | `src/scheduler/runner.py`, `src/config.py` | Heartbeat-driven Daikin calls 12-24/day → **0/day**; cadence 120s → 300s |
| **A5** | Backfill LIMIT 1 → all-rows dedup | `src/db.py:update_execution_log_metered` + new test | Stragglers no longer double-count in legacy realised_cost_gbp |
| **A6** | Prod `.env` clamp date | manual ops follow-up | `AGILE_TARIFF_START_DATE=2026-04-17` (was 2026-04-01) — corrects ~£28 of April "saved" inflation |

## Tests
- 857/857 full suite pass
- New `test_backfill_dedupes_stragglers_in_slot_window` asserts exactly 1 metered row remains after backfill on a slot with 3 estimated stragglers

## Validation pre-merge
- Local validation against prod-DB snapshot: `import_kwh=6.60` matches Fox app exactly
- Prod skill log manual rebuild: 24 hourly rows for 2026-05-09 with Quartz predicted_pv_kwh + Fox actual_pv_kwh both populated

## Post-merge plan
1. Wait for docker-publish (~3 min)
2. `docker compose pull && systemctl restart hem` on prod
3. Edit `/srv/hem/.env` → `AGILE_TARIFF_START_DATE=2026-04-17` (A6)
4. Restart hem to pick up the env change
5. Manual backfill for last 8 days to populate `octopus_daily_meter` retroactively (otherwise the audit line only appears tomorrow)
6. 08:00 BST morning brief is the first one with new audit + forecast-skill lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)