### PR TITLE
fix(notify): clean Telegram message rendering

### DIFF
--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -60,8 +60,11 @@ def build_morning_payload() -> str:
     # Peak-export commitments from the latest LP run with peak_export slots.
     pe_summary = _peak_export_commitments_for_today(today, tz)
 
+    # No "## Morning brief" headline here — the notifier prepends "🌅 Morning
+    # brief" (Telegram) and the action_log/journalctl entries already carry the
+    # ``[morning_report]`` alert-type tag. Duplicating the title produced a
+    # stacked header on Telegram (#330).
     lines: list[str] = [
-        "## ☀️ Morning brief",
         f"**Today ({today})**",
         strategy,
         "",
@@ -132,8 +135,10 @@ def build_night_payload() -> str:
 
     pe_today = _peak_export_outcomes_for_today(today, tz)
 
+    # No "## Night brief" headline — same reason as the morning brief above
+    # (#330): the notifier prepends "🌙 Night brief" on the Telegram path and
+    # the alert-type tag is on the action_log entry already.
     lines: list[str] = [
-        "## 🌙 Night brief",
         f"**Today ({today})** — actuals",
         "",
         _mode_status_line(),

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -236,21 +236,41 @@ def _build_telegram_dispatch_body(
     *,
     urgent: bool,
     extra: dict[str, Any] | None,
+    header_override: str | None = None,
 ) -> str:
     """Compose a Telegram message for ``_dispatch`` flows.
 
     Strips the ``[HH:MM] [info] energy-manager [kind]`` debug prefix that the
-    OpenClaw path used (the LLM ignored it anyway). Headline + caller body +
-    optional structured ``extra`` rendered as an inline code block. The string
-    returned is HEM-flavoured Markdown — ``send_message`` does the HTML escape.
+    OpenClaw path used (the LLM ignored it anyway). The structured ``extra``
+    dict is **not** rendered on the Telegram path — callers already include
+    the relevant facts in *message*; ``extra`` exists only for the OpenClaw
+    hook + action_log payloads (#330).
+
+    ``header_override`` lets a caller swap the static ``_TELEGRAM_HEADERS[...]``
+    headline for one that carries dynamic context — e.g. the appliance name
+    (``🧺 Washing machine armed``) instead of the generic class
+    (``🧺 Appliance armed``). Set to a non-empty string to override; ``None``
+    (default) keeps the static lookup.
     """
-    head = _telegram_header_for(alert_key)
+    if header_override:
+        head = header_override
+    else:
+        head = _telegram_header_for(alert_key)
     if urgent and not head.startswith(("🚨", "⚠️")):
         head = f"🚨 {head}"
-    parts = [f"**{head}**", message]
-    if extra:
-        snippet = json.dumps(extra, default=str)[:400]
-        parts.append(f"`{snippet}`")
+    # Drop a body's own leading ``## ...`` headline if it duplicates the
+    # dispatcher header (the briefs used to embed their own `## ☀️ Morning
+    # brief` line; #330 strips it from the source, but defensive cleanup here
+    # keeps any straggler — or third-party caller — from producing two
+    # stacked headers.
+    stripped = message.lstrip("\n")
+    if stripped.startswith("##"):
+        first_nl = stripped.find("\n")
+        if first_nl == -1:
+            stripped = ""
+        else:
+            stripped = stripped[first_nl + 1 :]
+    parts = [f"**{head}**", stripped]
     return "\n".join(p for p in parts if p)
 
 
@@ -477,6 +497,7 @@ def _dispatch(
     *,
     urgent: bool = False,
     extra: dict[str, Any] | None = None,
+    telegram_header_override: str | None = None,
 ) -> None:
     full_msg = _compose_delivery_body(kind, message, urgent=urgent, extra=extra)
     _record_notification(kind, message, urgent=urgent, extra=extra, full_msg=full_msg)
@@ -488,7 +509,9 @@ def _dispatch(
     # Direct Telegram is preferred when configured — bypasses OpenClaw LLM.
     if telegram_transport.is_configured():
         body = _build_telegram_dispatch_body(
-            kind.value, message, urgent=urgent, extra=extra
+            kind.value, message,
+            urgent=urgent, extra=extra,
+            header_override=telegram_header_override,
         )
         telegram_transport.send_message(body, silent=silent)
         return
@@ -546,11 +569,15 @@ def notify_appliance_starting(
 
     Inlines a 4-line forward-looking brief so the family sees today + tomorrow
     tariff windows and the running PnL alongside the start confirmation.
+
+    Telegram headline carries the appliance name dynamically (``🧺 Washing
+    machine starting``) so the body doesn't have to repeat ``🧺 **Name**`` on
+    a second line. The static map's ``🧺 Appliance starting`` is still the
+    fallback for OpenClaw / action_log consumers (#330 follow-up).
     """
     body_lines = [
-        f"🧺 **{appliance_name}** starting now",
-        f"Window: {planned_start_local} → end ≤ {deadline_local}",
-        f"Cycle: {duration_minutes} min · avg {avg_price_pence:.1f}p/kWh",
+        f"{planned_start_local} → end ≤ {deadline_local}",
+        f"{duration_minutes} min · avg {avg_price_pence:.1f}p/kWh",
     ]
     if brief_md:
         body_lines.extend(["", brief_md])
@@ -562,7 +589,10 @@ def notify_appliance_starting(
         "avg_price_pence": round(float(avg_price_pence), 2),
         "duration_minutes": int(duration_minutes),
     }
-    _dispatch(AlertType.APPLIANCE_STARTING, body, urgent=False, extra=extra)
+    _dispatch(
+        AlertType.APPLIANCE_STARTING, body, urgent=False, extra=extra,
+        telegram_header_override=f"🧺 {appliance_name} starting",
+    )
 
 
 def notify_appliance_finished(
@@ -601,7 +631,6 @@ def notify_appliance_finished(
     else:
         cost_line = ""
     body_lines = [
-        f"✅ **{appliance_name}** cycle complete",
         f"{started_local} → {ended_local} ({duration_minutes} min)" + (f" · {cost_line}" if cost_line else ""),
     ]
     if brief_md:
@@ -620,7 +649,10 @@ def notify_appliance_finished(
     if estimated_cost_p is not None:
         key = "actual_cost_pence" if kwh_is_measured else "estimated_cost_pence"
         extra[key] = round(float(estimated_cost_p), 2)
-    _dispatch(AlertType.APPLIANCE_FINISHED, body, urgent=False, extra=extra)
+    _dispatch(
+        AlertType.APPLIANCE_FINISHED, body, urgent=False, extra=extra,
+        telegram_header_override=f"✅ {appliance_name} cycle complete",
+    )
 
 
 def notify_appliance_armed(
@@ -639,15 +671,10 @@ def notify_appliance_armed(
     row OR when an existing job's planned window shifted via re-plan (in which
     case ``replan=True`` so OpenClaw can phrase the message as a revision).
     """
-    headline = "🧺 **{name}** {verb} for {start} → {end}".format(
-        name=appliance_name,
-        verb="re-armed" if replan else "armed",
-        start=planned_start_local,
-        end=planned_end_local,
-    )
+    verb = "re-armed" if replan else "armed"
     body = "\n".join([
-        headline,
-        f"Cycle: {duration_minutes} min · avg {avg_price_pence:.1f}p/kWh · deadline {deadline_local}",
+        f"{planned_start_local} → {planned_end_local} ({duration_minutes} min)",
+        f"avg {avg_price_pence:.1f}p/kWh · deadline {deadline_local}",
     ])
     extra = {
         "appliance": appliance_name,
@@ -658,7 +685,10 @@ def notify_appliance_armed(
         "avg_price_pence": round(float(avg_price_pence), 2),
         "replan": bool(replan),
     }
-    _dispatch(AlertType.APPLIANCE_ARMED, body, urgent=False, extra=extra)
+    _dispatch(
+        AlertType.APPLIANCE_ARMED, body, urgent=False, extra=extra,
+        telegram_header_override=f"🧺 {appliance_name} {verb}",
+    )
 
 
 def notify_appliance_cancelled(
@@ -674,7 +704,7 @@ def notify_appliance_cancelled(
     ``replanned`` — LP picked a different window; new ARMED hook follows
     ``deadline_passed`` — deadline expired before a feasible window opened
     """
-    body_lines = [f"🚫 **{appliance_name}** cycle cancelled", f"Reason: {reason}"]
+    body_lines = [f"Reason: {reason}"]
     if planned_start_local:
         body_lines.append(f"Was scheduled for {planned_start_local}")
     body = "\n".join(body_lines)
@@ -684,7 +714,10 @@ def notify_appliance_cancelled(
     }
     if planned_start_local:
         extra["planned_start_local"] = planned_start_local
-    _dispatch(AlertType.APPLIANCE_CANCELLED, body, urgent=False, extra=extra)
+    _dispatch(
+        AlertType.APPLIANCE_CANCELLED, body, urgent=False, extra=extra,
+        telegram_header_override=f"🚫 {appliance_name} cancelled",
+    )
 
 
 def notify_plan_revision(body: str, *, trigger_reason: str | None = None) -> None:
@@ -736,7 +769,11 @@ def push_negative_window_start(
 def notify_strategy_update(summary: str, warnings: Any = None) -> None:
     msg = summary
     if warnings:
-        msg += f"\nWarnings: {warnings}"
+        if isinstance(warnings, (list, tuple)):
+            bullet_lines = "\n".join(f"  • {w}" for w in warnings)
+            msg += f"\n\nWarnings ({len(warnings)}):\n{bullet_lines}"
+        else:
+            msg += f"\n\nWarnings: {warnings}"
     _dispatch(AlertType.STRATEGY_UPDATE, msg, extra={"warnings": warnings} if warnings else None)
 
 

--- a/src/telegram_transport.py
+++ b/src/telegram_transport.py
@@ -30,6 +30,9 @@ _TELEGRAM_MAX_CHARS = 4096
 # would render as malformed entities. The OpenClaw LLM didn't use italic either.
 _BOLD_RE = re.compile(r"\*\*([^*\n][^*]*?)\*\*")
 _CODE_RE = re.compile(r"`([^`\n]+?)`")
+# Markdown ATX headers (``## Title``, ``### Sub``). Telegram HTML has no header
+# tags; without this conversion the leading ``#`` characters show up literally.
+_HEADER_RE = re.compile(r"^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$", re.MULTILINE)
 
 
 def is_configured() -> bool:
@@ -51,6 +54,7 @@ def markdown_to_html(text: str) -> str:
     if not text:
         return ""
     escaped = html.escape(text, quote=False)
+    escaped = _HEADER_RE.sub(r"<b>\1</b>", escaped)
     escaped = _BOLD_RE.sub(r"<b>\1</b>", escaped)
     escaped = _CODE_RE.sub(r"<code>\1</code>", escaped)
     return escaped

--- a/tests/test_appliance_notifications.py
+++ b/tests/test_appliance_notifications.py
@@ -33,6 +33,10 @@ def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 # ---------- Notifier helpers ----------
 
 def test_notify_appliance_starting_dispatches_with_correct_alert_type() -> None:
+    """Post-#330: appliance name + action verb live in the Telegram header
+    (dispatcher prepends ``🧺 Washer starting``); the body carries only the
+    schedule details so the message has no duplicated ``🧺 **Washer** starting``
+    second-line lead."""
     with patch("src.notifier._dispatch") as mock_dispatch:
         notify_appliance_starting(
             appliance_name="Washer",
@@ -46,12 +50,15 @@ def test_notify_appliance_starting_dispatches_with_correct_alert_type() -> None:
     args, kwargs = mock_dispatch.call_args
     assert args[0] == AlertType.APPLIANCE_STARTING
     body = args[1]
-    assert "Washer" in body
+    # Body MUST NOT repeat the name/action that the dispatcher header carries.
+    assert "Washer" not in body
+    assert "starting" not in body
     assert "Sat 04:30" in body
     assert "77 min" in body
     assert "3.7p/kWh" in body
     assert "🔆 Today" in body
     assert kwargs["urgent"] is False
+    assert kwargs["telegram_header_override"] == "🧺 Washer starting"
     extra = kwargs["extra"]
     assert extra["appliance"] == "Washer"
     assert extra["duration_minutes"] == 77
@@ -74,7 +81,10 @@ def test_notify_appliance_finished_dispatches_with_correct_alert_type() -> None:
     args, kwargs = mock_dispatch.call_args
     assert args[0] == AlertType.APPLIANCE_FINISHED
     body = args[1]
-    assert "Washer" in body
+    # Header carries the name + "cycle complete"; body keeps the timing.
+    assert "Washer" not in body
+    assert "cycle complete" not in body
+    assert kwargs["telegram_header_override"] == "✅ Washer cycle complete"
     assert "04:30" in body and "05:47" in body
     assert "77 min" in body
     assert "≈ 0.60 kWh" in body
@@ -139,7 +149,11 @@ def test_notify_appliance_armed_first_arm() -> None:
     args, kwargs = mock_dispatch.call_args
     assert args[0] == AlertType.APPLIANCE_ARMED
     body = args[1]
-    assert "armed" in body and "re-armed" not in body
+    # First-arm path: header is "🧺 Washer armed" (NOT "re-armed").
+    assert kwargs["telegram_header_override"] == "🧺 Washer armed"
+    # Body holds only schedule details; no name/verb repeats.
+    assert "Washer" not in body
+    assert "armed" not in body
     assert "Sat 01:00" in body and "03:15" in body and "07:00" in body
     assert "135 min" in body
     assert "4.5p/kWh" in body
@@ -150,8 +164,9 @@ def test_notify_appliance_armed_first_arm() -> None:
 
 
 def test_notify_appliance_armed_replan_phrasing() -> None:
-    """A re-plan flips the verb to 're-armed' so OpenClaw can phrase the
-    Telegram message as a window revision rather than a new arm."""
+    """A re-plan flips the verb to 're-armed' so the Telegram header reads
+    ``🧺 Washer re-armed`` instead of ``armed`` — a window revision rather
+    than a new arm."""
     with patch("src.notifier._dispatch") as mock_dispatch:
         notify_appliance_armed(
             appliance_name="Washer",
@@ -162,9 +177,9 @@ def test_notify_appliance_armed_replan_phrasing() -> None:
             avg_price_pence=4.0,
             replan=True,
         )
-    body = mock_dispatch.call_args.args[1]
-    assert "re-armed" in body
-    assert mock_dispatch.call_args.kwargs["extra"]["replan"] is True
+    kwargs = mock_dispatch.call_args.kwargs
+    assert kwargs["telegram_header_override"] == "🧺 Washer re-armed"
+    assert kwargs["extra"]["replan"] is True
 
 
 def test_notify_appliance_cancelled_dispatches_with_reason_and_planned_start() -> None:
@@ -178,8 +193,11 @@ def test_notify_appliance_cancelled_dispatches_with_reason_and_planned_start() -
     args, kwargs = mock_dispatch.call_args
     assert args[0] == AlertType.APPLIANCE_CANCELLED
     body = args[1]
-    assert "Washer" in body
-    assert "cancelled" in body
+    # Name + verb live in the dispatcher header.
+    assert kwargs["telegram_header_override"] == "🚫 Washer cancelled"
+    assert "Washer" not in body
+    assert "cancelled" not in body
+    # Reason + planned start stay in the body.
     assert "remote_mode_dropped" in body
     assert "Sat 01:00" in body
     extra = kwargs["extra"]
@@ -197,6 +215,7 @@ def test_notify_appliance_cancelled_omits_planned_start_when_unknown() -> None:
         )
     args, kwargs = mock_dispatch.call_args
     assert args[0] == AlertType.APPLIANCE_CANCELLED
+    assert kwargs["telegram_header_override"] == "🚫 Washer cancelled"
     assert "deadline_passed" in args[1]
     assert "planned_start_local" not in kwargs["extra"]
 

--- a/tests/test_daily_brief_split.py
+++ b/tests/test_daily_brief_split.py
@@ -19,12 +19,20 @@ def _isolated_db(monkeypatch, tmp_path):
 
 def test_morning_payload_renders_without_target_row():
     """Cold-start day with no daily_targets row should still produce a payload
-    (the fallback string path) instead of raising."""
+    (the fallback string path) instead of raising.
+
+    Post-#330 the body no longer carries its own "## ☀️ Morning brief" title
+    line — the notifier prepends the headline on the Telegram path. The body
+    starts at ``**Today (...)**`` straight away.
+    """
     from src.analytics.daily_brief import build_morning_payload
 
     body = build_morning_payload()
-    assert "Morning brief" in body
     assert "Today" in body
+    assert "Mode:" in body
+    # Body MUST NOT carry the old "## Morning brief" header — that was the
+    # source of the stacked-title bug on Telegram.
+    assert "Morning brief" not in body
 
 
 def test_night_payload_renders_with_zero_data():
@@ -32,8 +40,9 @@ def test_night_payload_renders_with_zero_data():
     from src.analytics.daily_brief import build_night_payload
 
     body = build_night_payload()
-    assert "Night brief" in body
     assert "actuals" in body
+    # Body must not contain the old "## Night brief" header (#330).
+    assert "Night brief" not in body
     # The brief now uses the structured "Net cost" line (was "Realised cost") —
     # see the daily-brief expansion for #207's follow-up. Either is acceptable.
     assert "Net cost:" in body

--- a/tests/test_telegram_transport.py
+++ b/tests/test_telegram_transport.py
@@ -101,6 +101,34 @@ class TestMarkdownToHtml:
         assert "<i>" not in out
         assert "action_log_duration" in out
 
+    def test_atx_header_h2_becomes_bold(self):
+        """``## Title`` would render literally on Telegram HTML — convert to <b>."""
+        from src.telegram_transport import markdown_to_html
+        out = markdown_to_html("## ☀️ Morning brief")
+        assert out == "<b>☀️ Morning brief</b>"
+        # The raw '#' must NOT remain in the output.
+        assert "#" not in out
+
+    def test_atx_header_h3_becomes_bold(self):
+        from src.telegram_transport import markdown_to_html
+        out = markdown_to_html("### Subsection")
+        assert out == "<b>Subsection</b>"
+
+    def test_header_inside_multiline_body_converted(self):
+        """A header in the middle of a body — multiline matching must catch it."""
+        from src.telegram_transport import markdown_to_html
+        text = "prelude\n## Section\nbody"
+        out = markdown_to_html(text)
+        assert "<b>Section</b>" in out
+        assert "## Section" not in out
+
+    def test_hashtag_in_middle_of_line_not_a_header(self):
+        """``check #123`` must not be mistaken for a header."""
+        from src.telegram_transport import markdown_to_html
+        out = markdown_to_html("see issue #123 for context")
+        assert "<b>" not in out
+        assert "#123" in out
+
 
 class TestIsConfigured:
     def test_true_when_both_set(self, monkeypatch):
@@ -293,6 +321,71 @@ class TestDispatchPrefersTelegram:
         # Debug-prefix line from OpenClaw flow must not leak through
         assert "energy-manager" not in text
 
+    def test_extra_dict_not_dumped_as_json_into_body(self, monkeypatch):
+        """The ``extra`` payload is for the hook + action_log, not for humans.
+
+        Before #330 the dispatcher appended ``json.dumps(extra)`` in an inline
+        code block, producing ``{"warnings": [...]}`` blobs right after a
+        human-readable summary that already contained the same info — ugly
+        and confusing. The Telegram body must omit it.
+        """
+        from src import notifier, telegram_transport
+
+        cfg = _make_config()
+        _patch_config(monkeypatch, cfg)
+        self._route_active(monkeypatch)
+
+        captured: list[str] = []
+
+        def fake_send(text, *, silent=False, convert_markdown=True, parse_mode="HTML"):
+            captured.append(text)
+            return True
+
+        monkeypatch.setattr(telegram_transport, "is_configured", lambda: True)
+        monkeypatch.setattr(telegram_transport, "send_message", fake_send)
+
+        notifier._dispatch(
+            notifier.AlertType.STRATEGY_UPDATE,
+            "summary line",
+            extra={"warnings": ["a", "b", "c"]},
+        )
+
+        assert len(captured) == 1
+        text = captured[0]
+        assert "summary line" in text
+        assert '{"warnings"' not in text
+        assert "json" not in text.lower()
+
+    def test_leading_markdown_header_in_body_stripped(self, monkeypatch):
+        """A body that still leads with ``## ...`` must not stack on top of the
+        dispatcher's own bold headline (#330)."""
+        from src import notifier, telegram_transport
+
+        cfg = _make_config()
+        _patch_config(monkeypatch, cfg)
+        self._route_active(monkeypatch)
+
+        captured: list[str] = []
+
+        def fake_send(text, *, silent=False, convert_markdown=True, parse_mode="HTML"):
+            captured.append(text)
+            return True
+
+        monkeypatch.setattr(telegram_transport, "is_configured", lambda: True)
+        monkeypatch.setattr(telegram_transport, "send_message", fake_send)
+
+        notifier._dispatch(
+            notifier.AlertType.MORNING_REPORT,
+            "## ☀️ Morning brief\n**Today (2026-05-13)**\nstrategy line",
+        )
+
+        assert len(captured) == 1
+        text = captured[0]
+        # Only the dispatcher's headline survives; the inner duplicate is gone.
+        assert text.count("Morning brief") == 1
+        assert "## ☀️" not in text
+        assert "Today (2026-05-13)" in text
+
     def test_falls_back_to_openclaw_when_telegram_unset(self, monkeypatch):
         from src import notifier, telegram_transport
 
@@ -380,6 +473,196 @@ class TestPushAlertTelegramRendering:
         assert "Octopus is paying us" in text  # body content
         assert "SoC 70" in text
         assert "-3.5p/kWh" in text
+
+
+# ---------------------------------------------------------------------------
+# notify_strategy_update — warnings as bullets, no Python repr / no JSON dump
+# ---------------------------------------------------------------------------
+
+class TestStrategyUpdateFormatting:
+    def _setup(self, monkeypatch):
+        from src import notifier, telegram_transport
+
+        captured: list[str] = []
+
+        def fake_send(text, *, silent=False, convert_markdown=True, parse_mode="HTML"):
+            captured.append(text)
+            return True
+
+        _patch_config(monkeypatch, _make_config())
+        monkeypatch.setattr(telegram_transport, "is_configured", lambda: True)
+        monkeypatch.setattr(telegram_transport, "send_message", fake_send)
+        monkeypatch.setattr(notifier.db, "log_action", lambda **kw: None)
+        monkeypatch.setattr(notifier.db, "get_notification_route", lambda _: {
+            "enabled": 1, "severity": "reports",
+            "target_override": None, "channel_override": None, "silent": 0,
+        })
+        return captured
+
+    def test_warnings_list_rendered_as_bullets(self, monkeypatch):
+        """``['a', 'b']`` was being str()'d into the message, producing
+        Python repr ``Warnings: ['a', 'b']``. After #330 the list becomes
+        a bullet list and the JSON dump is gone."""
+        from src import notifier
+        captured = self._setup(monkeypatch)
+
+        notifier.notify_strategy_update(
+            "Daikin write-budget guard active",
+            warnings=[
+                "tank_idle_overnight@2026-05-09T21:00:00Z",
+                "pre_heat@2026-05-10T12:00:00Z",
+            ],
+        )
+
+        assert len(captured) == 1
+        text = captured[0]
+        assert "Daikin write-budget guard active" in text
+        assert "Warnings (2)" in text
+        assert "• tank_idle_overnight@2026-05-09T21:00:00Z" in text
+        assert "• pre_heat@2026-05-10T12:00:00Z" in text
+        # No Python-repr brackets, no JSON dump duplicate.
+        assert "['tank_idle_overnight" not in text
+        assert '{"warnings"' not in text
+
+    def test_no_warnings_keeps_message_clean(self, monkeypatch):
+        from src import notifier
+        captured = self._setup(monkeypatch)
+        notifier.notify_strategy_update("plain summary")
+        assert len(captured) == 1
+        text = captured[0]
+        assert "plain summary" in text
+        assert "Warnings" not in text
+
+
+# ---------------------------------------------------------------------------
+# Appliance lifecycle — dynamic Telegram header (no duplicated emoji/name/verb)
+# ---------------------------------------------------------------------------
+
+class TestApplianceTelegramHeader:
+    """The static ``_TELEGRAM_HEADERS`` map gives every alert a generic
+    headline (``🧺 Appliance armed``). For appliance lifecycle events, the
+    body used to repeat the name + verb on the next line — producing the
+    stacked ``🧺 Appliance armed / 🧺 Washing machine armed for …`` look the
+    user flagged. Each helper now injects a dynamic
+    ``telegram_header_override`` so the header carries the specific name
+    (``🧺 Washing machine armed``) and the body holds only schedule details.
+    """
+
+    def _setup(self, monkeypatch):
+        from src import notifier, telegram_transport
+
+        captured: list[str] = []
+
+        def fake_send(text, *, silent=False, convert_markdown=True, parse_mode="HTML"):
+            captured.append(text)
+            return True
+
+        _patch_config(monkeypatch, _make_config())
+        monkeypatch.setattr(telegram_transport, "is_configured", lambda: True)
+        monkeypatch.setattr(telegram_transport, "send_message", fake_send)
+        monkeypatch.setattr(notifier.db, "log_action", lambda **kw: None)
+        monkeypatch.setattr(notifier.db, "get_notification_route", lambda _: {
+            "enabled": 1, "severity": "reports",
+            "target_override": None, "channel_override": None, "silent": 0,
+        })
+        return captured
+
+    def test_armed_header_carries_appliance_name(self, monkeypatch):
+        from src import notifier
+        captured = self._setup(monkeypatch)
+        notifier.notify_appliance_armed(
+            appliance_name="Washing machine",
+            planned_start_local="Wed 15:00",
+            planned_end_local="16:17",
+            deadline_local="07:00",
+            duration_minutes=77,
+            avg_price_pence=2.3,
+            replan=False,
+        )
+        assert len(captured) == 1
+        text = captured[0]
+        # The bold dispatcher header carries the appliance name + verb.
+        assert "**🧺 Washing machine armed**" in text
+        # Body should NOT repeat the appliance name + emoji + verb again.
+        body_only = text.split("\n", 1)[1]
+        assert "Washing machine" not in body_only
+        assert "🧺" not in body_only
+        assert "armed" not in body_only
+        # Schedule details still in the body.
+        assert "Wed 15:00" in text
+        assert "16:17" in text
+        assert "2.3p/kWh" in text
+        # No JSON tail from #330 — make sure that fix still holds on this path.
+        assert '{"appliance"' not in text
+
+    def test_armed_replan_header_uses_re_armed(self, monkeypatch):
+        from src import notifier
+        captured = self._setup(monkeypatch)
+        notifier.notify_appliance_armed(
+            appliance_name="Dishwasher",
+            planned_start_local="Wed 02:00",
+            planned_end_local="03:30",
+            deadline_local="07:00",
+            duration_minutes=90,
+            avg_price_pence=2.1,
+            replan=True,
+        )
+        text = captured[0]
+        assert "**🧺 Dishwasher re-armed**" in text
+        assert "armed" in text  # substring of re-armed; that's fine
+
+    def test_starting_header_and_clean_body(self, monkeypatch):
+        from src import notifier
+        captured = self._setup(monkeypatch)
+        notifier.notify_appliance_starting(
+            appliance_name="Dryer",
+            planned_start_local="15:00",
+            deadline_local="17:00",
+            avg_price_pence=4.2,
+            duration_minutes=60,
+        )
+        text = captured[0]
+        assert "**🧺 Dryer starting**" in text
+        body_only = text.split("\n", 1)[1]
+        assert "Dryer" not in body_only
+        assert "starting" not in body_only
+        assert "15:00" in body_only
+        assert "60 min" in body_only
+
+    def test_finished_header_and_clean_body(self, monkeypatch):
+        from src import notifier
+        captured = self._setup(monkeypatch)
+        notifier.notify_appliance_finished(
+            appliance_name="Washing machine",
+            started_local="15:00",
+            ended_local="16:17",
+            duration_minutes=77,
+            estimated_kwh=0.85,
+            estimated_cost_p=1.9,
+            kwh_is_measured=True,
+        )
+        text = captured[0]
+        assert "**✅ Washing machine cycle complete**" in text
+        body_only = text.split("\n", 1)[1]
+        assert "Washing machine" not in body_only
+        assert "cycle complete" not in body_only
+        assert "0.85 kWh" in body_only
+
+    def test_cancelled_header_and_clean_body(self, monkeypatch):
+        from src import notifier
+        captured = self._setup(monkeypatch)
+        notifier.notify_appliance_cancelled(
+            appliance_name="Washing machine",
+            reason="replanned",
+            planned_start_local="Wed 15:00",
+        )
+        text = captured[0]
+        assert "**🚫 Washing machine cancelled**" in text
+        body_only = text.split("\n", 1)[1]
+        assert "Washing machine" not in body_only
+        assert "cancelled" not in body_only
+        assert "replanned" in body_only
+        assert "Wed 15:00" in body_only
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four formatting bugs in the post-#284 direct-Telegram path were stacking on top of each other in the daily brief + strategy update, producing the message screenshots from this morning:

- Morning brief had **two headlines** stacked: `🌅 Morning brief` (notifier) right above `## ☀️ Morning brief` (body).
- The body's `## ...` showed up **literally** because Telegram HTML has no header tag.
- Strategy updates duplicated their warnings — once as `Warnings: ['a', 'b']` (Python repr) inline, then again as a `json.dumps(extra)` code block underneath.
- Other dispatch alerts also got the noisy `{"warnings": [...]}` JSON tail.

## Fixes

1. `markdown_to_html` now converts ATX headers (`## Title`, `### Sub`) to `<b>...</b>` so any stray markdown header renders cleanly instead of literally.
2. `build_morning_payload` / `build_night_payload` no longer emit their own title line — the notifier is the canonical source of the headline on Telegram, and action_log/journalctl entries still carry the alert-type tag.
3. `_build_telegram_dispatch_body` stops appending `json.dumps(extra)` as a code block. `extra` is still preserved on the OpenClaw hook path + action_log row (machine-readable consumers).
4. `_build_telegram_dispatch_body` defensively strips a leading `## ...` line if any body still ships one — so a missed migration in another body builder can't reintroduce the stacked-header look.
5. `notify_strategy_update` renders list/tuple warnings as a bulleted block with a count, not `Warnings: ['a', 'b']`.

## Test plan

- [x] `pytest tests/` — 1057 passed (ignoring known-broken `test_mcp_singleton.py` and the heavy `test_lp_solver_full.py`)
- [x] New unit coverage in `tests/test_telegram_transport.py`:
  - `## ☀️ Morning brief` → `<b>☀️ Morning brief</b>`
  - hashtag mid-line (`see #123`) NOT promoted to header
  - dispatch never includes `{"warnings": ...}` in body
  - duplicate-`##` leader stripped from briefs even if a builder regresses
  - strategy-update warnings rendered as `Warnings (2):\n  • ...` bullets
- [x] `tests/test_daily_brief_split.py` updated to assert the *absence* of the old title line (was actively asserting the bug).
- [ ] **Validate in prod** — deploy on Hetzner via the usual SHA-bump + `systemctl restart hem`, then watch the 22:00 night brief and tomorrow's 08:00 morning brief on Telegram. Stacked title gone, no `##` literal, no JSON tail.

Closes #330 (if filed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)