### PR TITLE
refactor(lp): drop t_in[i] indoor-temp variable; heating model = f(outdoor) (Phase B1)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1315,10 +1315,11 @@ async def optimization_inputs(horizon_hours: int | None = None):
             "soc_kwh": round(float(initial.soc_kwh), 3),
             "soc_pct": round(float(initial.soc_kwh) / float(config.BATTERY_CAPACITY_KWH) * 100.0, 1) if config.BATTERY_CAPACITY_KWH else None,
             "tank_c": round(float(initial.tank_temp_c), 2),
-            "indoor_c": round(float(initial.indoor_temp_c), 2),
+            # PR Phase B: indoor_c retained as null for back-compat with frontend.
+            "indoor_c": None,
             "soc_source": getattr(initial, "soc_source", "unknown"),
             "tank_source": getattr(initial, "tank_source", "unknown"),
-            "indoor_source": getattr(initial, "indoor_source", "unknown"),
+            "indoor_source": "removed_phase_b",
         }
     except Exception as e:
         initial_block = {

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -228,19 +228,12 @@ def _lwt_offset_from_plan(i: int, plan: LpPlan) -> float:
     decision — bounded by the physical climate curve — into the exact Daikin offset command
     needed to deliver that energy draw.
 
-    Falls back to an indoor-error proportional estimate when the LP output is unavailable
-    (e.g. heuristic plan that never filled ``lwt_offset_c``).
+    PR Phase B: indoor-temp fallback removed (no plan.indoor_temp_c). When
+    ``plan.lwt_offset_c`` is empty (heuristic / legacy path), default to 0.
     """
     if plan.lwt_offset_c and i < len(plan.lwt_offset_c):
         return float(plan.lwt_offset_c[i])
-    # Fallback: proportional to indoor temperature error (heuristic / legacy path)
-    if i + 1 >= len(plan.indoor_temp_c):
-        return 0.0
-    err = float(config.INDOOR_SETPOINT_C) - plan.indoor_temp_c[i + 1]
-    raw = max(-1.0, min(1.0, err * 0.6))
-    lo = float(config.LWT_OFFSET_MIN)
-    hi = float(config.LWT_OFFSET_MAX)
-    return max(lo, min(hi, raw * (config.LWT_OFFSET_MAX - config.LWT_OFFSET_MIN) / 10.0))
+    return 0.0
 
 
 def _merge_half_hour_slots_for_daikin(plan: LpPlan) -> list[tuple[datetime, datetime, str, int]]:

--- a/src/scheduler/lp_initial_state.py
+++ b/src/scheduler/lp_initial_state.py
@@ -1,4 +1,11 @@
-"""Read physical initial state for the PuLP MILP (battery SoC, DHW tank, indoor air)."""
+"""Read physical initial state for the PuLP MILP (battery SoC + DHW tank).
+
+PR Phase B (#306 follow-up): ``indoor_temp_c`` removed. The Daikin Altherma
+exposes no room sensor (0% heartbeat coverage observed) and the LP no longer
+carries an indoor-temp decision variable — heating demand is bound by
+``get_daikin_heating_kw(t_outdoor)`` directly. This file no longer reads
+``room_temperature`` from Daikin.
+"""
 from __future__ import annotations
 
 import logging
@@ -18,19 +25,20 @@ def read_lp_initial_state(
     *,
     allow_daikin_refresh: bool = True,
 ) -> LpInitialState:
-    """SoC from FoxESS cache (or DB realtime snapshot); tank and room from Daikin cache if available; else execution_log / defaults.
+    """SoC from FoxESS cache (or DB realtime snapshot); tank from Daikin cache.
 
     Priority order for SoC:
-    1. Live Fox realtime cache (get_cached_realtime) — fresh within seconds
-    2. DB fox_realtime_snapshot — fresh within 15 min (set by MPC job)
+    1. Live Fox realtime cache (``get_cached_realtime``) — fresh within seconds
+    2. DB ``fox_realtime_snapshot`` — fresh within 15 min (set by MPC job)
     3. Config default (50% capacity)
 
-    Daikin telemetry is sourced from the cached service (get_cached_devices) — the ``daikin``
-    parameter is kept for backwards-compat but no longer issues HTTP calls. Quota is preserved.
+    Daikin telemetry is sourced from the cached service (``get_cached_devices``)
+    — the ``daikin`` parameter is kept for backwards-compat but no longer issues
+    HTTP calls. Quota is preserved.
 
-    Phase 4 review: ``allow_daikin_refresh=False`` forbids any cache-miss refresh
-    that would burn Daikin quota. Simulation paths pass this to honor the
-    "no quota burn" guarantee even when the MCP-process cache is cold.
+    ``allow_daikin_refresh=False`` forbids any cache-miss refresh that would
+    burn Daikin quota. Simulation paths pass this to honor the "no quota burn"
+    guarantee even when the MCP-process cache is cold.
     """
     soc_kwh = float(config.BATTERY_CAPACITY_KWH) * 0.5
     soc_source = "default"
@@ -40,7 +48,6 @@ def read_lp_initial_state(
         soc_source = "fox_realtime_cache"
     except Exception as e:
         logger.debug("LP initial SoC live fallback: %s", e)
-        # Try DB snapshot (written by MPC job)
         try:
             snap = db.get_fox_realtime_snapshot()
             if snap and snap.get("soc_pct") is not None:
@@ -52,23 +59,13 @@ def read_lp_initial_state(
     logger.debug("LP initial SoC=%.2f kWh (source=%s)", soc_kwh, soc_source)
 
     tank = float(config.DHW_TEMP_NORMAL_C)
-    indoor = float(config.INDOOR_SETPOINT_C)
     tank_source = "default"
-    indoor_source = "default"
 
     try:
-        # #55 — use the cached/estimator wrapper so LP still seeds sensibly
-        # when the Daikin daily quota (200/day) is exhausted. When
-        # ``allow_daikin_refresh=False`` (simulation paths that must not burn
-        # quota), we still read cached live telemetry + estimator — both are
-        # local SQLite and don't touch the Onecta API.
         if allow_daikin_refresh:
             state = daikin_service.get_lp_state_cached_or_estimated(actor="lp_init")
         else:
-            # Simulation: skip the live-fetch branch by not letting the wrapper
-            # call get_cached_devices(allow_refresh=True). A lightweight reread
-            # via the cached-devices path is still safe (it never burns quota
-            # when allow_refresh=False).
+            # Simulation: cache-only path; never burns Daikin quota.
             result = daikin_service.get_cached_devices(
                 allow_refresh=False,
                 max_age_seconds=config.DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS,
@@ -78,45 +75,19 @@ def read_lp_initial_state(
                 "tank_temp_c": result.devices[0].tank_temperature
                 if result.devices
                 else None,
-                "indoor_temp_c": (
-                    getattr(result.devices[0].temperature, "room_temperature", None)
-                    if result.devices
-                    else None
-                ),
                 "source": result.source,
             }
         src = str(state.get("source") or "daikin_unknown")
         if state.get("tank_temp_c") is not None:
             tank = float(state["tank_temp_c"])
             tank_source = src
-        if state.get("indoor_temp_c") is not None:
-            indoor = float(state["indoor_temp_c"])
-            indoor_source = src
-        logger.debug(
-            "LP Daikin seed: tank=%.1f°C indoor=%.1f°C source=%s",
-            tank,
-            indoor,
-            state.get("source"),
-        )
+        logger.debug("LP Daikin seed: tank=%.1f°C source=%s", tank, state.get("source"))
     except Exception as e:
         logger.debug("LP Daikin telemetry fallback: %s", e)
-
-    # Last known room from execution logs if still default-shaped
-    try:
-        rows = db.get_execution_logs(limit=1)
-        if rows and indoor == float(config.INDOOR_SETPOINT_C):
-            r = rows[0].get("daikin_room_temp")
-            if r is not None:
-                indoor = float(r)
-                indoor_source = "execution_log"
-    except Exception:
-        pass
 
     return LpInitialState(
         soc_kwh=soc_kwh,
         tank_temp_c=tank,
-        indoor_temp_c=indoor,
         soc_source=soc_source,
         tank_source=tank_source,
-        indoor_source=indoor_source,
     )

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -38,11 +38,18 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class LpInitialState:
-    """Physical state at the start of slot 0."""
+    """Physical state at the start of slot 0.
+
+    PR Phase B (#306 follow-up): ``indoor_temp_c`` was removed because the
+    Daikin Altherma exposes no room sensor (0% coverage in heartbeat) and the
+    LP's old comfort-band variable was modelling fiction. Space-heating demand
+    is now driven by ``get_daikin_heating_kw(t_outdoor)`` directly — the
+    physics floor + ceiling derived from the configured Daikin weather curve.
+    Tank thermal loss uses ``INDOOR_SETPOINT_C`` as a constant ambient.
+    """
 
     soc_kwh: float
     tank_temp_c: float
-    indoor_temp_c: float
     # Provenance strings ("fox_realtime_cache", "db_realtime_snapshot",
     # "daikin_live", "daikin_cache", "daikin_estimate", "execution_log",
     # "default"). Persisted to lp_inputs_snapshot so the History view can show
@@ -50,7 +57,6 @@ class LpInitialState:
     # backwards-compat for callers that construct LpInitialState directly.
     soc_source: str = "unknown"
     tank_source: str = "unknown"
-    indoor_source: str = "unknown"
 
 
 @dataclass
@@ -72,7 +78,6 @@ class LpPlan:
     space_electric_kwh: list[float] = field(default_factory=list)
     lwt_offset_c: list[float] = field(default_factory=list)  # back-computed per slot
     tank_temp_c: list[float] = field(default_factory=list)   # len N+1
-    indoor_temp_c: list[float] = field(default_factory=list)  # len N+1
     soc_kwh: list[float] = field(default_factory=list)       # len N+1
     temp_outdoor_c: list[float] = field(default_factory=list)
     peak_threshold_pence: float = 0.0
@@ -90,23 +95,11 @@ def _parse_hhmm_to_minutes(s: str) -> int:
     return h * 60 + m
 
 
-def _slot_occupancy_bounds(
-    slot_start_utc: datetime,
-    tz: ZoneInfo,
-) -> tuple[float, float]:
-    """Return (T_in_min, T_in_max) comfort bounds for this slot's *end* state."""
-    local = slot_start_utc.astimezone(tz)
-    minutes = local.hour * 60 + local.minute
-    ms = _parse_hhmm_to_minutes(config.LP_OCCUPIED_MORNING_START)
-    me = _parse_hhmm_to_minutes(config.LP_OCCUPIED_MORNING_END)
-    es = _parse_hhmm_to_minutes(config.LP_OCCUPIED_EVENING_START)
-    ee = _parse_hhmm_to_minutes(config.LP_OCCUPIED_EVENING_END)
-    sp = float(config.INDOOR_SETPOINT_C)
-    band = float(config.INDOOR_COMFORT_BAND_C)
-    if ms <= minutes < me or es <= minutes < ee:
-        return sp - band, sp + band
-    floor = float(config.LP_OVERNIGHT_COMFORT_FLOOR_C)
-    return floor, 24.0
+# PR Phase B: ``_slot_occupancy_bounds`` deleted — comfort-band logic depended
+# on the indoor_temp state variable, which was based on a non-existent room
+# sensor. Heating demand is now driven by the outdoor-temp physics floor +
+# LWT-offset choice variable; comfort is the firmware's job under its weather
+# curve, not the LP's.
 
 
 def _shower_slot_mask(
@@ -394,11 +387,9 @@ def solve_lp(
     sqrt_eta = math.sqrt(max(0.01, min(1.0, eta)))
     c_tank = float(config.DHW_TANK_LITRES) * float(config.DHW_WATER_CP)  # J/K
     ua_tank = float(config.DHW_TANK_UA_W_PER_K)
-    ua_bld = float(config.BUILDING_UA_W_PER_K)
-    c_bld = float(config.BUILDING_THERMAL_MASS_KWH_PER_K) * 3.6e6  # J/K
     j_per_kwh = 3.6e6
-    q_int_j = 0.1 * j_per_kwh
-    sg = float(config.SOLAR_GAIN_FRACTION)
+    # PR Phase B: ua_bld / c_bld / q_int_j / sg removed — building thermal
+    # dynamics no longer modelled in the LP (no indoor temp state variable).
 
     # Grid import cap per slot, derived from the inverter's AC import rating
     # (FoxESS app: "max charge from grid"). 10500 W → 5.25 kWh per 30 min slot.
@@ -479,10 +470,9 @@ def solve_lp(
 
     soc = pulp.LpVariable.dicts("soc", range(n + 1), lowBound=soc_min, upBound=soc_max)
     tank = pulp.LpVariable.dicts("tank", range(n + 1), lowBound=tank_lo, upBound=tank_hi)
-    t_in = pulp.LpVariable.dicts("indoor", range(n + 1), lowBound=10.0, upBound=28.0)
-
-    s_lo = pulp.LpVariable.dicts("comfort_slack_lo", range(n), lowBound=0)
-    s_hi = pulp.LpVariable.dicts("comfort_slack_hi", range(n), lowBound=0)
+    # PR Phase B: t_in / s_lo / s_hi removed. Heating demand is now bounded by
+    # space_floor_kwh / space_ceil_kwh (physics from get_daikin_heating_kw),
+    # not by indoor-temp tracking against a phantom room sensor.
 
     # Piecewise stress auxiliary variables (one per battery power slot)
     stress_aux: dict[int, pulp.LpVariable] = {}
@@ -494,13 +484,12 @@ def solve_lp(
     # -----------------------------------------------------------------------
     prob += soc[0] == initial.soc_kwh
     prob += tank[0] == initial.tank_temp_c
-    prob += t_in[0] == initial.indoor_temp_c
 
     # -----------------------------------------------------------------------
     # Per-slot constraints
     # -----------------------------------------------------------------------
     cycle_pen = float(config.LP_CYCLE_PENALTY_PENCE_PER_KWH)
-    comfort_pen = float(config.LP_COMFORT_SLACK_PENCE_PER_DEGC_SLOT)
+    # PR Phase B: comfort_pen unused — comfort slack vars removed.
     flat_export_rate = float(config.EXPORT_RATE_PENCE)
     # Per-slot export prices (Octopus Outgoing Agile) when supplied; flat fallback otherwise.
     export_rate_line: list[float] = (
@@ -612,22 +601,24 @@ def solve_lp(
             # mode flag=1 with zero power, so add explicit binding)
             prob += e_dhw[i] + e_space[i] >= 0  # already set; kept for clarity
 
-        # DHW tank thermodynamics
+        # DHW tank thermodynamics — PR Phase B: indoor temp is no longer a
+        # state variable. Tank loss uses INDOOR_SETPOINT_C as the constant
+        # ambient (tank usually sits in a heated utility space at ~setpoint;
+        # if it's outside that's a fixed offset already absorbed into
+        # ``DHW_TANK_STANDING_LOSS_W_PER_K`` calibration).
         q_heat_dhw = e_dhw[i] * cop_dhw[i] * j_per_kwh
-        loss_tank_j = ua_tank * (tank[i] - t_in[i]) * dt_s
+        loss_tank_j = ua_tank * (tank[i] - float(config.INDOOR_SETPOINT_C)) * dt_s
         # DHW draw on shower-window slots (static-physics model). Pre-computed
         # in shower_draw_j[i]; zero outside shower windows.
         draw_j_i = shower_draw_j[i]
         prob += tank[i + 1] == tank[i] + (q_heat_dhw - loss_tank_j - draw_j_i) / c_tank
 
-        # Building thermodynamics
-        q_heat_space = e_space[i] * cop_space[i] * j_per_kwh
-        loss_bld_j = ua_bld * (t_in[i] - t_out[i]) * dt_s
-        q_sol_j = sg * pv_avail[i] * j_per_kwh
-        prob += t_in[i + 1] == t_in[i] + (q_heat_space - loss_bld_j + q_sol_j + q_int_j) / c_bld
-
-        # Radiator output cap (skip in passive — the firmware respects this physically
-        # and prediction-based equality may otherwise sit at the boundary).
+        # PR Phase B: building thermodynamics + comfort constraints removed.
+        # Active mode now relies on the same physics floor as passive: the
+        # heat pump WILL run on its weather curve. The LP's only choice is
+        # WHEN within the (floor, ceil) corridor + lwt_offset — bounded by
+        # ``space_floor_kwh[i]`` / ``space_ceil_kwh[i]`` already enforced
+        # below in the active branch.
         if not passive_daikin:
             prob += e_space[i] * cop_space[i] <= float(config.RADIATOR_MAX_KW) * slot_h
 
@@ -636,11 +627,6 @@ def solve_lp(
             # on cold overnight slots (which the heuristic can't fix after the fact).
             if space_floor_kwh[i] > 0:
                 prob += e_space[i] + e_dhw[i] >= space_floor_kwh[i]
-
-        # Comfort soft constraints
-        t_end_lo, t_end_hi = _slot_occupancy_bounds(slot_starts_utc[i], tz)
-        prob += t_in[i + 1] >= t_end_lo - s_lo[i]
-        prob += t_in[i + 1] <= t_end_hi + s_hi[i]
 
         # Piecewise-linear inverter stress cost
         if use_stress:
@@ -799,7 +785,7 @@ def solve_lp(
         else:
             terminal_dhw_floor = float(getattr(config, "DHW_TEMP_MIN_FLOOR_C", 30.0))
         prob += tank[n] >= terminal_dhw_floor
-        prob += t_in[n] >= float(config.INDOOR_SETPOINT_C) - 0.5
+        # PR Phase B: terminal indoor-temp floor removed (no t_in variable).
 
     # -----------------------------------------------------------------------
     # Total Variation penalties
@@ -859,7 +845,8 @@ def solve_lp(
             if top_q_indices:
                 obj_grid -= rank_bonus_p * pulp.lpSum(exp[i] for i in top_q_indices)
     obj_cycle = cycle_pen * pulp.lpSum(chg[i] + dis[i] for i in range(n))
-    obj_comfort = comfort_pen * pulp.lpSum(s_lo[i] + s_hi[i] for i in range(n))
+    # PR Phase B: obj_comfort removed (no s_lo / s_hi slack variables).
+    obj_comfort = 0.0
     # DHW overshoot above the comfort ceiling is not a comfort issue — it's just stored
     # hot water that will drift back naturally via tank losses. A *tiny* penalty
     # (default 0.01 p/°C-slot, configurable via ``LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT``;
@@ -981,6 +968,5 @@ def solve_lp(
     for i in range(n + 1):
         plan.soc_kwh.append(_v(soc[i]))
         plan.tank_temp_c.append(_v(tank[i]))
-        plan.indoor_temp_c.append(_v(t_in[i]))
 
     return plan

--- a/src/scheduler/lp_replay.py
+++ b/src/scheduler/lp_replay.py
@@ -270,10 +270,8 @@ def replay_run(
         initial = LpInitialState(
             soc_kwh=float(inputs.get("soc_initial_kwh") or 0.0),
             tank_temp_c=float(inputs.get("tank_initial_c") or 45.0),
-            indoor_temp_c=float(inputs.get("indoor_initial_c") or 20.0),
             soc_source=str(inputs.get("soc_source") or "snapshot"),
             tank_source=str(inputs.get("tank_source") or "snapshot"),
-            indoor_source=str(inputs.get("indoor_source") or "snapshot"),
         )
 
     # Weather: prefer the exact forecast fetch referenced by the LP snapshot;
@@ -925,7 +923,7 @@ def _state_at(plan: LpPlan, when_utc: datetime) -> LpInitialState:
     """
     starts = plan.slot_starts_utc
     if not starts:
-        return LpInitialState(soc_kwh=0.0, tank_temp_c=45.0, indoor_temp_c=20.0)
+        return LpInitialState(soc_kwh=0.0, tank_temp_c=45.0)
     if when_utc <= starts[0]:
         idx = 0
     elif when_utc >= starts[-1]:
@@ -939,14 +937,11 @@ def _state_at(plan: LpPlan, when_utc: datetime) -> LpInitialState:
                 break
     soc = plan.soc_kwh[idx] if idx < len(plan.soc_kwh) else (plan.soc_kwh[-1] if plan.soc_kwh else 0.0)
     tank = plan.tank_temp_c[idx] if idx < len(plan.tank_temp_c) else (plan.tank_temp_c[-1] if plan.tank_temp_c else 45.0)
-    indoor = plan.indoor_temp_c[idx] if idx < len(plan.indoor_temp_c) else (plan.indoor_temp_c[-1] if plan.indoor_temp_c else 20.0)
     return LpInitialState(
         soc_kwh=float(soc),
         tank_temp_c=float(tank),
-        indoor_temp_c=float(indoor),
         soc_source="replay_chain",
         tank_source="replay_chain",
-        indoor_source="replay_chain",
     )
 
 

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1147,10 +1147,13 @@ def _persist_lp_snapshots(
         "horizon_hours": int(config.LP_HORIZON_HOURS),
         "soc_initial_kwh": float(initial.soc_kwh),
         "tank_initial_c": float(initial.tank_temp_c),
-        "indoor_initial_c": float(initial.indoor_temp_c),
+        # PR Phase B: indoor_initial_c retained as schema column for back-compat
+        # but now written as None — the LP no longer carries an indoor-temp
+        # state variable (Daikin Altherma has no room sensor here).
+        "indoor_initial_c": None,
         "soc_source": getattr(initial, "soc_source", "unknown"),
         "tank_source": getattr(initial, "tank_source", "unknown"),
-        "indoor_source": getattr(initial, "indoor_source", "unknown"),
+        "indoor_source": "removed_phase_b",
         "base_load_json": json.dumps([round(float(x), 4) for x in base_load]),
         "micro_climate_offset_c": float(micro_climate_offset or 0.0),
         "forecast_fetch_at_utc": forecast_fetch_at_utc,
@@ -1184,7 +1187,8 @@ def _persist_lp_snapshots(
             "space_kwh": float(plan.space_electric_kwh[i]) if i < len(plan.space_electric_kwh) else None,
             "soc_kwh": float(plan.soc_kwh[i + 1]) if (i + 1) < len(plan.soc_kwh) else None,
             "tank_temp_c": float(plan.tank_temp_c[i + 1]) if (i + 1) < len(plan.tank_temp_c) else None,
-            "indoor_temp_c": float(plan.indoor_temp_c[i + 1]) if (i + 1) < len(plan.indoor_temp_c) else None,
+            # PR Phase B: indoor_temp_c column retained, value now always None.
+            "indoor_temp_c": None,
             "outdoor_temp_c": float(plan.temp_outdoor_c[i]) if i < len(plan.temp_outdoor_c) else None,
             "lwt_offset_c": float(plan.lwt_offset_c[i]) if i < len(plan.lwt_offset_c) else None,
         })

--- a/tests/test_active_mode_guardrails.py
+++ b/tests/test_active_mode_guardrails.py
@@ -189,7 +189,7 @@ def test_lp_respects_tank_floor_under_extreme_prices(monkeypatch):
     )
     prices = [60.0] * n  # Expensive imports — LP wants to minimise DHW heating
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=8.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    st = LpInitialState(soc_kwh=8.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -203,8 +203,7 @@ def test_lp_respects_tank_floor_under_extreme_prices(monkeypatch):
     assert all(t >= 20.0 - 1e-6 for t in plan.tank_temp_c), (
         f"Tank fell below 20 °C floor: min={min(plan.tank_temp_c):.2f}"
     )
-    # Indoor floor is 10 °C (variable bound in lp_optimizer.py); also assert no
-    # extreme dip even at 10 (catch a regression where comfort_pen disappears).
-    assert all(t >= 10.0 - 1e-6 for t in plan.indoor_temp_c), (
-        f"Indoor fell below 10 °C bound: min={min(plan.indoor_temp_c):.2f}"
-    )
+    # PR Phase B: indoor_temp_c removed from LpPlan — comfort floor is no
+    # longer LP-enforced; the heat pump runs on its weather curve via
+    # space_floor_kwh. The tank floor assertion above remains the canonical
+    # safety check for guardrail enforcement.

--- a/tests/test_daikin_passive_mode.py
+++ b/tests/test_daikin_passive_mode.py
@@ -140,7 +140,7 @@ def _solve_minimal(passive: bool):
         cop_space=[3.0] * n,
         cop_dhw=[2.5] * n,
     )
-    init = LpInitialState(soc_kwh=5.0, tank_temp_c=48.0, indoor_temp_c=21.0)
+    init = LpInitialState(soc_kwh=5.0, tank_temp_c=48.0)
     return solve_lp(
         slot_starts_utc=slots,
         price_pence=[10.0, 5.0, 25.0, 8.0],

--- a/tests/test_lp_dhw_draw_model.py
+++ b/tests/test_lp_dhw_draw_model.py
@@ -61,7 +61,7 @@ def test_dhw_draw_model_drops_tank_temp_during_shower_window(
         price_pence=[20.0] * n,
         base_load_kwh=[0.3] * n,
         weather=_make_weather(slots),
-        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0, indoor_temp_c=21.0),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0),
         tz=ZoneInfo("Europe/London"),
     )
     assert plan.ok, plan.status
@@ -140,7 +140,7 @@ def test_dhw_draw_per_day_normalization_2day_horizon(
         price_pence=[20.0] * n2,
         base_load_kwh=[0.3] * n2,
         weather=_make_weather(slots2),
-        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0, indoor_temp_c=21.0),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0),
         tz=tz,
     )
     assert plan.ok, plan.status
@@ -197,7 +197,7 @@ def test_dhw_draw_model_zero_litres_disables_draw(
         price_pence=[20.0] * n,
         base_load_kwh=[0.3] * n,
         weather=_make_weather(slots),
-        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0, indoor_temp_c=21.0),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0),
         tz=ZoneInfo("Europe/London"),
     )
     assert plan.ok, plan.status
@@ -255,7 +255,7 @@ def test_dhw_draw_model_forces_pv_time_heating(
         price_pence=prices,
         base_load_kwh=[0.3] * n,
         weather=_make_weather(slots, pv_kwh=pv),
-        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0, indoor_temp_c=21.0),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=50.0),
         tz=ZoneInfo("Europe/London"),
     )
     assert plan.ok, plan.status

--- a/tests/test_lp_dhw_shower_schedule.py
+++ b/tests/test_lp_dhw_shower_schedule.py
@@ -189,7 +189,7 @@ def test_lp_solves_cleanly_with_default_schedule(monkeypatch: pytest.MonkeyPatch
             cop_space=[3.5] * n,
             cop_dhw=[3.0] * n,
         ),
-        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=45.0, indoor_temp_c=21.0),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=45.0),
         tz=ZoneInfo("Europe/London"),
     )
     assert plan.ok, plan.status
@@ -233,7 +233,7 @@ def test_lp_enforces_tight_floor_when_horizon_ends_in_shower_window(
             cop_space=[3.5] * n,
             cop_dhw=[3.0] * n,
         ),
-        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=45.0, indoor_temp_c=21.0),
+        initial=LpInitialState(soc_kwh=4.0, tank_temp_c=45.0),
         tz=ZoneInfo("Europe/London"),
     )
     assert plan.ok, plan.status

--- a/tests/test_lp_export_per_slot.py
+++ b/tests/test_lp_export_per_slot.py
@@ -108,7 +108,7 @@ def test_solve_lp_uses_per_slot_export_when_provided():
         cop_space=[3.5] * n,
         cop_dhw=[3.0] * n,
     )
-    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     pv = pv  # silence linter
     plan = solve_lp(
         slot_starts_utc=slots,
@@ -140,7 +140,7 @@ def test_solve_lp_export_length_mismatch_raises():
         cop_space=[3.5] * n,
         cop_dhw=[3.0] * n,
     )
-    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     with pytest.raises(ValueError, match="export_price_pence length"):
         solve_lp(
             slot_starts_utc=slots,

--- a/tests/test_lp_optimizer.py
+++ b/tests/test_lp_optimizer.py
@@ -47,7 +47,7 @@ def test_micro_climate_offset_is_applied_as_forecast_plus_offset():
     """
     base = datetime(2026, 7, 1, 0, 0, tzinfo=UTC)
     slots, w = _series(1, base)
-    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0)
 
     plan = solve_lp(
         slot_starts_utc=slots,
@@ -69,7 +69,7 @@ def test_micro_climate_offset_by_hour_overrides_flat_default():
     """Per-hour offsets win over the flat default for matching UTC hours."""
     base = datetime(2026, 7, 1, 0, 0, tzinfo=UTC)
     slots, w = _series(2, base)
-    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0)
 
     plan = solve_lp(
         slot_starts_utc=slots,
@@ -93,7 +93,7 @@ def test_micro_climate_offset_clamped_to_five_degrees():
     """Anomalous offsets must not move t_out by more than ±5 °C."""
     base = datetime(2026, 7, 1, 0, 0, tzinfo=UTC)
     slots, w = _series(1, base)
-    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0)
 
     plan = solve_lp(
         slot_starts_utc=slots,
@@ -119,7 +119,7 @@ def test_lp_solves_optimal_small_horizon():
     base_load = [0.4] * n
     # indoor_temp_c at 20.5 (= INDOOR_SETPOINT_C − 0.5) matches the solver's terminal floor
     # so short horizons remain feasible under the tighter LWT offset cap.
-    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -142,7 +142,7 @@ def test_seg_export_bounded_by_pv_and_discharge():
     prices = [30.0] * n
     base_load = [0.3] * n
     # Tank starts at the new DHW_TEMP_COMFORT_C ceiling (48°C) for positive-price slots.
-    st = LpInitialState(soc_kwh=8.0, tank_temp_c=48.0, indoor_temp_c=21.0)
+    st = LpInitialState(soc_kwh=8.0, tank_temp_c=48.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -166,7 +166,7 @@ def test_terminal_soc_at_least_initial(monkeypatch):
     base_load = [0.45] * n
     # indoor_temp_c must be close to INDOOR_SETPOINT_C (21°C) — the solver has a
     # hard terminal floor of INDOOR_SETPOINT_C-0.5 that short horizons can't recover from.
-    st = LpInitialState(soc_kwh=3.0, tank_temp_c=42.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=3.0, tank_temp_c=42.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -189,7 +189,7 @@ def test_terminal_soc_hard_floor(monkeypatch):
     prices = [8.0] * n
     base_load = [0.3] * n
     # indoor_temp_c at 20.5 = terminal floor; otherwise short horizons can't recover.
-    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -217,7 +217,7 @@ def test_terminal_soc_value_changes_terminal_soc(monkeypatch):
     # With terminal value=20p/kWh, the 22p spread is < 20p → keep battery.
     prices = [30.0] * 4 + [8.0] * (n - 4)
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=6.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=6.0, tank_temp_c=45.0)
 
     monkeypatch.setattr(app_config, "LP_SOC_FINAL_KWH", 1.0)
 
@@ -269,7 +269,7 @@ def test_pv_curtailment_slack_prevents_infeasible():
     prices = [5.0] * n
     base_load = [0.2] * n
     # Tank capped at DHW_TEMP_COMFORT_C=48 °C for positive-price slots.
-    st = LpInitialState(soc_kwh=9.0, tank_temp_c=48.0, indoor_temp_c=22.0)
+    st = LpInitialState(soc_kwh=9.0, tank_temp_c=48.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -292,7 +292,7 @@ def test_smoothing_penalties_and_price_quantize_still_optimal(monkeypatch):
     slots, w = _series(n, base)
     prices = [10.2, 11.7, 10.1, 12.3, 9.8, 10.0, 11.1, 10.9, 12.0, 10.5]
     base_load = [0.35] * n
-    st = LpInitialState(soc_kwh=5.0, tank_temp_c=48.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=48.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -315,7 +315,7 @@ def test_inverter_stress_reduces_peak_battery_power(monkeypatch):
     # Flat price: without stress, solver is free to charge at max every slot
     prices = [10.0] * n
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=2.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=2.0, tank_temp_c=45.0)
 
     monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
     plan_no_stress = solve_lp(
@@ -364,7 +364,7 @@ def test_simplified_hp_model_continuous_power(monkeypatch):
     prices = [6.0] * n  # cheap — heat pump should run
     base_load = [0.3] * n
     # indoor_temp_c must be close to INDOOR_SETPOINT_C (21°C) — see terminal-floor note in earlier test.
-    st = LpInitialState(soc_kwh=5.0, tank_temp_c=40.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=40.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -424,7 +424,7 @@ def test_negative_price_max_charges_battery(monkeypatch):
     prices = [-5.0] * n
     base_load = [0.3] * n
     initial_soc = 2.0
-    st = LpInitialState(soc_kwh=initial_soc, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=initial_soc, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -449,7 +449,7 @@ def test_dhw_ceiling_48_when_positive_price():
     # First half positive, second half negative
     prices = [10.0] * 12 + [-3.0] * 12
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -483,7 +483,7 @@ def test_no_grid_to_battery_before_plunge():
     )
     prices = [12.0] * 8 + [-2.0] * 8  # positive morning, negative afternoon
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -510,7 +510,7 @@ def test_lwt_offset_capped_at_5():
     slots, w = _series(n, base)
     prices = [8.0] * n
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -547,7 +547,7 @@ def test_dis_zero_during_negative_slots():
     # if the LP were allowed to swing battery both ways within the horizon).
     prices = [-3.0] * 4 + [35.0] * 4
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=9.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=9.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -582,7 +582,7 @@ def test_stress_cost_inactive_during_negative_prices(monkeypatch):
     )
     prices = [-2.0] * n
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=2.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=2.0, tank_temp_c=45.0)
 
     monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
     plan_no = solve_lp(
@@ -651,7 +651,7 @@ def test_negative_run_has_no_charge_gaps(monkeypatch):
     prices = [-1.24, -0.90, -1.30, -1.30, -1.10, -0.95]
     base_load = [0.3] * n
     # SoC=5 kWh (50%): battery has ~5 kWh of headroom — ~2 slots of full-power charging.
-    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,

--- a/tests/test_lp_optimizer_space_floor.py
+++ b/tests/test_lp_optimizer_space_floor.py
@@ -53,7 +53,7 @@ def test_solution_respects_minimum_hp_electric_vs_space_floor(monkeypatch: pytes
     base_load = [0.4] * n
     # indoor_temp_c at 20.5 matches the solver's terminal floor (INDOOR_SETPOINT_C−0.5) —
     # short horizons can't recover if it starts below, especially under the tighter LWT cap.
-    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0, indoor_temp_c=20.5)
+    st = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,

--- a/tests/test_lp_peak_export_rank_bonus.py
+++ b/tests/test_lp_peak_export_rank_bonus.py
@@ -85,7 +85,7 @@ def test_rank_bonus_solves_cleanly_on_flat_day(
         cop_space=[3.5] * n,
         cop_dhw=[3.0] * n,
     )
-    init = LpInitialState(soc_kwh=10.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    init = LpInitialState(soc_kwh=10.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=[5.0] * n,
@@ -126,7 +126,7 @@ def test_rank_bonus_objective_term_only_when_export_prices_provided(
         cop_space=[3.5] * n,
         cop_dhw=[3.0] * n,
     )
-    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    init = LpInitialState(soc_kwh=5.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=[20.0] * n,
@@ -167,7 +167,7 @@ def test_rank_bonus_does_not_force_curtailment_at_zero_export_price(
         cop_space=[3.5] * n,
         cop_dhw=[3.0] * n,
     )
-    init = LpInitialState(soc_kwh=10.0, tank_temp_c=45.0, indoor_temp_c=21.0)
+    init = LpInitialState(soc_kwh=10.0, tank_temp_c=45.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=[5.0] * n,

--- a/tests/test_lp_plunge_window.py
+++ b/tests/test_lp_plunge_window.py
@@ -42,15 +42,13 @@ def _flat_weather(starts: list[datetime], pv_per_slot: float = 0.0) -> WeatherLp
 
 
 def _initial() -> LpInitialState:
-    # indoor_temp_c=20.5 matches the LP's terminal floor (INDOOR_SETPOINT_C − 0.5
+    #  matches the LP's terminal floor (INDOOR_SETPOINT_C − 0.5
     # = 21 − 0.5) — keeps the small-horizon LP feasible without forcing space heat.
     return LpInitialState(
         soc_kwh=2.5,                 # 50% of 5 kWh
         tank_temp_c=48.0,
-        indoor_temp_c=20.5,
         soc_source="test",
         tank_source="test",
-        indoor_source="test",
     )
 
 

--- a/tests/test_lp_price_quantization.py
+++ b/tests/test_lp_price_quantization.py
@@ -104,7 +104,7 @@ def test_lp_solve_uses_conservative_quantization(
         cop_dhw=[3.0] * n,
     )
     init = LpInitialState(
-        soc_kwh=2.5, tank_temp_c=48.0, indoor_temp_c=20.5,
+        soc_kwh=2.5, tank_temp_c=48.0,
     )
 
     plan = solve_lp(

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -38,7 +38,7 @@ def _make_weather(slots, pv_kwh):
 def _solve(slots, prices, pv, base_load, init_soc=8.0, init_tank=40.0,
            export_prices=None, **monkeyed_config):
     from src.scheduler.lp_optimizer import LpInitialState, solve_lp
-    init = LpInitialState(soc_kwh=init_soc, tank_temp_c=init_tank, indoor_temp_c=21.0)
+    init = LpInitialState(soc_kwh=init_soc, tank_temp_c=init_tank)
     return solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,

--- a/tests/test_lp_replay.py
+++ b/tests/test_lp_replay.py
@@ -99,7 +99,7 @@ def _solve_baseline(
         prices = [12.0] * n
     if base_load is None:
         base_load = [0.4] * n
-    initial = LpInitialState(soc_kwh=soc0, tank_temp_c=tank0, indoor_temp_c=indoor0)
+    initial = LpInitialState(soc_kwh=soc0, tank_temp_c=tank0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -146,10 +146,10 @@ def _persist_plan_as_run(
         "horizon_hours": int(len(slots) * 0.5),
         "soc_initial_kwh": initial.soc_kwh,
         "tank_initial_c": initial.tank_temp_c,
-        "indoor_initial_c": initial.indoor_temp_c,
+        "indoor_initial_c": None,
         "soc_source": initial.soc_source,
         "tank_source": initial.tank_source,
-        "indoor_source": initial.indoor_source,
+        "indoor_source": "removed_phase_b",
         "base_load_json": json.dumps(base_load),
         "micro_climate_offset_c": 0.0,
         "forecast_fetch_at_utc": fetch_at,
@@ -178,7 +178,7 @@ def _persist_plan_as_run(
             "space_kwh": float(plan.space_electric_kwh[i]),
             "soc_kwh": float(plan.soc_kwh[i + 1]) if i + 1 < len(plan.soc_kwh) else 0.0,
             "tank_temp_c": float(plan.tank_temp_c[i + 1]) if i + 1 < len(plan.tank_temp_c) else 0.0,
-            "indoor_temp_c": float(plan.indoor_temp_c[i + 1]) if i + 1 < len(plan.indoor_temp_c) else 0.0,
+            "indoor_temp_c": None,
             "outdoor_temp_c": float(plan.temp_outdoor_c[i]) if i < len(plan.temp_outdoor_c) else 10.0,
             "lwt_offset_c": float(plan.lwt_offset_c[i]) if i < len(plan.lwt_offset_c) else 0.0,
         })
@@ -259,7 +259,7 @@ def test_replay_run_v11a_honest_fidelity_when_cloud_cover_persisted():
             heating_demand_factor=compute_heating_demand_factor(12.0),
         ))
     w = forecast_to_lp_inputs(forecast, slots, pv_scale=1.0)
-    initial = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0, indoor_temp_c=20.5)
+    initial = LpInitialState(soc_kwh=4.0, tank_temp_c=44.0)
     plan = solve_lp(
         slot_starts_utc=slots, price_pence=[12.0] * 8, base_load_kwh=[0.4] * 8,
         weather=w, initial=initial, tz=ZoneInfo("Europe/London"),
@@ -322,7 +322,7 @@ def test_replay_run_missing_weather_returns_clean_error():
         "horizon_hours": 4,
         "soc_initial_kwh": initial.soc_kwh,
         "tank_initial_c": initial.tank_temp_c,
-        "indoor_initial_c": initial.indoor_temp_c,
+        "indoor_initial_c": None,
         "soc_source": "test", "tank_source": "test", "indoor_source": "test",
         "base_load_json": json.dumps(base_load),
         "micro_climate_offset_c": 0.0,
@@ -355,9 +355,20 @@ def test_replay_run_unknown_run_id_returns_error():
 
 
 def test_replay_run_forward_mode_changes_under_config_drift(monkeypatch):
-    """Forward mode uses today's config; mutating config should change the result."""
+    """Forward mode uses today's config; mutating config should change the result.
+
+    Uses a peaky price curve so battery capacity has a measurable impact on the
+    optimal arbitrage strategy (the LP's decision space narrows when capacity
+    halves). PR Phase B note: the previous flat-price test relied on the old
+    indoor-temp comfort variable absorbing config sensitivity; with that
+    variable removed, flat prices give an LP-invariant result.
+    """
     base = datetime(2026, 7, 2, 0, 0, tzinfo=UTC)
-    plan, slots, prices, base_load, initial, forecast = _solve_baseline(8, base)
+    # Peaky: cheap-then-peak across 8 slots so battery sizing matters.
+    prices = [5.0, 5.0, 5.0, 5.0, 35.0, 35.0, 35.0, 35.0]
+    plan, slots, prices, base_load, initial, forecast = _solve_baseline(
+        8, base, prices=prices,
+    )
     # Capture current battery capacity so we can stash it in the snapshot.
     snap_capacity = float(app_config.BATTERY_CAPACITY_KWH)
     run_id = _persist_plan_as_run(

--- a/tests/test_lp_restore_window.py
+++ b/tests/test_lp_restore_window.py
@@ -49,7 +49,7 @@ def _build_plan_with_peak():
     # Peak in the middle (slots 4-5)
     prices = [10.0] * 4 + [40.0, 40.0] + [10.0] * 4
     base_load = [0.4] * n
-    st = LpInitialState(soc_kwh=8.0, tank_temp_c=48.0, indoor_temp_c=21.0)
+    st = LpInitialState(soc_kwh=8.0, tank_temp_c=48.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,

--- a/tests/test_mcp_simulate_plan.py
+++ b/tests/test_mcp_simulate_plan.py
@@ -31,7 +31,7 @@ def _fake_sim_result() -> MagicMock:
     result.forecast_solar_kwh_horizon = 6.2
     result.pv_scale_factor = 0.87
     result.mu_load_kwh = 0.42
-    result.initial = MagicMock(soc_kwh=5.2, tank_temp_c=45.0, indoor_temp_c=20.1)
+    result.initial = MagicMock(soc_kwh=5.2, tank_temp_c=45.0)
     result.plan = MagicMock(ok=True, objective_pence=-125.50, status="Optimal")
     result.error = None
     return result

--- a/tests/test_pv_curtail_penalty.py
+++ b/tests/test_pv_curtail_penalty.py
@@ -58,7 +58,7 @@ def test_penalty_eliminates_curtailment_when_export_feasible(monkeypatch):
     slots, w = _series_with_pv(n, base, pv_per_slot=1.0)
     prices = [10.0] * n      # standard import
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=8.0, tank_temp_c=48.0, indoor_temp_c=21.0)
+    st = LpInitialState(soc_kwh=8.0, tank_temp_c=48.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -87,7 +87,7 @@ def test_legacy_zero_penalty_allows_curtailment(monkeypatch):
     # Negative-price slots so the LP wants max imp; PV becomes "competition"
     prices = [-7.0] * n
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=2.0, tank_temp_c=48.0, indoor_temp_c=21.0)
+    st = LpInitialState(soc_kwh=2.0, tank_temp_c=48.0)
     plan = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,
@@ -115,7 +115,7 @@ def test_penalty_value_reduces_curtailment_under_chg_cap(monkeypatch):
     slots, w = _series_with_pv(n, base, pv_per_slot=1.5)
     prices = [-7.0] * n
     base_load = [0.3] * n
-    st = LpInitialState(soc_kwh=2.0, tank_temp_c=48.0, indoor_temp_c=21.0)
+    st = LpInitialState(soc_kwh=2.0, tank_temp_c=48.0)
     plan_with = solve_lp(
         slot_starts_utc=slots,
         price_pence=prices,

--- a/tests/test_schedule_timezones.py
+++ b/tests/test_schedule_timezones.py
@@ -106,7 +106,6 @@ def test_daikin_action_schedule_keeps_utc_z_suffix():
         space_electric_kwh=[0.0, 0.5],
         lwt_offset_c=[5.0, 5.0],
         tank_temp_c=[45.0, 55.0, 60.0],
-        indoor_temp_c=[21.0, 21.0, 21.0],
         soc_kwh=[5.0, 8.0, 10.0],
         temp_outdoor_c=[10.0, 10.0],
         peak_threshold_pence=30.0,


### PR DESCRIPTION
Phase B1 of the data-quality plan. Removes the LP's fictional indoor-temp decision variable and the comfort-band constraints around it. Heating demand is now driven entirely by the configured Daikin weather curve via the existing `get_daikin_heating_kw(t_outdoor)` physics function.

User-confirmed direction (2026-05-10): the Daikin Altherma here exposes no room sensor (0% heartbeat coverage from #308's audit), so the LP was carrying a fictional state variable seeded with a 21°C default. The model becomes simpler and more honest after this PR.

## What's removed

| Symbol | Location | Why |
|---|---|---|
| `t_in[i]` LpVariable | `lp_optimizer.py` | No measurement to anchor; existed only to enforce fictional comfort |
| `s_lo` / `s_hi` comfort slack | same | Slacks for fictional comfort constraints |
| `_slot_occupancy_bounds()` | same | Defined the fictional comfort window |
| Building thermal dynamics | same | Required `t_in` state; not modelled now |
| `obj_comfort` objective term | same | Penalised slack on fictional constraints |
| Terminal `t_in[n] >= setpoint - 0.5` | same | Fictional final-state floor |
| `LpInitialState.indoor_temp_c` | dataclass | Removed field |
| `LpPlan.indoor_temp_c` list | dataclass | Removed field |
| Daikin room_temp read in `lp_initial_state.py` | cascade | Always returned None for this unit anyway |
| LWT offset "indoor-error" fallback | `lp_dispatch.py` | Heuristic path that depended on plan.indoor_temp_c |

## What's kept

- `space_floor_kwh[i]` / `space_ceil_kwh[i]` constraints on `e_space[i]` — already physics-derived from Daikin weather curve. The heat pump WILL run on its curve regardless.
- `lwt_offset[i]` decision variable (±10°C bounded) — the LP's only space-heating time-shift knob.
- Tank loss now uses `INDOOR_SETPOINT_C` as constant ambient (calibration is already absorbed into `DHW_TANK_STANDING_LOSS_W_PER_K`).
- Schema columns `lp_inputs_snapshot.indoor_initial_c` and `lp_plan_snapshot.indoor_temp_c` retained for back-compat; new rows write NULL.

## Risk + mitigation (per approved plan)

Trade-off acknowledged: surrenders the "coast through peak" comfort-band optimisation. Mitigations:
- `lwt_offset[i]` retains some time-shift ability
- Phase B2 (tariff-aware load forecast) compensates with better LP inputs
- Regression baseline (`check_lp_regression.py`) gates aggregate cost
- Active mode now has the same heating model as passive — clean unification

## Tests

857/857 pass. ~18 test files updated to drop `indoor_temp_c=X` constructor args. One test (`test_replay_run_forward_mode_changes_under_config_drift`) needed a peaky price profile — the flat-price version relied on the now-removed comfort-band absorbing config sensitivity.

## Plan reference

`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md` Phase B1.

Phase B2 (tariff-window-aware base load forecast) ships separately. B3 (CoP audit) is read-only. B4 (regression baseline refresh) after B1+B2 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)