### PR TITLE
fix(lp): relax soc[0] lowBound so LP stays feasible below reserve

### DIFF
--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -473,7 +473,19 @@ def solve_lp(
     a_grid = pulp.LpVariable.dicts("grid_import_mode", range(n), cat="Binary")
     b_bat = pulp.LpVariable.dicts("bat_charge_mode", range(n), cat="Binary")
 
+    # Forward slots ``soc[1..n]`` keep the operational reserve as a hard
+    # lower bound (``soc_min``). Slot 0 is relaxed below to ``[0, soc_max]``
+    # so the hard equality ``soc[0] == initial.soc_kwh`` (line 491) remains
+    # satisfiable when realtime SoC has slipped below the operational
+    # reserve. Previously a single ``lowBound=soc_min`` for ALL slots —
+    # combined with the hard equality — made every solve Infeasible whenever
+    # realtime SoC dipped below reserve, which then fell back to the
+    # heuristic that destructively grid-overcharged the battery (see
+    # [[project_heuristic_fox_dispatch_bug]] + PR #338). Observed 4× on
+    # 2026-05-18 when realtime SoC was 12-15 % overnight on prod (10.36 kWh
+    # battery, 15 % reserve = 1.55 kWh, realtime down to 1.04 kWh).
     soc = pulp.LpVariable.dicts("soc", range(n + 1), lowBound=soc_min, upBound=soc_max)
+    soc[0].lowBound = 0.0
     tank = pulp.LpVariable.dicts("tank", range(n + 1), lowBound=tank_lo, upBound=tank_hi)
     # PR Phase B: t_in / s_lo / s_hi removed. Heating demand is now bounded by
     # space_floor_kwh / space_ceil_kwh (physics from get_daikin_heating_kw),

--- a/tests/scheduler/test_soc_below_reserve_feasibility.py
+++ b/tests/scheduler/test_soc_below_reserve_feasibility.py
@@ -1,0 +1,153 @@
+"""When realtime SoC has slipped below the operational reserve
+(``MIN_SOC_RESERVE_PERCENT``), the LP must stay feasible.
+
+Pre-fix bug: ``soc`` LpVariable had ``lowBound=soc_min`` AND ``soc[0] ==
+initial.soc_kwh`` was a hard equality. Whenever realtime SoC < reserve, that
+combination was unsatisfiable → PuLP returned ``Infeasible`` → optimizer.py
+fell back to the heuristic which uploaded Fox V3 ForceCharge groups with
+``fdPwr=3000 W, fdSoc=95`` defaults, destructively grid-charging the battery
+(see [[project_heuristic_fox_dispatch_bug]]).
+
+Audit on 2026-05-18 found four such infeasibles in a single overnight when
+prod's realtime SoC dipped to 12-15 % (= 1.04-1.55 kWh on a 10.36 kWh
+battery with 15 % reserve = 1.55 kWh).
+
+Fix: relax ``soc[0]`` lowBound to 0 (so the equality with the realtime
+initial value is always satisfiable). Forward slots ``soc[1..n]`` keep the
+hard reserve bound — the LP must plan a path that gets back to reserve in
+slot 1, which is normally feasible (just charge from grid). The residual
+case where pre-plunge or PV-sufficiency guards also block slot-0 charging
+is caught by PR #338's defensive hold-previous-schedule fallback.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db as _db
+from src.config import config
+from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+from src.weather import WeatherLpSeries
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    _db.init_db()
+
+
+def _starts(n: int, base: datetime) -> list[datetime]:
+    return [base + timedelta(minutes=30 * i) for i in range(n)]
+
+
+def _weather(starts: list[datetime], outdoor_c: float = 12.0) -> WeatherLpSeries:
+    """Mild outdoor + no PV. Forces the LP to lean on initial SoC + grid."""
+    n = len(starts)
+    return WeatherLpSeries(
+        slot_starts_utc=list(starts),
+        temperature_outdoor_c=[outdoor_c] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[100.0] * n,
+        pv_kwh_per_slot=[0.0] * n,
+        cop_space=[3.0] * n,
+        cop_dhw=[2.5] * n,
+    )
+
+
+def test_lp_feasible_when_initial_soc_below_reserve(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pre-fix regression. Initial SoC = 12 % (1.24 kWh on a 10.36 kWh
+    battery with 15 % reserve = 1.55 kWh). Pre-fix: PuLP Infeasible. Post-fix:
+    Optimal with the first slots paying the reserve slack until natural
+    charging recovers SoC.
+    """
+    monkeypatch.setattr(config, "BATTERY_CAPACITY_KWH", 10.36)
+    monkeypatch.setattr(config, "MIN_SOC_RESERVE_PERCENT", 15.0)
+    monkeypatch.setattr(config, "DAIKIN_CONTROL_MODE", "passive")  # skip shower/legionella hard floors
+
+    n = 12
+    starts = _starts(n, datetime(2026, 5, 18, 1, 0, tzinfo=UTC))
+    plan = solve_lp(
+        slot_starts_utc=starts,
+        price_pence=[15.0] * n,
+        base_load_kwh=[0.3] * n,
+        weather=_weather(starts),
+        initial=LpInitialState(soc_kwh=1.24, tank_temp_c=45.0),
+        tz=starts[0].tzinfo,
+    )
+    assert plan.ok, f"LP should solve from below-reserve SoC, got status={plan.status!r}"
+    assert plan.soc_kwh[0] == pytest.approx(1.24, abs=0.01), (
+        "Initial SoC must be preserved exactly, not silently clamped"
+    )
+    # Battery should recover toward / above reserve within a few slots
+    # (LP_SOC_RESERVE_PENALTY = 100 p/kWh dominates a 15 p Agile slot).
+    last_soc = plan.soc_kwh[-1]
+    soc_min = 10.36 * 0.15
+    assert last_soc >= soc_min - 1e-6, (
+        f"LP should recover SoC to >= reserve {soc_min:.3f}, got {last_soc:.3f}"
+    )
+
+
+def test_lp_feasible_at_realistic_prod_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reproduces the 2026-05-18 00:58 UTC prod infeasible: SoC=12 % overnight,
+    tank=57 °C, outdoor=7 °C, no PV. Daikin in active mode (the prod default).
+    """
+    monkeypatch.setattr(config, "BATTERY_CAPACITY_KWH", 10.36)
+    monkeypatch.setattr(config, "MIN_SOC_RESERVE_PERCENT", 15.0)
+    monkeypatch.setattr(config, "DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr(config, "ENERGY_STRATEGY_MODE", "savings_first")
+
+    n = 24  # 12 h horizon
+    starts = _starts(n, datetime(2026, 5, 18, 1, 0, tzinfo=UTC))
+    pv_kwh = ([0.0] * 8 + [0.2, 0.4, 0.7, 1.0, 1.2, 1.3, 1.2, 1.0,
+                            0.8, 0.5, 0.2, 0.0, 0.0, 0.0, 0.0, 0.0])
+    weather = WeatherLpSeries(
+        slot_starts_utc=list(starts),
+        temperature_outdoor_c=[7.0] * n,
+        shortwave_radiation_wm2=[0.0] * 8 + [50, 200, 400, 600, 700, 750, 700, 600,
+                                              400, 200, 50, 0, 0, 0, 0, 0],
+        cloud_cover_pct=[80.0] * n,
+        pv_kwh_per_slot=pv_kwh,
+        cop_space=[2.5] * n,
+        cop_dhw=[2.2] * n,
+    )
+    plan = solve_lp(
+        slot_starts_utc=starts,
+        price_pence=[18.0] * 6 + [14.0] * 4 + [20.0] * 4 + [30.0] * 4 + [15.0] * 6,
+        base_load_kwh=[0.4] * n,
+        weather=weather,
+        initial=LpInitialState(soc_kwh=1.24, tank_temp_c=57.0),
+        tz=starts[0].tzinfo,
+    )
+    assert plan.ok, (
+        f"LP must remain feasible at the prod state that triggered four "
+        f"infeasibles on 2026-05-18, got status={plan.status!r}"
+    )
+
+
+def test_lp_normal_state_still_optimal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: the relaxation doesn't degrade behavior in the normal case
+    (SoC well above reserve). LP still finds Optimal and SoC never dips
+    below reserve when no forcing condition requires it.
+    """
+    monkeypatch.setattr(config, "BATTERY_CAPACITY_KWH", 10.36)
+    monkeypatch.setattr(config, "MIN_SOC_RESERVE_PERCENT", 15.0)
+    monkeypatch.setattr(config, "DAIKIN_CONTROL_MODE", "passive")
+
+    n = 12
+    starts = _starts(n, datetime(2026, 5, 18, 12, 0, tzinfo=UTC))
+    plan = solve_lp(
+        slot_starts_utc=starts,
+        price_pence=[15.0] * n,
+        base_load_kwh=[0.3] * n,
+        weather=_weather(starts),
+        initial=LpInitialState(soc_kwh=5.0, tank_temp_c=45.0),
+        tz=starts[0].tzinfo,
+    )
+    assert plan.ok
+    soc_min = 10.36 * 0.15
+    # All forward soc[i] (i>=1) must respect reserve — no slack needed
+    for i, s in enumerate(plan.soc_kwh[1:], start=1):
+        assert s >= soc_min - 1e-4, (
+            f"Forward soc[{i}]={s:.3f} dipped below reserve {soc_min:.3f} "
+            f"with no forcing condition — soft reserve must still bind in normal state"
+        )


### PR DESCRIPTION
## Summary

- Root cause for the LP infeasibility rate that triggered PR #338: ``soc`` LpVariable was bounded at ``[soc_min, soc_max]`` for every slot **including slot 0**, while ``soc[0] == initial.soc_kwh`` is a hard equality (line 491). Whenever realtime SoC slipped below the 15 % operational reserve those two became unsatisfiable → PuLP Infeasible → heuristic fallback.
- Fix: relax slot 0 specifically with ``soc[0].lowBound = 0``. ``soc[1..n]`` keep the hard ``soc_min`` bound, so the LP must plan a recovery to ≥ reserve by slot 1 (normally trivial — a small grid charge).
- Adds 3 tests in ``tests/scheduler/test_soc_below_reserve_feasibility.py``: feasibility at the prod 2026-05-18 state, behaviour at normal SoC unchanged.

## Why

Audit on 2026-05-18 found 8 explicit ``LP solver returned Infeasible`` events in the previous 72 h of docker logs (~110/30d, ~10× the prior baseline captured in the old ``project_lp_infeasibles`` memory). All four overnight 2026-05-18 Mon infeasibles had realtime SoC at 12-15 % on a 10.36 kWh battery with 15 % reserve = 1.55 kWh, i.e. ``initial.soc_kwh ≤ 1.55``. Pre-fix, ``soc[0] == 1.04`` AND ``soc[0] >= 1.55`` (from the LpVariable lowBound) cannot both hold.

The infeasibility cascaded into the heuristic-fallback bug fixed by PR #338 — every infeasible solve uploaded a Fox V3 schedule with ``fdPwr=3000, fdSoc=95`` defaults, costing roughly +£0.35-1.30/day in unwanted grid charging.

## Considered alternatives

- **Clamp ``initial.soc_kwh`` to ``≥ soc_min`` at read time.** Lies about the inverter state to the LP — dispatch would be biased.
- **Soft-reserve slack on ALL slots.** Clean model, but CBC's branch-and-bound with the extra ``n+1`` continuous slack variables busted the existing 15s time limit on a 48-slot horizon (verified by re-solving the dumped LP at the prod time limit — CBC returned a suboptimal solution that violated the slack constraint with no slack used). Rejected for that reason.
- **Per-slot bound relaxation (this PR).** Single ``lowBound`` adjustment, no new variables, no constraint count change. Forward slots keep the hard reserve — if pre-plunge / PV-sufficiency guards ALSO block slot-0 grid charging, the LP can still go Infeasible, but that's now the narrower (and rarer) residual case caught by PR #338's defensive hold-previous-schedule fallback.

## Test plan

- [x] ``pytest tests/scheduler/test_soc_below_reserve_feasibility.py`` — 3 passed
- [x] ``pytest tests/ --ignore=tests/test_mcp_singleton.py`` — 1074 passed
- [ ] On prod after merge: ``docker logs hem | grep 'LP solver returned Infeasible'`` should drop substantially. PR #338's ``optimizer_log.strategy_summary LIKE '%held previous schedule%'`` rows should also drop.

## Related

- PR #338 — defensive fallback (already merged / pending)
- Memory: ``project_lp_infeasibles`` (rate updated this session), ``project_heuristic_fox_dispatch_bug``

🤖 Generated with [Claude Code](https://claude.com/claude-code)