### PR TITLE
feat(lp): tariff-window-aware base load forecast (Phase B2)

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1582,6 +1582,159 @@ def half_hourly_residual_load_profile_kwh(
     return profile
 
 
+def tariff_aware_residual_load_profile_kwh(
+    *,
+    window_days: int = 30,
+    min_samples_per_kind: int = 5,
+) -> dict[tuple, float]:
+    """Per-(hour, minute, slot_kind) MEDIAN residual load — captures the
+    household's tariff-driven behavioural shift (e.g. cooking pulled into
+    cheap windows; heating deferred during peak).
+
+    Phase B2 (#306 follow-up): the legacy
+    :func:`half_hourly_residual_load_profile_kwh` returned one median per
+    half-hour bucket regardless of price tier. After ~14 days on Agile, the
+    family changed routines (lunch ~12:00 in cheap quartile, evening peak
+    avoidance) but the LP forecast was treating "13:00 cheap day" the same
+    as "13:00 peak day". This function adds the slot_kind dimension by
+    joining with ``execution_log.slot_kind`` retrospectively.
+
+    Returns a dict whose keys may be 2-tuples ``(hour, minute)`` or 3-tuples
+    ``(hour, minute, kind)``. Caller looks up the most specific bucket
+    available, falling back to the plain bucket. ``kind`` ∈ {``negative``,
+    ``cheap``, ``standard``, ``peak``}.
+
+    Buckets with fewer than ``min_samples_per_kind`` samples are dropped
+    (graceful degradation): the caller's fallback to ``(hour, minute)``
+    median still applies.
+    """
+    from .config import config, cop_at_temperature
+    from .physics import predict_passive_daikin_load
+
+    cutoff_iso = (datetime.now(UTC) - timedelta(days=window_days)).isoformat().replace("+00:00", "Z")
+    cop_curve = config.DAIKIN_COP_CURVE
+
+    # Step 1: build slot_kind lookup by half-hour bucket from execution_log.
+    # Key shape: (YYYY-MM-DD, hour, 0|30) → kind.
+    kind_by_slot: dict[tuple[str, int, int], str] = {}
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT timestamp, slot_kind FROM execution_log
+                   WHERE timestamp > ? AND slot_kind IS NOT NULL""",
+                (cutoff_iso,),
+            )
+            for row in cur.fetchall():
+                ts_str = str(row["timestamp"])
+                k = str(row["slot_kind"]).strip().lower()
+                if not k:
+                    continue
+                try:
+                    from datetime import datetime as _dt
+                    ts = _dt.fromisoformat(ts_str.replace("Z", "+00:00"))
+                    local = ts.astimezone(ZoneInfo(config.BULLETPROOF_TIMEZONE))
+                except (ValueError, TypeError):
+                    continue
+                slot_key = (
+                    local.date().isoformat(),
+                    local.hour,
+                    30 if local.minute >= 30 else 0,
+                )
+                # First-seen wins (heartbeat may write multiple rows per slot
+                # before #308 dedup; slot_kind is consistent across them).
+                kind_by_slot.setdefault(slot_key, k)
+        finally:
+            conn.close()
+
+    # Step 2: walk pv_realtime samples, compute residual, key by both
+    # (hour, minute) and (hour, minute, kind) when known.
+    samples_used = 0
+    samples_dropped_no_meteo = 0
+    by_hm: dict[tuple[int, int], list[float]] = {}
+    by_hmk: dict[tuple[int, int, str], list[float]] = {}
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT pv.captured_at, pv.load_power_kw,
+                          (SELECT mv.temp_c
+                           FROM meteo_forecast_value mv
+                           JOIN meteo_forecast_snapshot ms
+                             ON ms.forecast_fetch_at_utc = mv.forecast_fetch_at_utc
+                           WHERE substr(mv.slot_time, 1, 13) = substr(pv.captured_at, 1, 13)
+                             AND ms.forecast_fetch_at_utc < pv.captured_at
+                           ORDER BY ms.forecast_fetch_at_utc DESC LIMIT 1) AS outdoor_history_c,
+                          (SELECT mv.temp_c
+                           FROM meteo_forecast_value mv
+                           JOIN meteo_forecast_latest_state ls
+                             ON ls.id = 1
+                            AND ls.forecast_fetch_at_utc = mv.forecast_fetch_at_utc
+                           WHERE substr(mv.slot_time, 1, 13) = substr(pv.captured_at, 1, 13)
+                           LIMIT 1) AS outdoor_latest_c
+                   FROM pv_realtime_history pv
+                   WHERE pv.captured_at > ? AND pv.load_power_kw IS NOT NULL""",
+                (cutoff_iso,),
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+    from datetime import datetime as _dt
+    for row in rows:
+        ts_str = row["captured_at"]
+        load_kw = float(row["load_power_kw"])
+        outdoor = row["outdoor_history_c"]
+        if outdoor is None:
+            outdoor = row["outdoor_latest_c"]
+        if outdoor is None:
+            samples_dropped_no_meteo += 1
+            continue
+        outdoor_c = float(outdoor)
+        cop_at_t = cop_at_temperature(cop_curve, outdoor_c)
+        e_space, e_dhw = predict_passive_daikin_load(
+            [outdoor_c], [cop_at_t], [cop_at_t], slot_h=0.5
+        )
+        daikin_slot_kwh = e_space[0] + e_dhw[0]
+        sample_slot_kwh = load_kw * 0.5
+        residual = max(0.0, sample_slot_kwh - daikin_slot_kwh)
+        try:
+            ts = _dt.fromisoformat(str(ts_str).replace("Z", "+00:00"))
+            local = ts.astimezone(ZoneInfo(config.BULLETPROOF_TIMEZONE))
+        except (ValueError, TypeError):
+            continue
+        minute_bucket = 30 if local.minute >= 30 else 0
+        hm = (local.hour, minute_bucket)
+        by_hm.setdefault(hm, []).append(residual)
+        slot_key = (local.date().isoformat(), local.hour, minute_bucket)
+        kind = kind_by_slot.get(slot_key)
+        if kind:
+            by_hmk.setdefault((local.hour, minute_bucket, kind), []).append(residual)
+        samples_used += 1
+
+    # Step 3: build profile.
+    profile: dict[tuple, float] = {}
+    for hm, vs in by_hm.items():
+        if vs:
+            vs_sorted = sorted(vs)
+            profile[hm] = vs_sorted[len(vs_sorted) // 2]
+    for hmk, vs in by_hmk.items():
+        if len(vs) >= min_samples_per_kind:
+            vs_sorted = sorted(vs)
+            profile[hmk] = vs_sorted[len(vs_sorted) // 2]
+
+    n_kind_buckets = sum(1 for k in profile if len(k) == 3)
+    logger.info(
+        "tariff_aware_residual_profile: %d samples (%d dropped no-meteo); "
+        "%d (h,m) buckets, %d (h,m,kind) buckets ≥%d samples each",
+        samples_used, samples_dropped_no_meteo,
+        sum(1 for k in profile if len(k) == 2),
+        n_kind_buckets,
+        min_samples_per_kind,
+    )
+    return profile
+
+
 def half_hourly_load_profile_kwh(
     limit: int = 2016,
     *,

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1319,25 +1319,57 @@ def _run_optimizer_lp(
     if not slots:
         return _self_use_fallback(fox, reason="No half-hour slots in LP horizon — check Agile rates coverage")
 
-    # Per-slot residual load (Daikin physics subtracted per S10.13 / #179)
+    # Per-slot residual load (Daikin physics subtracted per S10.13 / #179).
+    # Phase B2 (#306 follow-up): use the tariff-aware profile when available
+    # so cooking-pulled-into-cheap and peak-avoidance behaviours are
+    # captured in the LP forecast. Falls back to plain (h, m) when a
+    # (h, m, kind) bucket lacks samples; falls back to flat when both miss.
     _profile_limit = int(getattr(config, "LP_LOAD_PROFILE_SLOTS", 2016))
-    _load_profile = db.half_hourly_residual_load_profile_kwh()
-    # Fall back to Fox daily mean when execution_log is cold
+    _load_profile = db.tariff_aware_residual_load_profile_kwh()
+    if not _load_profile:
+        # Cold-start: legacy plain profile until 30 days of slot_kind history
+        # accumulates.
+        _load_profile = db.half_hourly_residual_load_profile_kwh()
     _fox_mean = db.mean_fox_load_kwh_per_slot(limit=60)
     _flat = _fox_mean if _fox_mean is not None else db.mean_consumption_kwh_from_execution_logs(limit=_profile_limit)
     if _load_profile:
-        logger.info(
-            "LP base_load: 48 buckets built; min=%.3f max=%.3f early-morning(03-07)=%s",
-            min(_load_profile.values()),
-            max(_load_profile.values()),
-            {f"{h:02d}:{m:02d}": round(_load_profile[(h, m)], 3)
-             for h in range(3, 8) for m in (0, 30) if (h, m) in _load_profile},
-        )
+        # Log only the (h, m) entries — the (h, m, kind) entries vary too
+        # widely to summarise in one line.
+        plain = {k: v for k, v in _load_profile.items() if len(k) == 2}
+        kind_count = sum(1 for k in _load_profile if len(k) == 3)
+        if plain:
+            logger.info(
+                "LP base_load: %d (h,m) buckets, %d (h,m,kind) buckets; "
+                "early-morning(03-07)=%s",
+                len(plain), kind_count,
+                {f"{h:02d}:{m:02d}": round(plain[(h, m)], 3)
+                 for h in range(3, 8) for m in (0, 30) if (h, m) in plain},
+            )
+
+    # Slot-kind classifier mirrors the LP's eventual classification so the
+    # base-load lookup is consistent with downstream slot-kind decisions.
+    _peak_thresh = float(getattr(config, "OPTIMIZATION_PEAK_THRESHOLD_PENCE", 25))
+    _cheap_thresh = float(getattr(config, "OPTIMIZATION_CHEAP_THRESHOLD_PENCE", 5))
+
+    def _classify_price(price_p: float) -> str:
+        if price_p < 0:
+            return "negative"
+        if price_p <= _cheap_thresh:
+            return "cheap"
+        if price_p >= _peak_thresh:
+            return "peak"
+        return "standard"
+
     base_load = []
     for s in slots:
         _local = s.start_utc.astimezone(tz)
-        _bucket = (_local.hour, 30 if _local.minute >= 30 else 0)
-        base_load.append(_load_profile.get(_bucket, _flat))
+        _hm = (_local.hour, 30 if _local.minute >= 30 else 0)
+        _kind = _classify_price(float(s.price_pence))
+        # Most-specific lookup first.
+        v = _load_profile.get((_hm[0], _hm[1], _kind))
+        if v is None:
+            v = _load_profile.get(_hm, _flat)
+        base_load.append(v)
     residual_base_load = list(base_load)
     appliance_profile_kwh = [0.0] * len(base_load)
 

--- a/tests/test_tariff_aware_load_profile.py
+++ b/tests/test_tariff_aware_load_profile.py
@@ -1,0 +1,133 @@
+"""Tariff-aware residual load profile (Phase B2 / #306 follow-up).
+
+Bucket-by-(hour, minute, slot_kind) so the LP captures household behaviour
+that shifts with tariff windows (cooking pulled into cheap quartile, evening
+peak avoidance). Falls back to plain (hour, minute) when a kind-specific
+bucket has fewer than ``min_samples_per_kind`` samples.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+def _save_pv_load(ts: datetime, load_kw: float) -> None:
+    db.save_pv_realtime_sample(
+        captured_at=ts.isoformat().replace("+00:00", "Z"),
+        solar_power_kw=0.0,
+        soc_pct=50.0,
+        load_power_kw=load_kw,
+        grid_import_kw=0.0,
+        grid_export_kw=0.0,
+        battery_charge_kw=0.0,
+        battery_discharge_kw=0.0,
+        source="test",
+    )
+
+
+def _save_exec_with_kind(ts: datetime, kind: str, agile_p: float = 20.0) -> None:
+    db.log_execution(
+        {
+            "timestamp": ts.isoformat().replace("+00:00", "Z"),
+            "consumption_kwh": 0.5,
+            "agile_price_pence": agile_p,
+            "slot_kind": kind,
+        }
+    )
+
+
+def _save_meteo(ts: datetime, temp_c: float = 12.0) -> None:
+    """Persist a forecast snapshot covering ts so the residual subtraction
+    has an outdoor-temp anchor."""
+    fetch_at = (ts - timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    rows = [
+        {
+            "slot_time": ts.replace(minute=0, second=0, microsecond=0).isoformat().replace("+00:00", "Z"),
+            "temp_c": temp_c,
+            "solar_w_m2": 0.0,
+            "cloud_cover_pct": 50.0,
+        }
+    ]
+    db.save_meteo_forecast_snapshot(fetch_at, rows, mark_latest=True)
+
+
+def test_tariff_aware_profile_separates_cheap_vs_peak_for_same_clock_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """13:00 cheap-day samples → 0.4 kWh; 13:00 peak-day samples → 1.2 kWh.
+    The (h, m, kind) bucket should reflect the difference; (h, m) median
+    blends both."""
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)  # 13:00 BST
+
+    # Seed 6 cheap-day samples with low load (cooking moved to cheap window
+    # so 13:00 is *more* expensive than usual? wait — let's invert:
+    # we'll model "13:00 is cheap; cooking pulls in here, so load is HIGH".
+    # 6 cheap-tagged samples with high load.
+    for i in range(6):
+        ts = base + timedelta(days=i)
+        _save_meteo(ts, temp_c=20.0)  # warm so Daikin draw ~ 0
+        _save_pv_load(ts, load_kw=2.4)  # 2.4 kW × 0.5 h = 1.2 kWh
+        _save_exec_with_kind(ts, kind="cheap", agile_p=4.0)
+
+    # 6 peak-tagged samples with low load (peak avoidance).
+    for i in range(6):
+        ts = base + timedelta(days=i + 7)
+        _save_meteo(ts, temp_c=20.0)
+        _save_pv_load(ts, load_kw=0.8)  # 0.8 kW × 0.5 h = 0.4 kWh
+        _save_exec_with_kind(ts, kind="peak", agile_p=30.0)
+
+    profile = db.tariff_aware_residual_load_profile_kwh(min_samples_per_kind=5)
+
+    # Expect both kind-aware buckets present (6 samples each ≥ 5)
+    cheap_key = (13, 0, "cheap")
+    peak_key = (13, 0, "peak")
+    plain_key = (13, 0)
+    assert cheap_key in profile, f"missing {cheap_key}"
+    assert peak_key in profile, f"missing {peak_key}"
+    assert plain_key in profile
+
+    assert profile[cheap_key] == pytest.approx(1.2, abs=0.05), profile[cheap_key]
+    assert profile[peak_key] == pytest.approx(0.4, abs=0.05), profile[peak_key]
+    # The kind-aware buckets meaningfully diverge — that's the point: LP
+    # forecast for "13:00 cheap" uses 1.2 kWh, "13:00 peak" uses 0.4 kWh,
+    # capturing the household behavioural shift. Plain median (n=12, lower-
+    # median index n//2 = 6th sorted value) equals the high-load group.
+    assert profile[cheap_key] != profile[peak_key]
+    assert profile[cheap_key] - profile[peak_key] > 0.5  # meaningful divergence
+
+
+def test_tariff_aware_profile_drops_buckets_below_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Buckets with <5 samples are dropped from the kind-aware index so the
+    LP gracefully falls back to the plain (h, m) median rather than over-
+    fitting to noise."""
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    # Only 3 cheap samples — below threshold
+    for i in range(3):
+        ts = base + timedelta(days=i)
+        _save_meteo(ts, temp_c=20.0)
+        _save_pv_load(ts, load_kw=2.4)
+        _save_exec_with_kind(ts, kind="cheap", agile_p=4.0)
+
+    profile = db.tariff_aware_residual_load_profile_kwh(min_samples_per_kind=5)
+
+    assert (13, 0, "cheap") not in profile
+    assert (13, 0) in profile  # plain fallback always available
+
+
+def test_tariff_aware_profile_returns_empty_when_no_samples() -> None:
+    """No history → empty dict. Caller falls back to legacy profile."""
+    profile = db.tariff_aware_residual_load_profile_kwh()
+    assert profile == {}


### PR DESCRIPTION
Phase B2 of the data-quality plan. Adds a per-(hour, minute, slot_kind) load-forecast bucket so the LP captures the household's tariff-driven behavioural shift (cooking pulled into cheap windows; peak-hour avoidance).

User-confirmed direction (2026-05-10): "future house load should be calculated to a given window of time. we have accurate information about load usage and pattern, we should be able to prepare it better. Lets say we want to know our morning behavior, afternoon and evening or something matching the tariff changes would be a good approach?"

## What changes

### `src/db.py`: new `tariff_aware_residual_load_profile_kwh()`

Joins `pv_realtime_history.load_power_kw` (residual = total minus Daikin physics, same as legacy) with `execution_log.slot_kind` retrospectively by half-hour bucket. Returns dict with possible keys:

- `(hour, minute)` — always present when samples exist
- `(hour, minute, kind)` — only when ≥ 5 samples; `kind` ∈ {negative, cheap, standard, peak}

### `src/scheduler/optimizer.py`: lookup uses kind-aware bucket first

```python
v = profile.get((hour, minute, classify(price)))   # most specific
if v is None: v = profile.get((hour, minute), flat) # plain → flat fallback
```

Cold-start: when `tariff_aware` returns empty (no slot_kind history yet), code transparently falls back to legacy `half_hourly_residual_load_profile_kwh`.

## Why this matters concretely

The brief from 2026-05-10 audit showed real divergences on certain weekdays where the family started moving cooking into the cheap-quartile window. The LP was forecasting low load there (because plain median was averaged across many days when the cheap window didn't see cooking) and getting blindsided when actual load arrived. Same in reverse for peak hours where evening behaviour now coasts on stored heat.

## Tests

3 new tests in `tests/test_tariff_aware_load_profile.py` (all pass):
- Separates cheap-vs-peak bucket medians for same clock time
- Drops kind-aware buckets below 5-sample threshold (graceful degradation)
- Returns empty when no samples (cold-start)

**860/860 full suite passes.**

## Plan reference

`/home/stkoverflow/.claude/plans/i-think-you-can-glowing-candy.md` Phase B2.

B3 (CoP audit) is a read-only verification — separate. B4 (regression baseline refresh) runs after B1+B2 both land in prod and we have a few days of observed behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)