### PR TITLE
fix(lp): drop yesterday warm-start; unobserved hours → tf=1.0

### DIFF
--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -61,65 +61,6 @@ def _now_utc() -> datetime:
     return datetime.now(UTC)
 
 
-def _load_yesterday_today_factor_by_hour() -> dict[int, float]:
-    """Read yesterday's per-hour today-factor table from the previous LP snapshot.
-
-    Used as a warm-start for hours not yet observed today. Without this, the
-    today-aware adjuster falls back to "median of observed hours" which on a
-    cloudy-morning day drags afternoon hours down to morning's bias even
-    though afternoons typically shed the cloud bias.
-
-    Returns ``{}`` when no usable previous snapshot exists (first day of
-    operation, schema mismatch, JSON parse failure, etc.) — caller treats it
-    as "no warm-start available" and behaves as before.
-    """
-    import sqlite3
-
-    try:
-        yesterday = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
-        with db._lock:
-            conn = db.get_connection()
-            try:
-                cur = conn.execute(
-                    """SELECT exogenous_snapshot_json FROM lp_inputs_snapshot
-                       WHERE substr(plan_date, 1, 10) = ?
-                         AND exogenous_snapshot_json IS NOT NULL
-                       ORDER BY run_id DESC""",
-                    (yesterday,),
-                )
-                rows = cur.fetchall()
-            finally:
-                conn.close()
-    except (sqlite3.OperationalError, sqlite3.DatabaseError):
-        return {}
-    if not rows:
-        return {}
-    # Newest-first; return the first snapshot whose JSON still has
-    # today_factor_by_hour populated.
-    for row in rows:
-        raw = (row[0] or "{}") if row else "{}"
-        try:
-            payload = json.loads(raw)
-        except (TypeError, ValueError):
-            continue
-        adj = (payload or {}).get("weather_adjustment") or {}
-        # Prefer the post-warm-start "effective" map so the warm-start chains
-        # across days when today's observations are sparse. Fall back to the
-        # raw observed map for snapshots written before that key existed.
-        by_hour = adj.get("today_factor_effective_by_hour") or adj.get("today_factor_by_hour")
-        if not isinstance(by_hour, dict) or not by_hour:
-            continue
-        out: dict[int, float] = {}
-        for k, v in by_hour.items():
-            try:
-                out[int(k)] = float(v)
-            except (TypeError, ValueError):
-                continue
-        if out:
-            return out
-    return {}
-
-
 def _ceil_to_half_hour_utc(dt: datetime) -> datetime:
     """Round *dt* up to the next :00 or :30 boundary in UTC."""
     dt = dt.astimezone(UTC).replace(second=0, microsecond=0)
