### PR TITLE
feat(dhw+forecast): runtime-tunable PV abundance target + night temp bias (#325 + #324)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,9 +211,27 @@ DHW_PEAK_TANK_STRATEGY=shutdown                 # `shutdown` cuts tank power dur
                                                  # -1.97 °C/h), still ≥ 44 °C for evening showers.
                                                  # IMPORTANT: tank pre-charge above 45 °C only happens when there's
                                                  # an economic reason — `negative` (paid to import → 65 °C max),
-                                                 # `solar_charge` (free PV → 55 °C), `cheap` (modest → 48 °C). Peak
-                                                 # avoidance does NOT trigger pre-charging — see issue #322 for
-                                                 # conditional shutdown commit based on tank state at peak entry.
+                                                 # `solar_charge` (free PV → DHW_TEMP_PV_ABUNDANCE_TARGET_C, default
+                                                 # 45 → runtime-tunable per household occupancy), `cheap` (modest
+                                                 # → 48 °C). Peak avoidance does NOT trigger pre-charging — see
+                                                 # issue #322 for conditional shutdown commit.
+DHW_TEMP_PV_ABUNDANCE_TARGET_C=45               # tank target during solar_charge / solar_preheat slots. Runtime-
+                                                 # tunable via runtime_settings (PUT /api/v1/settings or MCP
+                                                 # `set_setting`). Raise per household: single ~42, family of 4
+                                                 # ~50, larger ~55. Default lowered from 55 → 45 (#325, 2026-05-12)
+                                                 # after Daikin telemetry showed overnight DHW reheat = 0 even at 45.
+
+# --- Forecast night bias (issue #324, minimal) ---
+FORECAST_NIGHT_TEMP_BIAS_C=-3.0                 # subtract this from Open Meteo's `temperature_c` when the LP
+                                                 # reads forecast slots inside the configured night window. The
+                                                 # ~10 km grid Open Meteo runs on tends to under-estimate how cold
+                                                 # the W4 1DZ microclimate gets overnight (observed 2026-05-12:
+                                                 # forecast 8 °C vs Daikin sensor 5 °C). Daikin's weather curve
+                                                 # still reacts to its OWN sensor — this is a planning-side
+                                                 # correction so the LP budgets heat-pump electric demand
+                                                 # realistically. Zero = disable.
+FORECAST_NIGHT_START_HOUR_UTC=21                # bias active from (inclusive)
+FORECAST_NIGHT_END_HOUR_UTC=6                   # bias active until (exclusive); wraps midnight when start > end
 
 # --- Scenario LP for peak-export robustness (see docs/DISPATCH_DECISIONS.md) ---
 LP_SCENARIO_OPTIMISTIC_TEMP_DELTA_C=1.0          # +°C applied to outdoor forecast

--- a/src/config.py
+++ b/src/config.py
@@ -597,9 +597,9 @@ class Config:
     # default 55 °C gives margin for guests + minor forecast error while
     # avoiding the heavy standing losses of holding 65 °C through the day.
     # Lower this toward 45 °C if standing-loss bleed-back becomes a concern.
-    DHW_TEMP_PV_ABUNDANCE_TARGET_C: float = float(
-        os.getenv("DHW_TEMP_PV_ABUNDANCE_TARGET_C", "55.0")
-    )
+    # DHW_TEMP_PV_ABUNDANCE_TARGET_C is now runtime-tunable via runtime_settings
+    # (see @property below). Default lowered from 55 → 45 (= DHW_TEMP_NORMAL_C);
+    # override per household occupancy at runtime without restart.
     # Strategy for tank during peak / peak_export windows (climate is always
     # off during peak — this is just about the tank):
     #   "idle" (default) — tank_power=True, target=DHW_TEMP_MIN_FLOOR_C (30°C).
@@ -621,6 +621,23 @@ class Config:
     #   45 °C effectively disables the override.
     DHW_TANK_OVERNIGHT_TARGET_C: float = float(
         os.getenv("DHW_TANK_OVERNIGHT_TARGET_C", "38.0")
+    )
+    # Forecast night-temperature bias (minimal #324 implementation).
+    # Open Meteo's grid coverage (~10 km) over-estimates the W4 1DZ
+    # microclimate's overnight outdoor temperature by ~3 °C in the household's
+    # forecast_skill_log (2026-05-12: pred 8.1 °C / actual 5.0 °C at 23 UTC).
+    # The bias is applied when the LP reads the forecast for slots inside the
+    # configured night window — the Daikin sensor still drives the actual
+    # weather curve, so this only corrects the LP's planning side, no
+    # comfort impact. Set the bias to 0.0 to disable.
+    FORECAST_NIGHT_TEMP_BIAS_C: float = float(
+        os.getenv("FORECAST_NIGHT_TEMP_BIAS_C", "-3.0")
+    )
+    FORECAST_NIGHT_START_HOUR_UTC: int = int(
+        os.getenv("FORECAST_NIGHT_START_HOUR_UTC", "21")
+    )
+    FORECAST_NIGHT_END_HOUR_UTC: int = int(
+        os.getenv("FORECAST_NIGHT_END_HOUR_UTC", "6")
     )
     # Toggle the post-shower overnight override. Default true. Set to false
     # to let overnight slots fall back to plain "standard" (no Daikin write,
@@ -989,6 +1006,14 @@ class Config:
     @DHW_TEMP_NORMAL_C.setter
     def DHW_TEMP_NORMAL_C(self, value: float) -> None:
         self._rt_set("DHW_TEMP_NORMAL_C", float(value))
+
+    @property
+    def DHW_TEMP_PV_ABUNDANCE_TARGET_C(self) -> float:
+        return float(self._rt_get("DHW_TEMP_PV_ABUNDANCE_TARGET_C"))
+
+    @DHW_TEMP_PV_ABUNDANCE_TARGET_C.setter
+    def DHW_TEMP_PV_ABUNDANCE_TARGET_C(self, value: float) -> None:
+        self._rt_set("DHW_TEMP_PV_ABUNDANCE_TARGET_C", float(value))
 
     @property
     def INDOOR_SETPOINT_C(self) -> float:

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -352,6 +352,29 @@ SCHEMA: dict[str, SettingSpec] = {
             "legionella thermal-shock cycle handles pasteurisation)."
         ),
     ),
