### PR TITLE
feat(lp): snapshot inputs on infeasible runs for offline replay

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -616,7 +616,8 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
             cheap_threshold_p        REAL,
             daikin_control_mode      TEXT,
             optimization_preset      TEXT,
-            energy_strategy_mode     TEXT
+            energy_strategy_mode     TEXT,
+            lp_status                TEXT
         )"""
     )
     conn.execute(
@@ -917,6 +918,12 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN dhw_draw_prior_json TEXT")
     if "occupancy_prior_json" not in lp_cols:
         conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN occupancy_prior_json TEXT")
+    # Infeasible-replay column. NULL on rows written before this migration
+    # (interpret as 'Optimal' — only successful solves were snapshotted prior).
+    # From 2026-05-19 onwards the Infeasible branch in _run_optimizer_lp also
+    # writes a snapshot so the constraints can be replayed offline.
+    if "lp_status" not in lp_cols:
+        conn.execute("ALTER TABLE lp_inputs_snapshot ADD COLUMN lp_status TEXT")
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_lp_inputs_snapshot_forecast_fetch ON lp_inputs_snapshot(forecast_fetch_at_utc)"
     )
@@ -4063,17 +4070,18 @@ def save_lp_snapshots(
                     soc_source, tank_source, indoor_source,
                     base_load_json, micro_climate_offset_c, forecast_fetch_at_utc, exogenous_snapshot_json, config_snapshot_json,
                     price_quantize_p, peak_threshold_p, cheap_threshold_p,
-                    daikin_control_mode, optimization_preset, energy_strategy_mode)
+                    daikin_control_mode, optimization_preset, energy_strategy_mode, lp_status)
                    VALUES (:run_id, :run_at_utc, :plan_date, :horizon_hours,
                            :soc_initial_kwh, :tank_initial_c, :indoor_initial_c,
                            :soc_source, :tank_source, :indoor_source,
                            :base_load_json, :micro_climate_offset_c, :forecast_fetch_at_utc, :exogenous_snapshot_json, :config_snapshot_json,
                            :price_quantize_p, :peak_threshold_p, :cheap_threshold_p,
-                           :daikin_control_mode, :optimization_preset, :energy_strategy_mode)""",
+                           :daikin_control_mode, :optimization_preset, :energy_strategy_mode, :lp_status)""",
                 {
                     "run_id": run_id,
                     "forecast_fetch_at_utc": inputs_row.get("forecast_fetch_at_utc"),
                     "exogenous_snapshot_json": inputs_row.get("exogenous_snapshot_json"),
+                    "lp_status": inputs_row.get("lp_status"),
                     **inputs_row,
                 },
             )

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1045,6 +1045,7 @@ def _persist_lp_snapshots(
     micro_climate_offset: float,
     forecast_fetch_at_utc: str | None = None,
     exogenous_snapshot: dict[str, Any] | None = None,
+    lp_status: str = "Optimal",
 ) -> None:
     """Build and persist the inputs + per-slot rows for this LP run.
 