@@ -1497,30 +1438,31 @@ def _run_optimizer_lp(
     today_factor_by_hour, today_diag_by_hour = compute_today_pv_correction_factor_by_hour()
     today_factor, today_diag = compute_today_pv_correction_factor()
 
-    # #1: today_factor must NOT contaminate tomorrow's slots in the same 48h
+    # today_factor must NOT contaminate tomorrow's slots in the same 48h
     # solve. A cloudy-morning solve at 19:00 today produces today_factor ≈ 0.31;
     # without scoping that scalar hammers tomorrow's morning predictions too,
     # so the LP plans a grid charge before the next day's actuals can correct
     # the bias.
     today_utc_date = datetime.now(UTC).date()
 
-    # #5: warm-start unobserved hours from yesterday's per-hour factor table
-    # (persisted in the previous LP snapshot's exogenous_snapshot_json). This
-    # keeps the asymmetric per-hour shape from yesterday instead of the
-    # bias-dragging "median of observed" fallback. Best-effort — when there is
-    # no yesterday snapshot or the JSON path is empty, falls back silently.
-    yesterday_factor_by_hour = _load_yesterday_today_factor_by_hour()
-
+    # Imputation policy (2026-05-15 fix, ref: docs/PV_TRUST_GUARDRAIL.md +
+    # incident follow-up): unobserved hours get factor 1.0 — NOT a warm-start
+    # from yesterday and NOT today's observed median. Yesterday is a single
+    # noisy sample whose outliers shouldn't cascade into today's plan; the
+    # 30-day per-hour statistical baseline is already in
+    # ``pv_calibration_hourly`` (the ``cal`` term stacked separately at
+    # apply-time). Setting tf=1.0 for unobserved hours defers cleanly to
+    # the multi-day pattern. Observed hours TODAY still pull today's weather
+    # in via ``compute_today_pv_correction_factor_by_hour``.
     if today_factor_by_hour:
         logger.info(
             "PV calibration: per-hour today-aware adjuster active "
-            "(n_observed=%d, n_imputed=%d, median_ratio=%.3f, clamped_hours=%s, "
-            "warm_start_hours=%d)",
+            "(n_observed=%d, n_imputed=%d, median_ratio=%.3f, clamped_hours=%s; "
+            "imputed hours use tf=1.0 — defer to pv_calibration_hourly)",
             today_diag_by_hour.get("n_observed", 0),
             today_diag_by_hour.get("n_imputed", 0),
             today_diag_by_hour.get("median_ratio", 0.0),
             today_diag_by_hour.get("clamped_hours", []),
-            len(yesterday_factor_by_hour),
         )
     elif today_factor != 1.0:
         logger.info(
@@ -1535,19 +1477,10 @@ def _run_optimizer_lp(
             today_diag.get("reason", "no diagnostic"),
         )
 
-    # Build the per-hour map actually consumed by the LP: prefer today's
-    # observation if we have one, else warm-start from yesterday's value, else
-    # 1.0 (no per-hour bias). Exposed for the snapshot below.
-    today_factor_by_hour_imputed = today_diag_by_hour.get("imputed_hours") or []
-    effective_factor_by_hour: dict[int, float] = {}
-    if today_factor_by_hour:
-        for h in range(24):
-            if h not in today_factor_by_hour_imputed:
-                effective_factor_by_hour[h] = today_factor_by_hour[h]
-            elif h in yesterday_factor_by_hour:
-                effective_factor_by_hour[h] = yesterday_factor_by_hour[h]
-            else:
-                effective_factor_by_hour[h] = today_factor_by_hour[h]
+    # The per-hour map is now passed through verbatim — observed hours hold
+    # today's ratio, imputed hours hold 1.0 (set by
+    # compute_today_pv_correction_factor_by_hour per the new policy).
+    effective_factor_by_hour: dict[int, float] = dict(today_factor_by_hour) if today_factor_by_hour else {}
 
     def _pv_scale_callable(
         hour_utc: int,
@@ -1604,21 +1537,18 @@ def _run_optimizer_lp(
                 if today_factor_by_hour else None
             ),
             "today_diag_by_hour": today_diag_by_hour,
-            # #5 — values actually consumed by the LP after the
-            # warm-start-from-yesterday fill-in. Distinct from
-            # today_factor_by_hour (raw observations + median fallback) so
-            # tomorrow's warm-start can read THIS dict instead of pulling
-            # in yesterday's median-fallback values.
+            # Per-hour map actually consumed by the LP. Observed hours hold
+            # today's actual/forecast ratio; imputed (not-yet-observed)
+            # hours hold 1.0 (defer to pv_calibration_hourly's multi-day
+            # baseline rather than yesterday or today's median).
             "today_factor_effective_by_hour": (
                 {str(h): round(float(v), 6) for h, v in effective_factor_by_hour.items()}
                 if effective_factor_by_hour else None
             ),
-            # #5 diag — non-empty when warm-start filled at least one hour.
-            "warm_start_from_yesterday_hours": sorted(
-                h for h in effective_factor_by_hour
-                if h in today_factor_by_hour_imputed and h in yesterday_factor_by_hour
-            ) if effective_factor_by_hour else [],
-            # #1 diag — applied today_factor only to today's UTC date.
+            # Imputation policy in effect. ``neutral_1.0`` since 2026-05-15;
+            # previous ``yesterday_warmstart`` / ``observed_median`` are gone.
+            "imputation_policy": "neutral_1.0",
+            # Diag — applied today_factor only to today's UTC date.
             "today_factor_scoped_to_utc_date": today_utc_date.isoformat(),
         },
         "temperature_adjustment": {

--- a/src/weather.py
+++ b/src/weather.py
@@ -1101,16 +1101,27 @@ def compute_today_pv_correction_factor_by_hour(
         these and applies the same correction at every hour, so
         afternoons stay under-forecast even after the adjuster runs.
       - With per-hour ratios, an observation at hour 9 (e.g. actual/cal
-        = 1.20) lifts the prediction at hour 9 specifically. Hours we
-        haven't observed yet inherit the median of observed hours so
-        the LP still sees today's general "weather vibe" applied to
-        unobserved future hours.
+        = 1.20) lifts the prediction at hour 9 specifically.
+
+    Imputation policy (2026-05-15 fix):
+      - Hours WITHOUT today's observation are set to ``1.0`` (no
+        intraday adjustment). The legitimate multi-day deviation pattern
+        is already in ``pv_calibration_hourly`` (the ``cal`` term that
+        is stacked separately at apply-time). Imputing yesterday's
+        factor or today's observed median for unobserved hours pulls a
+        SINGLE noisy sample on top of the statistical baseline, which is
+        wrong: outliers cascade into the next day's plan. Setting
+        ``tf=1.0`` for unobserved hours defers cleanly to the 30-day
+        statistical pattern. AM hours that ALREADY happened today (and
+        underperformed) still pull AM down via observed; PM hours that
+        haven't happened yet trust the long-term per-hour shape, which
+        is precisely what we want for a site with structural AM-over /
+        PM-under asymmetry.
 
     Returns ``(factor_by_hour, diag)``:
       - ``factor_by_hour`` covers all 24 UTC hours, populated for hours
         that had both forecast + actual today (clamped per-hour) and
-        with the observed median for the rest. Returns ``{}`` when not
-        enough data exists.
+        ``1.0`` for the rest. Returns ``{}`` when not enough data exists.
       - ``diag`` includes ``observed_hours``, ``imputed_hours``,
         ``median_ratio``, ``ratios_per_hour``, ``n_observed``,
         ``clamped_hours``.
@@ -1226,13 +1237,20 @@ def compute_today_pv_correction_factor_by_hour(
     else:
         median = (sorted_obs[n_obs // 2 - 1] + sorted_obs[n_obs // 2]) / 2.0
 
+    # Imputation policy: unobserved hours get factor 1.0 (no intraday
+    # adjustment), NOT yesterday's value or today's observed median.
+    # The 30-day per-hour deviation pattern is in ``pv_calibration_hourly``
+    # (the ``cal`` term in the LP's _pv_scale_callable). Stacking a
+    # single-day noisy sample on top would propagate outliers — see
+    # 2026-05-15 incident follow-up. Observed hours still pull today's
+    # weather in; unobserved hours defer cleanly to the multi-day baseline.
     factor_by_hour: dict[int, float] = {h: 1.0 for h in range(24)}
     imputed_hours: list[int] = []
     for h in range(24):
         if h in observed:
             factor_by_hour[h] = observed[h]
         else:
-            factor_by_hour[h] = median
+            # factor_by_hour[h] stays at the init value 1.0 — no override.
             imputed_hours.append(h)
 
     return factor_by_hour, {
@@ -1240,6 +1258,7 @@ def compute_today_pv_correction_factor_by_hour(
         "n_imputed": len(imputed_hours),
         "median_ratio": round(median, 4),
         "median_source": "unclamped_only" if median_source is unclamped else "all_observed",
+        "imputation_policy": "neutral_1.0",  # was "median_of_observed" pre 2026-05-15
         "ratios_per_hour": {h: round(v, 4) for h, v in observed.items()},
         "imputed_hours": imputed_hours,
         "clamped_hours": clamped_hours,

--- a/tests/test_pv_today_aware_calibration.py
+++ b/tests/test_pv_today_aware_calibration.py
@@ -149,8 +149,10 @@ def test_dawn_dusk_hours_excluded() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_per_hour_returns_observed_ratios_and_imputes_unobserved():
-    """Two observed hours produce per-hour factors; the rest get the median."""
+def test_per_hour_returns_observed_ratios_and_imputes_unobserved_to_one():
+    """Two observed hours produce per-hour factors; the rest get tf=1.0
+    (2026-05-15 policy: unobserved hours defer to pv_calibration_hourly,
+    NOT to today's observed median or yesterday's warm-start)."""
     from src.weather import compute_today_pv_correction_factor_by_hour
 
     # Morning ratio = 1.5 (sunny morning beats forecast); midday spot-on.
@@ -162,16 +164,20 @@ def test_per_hour_returns_observed_ratios_and_imputes_unobserved():
     by_hour, diag = compute_today_pv_correction_factor_by_hour()
     assert by_hour, f"expected non-empty map; diag={diag}"
     assert diag["n_observed"] == 2
+    assert diag.get("imputation_policy") == "neutral_1.0"
     # Observed hours get their own ratios.
     assert 9 in diag["ratios_per_hour"]
     assert 11 in diag["ratios_per_hour"]
-    # Unobserved hours get the median (between 1.0 and 1.5 → median 1.5
-    # because there are only 2 values; sorted_obs[1] = 1.5). ``median_ratio``
-    # in diag is rounded to 4 places; ``by_hour`` values carry full precision.
-    median = diag["median_ratio"]
-    assert by_hour[3] == pytest.approx(median, abs=1e-3)
-    assert by_hour[14] == pytest.approx(median, abs=1e-3)
-    # Observed hour ratios are NOT the median (asymmetry preserved).
+    # Unobserved hours get tf=1.0 — they defer to pv_calibration_hourly
+    # (the multi-day per-hour deviation baseline) instead of pulling a
+    # single-day noisy sample on top.
+    assert by_hour[3] == 1.0
+    assert by_hour[14] == 1.0
+    assert by_hour[23] == 1.0
+    # Observed-hour ratios are NOT 1.0 (asymmetry preserved on hours we DID
+    # measure today).
+    assert by_hour[9] != 1.0
+    assert by_hour[11] != 1.0 or pytest.approx(by_hour[11], abs=1e-6) == 1.0  # 1.0 only if midday IS spot-on
     assert by_hour[9] != by_hour[11], f"observed hours should keep their own factor: {by_hour}"
 
 

--- a/tests/test_today_factor_scope.py
+++ b/tests/test_today_factor_scope.py
@@ -1,25 +1,30 @@
-"""today_factor scoped to today + warm-start from yesterday's per-hour table.
+"""today_factor scoping rules in the LP PV-scale closure.
 
 Two behaviors locked in here:
+
 1. Slots in tomorrow's UTC date must NOT receive today's PV-bias factor.
    A cloudy-morning solve at 19:00 today produces today_factor ≈ 0.31; before
    the fix that scalar contaminated tomorrow's morning predictions in the
    same 48h solve. Tomorrow's slots now ignore today_factor entirely.
-2. Hours unobserved today are warm-started from yesterday's per-hour map
-   (persisted in lp_inputs_snapshot.exogenous_snapshot_json) instead of
-   inheriting the median of today's observations.
+
+2. Hours unobserved today get tf=1.0 (no intraday adjustment) — they defer
+   to ``pv_calibration_hourly`` (the multi-day per-hour statistical
+   baseline) instead of pulling a single-day noisy sample on top. The
+   previous "warm-start from yesterday's snapshot" mechanism was removed
+   in 2026-05-15 as part of the PV-trust-guard-rail follow-up:
+   ``compute_today_pv_correction_factor_by_hour`` returns 1.0 for
+   unobserved hours; ``optimizer._run_optimizer_lp`` passes the map
+   through verbatim (no warm-start fill-in).
 """
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 from src import db
 from src.config import config as app_config
-from src.scheduler.optimizer import _load_yesterday_today_factor_by_hour
 
 
 @pytest.fixture(autouse=True)
@@ -28,60 +33,57 @@ def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     db.init_db()
 
 
-def _seed_yesterday_snapshot(*, run_id: int, plan_date: str, snapshot_json: str) -> None:
-    """Insert one lp_inputs_snapshot row dated yesterday with the given JSON."""
-    db.save_lp_snapshots(
-        run_id=run_id,
-        inputs_row={
-            "run_at_utc": (datetime.now(UTC) - timedelta(hours=12)).isoformat(),
-            "plan_date": plan_date,
-            "horizon_hours": 48,
-            "soc_initial_kwh": 5.0,
-            "tank_initial_c": 45.0,
-            "indoor_initial_c": 20.0,
-            "soc_source": "test",
-            "tank_source": "test",
-            "indoor_source": "test",
-            "base_load_json": "[]",
-            "micro_climate_offset_c": 0.0,
-            "forecast_fetch_at_utc": None,
-            "exogenous_snapshot_json": snapshot_json,
-            "config_snapshot_json": "{}",
-            "price_quantize_p": 0.1,
-            "peak_threshold_p": 30.0,
-            "cheap_threshold_p": 10.0,
-            "daikin_control_mode": "off",
-            "optimization_preset": "normal",
-            "energy_strategy_mode": "savings_first",
-        },
-        solution_rows=[],
-    )
+def test_unobserved_hours_imputed_to_one_not_yesterday() -> None:
+    """When no observation exists for an hour today, the per-hour map returns
+    1.0 — NOT yesterday's value, NOT today's observed median. The 30-day
+    baseline in ``pv_calibration_hourly`` is the only legitimate signal for
+    unobserved hours.
+    """
+    from src.weather import compute_today_pv_correction_factor_by_hour
 
+    today = datetime.now(UTC).date()
 
-def test_load_yesterday_factor_returns_empty_when_no_history() -> None:
-    """First-day-of-operation: no previous snapshot → return {} (no warm-start)."""
-    assert _load_yesterday_today_factor_by_hour() == {}
+    def _seed(hour: int, kw: float, irr: float) -> None:
+        for i in range(12):
+            ts = datetime.combine(today, datetime.min.time()).replace(
+                hour=hour, minute=i * 5, tzinfo=UTC,
+            )
+            db.save_pv_realtime_sample(
+                captured_at=ts.isoformat().replace("+00:00", "Z"),
+                solar_power_kw=kw,
+                soc_pct=50.0, load_power_kw=0.5,
+                grid_import_kw=0.0, grid_export_kw=kw,
+                battery_charge_kw=0.0, battery_discharge_kw=0.0,
+                source="seed",
+            )
+        ts0 = datetime.combine(today, datetime.min.time()).replace(
+            hour=hour, tzinfo=UTC,
+        )
+        db.save_meteo_forecast(
+            [{
+                "slot_time": ts0.isoformat(),
+                "temp_c": 15.0,
+                "solar_w_m2": irr,
+                "cloud_cover_pct": 0.0,
+            }],
+            today.isoformat(),
+        )
 
+    _seed(9, 2.0, 350.0)   # ratio ~1.5
+    _seed(10, 2.5, 500.0)  # ratio ~1.25
 
-def test_load_yesterday_factor_reads_effective_map_when_present() -> None:
-    """The post-#5 snapshot writes today_factor_effective_by_hour. The loader
-    must prefer it over the raw observed map so the warm-start chains across
-    days (yesterday's effective factor was already a warm-start mix)."""
-    yesterday = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
-    snapshot_json = '{"weather_adjustment": {"today_factor_by_hour": {"6":0.4}, "today_factor_effective_by_hour": {"6":0.9, "12":1.1, "16":1.4}}}'
-    _seed_yesterday_snapshot(run_id=1, plan_date=yesterday, snapshot_json=snapshot_json)
-    out = _load_yesterday_today_factor_by_hour()
-    # Effective map wins, not the raw observed map (which only has hour 6).
-    assert out == {6: 0.9, 12: 1.1, 16: 1.4}
-
-
-def test_load_yesterday_factor_falls_back_to_raw_for_old_snapshots() -> None:
-    """Pre-#5 snapshots only have today_factor_by_hour. The loader must still
-    return that map so the upgrade is backwards compatible."""
-    yesterday = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
-    snapshot_json = '{"weather_adjustment": {"today_factor_by_hour": {"7":0.5, "13":1.05}}}'
-    _seed_yesterday_snapshot(run_id=2, plan_date=yesterday, snapshot_json=snapshot_json)
-    assert _load_yesterday_today_factor_by_hour() == {7: 0.5, 13: 1.05}
+    by_hour, diag = compute_today_pv_correction_factor_by_hour()
+    assert by_hour, f"expected non-empty map; diag={diag}"
+    # Imputation policy reported in diag — guards regressions if the
+    # imputation default changes back to median or to a warm-start.
+    assert diag.get("imputation_policy") == "neutral_1.0"
+    # Unobserved hours (any hour not in {9, 10}) get exactly 1.0.
+    assert by_hour[3] == 1.0
+    assert by_hour[15] == 1.0
+    assert by_hour[20] == 1.0
+    # Observed hours keep their measured ratio (not 1.0).
+    assert by_hour[9] != 1.0
+    assert by_hour[10] != 1.0
 
 
 def test_pv_scale_callable_skips_today_factor_for_tomorrow_slots() -> None:


### PR DESCRIPTION
## Why

The PV calibration pipeline stacks two corrections at LP apply-time:

```
per_slot_pv = forecast × cal × tf
              cal = pv_calibration_hourly[h]   # 30-day per-hour statistical baseline (refreshed daily since #331)
              tf  = today_factor_by_hour[h]    # intraday observation-based correction
```

For hours **not yet observed today** (always the case for the 00:05 UTC `bulletproof_plan_push`), `tf` previously fell back to:

1. Yesterday's per-hour factor (warm-start from prior `lp_inputs_snapshot.exogenous_snapshot_json.today_factor_effective_by_hour`), **or**
2. Today's observed-hour median (fallback when no yesterday snapshot)

**Both are wrong.** Yesterday is a single noisy sample; cascading its outliers into today's plan is exactly the "calibrate by deviation distribution, not by yesterday" anti-pattern the user called out. Median-of-observed-today drags AM cloud bias onto unobserved PM hours that typically shed it (W4 1DZ has an AM-over / PM-under structural pattern — `docs/PV_TRUST_GUARDRAIL.md` §2 / 7).

## What

Unobserved hours get `tf = 1.0`. The legitimate multi-day per-hour deviation baseline is already in `cal` (`pv_calibration_hourly`, refreshed daily by the cron added in #331). Letting `tf=1.0` defer to that baseline keeps the calibration statistically clean.

Observed hours TODAY are unchanged — they continue to pull today's measured ratio into the LP. The asymmetry between "observed h=8 today crashed to 0.3" + "unobserved h=14 trusts the long-term 1.0" is precisely desired: AM-specific bad weather today pulls AM down; PM hasn't happened yet so trust the statistical pattern.

## Code changes

| File | Change |
|---|---|
| `src/weather.py` | `compute_today_pv_correction_factor_by_hour`: unobserved hours stay at dict-init 1.0 (was overridden to `median`). Diag dict adds `imputation_policy: "neutral_1.0"`. |
| `src/scheduler/optimizer.py` | `_load_yesterday_today_factor_by_hour` deleted entirely (60 LOC). `effective_factor_by_hour` is now a simple pass-through of `today_factor_by_hour`. `warm_start_from_yesterday_hours` dropped from snapshot dict — no external readers (confirmed via grep across `src/`). |
| `tests/test_pv_today_aware_calibration.py` | One existing test was asserting the old median-imputation behaviour; renamed + updated to assert `tf=1.0` for unobserved hours + `imputation_policy=neutral_1.0` in diag. |

Net: **−110 / +65** lines (mostly the deleted dead warm-start fn).

## Validation

- [x] 178 unit tests pass (`tests/test_pv_today_aware_calibration.py` + `tests/scheduler/` + `tests/test_lp_*.py` + `tests/test_fox_lp_dispatch_soc.py` + `tests/test_dispatch_decisions_api.py`)
- [x] LP regression gate (`scripts/check_lp_regression.py` against prod DB inside one-shot container): **PASS** with Δ £0.00 vs the just-refreshed baseline from #332.

## Caveat — this patch is invisible to current regression test

The replay path (`src/scheduler/lp_replay.py:_reconstruct_weather`) calls `forecast_to_lp_inputs(..., pv_scale=1.0)` which bypasses `today_factor` entirely. So `check_lp_regression.py` doesn't exercise this patch's behavior. The patch IS real for production solves (which use the `_pv_scale_callable` closure).

A follow-up improvement to the regression script (compare current-branch vs main on same data — the user's "Patch 2") will close that observability gap.

## Risk

Low. The behaviour change kicks in only for unobserved hours and only when `pv_calibration_hourly` already has values (which it does — refreshed daily). On a fresh container with no calibration data, `cal=1.0` and `tf=1.0` → forecast goes through unmodified, same as before.

## Rollback

Revert this commit. No env vars, no DB schema changes, no cron changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)