### PR TITLE
fix(dispatch): hold previous schedule on LP infeasible (drop heuristic fallback)

### DIFF
--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1580,8 +1580,49 @@ def _run_optimizer_lp(
         export_price_pence=export_prices,
     )
     if not plan.ok:
-        logger.warning("PuLP status %s — falling back to heuristic classifier", plan.status)
-        return _run_optimizer_heuristic(fox, daikin)
+        # Defensive: do NOT call _run_optimizer_heuristic on LP failure. The
+        # heuristic builds Fox V3 ForceCharge groups from a slot list that has
+        # no LP-derived lp_grid_import_w / target_soc_pct, so _slot_fox_tuple
+        # falls back to FOX_FORCE_CHARGE_NORMAL_PWR (3000 W) and fdSoc=95 — the
+        # inverter then grid-charges at full power until 95 % SoC. Audit on
+        # 2026-05-18 measured +£0.35-1.30/day vs the LP objective every day a
+        # fallback fired (LP infeasibles ran ~110/30d after the Phase B
+        # refactor). Holding the previous schedule is strictly safer than
+        # replacing it with the heuristic's defaults: Fox V3 is daily-cyclic,
+        # so the last successful LP plan remains in effect until the next
+        # successful solve overwrites it. Explicit OPTIMIZER_BACKEND=heuristic
+        # is unaffected — only the auto-fallback path changes.
+        logger.warning(
+            "LP %s — holding previous Fox/Daikin schedule (defensive: heuristic fallback disabled)",
+            plan.status,
+        )
+        try:
+            actual_mean = float(mean(prices)) if prices else None
+            db.log_optimizer_run({
+                "run_at": _now_utc().isoformat(),
+                "rates_count": len(prices),
+                "cheap_slots": 0,
+                "peak_slots": 0,
+                "standard_slots": 0,
+                "negative_slots": 0,
+                "target_vwap": None,
+                "actual_agile_mean": actual_mean,
+                "battery_warning": False,
+                "strategy_summary": (
+                    f"{plan_date}: LP {plan.status} — held previous schedule "
+                    f"(no hardware writes; heuristic fallback disabled)"
+                ),
+                "fox_schedule_uploaded": False,
+                "daikin_actions_count": 0,
+            })
+        except Exception:  # noqa: BLE001 — audit log must never abort the return
+            logger.exception("optimizer_log write failed during LP-infeasible hold")
+        return {
+            "ok": False,
+            "error": f"LP {plan.status}",
+            "fallback": "hold_previous_schedule",
+            "optimizer_backend": "lp",
+        }
 
     # Fold the PV-sufficiency guard rail audit into the exogenous snapshot
     # (decided inside solve_lp; persisted alongside the inputs for the

