### PR TITLE
feat(brief): surface Daikin budget-guard drops in morning brief (#309 partial)

### DIFF
--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -230,6 +230,13 @@ def _format_pnl_block(pnl: dict[str, Any], *, day: date, tz: ZoneInfo) -> list[s
     skill_line = _forecast_skill_line(day)
     if skill_line:
         out.append(skill_line)
+    # #309: surface dispatch budget-guard drops so the user sees when the
+    # Daikin quota was tight enough that low-value plan pairs were pruned.
+    # Critical NEGATIVE/PEAK pairs are always preserved; only CHEAP /
+    # SOLAR_PREHEAT pairs get dropped, so this is an FYI not an alarm.
+    budget_line = _budget_guard_summary_line(day)
+    if budget_line:
+        out.append(budget_line)
 
     # Forecasted-export fallback: telemetry sometimes drops grid_export_kw
     # samples, leaving export_kwh=0 even on days where the LP committed
@@ -349,6 +356,58 @@ def _forecast_skill_line(day: date) -> str | None:
     if not parts:
         return None
     return f"- Forecast skill ({len(rows)}h): {', '.join(parts)}"
+
+
+def _budget_guard_summary_line(day: date) -> str | None:
+    """Format a one-line summary of any Daikin budget-guard drops on ``day``.
+
+    Reads ``action_log`` rows tagged ``action='budget_guard_drop'`` written
+    by ``write_daikin_from_lp_plan`` when the dispatch quota guard pruned
+    low-value pairs. Aggregates across the day. Returns ``None`` when no
+    drop events were logged.
+    """
+    try:
+        rows = db.get_action_logs(device="daikin", trigger="lp_dispatch", limit=200)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    iso_prefix = day.isoformat()
+    drop_rows = [
+        r for r in rows
+        if str(r.get("action") or "") == "budget_guard_drop"
+        and str(r.get("timestamp") or "").startswith(iso_prefix)
+    ]
+    if not drop_rows:
+        return None
+
+    total_dropped = 0
+    min_headroom = 9999
+    drop_kinds: dict[str, int] = {}
+    for r in drop_rows:
+        params = r.get("params") or {}
+        try:
+            n = int(params.get("n_dropped") or 0)
+        except (TypeError, ValueError):
+            n = 0
+        total_dropped += n
+        try:
+            hr = int(params.get("headroom") or 0)
+            if hr < min_headroom:
+                min_headroom = hr
+        except (TypeError, ValueError):
+            pass
+        # Each "dropped" entry is "action_type@timestamp"; tally by action_type.
+        for entry in params.get("dropped") or []:
+            kind = str(entry).split("@", 1)[0] or "unknown"
+            drop_kinds[kind] = drop_kinds.get(kind, 0) + 1
+    if total_dropped == 0:
+        return None
+    kinds_str = ", ".join(f"{n}× {k}" for k, n in sorted(drop_kinds.items()))
+    return (
+        f"- ⚠️ Daikin quota: dropped {total_dropped} low-value pair(s) "
+        f"({kinds_str}); critical NEGATIVE/PEAK preserved (min headroom={min_headroom})"
+    )
 
 
 def _forecasted_export_for_day(day: date, tz: ZoneInfo) -> tuple[float, float, int]:

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -713,14 +713,29 @@ def write_daikin_from_lp_plan(
         # FYI — it doesn't require operator action because the guard
         # already handled the situation by dropping low-value actions.
         # Log to journalctl + action_log only; do NOT push to Telegram.
-        # Operators who care can grep ``journalctl -u hem | grep
-        # 'budget guard'`` or query api_call_log for the underlying quota
-        # state.
+        # The morning brief queries action_log for these rows so the user
+        # can see "Daikin quota: dropped N pair(s) today" without manually
+        # grepping journalctl.
         logger.info(
             "Daikin write-budget guard: dropped %d low-value action(s) "
             "(headroom=%d). Dropped: %s",
             len(dropped), headroom, ",".join(dropped),
         )
+        try:
+            db.log_action(
+                device="daikin",
+                action="budget_guard_drop",
+                params={
+                    "dropped": dropped,
+                    "headroom": headroom,
+                    "reserve": reserve,
+                    "n_dropped": len(dropped),
+                },
+                result="dropped",
+                trigger="lp_dispatch",
+            )
+        except Exception as _e:
+            logger.warning("budget_guard_drop log_action failed (non-fatal): %s", _e)
     count = 0
     for restore_row, action_row in pairs:
         # Restore may be None when the next action immediately supersedes it

--- a/tests/test_brief_budget_guard_line.py
+++ b/tests/test_brief_budget_guard_line.py
@@ -1,0 +1,97 @@
+"""Daily brief surfaces Daikin budget-guard drops as a pull-based warning.
+
+#309 partial: when the dispatch budget guard prunes low-value pairs (CHEAP /
+SOLAR_PREHEAT) due to tight Daikin quota, the morning brief shows a one-line
+summary so the user knows their plan was reshaped without being pinged on
+Telegram (see memory: feedback_low_push_load.md).
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.analytics import daily_brief
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+def _log_drop(when: datetime, *, n_dropped: int, headroom: int, kinds: list[str]) -> None:
+    """Insert a budget_guard_drop row for the given timestamp."""
+    dropped_entries = [f"{k}@{when.isoformat()}" for k in kinds]
+    db.log_action(
+        device="daikin",
+        action="budget_guard_drop",
+        params={
+            "dropped": dropped_entries,
+            "headroom": headroom,
+            "reserve": 30,
+            "n_dropped": n_dropped,
+        },
+        result="dropped",
+        trigger="lp_dispatch",
+    )
+    # Override timestamp by direct UPDATE (log_action sets to now).
+    with db._lock:
+        conn = db.get_connection()
+        try:
+            conn.execute(
+                "UPDATE action_log SET timestamp = ? WHERE rowid = (SELECT MAX(rowid) FROM action_log)",
+                (when.isoformat().replace("+00:00", "Z"),),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def test_budget_guard_line_summarises_drops_for_day() -> None:
+    """Two drop events on the same day → one summary line aggregating them."""
+    day = datetime(2026, 5, 10, 0, 0, tzinfo=UTC).date()
+    _log_drop(
+        datetime(2026, 5, 10, 6, 5, tzinfo=UTC),
+        n_dropped=3,
+        headroom=2,
+        kinds=["pre_heat", "pre_heat", "solar_preheat"],
+    )
+    _log_drop(
+        datetime(2026, 5, 10, 12, 0, tzinfo=UTC),
+        n_dropped=1,
+        headroom=1,
+        kinds=["solar_preheat"],
+    )
+
+    line = daily_brief._budget_guard_summary_line(day)
+
+    assert line is not None
+    assert "dropped 4 low-value pair(s)" in line
+    # min headroom across both events
+    assert "headroom=1" in line
+    assert "pre_heat" in line and "solar_preheat" in line
+
+
+def test_budget_guard_line_returns_none_when_no_drops() -> None:
+    day = datetime(2026, 5, 10, 0, 0, tzinfo=UTC).date()
+    assert daily_brief._budget_guard_summary_line(day) is None
+
+
+def test_budget_guard_line_only_today_not_yesterday() -> None:
+    """A drop yesterday must not appear in today's brief."""
+    today = datetime(2026, 5, 10, 0, 0, tzinfo=UTC).date()
+    _log_drop(
+        datetime(2026, 5, 9, 14, 0, tzinfo=UTC),
+        n_dropped=2,
+        headroom=5,
+        kinds=["pre_heat", "pre_heat"],
+    )
+
+    assert daily_brief._budget_guard_summary_line(today) is None
+    # But it appears for yesterday's brief
+    yesterday = today - timedelta(days=1)
+    line = daily_brief._budget_guard_summary_line(yesterday)
+    assert line is not None
+    assert "dropped 2" in line


### PR DESCRIPTION
Partial close of #309. The dispatch budget guard already prioritises NEGATIVE / PEAK pairs over CHEAP / SOLAR_PREHEAT — that's good. But yesterday's silent drop of all low-value pairs (post-Phase-A rolling-window quota crunch) was effectively invisible until I deep-grep'd journalctl. The user discovered "0 Daikin actions queued" only via diagnosis. Pull-based visibility belongs in the brief.

## What changes

### `src/scheduler/lp_dispatch.py`
`write_daikin_from_lp_plan` now logs a `budget_guard_drop` row to `action_log` per drop event:
```json
{"dropped": [...], "headroom": N, "reserve": M, "n_dropped": K}
```
Telegram push still suppressed (matches user pull-based preference). Journalctl logging unchanged.

### `src/analytics/daily_brief.py`
New `_budget_guard_summary_line(day)` aggregates today's drop rows:
```
- ⚠️ Daikin quota: dropped 4 low-value pair(s) (3× pre_heat, 1× solar_preheat); critical NEGATIVE/PEAK preserved (min headroom=1)
```

## Why this is needed now (not in 7 days)

The "observe 7 days, retune `DAIKIN_RESERVE_FOR_HEARTBEAT`" item in #309 still applies — that's a tuning question.

But the **silent-drop visibility gap** is fixable today and prevents a repeat of yesterday's diagnostic detour. The user shouldn't have to ssh + grep to know dispatch was pruned.

## Tests
- 3 new tests covering aggregation, no-drops, and per-day scoping
- 863/863 full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)