@@ -1052,6 +1053,14 @@ def _persist_lp_snapshots(
     cockpit History replay source of truth. Config fields captured here are
     the LP-relevant tunables; other knobs can be recovered from
     ``config_audit`` joined by timestamp if needed.
+
+    When ``lp_status != "Optimal"`` (Infeasible / Unbounded / Not Solved) the
+    plan carries no per-slot decision vector — only ``slot_starts_utc``,
+    ``price_pence`` and ``temp_outdoor_c`` are populated by ``solve_lp``.
+    In that case we still persist the inputs row so the run can be replayed
+    offline (the whole purpose of capturing infeasibles), but skip the
+    ``lp_solution_snapshot`` writes which would all be NULL columns. The
+    ``lp_status`` column on ``lp_inputs_snapshot`` partitions the two cases.
     """
     # Config snapshot — everything the LP meaningfully conditioned on. Keep
     # compact; dashboards read this directly from the JSON.
@@ -1106,7 +1115,16 @@ def _persist_lp_snapshots(
         "daikin_control_mode": str(config.DAIKIN_CONTROL_MODE),
         "optimization_preset": str(config.OPTIMIZATION_PRESET),
         "energy_strategy_mode": str(config.ENERGY_STRATEGY_MODE),
+        "lp_status": str(lp_status),
     }
+
+    # Skip the per-slot snapshot when the LP didn't find an optimal plan —
+    # there is no per-slot decision vector to write. The inputs row is still
+    # persisted above so the run can be re-solved offline against the same
+    # inputs to find which constraint binds.
+    if lp_status != "Optimal":
+        db.save_lp_snapshots(run_id=int(run_id), inputs_row=inputs_row, solution_rows=[])
+        return
 
     # tank_temp_c, indoor_temp_c, soc_kwh are length N+1 (include initial);
     # we persist the end-of-slot state (index i+1) to match how slot results
@@ -1596,10 +1614,12 @@ def _run_optimizer_lp(
             "LP %s — holding previous Fox/Daikin schedule (defensive: heuristic fallback disabled)",
             plan.status,
         )
+        run_at_iso = _now_utc().isoformat()
+        run_id: int | None = None
         try:
             actual_mean = float(mean(prices)) if prices else None
-            db.log_optimizer_run({
-                "run_at": _now_utc().isoformat(),
+            run_id = db.log_optimizer_run({
+                "run_at": run_at_iso,
                 "rates_count": len(prices),
                 "cheap_slots": 0,
                 "peak_slots": 0,
@@ -1617,6 +1637,28 @@ def _run_optimizer_lp(
             })
         except Exception:  # noqa: BLE001 — audit log must never abort the return
             logger.exception("optimizer_log write failed during LP-infeasible hold")
+        # Persist the inputs side of the snapshot so the run can be replayed
+        # offline. Without this the audit script can only see "Infeasible"
+        # in optimizer_log but not which constraints bound. lp_status carries
+        # the solver verdict; per-slot solution columns stay NULL.
+        if run_id is not None:
+            try:
+                _persist_lp_snapshots(
+                    run_id=run_id,
+                    run_at_iso=run_at_iso,
+                    plan_date=plan_date,
+                    plan=plan,
+                    initial=initial,
+                    base_load=base_load,
+                    micro_climate_offset=micro_climate_offset,
+                    forecast_fetch_at_utc=(forecast_fetch_at_utc if forecast else None),
+                    exogenous_snapshot=exogenous_snapshot,
+                    lp_status=plan.status,
+                )
+            except Exception as e:
+                logger.warning(
+                    "LP infeasible-snapshot persistence failed (non-fatal): %s", e,
+                )
         return {
             "ok": False,
             "error": f"LP {plan.status}",

--- a/tests/test_lp_infeasible_hold.py
+++ b/tests/test_lp_infeasible_hold.py
@@ -165,3 +165,90 @@ def test_lp_infeasible_writes_audit_row(monkeypatch: pytest.MonkeyPatch) -> None
     assert row["daikin_actions_count"] == 0
     assert "Infeasible" in (row["strategy_summary"] or "")
     assert "held previous schedule" in (row["strategy_summary"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Infeasible-snapshot persistence — the inputs row must land in
+# lp_inputs_snapshot with lp_status='Infeasible' so the constraint set can be
+# replayed offline. Background: a residual class of above-reserve Infeasibles
+# survives PR #339 (most likely appliance+PV-down-revision interaction; see
+# 2026-05-19 prod incident). Without a snapshot we can only see "Infeasible"
+# in optimizer_log; with it we can reload solve_lp inputs and reproduce.
+# ---------------------------------------------------------------------------
+
+
+def _stub_infeasible_solve_realistic(
+    slot_starts_utc: list[datetime],
+    price_pence: list[float],
+    *_args: Any,
+    **_kwargs: Any,
+) -> LpPlan:
+    """Mirror real solve_lp's shape on Infeasible: slot_starts_utc + price_pence
+    + temp_outdoor_c populated, per-slot decision lists empty."""
+    plan = LpPlan(
+        ok=False,
+        status="Infeasible",
+        objective_pence=0.0,
+        peak_threshold_pence=18.0,
+        cheap_threshold_pence=8.0,
+    )
+    plan.slot_starts_utc = list(slot_starts_utc)
+    plan.price_pence = list(price_pence)
+    plan.temp_outdoor_c = [12.0] * len(slot_starts_utc)
+    return plan
+
+
+def test_lp_infeasible_persists_inputs_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Infeasible branch must persist an lp_inputs_snapshot row so the
+    audit/replay path can reload the exact inputs that broke. The row carries
+    ``lp_status='Infeasible'`` to distinguish from successful solves."""
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+
+    monkeypatch.setattr(
+        "src.scheduler.lp_optimizer.solve_lp", _stub_infeasible_solve_realistic,
+    )
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result["ok"] is False, result
+
+    # The optimizer_log row was written first; its id is the run_id we'd join on.
+    import sqlite3 as _sql
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, strategy_summary FROM optimizer_log ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert row is not None, "optimizer_log was not written"
+        run_id = int(row["id"])
+        assert "Infeasible" in (row["strategy_summary"] or "")
+
+        snap = conn.execute(
+            "SELECT * FROM lp_inputs_snapshot WHERE run_id = ?", (run_id,),
+        ).fetchone()
+        assert snap is not None, (
+            f"lp_inputs_snapshot row missing for infeasible run_id={run_id} — "
+            f"replay capability is broken"
+        )
+        assert dict(snap)["lp_status"] == "Infeasible", (
+            f"lp_status not tagged: {dict(snap)['lp_status']!r}"
+        )
+        # Replay-critical inputs must be present.
+        assert snap["soc_initial_kwh"] is not None
+        assert snap["tank_initial_c"] is not None
+        assert snap["base_load_json"], "base_load_json empty — replay impossible"
+        assert snap["config_snapshot_json"], "config_snapshot_json empty"
+        # And the per-slot solution rows must be EMPTY — there is no decision
+        # vector to write when the LP didn't solve. Writing NULL-filled rows
+        # would pollute the History view (which assumes lp_solution_snapshot
+        # rows describe a real solution).
+        n_solution = conn.execute(
+            "SELECT COUNT(*) FROM lp_solution_snapshot WHERE run_id = ?", (run_id,),
+        ).fetchone()[0]
+        assert n_solution == 0, (
+            f"lp_solution_snapshot wrote {n_solution} rows for an Infeasible "
+            f"solve — expected 0 (no decision vector exists)"
+        )
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- Persist ``lp_inputs_snapshot`` row on the LP-infeasible branch in ``_run_optimizer_lp`` (previously only ``optimizer_log`` was written)
- Add ``lp_status`` column to ``lp_inputs_snapshot`` (NULL = Optimal for legacy rows, ``'Infeasible'`` on new rows)
- Skip ``lp_solution_snapshot`` writes on non-Optimal runs (no decision vector exists)

## Why

The 2026-05-19 prod incident at 21:25 BST: LP returned Infeasible with SoC=68 % (well above the 10 % reserve floor), appliance dispatch had just armed a washing machine for Wed 02:00 (+0.75 kWh in base_load), PV calibration ratio dropped to 0.564 the same solve. PR #338 caught the infeasibility safely (held previous schedule), but with no inputs snapshot the constraints could not be replayed offline to find which intersection broke. Memory ``project_lp_dispatch_audit_landed`` flagged a "residual class" of above-reserve infeasibles ~110/30d before #338; this PR is the diagnostic enabler for characterising what's left.

## Test plan

- [x] ``tests/test_lp_infeasible_hold.py::test_lp_infeasible_persists_inputs_snapshot`` — new test asserts the inputs row is written, ``lp_status='Infeasible'`` is set, ``base_load_json`` + ``config_snapshot_json`` are populated, and ``lp_solution_snapshot`` has zero rows for that run_id.
- [x] Existing 4 hold-marker / no-heuristic / no-Fox / audit-row tests still pass.
- [x] Full ``tests/scheduler/`` + ``tests/test_heuristic_fallback.py`` + ``tests/test_lp_infeasible_hold.py`` — 55 passed, 1 xfailed (known).

## Follow-up

Once this lands and the prod DB starts collecting infeasible snapshots, the next residual-class event will be replayable via ``solve_lp(**inputs_from_snapshot)``. That's the substrate for PR-B (appliance-aware infeasibility retry) to be evaluated against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)