+    # PV abundance target — applied during ``solar_charge`` slots when free
+    # PV would otherwise be exported. Runtime-tunable per household occupancy:
+    # a 4-person household with evening shower load benefits from 50 °C; a
+    # solo dweller might drop to 42 to minimise standing loss. Default 45
+    # matches DHW_TEMP_NORMAL_C — assume "no extra °C unless household demands
+    # it". Bumped from a previous env-only default of 55, since 14-day Daikin
+    # consumption telemetry showed overnight DHW reheat = 0 even when tank
+    # exited PV-abundance windows at 45-48 °C.
+    "DHW_TEMP_PV_ABUNDANCE_TARGET_C": SettingSpec(
+        key="DHW_TEMP_PV_ABUNDANCE_TARGET_C",
+        type_name="float",
+        env_default=_float_env("DHW_TEMP_PV_ABUNDANCE_TARGET_C", "45"),
+        min_value=40.0,
+        max_value=60.0,
+        description=(
+            "Daikin tank target (°C) during solar_charge / solar_preheat "
+            "slots — PV-abundance window where free PV otherwise exports. "
+            "Default 45 (= DHW_TEMP_NORMAL_C). Raise per household size: "
+            "single/couple ~42, family of 4 ~48-50, larger ~55. Capped at "
+            "60 to keep the tank well below the legionella thermal-shock "
+            "ceiling and protect long-term tank life."
+        ),
+    ),
 }
 
 

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -455,7 +455,8 @@ def daikin_dispatch_preview(
             params["tank_power"] = True
             # Floor at DHW_TEMP_COMFORT_C (48 °C). Ceiling depends on slot kind:
             #   negative      → DHW_TEMP_MAX_C (65 °C). Grid pays us; load all the kWh.
-            #   solar_charge  → DHW_TEMP_PV_ABUNDANCE_TARGET_C (55 °C). PV is free
+            #   solar_charge  → DHW_TEMP_PV_ABUNDANCE_TARGET_C (45 °C default,
+            #                   runtime-tunable per household occupancy). PV is free
             #                   but holding 65 °C through afternoon bleeds standing
             #                   losses before evening showers. Cap at 55 °C captures
             #                   with margin without that bleed-back. Hard clamp

--- a/src/weather.py
+++ b/src/weather.py
@@ -1675,9 +1675,28 @@ def forecast_to_lp_inputs(
     # (falls back to capacity × η × 0.5 kWh/slot if no history available)
     hourly_ceil = _build_pv_hourly_ceiling()
 
+    # #324: night-temperature bias. Open Meteo under-estimates how cold the
+    # local microclimate gets overnight; without this correction the LP plans
+    # too-warm scenarios and the battery depletes faster than budgeted
+    # (observed 2026-05-12: pred 8 °C vs sensor 5 °C overnight). The bias is
+    # applied ONLY when the LP reads the forecast — the actual heat pump
+    # weather curve reacts to its own sensor, so this is a planning-side
+    # correction with no comfort impact. Set bias=0 to disable.
+    _night_bias = float(getattr(config, "FORECAST_NIGHT_TEMP_BIAS_C", 0.0))
+    _night_start = int(getattr(config, "FORECAST_NIGHT_START_HOUR_UTC", 21))
+    _night_end = int(getattr(config, "FORECAST_NIGHT_END_HOUR_UTC", 6))
+    _night_wraps_midnight = _night_start > _night_end
+
+    def _is_night_hour(h: int) -> bool:
+        if _night_wraps_midnight:
+            return h >= _night_start or h < _night_end
+        return _night_start <= h < _night_end
+
     for i in range(n):
         st = slot_starts_utc[i]
         temp_c = _interp_hourly_scalar(forecast, st, "temperature_c", 10.0)
+        if _night_bias != 0.0 and _is_night_hour(st.hour):
+            temp_c += _night_bias
         rad_wm2 = _interp_hourly_scalar(forecast, st, "shortwave_radiation_wm2", 0.0)
         cloud_pct = _interp_hourly_scalar(forecast, st, "cloud_cover_pct", 50.0)
         nearest = get_forecast_for_slot(st, forecast)

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -714,6 +714,13 @@ def test_dispatch_solar_preheat_picks_max_dhw_across_merged_window(
 
     monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
     monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
+    # Pin the PV-abundance ceiling at 55 °C for this test's invariant. Default
+    # was lowered to 45 °C in #325 (runtime-tunable per household occupancy);
+    # this test still asserts the OLD invariant ("dispatch emits the LP's
+    # mid-window peak target across the merged window"), which only triggers
+    # when the ceiling exceeds the peak (47.9). Households can still bump the
+    # ceiling at runtime via runtime_settings if they want this behaviour.
+    monkeypatch.setattr(app_config, "DHW_TEMP_PV_ABUNDANCE_TARGET_C", 55.0, raising=False)
     monkeypatch.setattr(
         "src.scheduler.lp_dispatch._optimization_preset_away_like",
         lambda: False,

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -94,6 +94,20 @@ def test_config_property_reads_runtime_value():
     assert config.DHW_TEMP_COMFORT_C == 52.5
 
 
+def test_dhw_temp_pv_abundance_target_runtime_tunable():
+    """#325: solar_preheat target tunes per household occupancy at runtime."""
+    # Default = 45 (matches DHW_TEMP_NORMAL_C — no extra °C unless household needs it)
+    assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 45.0
+    # Bump for a family of 4 with evening showers
+    rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 50.0)
+    assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 50.0
+    # Range guards (40..60)
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 35.0)
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 65.0)
+
+
 def test_config_enum_property_round_trip():
     rts.set_setting("OPTIMIZATION_PRESET", "guests")
     assert config.OPTIMIZATION_PRESET == "guests"

--- a/tests/test_weather_cop_preprocess.py
+++ b/tests/test_weather_cop_preprocess.py
@@ -33,6 +33,70 @@ def test_forecast_cop_lift_disabled_matches_legacy_subtract(monkeypatch: pytest.
         assert s.cop_dhw[i] == pytest.approx(max(1.0, s.cop_space[i] - 0.5))
 
 
+def test_forecast_night_temp_bias_applied_to_night_slots_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#324: FORECAST_NIGHT_TEMP_BIAS_C shifts the LP's outdoor reading for
+    night slots only — daytime slots stay at forecast value. The Daikin
+    weather curve reacts to its own sensor regardless, so this is a
+    planning-side correction with no comfort impact.
+    """
+    monkeypatch.setattr(app_config, "LP_COP_LIFT_PENALTY_PER_KELVIN", 0.0)
+    monkeypatch.setattr(app_config, "FORECAST_NIGHT_TEMP_BIAS_C", -3.0)
+    monkeypatch.setattr(app_config, "FORECAST_NIGHT_START_HOUR_UTC", 21)
+    monkeypatch.setattr(app_config, "FORECAST_NIGHT_END_HOUR_UTC", 6)
+
+    # Three slots: 22 UTC (night), 12 UTC (day), 03 UTC (night)
+    base_day = datetime(2026, 1, 10, 0, 0, tzinfo=UTC)
+    slots = [
+        base_day.replace(hour=22),
+        base_day.replace(hour=12),
+        base_day.replace(hour=3),
+    ]
+    forecast = [
+        HourlyForecast(
+            time_utc=t,
+            temperature_c=10.0,
+            cloud_cover_pct=40.0,
+            shortwave_radiation_wm2=100.0,
+            estimated_pv_kw=0.2,
+            heating_demand_factor=0.5,
+        )
+        for t in slots
+    ]
+    s = forecast_to_lp_inputs(forecast, slots)
+    # Night slots have -3 °C bias applied.
+    assert s.temperature_outdoor_c[0] == pytest.approx(7.0)  # 22 UTC → night
+    assert s.temperature_outdoor_c[2] == pytest.approx(7.0)  # 03 UTC → night
+    # Day slot stays at forecast value.
+    assert s.temperature_outdoor_c[1] == pytest.approx(10.0)  # 12 UTC → day
+
+
+def test_forecast_night_temp_bias_disabled_when_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting bias to 0 disables the correction (regression guard for ops
+    who want the legacy behaviour)."""
+    monkeypatch.setattr(app_config, "LP_COP_LIFT_PENALTY_PER_KELVIN", 0.0)
+    monkeypatch.setattr(app_config, "FORECAST_NIGHT_TEMP_BIAS_C", 0.0)
+    base = datetime(2026, 1, 10, 23, 0, tzinfo=UTC)  # night hour
+    slots = [base + timedelta(minutes=30 * i) for i in range(2)]
+    forecast = [
+        HourlyForecast(
+            time_utc=t,
+            temperature_c=10.0,
+            cloud_cover_pct=40.0,
+            shortwave_radiation_wm2=100.0,
+            estimated_pv_kw=0.0,
+            heating_demand_factor=0.5,
+        )
+        for t in slots
+    ]
+    s = forecast_to_lp_inputs(forecast, slots)
+    for t in s.temperature_outdoor_c:
+        assert t == pytest.approx(10.0)
+
+
 def test_forecast_cop_lift_reduces_cop_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app_config, "LP_COP_LIFT_PENALTY_PER_KELVIN", 0.02)
     monkeypatch.setattr(app_config, "LP_COP_LIFT_REFERENCE_DELTA_K", 20.0)


### PR DESCRIPTION
## Summary

Two epic [#327](https://github.com/albinati/home-energy-manager/issues/327) follow-ups, both **data-informed** from the household's Fox + Daikin overnight history (Jan-May 2026):

### 1. #325 — Make `DHW_TEMP_PV_ABUNDANCE_TARGET_C` runtime-tunable + lower default 55 → 45

- Property + setter pattern mirroring `DHW_TEMP_NORMAL_C` / `DHW_TEMP_COMFORT_C`.
- Default lowered to 45 °C: the user's preference ("tank > 45 só quando tem motivo econômico") + 14-day Daikin telemetry showed overnight DHW reheat = 0 even when tank exited PV-abundance windows at 45-48 °C.
- Tunes via `PUT /api/v1/settings` or MCP `set_setting(key="DHW_TEMP_PV_ABUNDANCE_TARGET_C", value=N, confirmed=True)` — range 40-60 °C. Use case: bump to 50 for a family of 4 during summer school holidays; drop to 42 when alone.

### 2. #324 (minimal) — Add `FORECAST_NIGHT_TEMP_BIAS_C` constant for night-hour planning

- Subtracts a fixed bias (default `-3.0` °C) from Open Meteo's `temperature_c` when the LP reads forecast slots inside the configured night window (default 21-06 UTC; wraps midnight).
- Applied in `weather.forecast_to_lp_inputs` at the same point the LP consumes the forecast.
- Daikin's own weather curve **still** reads the local sensor, so this is a **planning-side correction** only — no comfort impact, no LWT writes.
- Zero = disable the correction (preserves legacy behaviour for ops who want it).

## Why now (data anchor)

| Source | Number |
|---|---|
| Overnight (22-06 UTC) load March 2026 (winter) | **10.86 kWh/night** (78 % heat-pump) |
| Forecast skill (2026-05-12 morning brief) | 24h MAE 1.7 °C |
| Forecast vs sensor at 23 UTC last night | **predicted 8.1 °C vs actual 5.0 °C** — exactly the 3 °C night bias |
| LP SoC trajectory vs plan overnight | -0.5 to -1.5 kWh divergence (battery hit floor earlier than budgeted) |

Both knobs default to values that match what we observed last night — neither is speculative.

## What this is NOT

- **NOT** dynamic LWT compensation at heartbeat (#326 — closed, deferred, see comment for math).
- **NOT** rolling 14-day bias calibration — that's a future enhancement. This is the simplest possible version: one env var, applied to a fixed hour window.
- **NOT** a comfort change — `lwt_offset` is still strictly hands-off (PR #321 contract intact).

## Tests

- `test_runtime_settings.py::test_dhw_temp_pv_abundance_target_runtime_tunable` — round-trip + range validation
- `test_weather_cop_preprocess.py::test_forecast_night_temp_bias_applied_to_night_slots_only` — bias hits night slots only, day slots untouched
- `test_weather_cop_preprocess.py::test_forecast_night_temp_bias_disabled_when_zero` — zero bias preserves legacy behaviour

Full suite green locally (modulo the pre-existing `test_mcp_singleton` orphan that's unrelated).

## CLAUDE.md

Both knobs documented in the `.env` reference section.

## Follow-up

- #322 conditional shutdown commit
- #323 idle window regen bug
- #328 brief Mode text fix
- #326 deferred until October 2026 (re-eval with cold-weather telemetry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