--- a/tests/test_lp_infeasible_hold.py
+++ b/tests/test_lp_infeasible_hold.py
@@ -1,0 +1,167 @@
+"""When the LP solver returns Infeasible (or any non-Optimal status), the
+``_run_optimizer_lp`` path must HOLD the previously-uploaded Fox V3 schedule
+and Daikin actions rather than calling the heuristic classifier.
+
+Background: the heuristic builds Fox V3 ForceCharge groups from a slot list
+with no LP-derived ``lp_grid_import_w`` / ``target_soc_pct`` hints. The
+``_slot_fox_tuple`` defaults (``fdPwr=3000 W``, ``fdSoc=95``) then ship to
+the inverter, which grid-charges aggressively until 95 % SoC — empirically
++£0.35-1.30/day vs the LP objective on every day a fallback fired during
+the 2026-05-18 audit. Holding the previous (last-successful-LP) schedule is
+strictly safer: Fox V3 is daily-cyclic, so the previous plan remains in
+effect on the inverter until the next successful solve overwrites it.
+
+Explicit ``OPTIMIZER_BACKEND=heuristic`` is a separate code path and is
+unaffected by this change — see ``test_heuristic_fallback.py`` for that.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.scheduler import optimizer
+from src.scheduler.lp_optimizer import LpPlan
+
+TARIFF = "E-1R-AGILE-TEST-LP-HOLD"
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _lp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", TARIFF)
+    monkeypatch.setattr(app_config, "OPTIMIZER_BACKEND", "lp")
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", True)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _seed_realistic_day(start: datetime) -> None:
+    rows = []
+    vf = start
+    for _ in range(48):
+        if 1 <= vf.hour < 5:
+            price = -2.0
+        elif 5 <= vf.hour < 16:
+            price = 10.0
+        elif 16 <= vf.hour < 19:
+            price = 35.0
+        else:
+            price = 12.0
+        vt = vf + timedelta(minutes=30)
+        rows.append({"valid_from": _iso(vf), "valid_to": _iso(vt), "value_inc_vat": price})
+        vf = vt
+    db.save_agile_rates(rows, TARIFF)
+
+
+def _stub_infeasible_solve(*_args: Any, **_kwargs: Any) -> LpPlan:
+    return LpPlan(ok=False, status="Infeasible", objective_pence=0.0)
+
+
+def test_lp_infeasible_returns_hold_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LP infeasible → return dict marks ``fallback="hold_previous_schedule"``."""
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+
+    monkeypatch.setattr("src.scheduler.lp_optimizer.solve_lp", _stub_infeasible_solve)
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result["ok"] is False
+    assert result["fallback"] == "hold_previous_schedule"
+    assert result["error"] == "LP Infeasible"
+    assert result["optimizer_backend"] == "lp"
+
+
+def test_lp_infeasible_does_not_call_heuristic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LP infeasible must NOT invoke ``_run_optimizer_heuristic``.
+
+    This is the regression we're protecting against — the heuristic ships
+    ForceCharge groups with non-LP-aware defaults that overcharge from grid.
+    """
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+
+    monkeypatch.setattr("src.scheduler.lp_optimizer.solve_lp", _stub_infeasible_solve)
+
+    heuristic_calls: list[Any] = []
+
+    def _fail_heuristic(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        heuristic_calls.append((args, kwargs))
+        raise AssertionError(
+            "_run_optimizer_heuristic must not be invoked on LP infeasible "
+            "(would emit bad Fox V3 ForceCharge groups)"
+        )
+
+    monkeypatch.setattr(optimizer, "_run_optimizer_heuristic", _fail_heuristic)
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result["ok"] is False
+    assert heuristic_calls == []
+
+
+def test_lp_infeasible_does_not_upload_to_fox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LP infeasible must NOT trigger any Fox V3 upload — the previous
+    schedule on the inverter is daily-cyclic and remains in effect.
+    """
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+
+    monkeypatch.setattr("src.scheduler.lp_optimizer.solve_lp", _stub_infeasible_solve)
+
+    from src.scheduler import lp_dispatch
+
+    upload_calls: list[Any] = []
+
+    def _capture_upload(fox: Any, groups: Any) -> bool:
+        upload_calls.append(groups)
+        return False
+
+    monkeypatch.setattr(lp_dispatch, "upload_fox_if_operational", _capture_upload)
+    monkeypatch.setattr(optimizer, "upload_fox_if_operational", _capture_upload, raising=False)
+
+    fox = type("FakeFox", (), {"api_key": "x"})()
+    result = optimizer.run_optimizer(fox=fox, daikin=None)
+    assert result["ok"] is False
+    assert upload_calls == [], f"unexpected Fox upload on LP infeasible: {upload_calls}"
+
+
+def test_lp_infeasible_writes_audit_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LP infeasible must write an ``optimizer_log`` row so the gap is
+    visible in briefs / dashboards.
+    """
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+
+    monkeypatch.setattr("src.scheduler.lp_optimizer.solve_lp", _stub_infeasible_solve)
+
+    captured: list[dict[str, Any]] = []
+    real_log = db.log_optimizer_run
+
+    def _capture_log(row: dict[str, Any]) -> int:
+        captured.append(row)
+        return real_log(row)
+
+    monkeypatch.setattr(db, "log_optimizer_run", _capture_log)
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result["ok"] is False
+    assert captured, "optimizer_log row was not written during LP infeasible"
+    row = captured[-1]
+    assert row["fox_schedule_uploaded"] is False
+    assert row["daikin_actions_count"] == 0
+    assert "Infeasible" in (row["strategy_summary"] or "")
+    assert "held previous schedule" in (row["strategy_summary"] or "")


### PR DESCRIPTION
## Summary

- Stop calling `_run_optimizer_heuristic` when the LP solver returns Infeasible. Instead, log + write an `optimizer_log` audit row and **hold the previous Fox V3 schedule** (daily-cyclic, so the last successful LP plan remains in effect on the inverter).
- Explicit `OPTIMIZER_BACKEND=heuristic` is unaffected — only the auto-fallback path changes. Existing `tests/test_heuristic_fallback.py` continues to exercise the heuristic backend directly.
- New `tests/test_lp_infeasible_hold.py` asserts: returns `fallback="hold_previous_schedule"`, `_run_optimizer_heuristic` is NOT called, no Fox upload happens, and the audit row is written.

## Why

Audit on 2026-05-18 of the 2026-05-15 → 2026-05-17 window found realised energy cost ran **+£0.35-1.30/day** above the LP's own objective every day. Root cause is the heuristic-fallback path:

1. LP returns `Infeasible` (~110/30d after the Phase B refactor; was 12/30d at the prior baseline — ~10× rise).
2. Fallback at `optimizer.py:1582` calls `_run_optimizer_heuristic`.
3. Heuristic builds a `HalfHourSlot` list with no LP-derived `lp_grid_import_w` or `target_soc_pct`, so `_slot_fox_tuple` falls back to `FOX_FORCE_CHARGE_NORMAL_PWR` (3000 W) and `fdSoc=95`.
4. `_consolidate_fox_charge_block` additionally promotes standard gaps to "cheap" inside the overnight `[23h, 7h)` window.
5. Net: Fox V3 receives multiple `ForceCharge[long-window, fdPwr=3000, fdSoc=95]` groups → inverter charges at 3 kW from grid until 95 % SoC during slots the LP would have left as SelfUse.

### Definitive replay (LP run 805, uploaded 2026-05-17 03:55 UTC after the 00:55 UTC LP succeeded, then 03:55 LP infeasible)

| | Heuristic upload #775 (actual) | What the LP would have built from run 805 |
|---|---|---|
| Windows | 4× `ForceCharge` spanning 8h | 1× `ForceCharge` 05:30-09:30 + 2× SelfUse (Solar-Sponge) |
| `fdPwr` | 3000 W everywhere | **1232 W** |
| `fdSoc` | 95 % everywhere | **47 %** |
| Daytime mode | gaps only | **Solar-Sponge** (`maxSoc=100, minSocOnGrid=100`) |

Reproduced by importing prod's `lp_solution_snapshot` for run 805 back into an `LpPlan` and calling `build_fox_groups_from_lp` in the prod container.

## Why hold (not override with SelfUse)?

Fox V3 is daily-cyclic. The last successful LP plan is already on the inverter and remains in effect until the next successful solve overwrites it. Overriding it with a defensive SelfUse-only schedule would discard a still-valid plan on every transient infeasibility (and most infeasibilities are transient). Holding is strictly safer.

## Follow-up (separate PR)

Root cause of the infeasibility rate spike — likely one of the recent hard constraints (#317 legionella tank-floor, #331 PV-sufficiency guard, #311 tariff-aware base load). Investigation tracked separately; this PR is the defensive layer.

## Test plan

- [x] `pytest tests/test_lp_infeasible_hold.py tests/test_heuristic_fallback.py` — 7 passed
- [x] `pytest tests/ --ignore=tests/test_mcp_singleton.py` — 1071 passed (1 unrelated pre-existing import error in `test_mcp_singleton.py`)
- [ ] Verify on prod after merge: `optimizer_log.strategy_summary LIKE '%held previous schedule%'` rows appear at known infeasibility times, no new `fox_schedule_state` rows with `fdPwr=3000, fdSoc=95` from auto-fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)