### PR TITLE
feat(lp): plan weekly legionella cycle as a tank-floor constraint

### DIFF
--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -695,6 +695,41 @@ def solve_lp(
             if shower_mask[i]:
                 prob += tank[i + 1] >= t_min_dhw
 
+        # Weekly legionella thermal-shock cycle. When ``DHW_LEGIONELLA_DAY``
+        # ∈ [0,6] (Mon..Sun, Python weekday convention), force tank ≥ target
+        # at the END of every slot whose start lies inside the cycle window.
+        # The LP figures out the cheapest pre-heat schedule (likely the
+        # cheap window leading up to the cycle) — the natural physics
+        # handles the rest. Disabled when DAY = -1 (default).
+        from .. import runtime_settings as _rts
+        try:
+            _leg_day = int(_rts.get_setting("DHW_LEGIONELLA_DAY"))
+        except (TypeError, ValueError):
+            _leg_day = -1
+        if 0 <= _leg_day <= 6:
+            try:
+                _leg_hour = int(_rts.get_setting("DHW_LEGIONELLA_HOUR_LOCAL"))
+                _leg_minutes = int(_rts.get_setting("DHW_LEGIONELLA_DURATION_MIN"))
+                _leg_target_c = float(_rts.get_setting("DHW_LEGIONELLA_TANK_TARGET_C"))
+            except (TypeError, ValueError):
+                _leg_hour, _leg_minutes, _leg_target_c = 13, 60, 60.0
+            _cycle_window_h = max(0.5, (_leg_minutes / 60.0))
+            for i, _st in enumerate(slot_starts_utc):
+                _local = _st.astimezone(tz)
+                if _local.weekday() != _leg_day:
+                    continue
+                _hour_frac = _local.hour + _local.minute / 60.0
+                if not (_leg_hour <= _hour_frac < _leg_hour + _cycle_window_h):
+                    continue
+                # Cap at tank_hi − 1°C: the variable's upper bound is tank_hi
+                # exactly, but space_floor + mode-mutex constraints can force
+                # additional DHW heating that would push tank above the bound
+                # mid-cycle. 1°C of headroom keeps the constraint satisfiable
+                # without losing the safety value (60°C is the legionella floor;
+                # tank_hi is 65°C, so a 1°C dip is well within margin).
+                _floor = min(_leg_target_c, tank_hi - 1.0)
+                prob += tank[i + 1] >= _floor
+
     # Per-slot DHW ceiling — three tiers:
     #   negative-price → DHW_TEMP_MAX_C (default 65 °C). Grid pays us; load all the kWh in.
     #   PV-abundant   → DHW_TEMP_PV_ABUNDANCE_TARGET_C (default 55 °C). Lower than negative

--- a/tests/test_lp_legionella_cycle.py
+++ b/tests/test_lp_legionella_cycle.py
@@ -1,0 +1,143 @@
+"""LP forces tank ≥ legionella target at the configured weekly cycle.
+
+When ``DHW_LEGIONELLA_DAY`` is set (0=Mon..6=Sun), the LP must plan enough
+pre-heat to reach ``DHW_LEGIONELLA_TANK_TARGET_C`` for the duration of the
+cycle, on the configured weekday + local hour. Active mode only — passive
+delegates to firmware.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db, runtime_settings as rts
+from src.config import config as app_config
+from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+from src.weather import WeatherLpSeries
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _fast_solver(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "LP_CBC_TIME_LIMIT_SECONDS", 15)
+    monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
+    monkeypatch.setattr(app_config, "LP_HP_MIN_ON_SLOTS", 1)
+    monkeypatch.setattr(app_config, "LP_SOC_TERMINAL_VALUE_PENCE_PER_KWH", 0.0)
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active")
+
+
+def _solve_sunday_with_legionella(
+    *,
+    tank_initial: float = 38.0,
+    leg_day: int = 6,
+    leg_hour: int = 13,
+    leg_target: float = 60.0,
+    leg_duration_min: int = 60,
+) -> tuple[list[datetime], list[float]]:
+    """Solve a Sunday horizon spanning the legionella window. Returns
+    (slot_starts_utc, tank_temp_c_per_slot_end)."""
+    rts.set_setting("DHW_LEGIONELLA_DAY", str(leg_day))
+    rts.set_setting("DHW_LEGIONELLA_HOUR_LOCAL", str(leg_hour))
+    rts.set_setting("DHW_LEGIONELLA_DURATION_MIN", str(leg_duration_min))
+    rts.set_setting("DHW_LEGIONELLA_TANK_TARGET_C", str(leg_target))
+
+    # 2026-05-10 is a Sunday in BST. Horizon 11:00 BST → 16:00 BST = 10 slots.
+    base = datetime(2026, 5, 10, 10, 0, tzinfo=UTC)  # 11:00 BST
+    n = 10
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    weather = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[15.0] * n,
+        shortwave_radiation_wm2=[400.0] * n,
+        cloud_cover_pct=[40.0] * n,
+        pv_kwh_per_slot=[1.0] * n,
+        cop_space=[3.5] * n,
+        cop_dhw=[3.0] * n,
+    )
+    initial = LpInitialState(soc_kwh=8.0, tank_temp_c=tank_initial)
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=[12.0] * n,
+        base_load_kwh=[0.4] * n,
+        weather=weather,
+        initial=initial,
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, f"LP did not solve: {plan.status}"
+    return slots, plan.tank_temp_c
+
+
+def test_legionella_lifts_tank_to_target_at_cycle_window() -> None:
+    """Sunday 13:00–14:00 BST: tank must reach ≥60°C."""
+    slots, tank = _solve_sunday_with_legionella(
+        tank_initial=38.0, leg_day=6, leg_hour=13, leg_target=60.0,
+        leg_duration_min=60,
+    )
+    tz = ZoneInfo("Europe/London")
+    cycle_indices = [
+        i for i, st in enumerate(slots)
+        if st.astimezone(tz).weekday() == 6
+        and 13 <= st.astimezone(tz).hour + st.astimezone(tz).minute / 60.0 < 14
+    ]
+    assert len(cycle_indices) >= 1
+    for i in cycle_indices:
+        # tank state at END of this slot (index i+1 in plan.tank_temp_c).
+        assert tank[i + 1] >= 60.0 - 1e-3, (
+            f"slot {i} ({slots[i].astimezone(tz)}) tank end-state {tank[i + 1]:.2f}°C "
+            f"below 60°C floor"
+        )
+
+
+def test_legionella_disabled_does_not_force_tank() -> None:
+    """When DHW_LEGIONELLA_DAY = -1, the LP isn't constrained to lift tank."""
+    rts.set_setting("DHW_LEGIONELLA_DAY", "-1")
+    base = datetime(2026, 5, 10, 10, 0, tzinfo=UTC)
+    n = 10
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    weather = WeatherLpSeries(
+        slot_starts_utc=slots,
+        temperature_outdoor_c=[15.0] * n,
+        shortwave_radiation_wm2=[400.0] * n,
+        cloud_cover_pct=[40.0] * n,
+        pv_kwh_per_slot=[1.0] * n,
+        cop_space=[3.5] * n,
+        cop_dhw=[3.0] * n,
+    )
+    initial = LpInitialState(soc_kwh=8.0, tank_temp_c=38.0)
+    plan = solve_lp(
+        slot_starts_utc=slots,
+        price_pence=[12.0] * n,
+        base_load_kwh=[0.4] * n,
+        weather=weather,
+        initial=initial,
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok
+    # Tank doesn't need to reach 60 (no legionella forcing).
+    assert max(plan.tank_temp_c) < 60.0, (
+        f"with legionella disabled, tank should not be lifted to 60°C, got {max(plan.tank_temp_c):.1f}"
+    )
+
+
+def test_legionella_target_above_tank_hi_caps_with_headroom() -> None:
+    """Target above tank_hi is capped to tank_hi - 1°C so the LP can satisfy
+    space_floor + mode-mutex without conflict. LP stays feasible; tank
+    reaches at least the capped target."""
+    slots, tank = _solve_sunday_with_legionella(
+        tank_initial=38.0, leg_day=6, leg_hour=13, leg_target=70.0,  # > tank_hi=65
+        leg_duration_min=60,
+    )
+    tz = ZoneInfo("Europe/London")
+    cycle_idx = [
+        i for i, st in enumerate(slots)
+        if st.astimezone(tz).weekday() == 6
+        and 13 <= st.astimezone(tz).hour + st.astimezone(tz).minute / 60.0 < 14
+    ][0]
+    # Capped at tank_hi - 1 = 64°C
+    assert tank[cycle_idx + 1] >= 64.0 - 1e-3


### PR DESCRIPTION
User asked: "it needs to plan legionella every SUN 1pm. the energy it will take is the diff of existing tank temp and the 60 degrees target and will keep 60 for 1h at least."

## What

Adds an active-mode LP constraint: when `DHW_LEGIONELLA_DAY` ∈ [0,6] (Mon=0…Sun=6), force `tank[i+1] >= target` for every slot whose START lies inside the cycle window `[hour, hour + duration_min/60)`.

The LP figures out the cheapest pre-heat schedule. Natural physics handles the lift size — no hardcoded "diff from DHW_TEMP_NORMAL_C" assumption.

Cap at `tank_hi - 1°C` so `space_floor + mode-mutex` constraints don't conflict when target = tank_hi. With typical target=60 and tank_hi=65, doesn't bite.

## Settings (runtime — applied post-deploy)

```
DHW_LEGIONELLA_DAY            = 6        # Sunday  (was -1 = disabled)
DHW_LEGIONELLA_HOUR_LOCAL     = 13       # 13:00 local
DHW_LEGIONELLA_DURATION_MIN   = 60       # 1 hour hold
DHW_LEGIONELLA_TANK_TARGET_C  = 60.0     # safety target
```

## Why constraint vs fixed-energy uplift

The existing `predict_passive_daikin_load` adds a fixed-energy bump assuming static lift from `DHW_TEMP_NORMAL_C` to target. That's fine for passive mode (LP can't decide DHW). In active mode, real lift depends on actual tank trajectory at cycle start. Hard-coding mis-estimates.

Constraint approach: LP plans optimal pre-heat (likely PV-abundance or cheap quartile leading to cycle), holds for the 1h duration via consecutive constraints.

## Tests

3 new (all pass):
- Lifts tank to target during cycle window
- Disabled (DAY=-1) → no forcing
- Target above tank_hi → capped with safe headroom

866/866 full suite. Regression baseline: PASS, no impact on 14-day window (doesn't cross a Sunday 13:00 BST cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)