### PR TITLE
fix(config): bump DAIKIN_COP_CURVE_STR to Altherma 3 R EDLA11DA3 W35 spec (#312)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -819,9 +819,21 @@ class Config:
     # (mean difference between Daikin outdoor sensor and Open-Meteo forecast).
     DAIKIN_MICRO_CLIMATE_LOOKBACK: int = int(os.getenv("DAIKIN_MICRO_CLIMATE_LOOKBACK", "96"))
     DHW_TANK_UA_W_PER_K: float = float(os.getenv("DHW_TANK_UA_W_PER_K", "2.5"))
+    # Daikin Altherma 3 R EDLA11DA3 (11 kW R-32 split, low-temp).
+    # Values from manufacturer datasheet at W35 LWT (the operating range
+    # the user's weather curve produces — DAIKIN_WEATHER_CURVE_HIGH_LWT_C=22°C
+    # at A18°C, DAIKIN_WEATHER_CURVE_LOW_LWT_C=45°C at A-5°C).
+    # Source datasheet rows (A-T/W35):
+    #   A-7°C → COP 2.55,  A2°C → COP 3.54,  A7°C → COP 4.62,
+    #   A12°C → COP 4.98,  A20°C extrapolated → ~5.65
+    # Conservative ~5% derate applied to absorb real-world degradation +
+    # occasional DHW LWT lift (DHW penalty already covers W55 separately
+    # via ``COP_DHW_PENALTY``).
+    # Issue #312: prior placeholder curve was ~30% pessimistic at warm
+    # temps, biasing the LP toward over-provisioning electrical heating.
     DAIKIN_COP_CURVE_STR: str = os.getenv(
         "DAIKIN_COP_CURVE",
-        "-7:1.8,2:2.6,7:3.1,12:3.6,20:4.2",
+        "-7:2.4,2:3.4,7:4.3,12:4.7,20:5.2",
     )
     LP_OCCUPIED_MORNING_START: str = (os.getenv("LP_OCCUPIED_MORNING_START") or "06:30").strip()
     LP_OCCUPIED_MORNING_END: str = (os.getenv("LP_OCCUPIED_MORNING_END") or "08:30").strip()

--- a/tests/fixtures/lp_regression_baseline.json
+++ b/tests/fixtures/lp_regression_baseline.json
@@ -1,83 +1,83 @@
 {
   "days_back": 14,
-  "frozen_at_iso": "2026-05-10T09:43:57.007749+00:00",
-  "frozen_at_sha": "5a659a620c4ced5703993281f4d3f0a48aa99fb7",
+  "frozen_at_iso": "2026-05-10T10:43:53.324396+00:00",
+  "frozen_at_sha": "2384c50c5dbca153b8a6f16a9f268288b370b4e6",
   "per_date": {
     "2026-04-26": {
       "recalc_count": 21,
       "total_original_cost_p": 414.448505686299,
-      "total_replayed_cost_p": 189.7888951716099
+      "total_replayed_cost_p": 187.872741928815
     },
     "2026-04-27": {
       "recalc_count": 28,
       "total_original_cost_p": -3.244397772360004,
-      "total_replayed_cost_p": 31.867781108662502
+      "total_replayed_cost_p": 31.078304034879004
     },
     "2026-04-28": {
       "recalc_count": 21,
       "total_original_cost_p": 218.02443517591996,
-      "total_replayed_cost_p": 235.57032002529
+      "total_replayed_cost_p": 233.6502096896548
     },
     "2026-04-29": {
       "recalc_count": 15,
       "total_original_cost_p": 44.38751059609652,
-      "total_replayed_cost_p": 61.18631290506048
+      "total_replayed_cost_p": 59.19917084467648
     },
     "2026-04-30": {
       "recalc_count": 29,
       "total_original_cost_p": -65.80344537071902,
-      "total_replayed_cost_p": 70.65950136668097
+      "total_replayed_cost_p": 69.831577024475
     },
     "2026-05-01": {
       "recalc_count": 16,
       "total_original_cost_p": 106.39395686687499,
-      "total_replayed_cost_p": 117.4293447064185
+      "total_replayed_cost_p": 117.01553381653801
     },
     "2026-05-02": {
       "recalc_count": 28,
       "total_original_cost_p": 142.45791086247505,
-      "total_replayed_cost_p": 139.64679769593
+      "total_replayed_cost_p": 137.41392210440998
     },
     "2026-05-03": {
       "recalc_count": 18,
       "total_original_cost_p": 278.19815015286105,
-      "total_replayed_cost_p": 231.26571305508494
+      "total_replayed_cost_p": 229.605350167815
     },
     "2026-05-04": {
       "recalc_count": 15,
       "total_original_cost_p": 241.03035363538595,
-      "total_replayed_cost_p": 183.386825955123
+      "total_replayed_cost_p": 180.89766860764203
     },
     "2026-05-05": {
       "recalc_count": 16,
       "total_original_cost_p": 218.54022586813198,
-      "total_replayed_cost_p": 166.626471422817
+      "total_replayed_cost_p": 164.189789096823
     },
     "2026-05-06": {
       "recalc_count": 40,
       "total_original_cost_p": 470.28274986499804,
-      "total_replayed_cost_p": 303.06574635239
+      "total_replayed_cost_p": 300.48659998479496
     },
     "2026-05-07": {
       "recalc_count": 33,
       "total_original_cost_p": 353.86536378089295,
-      "total_replayed_cost_p": 218.6349428202954
+      "total_replayed_cost_p": 216.486853889376
     },
     "2026-05-08": {
       "recalc_count": 27,
       "total_original_cost_p": 208.9341804279004,
-      "total_replayed_cost_p": 101.21982897735
+      "total_replayed_cost_p": 99.93050172461501
     },
     "2026-05-09": {
       "recalc_count": 86,
       "total_original_cost_p": 56.15134596930167,
-      "total_replayed_cost_p": 82.56299323743148
+      "total_replayed_cost_p": 81.27492484396669
     },
     "2026-05-10": {
       "recalc_count": 5,
       "total_original_cost_p": -19.573012040970003,
-      "total_replayed_cost_p": 78.99790419817352
+      "total_replayed_cost_p": 77.49340992961051
     }
   },
-  "total_replayed_cost_p": 2132.9114748001443
+  "total_replayed_cost_p": 2186.4265576880916
 }

--- a/tests/test_daikin_passive_mode.py
+++ b/tests/test_daikin_passive_mode.py
@@ -152,14 +152,23 @@ def _solve_minimal(passive: bool):
 
 
 def test_lp_clamps_daikin_in_passive(passive_mode) -> None:
+    from src.config import config, cop_at_temperature
     from src.physics import predict_passive_daikin_load
 
     plan = _solve_minimal(passive=True)
     assert plan.ok and plan.status == "Optimal"
 
     n = len(plan.dhw_electric_kwh)
+    # Derive the same per-slot CoP the LP uses internally — the
+    # WeatherLpSeries.cop_* values get overridden by the LP from the
+    # configured DAIKIN_COP_CURVE (with COP_DHW_PENALTY applied to DHW),
+    # so the predict_passive_daikin_load call here must use the same
+    # source-of-truth values to produce comparable expected outputs.
+    base_cop = max(1.0, cop_at_temperature(config.DAIKIN_COP_CURVE, 5.0))
+    cop_space_curve = [base_cop] * n
+    cop_dhw_curve = [max(1.0, base_cop - float(config.COP_DHW_PENALTY))] * n
     exp_space, exp_dhw = predict_passive_daikin_load(
-        [5.0] * n, [2.5] * n, [3.0] * n, slot_h=0.5,
+        [5.0] * n, cop_dhw_curve, cop_space_curve, slot_h=0.5,
         max_kwh_per_slot=2.0 * 0.5,  # config.DAIKIN_MAX_HP_KW * slot_h
     )
     for i in range(n):


### PR DESCRIPTION
Closes #312.

User confirmed SKU: **Daikin Altherma 3 R EDLA11DA3C3** (11 kW R-32 split, low-temp). Old placeholder curve was meaningfully pessimistic.

## Datasheet vs old curve

| Outdoor | Datasheet A−T/W35 | Old | New |
|---|---|---|---|
| -7°C | 2.55 | 1.80 | **2.4** |
| 2°C | 3.54 | 2.60 | **3.4** |
| 7°C | 4.62 | 3.10 | **4.3** |
| 12°C | 4.98 | 3.60 | **4.7** |
| 20°C | ~5.65 | 4.20 | **5.2** |

W35 is the right reference because user's weather curve produces LWT 22–45°C — squarely W35 territory. ~5% derate absorbs real-world degradation + occasional DHW lift (DHW penalty is separate via `COP_DHW_PENALTY=0.5`).

## Verification

- **Regression baseline**: −£0.25 over 14 days vs post-#314 baseline (PASS). New baseline frozen.
- **863/863 full suite passes** after fixing one test (`test_lp_clamps_daikin_in_passive` was hardcoding `cop_dhw=2.5`; updated to derive from the curve so it stays a meaningful regression check).
- **LP behavior**: plans land slightly cheaper because the LP correctly attributes more thermal output per electrical kWh.

## Risk

If real-world CoP < W35 spec (aging unit, refrigerant under-charge), LP under-provisions heating → firmware imports the LP didn't predict.

Mitigation: ~5% spec derate; new audit line in brief (#308) surfaces forecast-vs-actual import deltas; `daikin_consumption_daily` table accumulates real kWh for future measured-CoP regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)