### PR TITLE
feat(lp): appliance-aware infeasibility retry

### DIFF
--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1579,6 +1579,68 @@ def _run_optimizer_lp(
         micro_climate_offset_by_hour_c=micro_climate_offset_by_hour,
         export_price_pence=export_prices,
     )
+
+    # Appliance-aware infeasibility retry. The 2026-05-19 prod incident showed
+    # that arming an appliance dispatch (washing machine, +0.75 kWh across 3
+    # cheap-overnight slots) can push an otherwise-feasible 48 h horizon over
+    # the constraint boundary when combined with a late-day PV down-revision
+    # and tight tank/battery competition. The deadline check in
+    # appliance_dispatch.reconcile() is a hard pre-LP filter — if it fits at
+    # all, it gets folded into base_load — so the LP has no freedom to slip
+    # the appliance even by one slot, and goes Infeasible. PR #338 then holds
+    # the previous schedule (stale by hours).
+    #
+    # Soft-deadline retry: when the LP fails AND there's a non-zero appliance
+    # contribution in base_load, re-solve once with the appliance load
+    # dropped. If that clears, ship the appliance-blind plan. The APScheduler
+    # cron registered by reconcile() is untouched — the appliance still fires
+    # at its planned time; the LP just won't have shaped its plan around the
+    # appliance run. Trade-off: slightly suboptimal coordination during the
+    # appliance window vs. shipping a 2-3 h stale held-schedule. The former
+    # is strictly the smaller perturbation.
+    appliance_kwh_total = float(sum(appliance_profile_kwh))
+    appliance_retry_dropped = False
+    if (not plan.ok) and appliance_kwh_total > 1e-6:
+        n_appliance_slots = sum(1 for v in appliance_profile_kwh if v > 1e-6)
+        logger.warning(
+            "LP %s with armed appliance load (+%.3f kWh across %d slot(s)) — "
+            "retrying without appliance contribution. Cron stays; LP plan "
+            "won't be shaped around the appliance run.",
+            plan.status, appliance_kwh_total, n_appliance_slots,
+        )
+        try:
+            plan_retry = solve_lp(
+                slot_starts_utc=starts,
+                price_pence=prices,
+                base_load_kwh=residual_base_load,
+                weather=weather,
+                initial=initial,
+                tz=tz,
+                micro_climate_offset_c=micro_climate_offset,
+                micro_climate_offset_by_hour_c=micro_climate_offset_by_hour,
+                export_price_pence=export_prices,
+            )
+        except Exception as _retry_exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                "LP appliance-drop retry raised %s — falling through to "
+                "held-schedule",
+                type(_retry_exc).__name__,
+            )
+            plan_retry = None
+        if plan_retry is not None and plan_retry.ok:
+            logger.info(
+                "LP appliance-drop retry: Optimal (objective %.0fp). Shipping "
+                "appliance-blind plan.",
+                plan_retry.objective_pence,
+            )
+            plan = plan_retry
+            base_load = list(residual_base_load)
+            appliance_retry_dropped = True
+            exogenous_snapshot["appliance_retry_dropped"] = True
+            exogenous_snapshot["appliance_retry_kwh_excluded"] = round(
+                appliance_kwh_total, 4,
+            )
+
     if not plan.ok:
         # Defensive: do NOT call _run_optimizer_heuristic on LP failure. The
         # heuristic builds Fox V3 ForceCharge groups from a slot list that has
@@ -1610,7 +1672,13 @@ def _run_optimizer_lp(
                 "battery_warning": False,
                 "strategy_summary": (
                     f"{plan_date}: LP {plan.status} — held previous schedule "
-                    f"(no hardware writes; heuristic fallback disabled)"
+                    f"(no hardware writes; heuristic fallback disabled"
+                    + (
+                        f"; appliance-drop retry also Infeasible "
+                        f"({appliance_kwh_total:.2f} kWh)"
+                        if appliance_kwh_total > 1e-6 else ""
+                    )
+                    + ")"
                 ),
                 "fox_schedule_uploaded": False,
                 "daikin_actions_count": 0,
@@ -1667,6 +1735,11 @@ def _run_optimizer_lp(
     naive_agile_cost = total_kwh * actual_mean
     savings_vs_svt_pence = max(0.0, naive_svt_cost - naive_agile_cost)
     strategy += f"; indicative vs SVT ~{savings_vs_svt_pence / 100:.2f} GBP/day at mean Agile"
+    if appliance_retry_dropped:
+        strategy += (
+            f"; appliance load (+{appliance_kwh_total:.2f} kWh) excluded "
+            f"from LP plan to clear Infeasible — cron still fires"
+        )
 
     db.save_daily_target(
         {

--- a/tests/test_lp_infeasible_appliance_retry.py
+++ b/tests/test_lp_infeasible_appliance_retry.py
@@ -1,0 +1,302 @@
+"""When ``_run_optimizer_lp`` returns Infeasible AND the base_load had a
+non-zero appliance contribution, the optimizer must retry once with the
+appliance kWh dropped. If that retry is Optimal the appliance-blind plan
+ships (the APScheduler cron is untouched — the appliance still fires at
+its planned time). If the retry is still Infeasible, behaviour falls
+through to the existing PR #338 held-schedule defensive path.
+
+Background: 2026-05-19 prod incident at 21:25 BST. LP went Infeasible on
+the tier_boundary MPC trigger. The only state change vs the previous
+(Optimal) solve at 18:55 was the appliance dispatch arming a washing
+machine for Wed 02:00 (+0.75 kWh across 3 cheap-overnight slots). PR-A
+captured the inputs; this PR makes the optimizer self-heal.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.scheduler import optimizer
+from src.scheduler.lp_optimizer import LpPlan
+
+TARIFF = "E-1R-AGILE-TEST-APPLIANCE-RETRY"
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _lp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", TARIFF)
+    monkeypatch.setattr(app_config, "OPTIMIZER_BACKEND", "lp")
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", True)
+    monkeypatch.setattr(app_config, "APPLIANCE_DISPATCH_ENABLED", True)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _seed_realistic_day(start: datetime) -> None:
+    rows = []
+    vf = start
+    for _ in range(48):
+        if 1 <= vf.hour < 5:
+            price = -2.0
+        elif 5 <= vf.hour < 16:
+            price = 10.0
+        elif 16 <= vf.hour < 19:
+            price = 35.0
+        else:
+            price = 12.0
+        vt = vf + timedelta(minutes=30)
+        rows.append({"valid_from": _iso(vf), "valid_to": _iso(vt), "value_inc_vat": price})
+        vf = vt
+    db.save_agile_rates(rows, TARIFF)
+
+
+def _seed_armed_washer(*, planned_start: datetime, duration_min: int = 90) -> int:
+    """Insert a washer + scheduled job covering ``[planned_start, +duration)``.
+    Returns the appliance id. Mirrors what appliance_dispatch.reconcile would
+    write after picking the cheapest contiguous window.
+    """
+    appliance_id = db.add_appliance(
+        vendor="smartthings",
+        vendor_device_id="test-washer-1",
+        name="Washing machine",
+        device_type="washer",
+        default_duration_minutes=duration_min,
+        deadline_local_time="07:00",
+        typical_kw=0.5,
+        enabled=True,
+    )
+    planned_end = planned_start + timedelta(minutes=duration_min)
+    deadline = planned_start + timedelta(hours=8)
+    db.create_appliance_job(
+        appliance_id=appliance_id,
+        armed_at_utc=_iso(planned_start - timedelta(hours=1)),
+        deadline_utc=_iso(deadline),
+        duration_minutes=duration_min,
+        planned_start_utc=_iso(planned_start),
+        planned_end_utc=_iso(planned_end),
+        avg_price_pence=-1.5,
+        status="scheduled",
+    )
+    return appliance_id
+
+
+class _TwoPhaseSolver:
+    """First call → Infeasible. Second call → Optimal. Records the
+    ``base_load_kwh`` arg of each call so the test can assert the retry was
+    invoked with the appliance contribution removed.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[float]] = []
+
+    def __call__(
+        self,
+        *,
+        slot_starts_utc: list[datetime],
+        price_pence: list[float],
+        base_load_kwh: list[float],
+        **_kwargs: Any,
+    ) -> LpPlan:
+        self.calls.append(list(base_load_kwh))
+        if len(self.calls) == 1:
+            plan = LpPlan(
+                ok=False, status="Infeasible", objective_pence=0.0,
+                peak_threshold_pence=18.0, cheap_threshold_pence=8.0,
+            )
+            plan.slot_starts_utc = list(slot_starts_utc)
+            plan.price_pence = list(price_pence)
+            plan.temp_outdoor_c = [12.0] * len(slot_starts_utc)
+            return plan
+        # Second call: realistic Optimal plan shape. Per-slot vectors length N;
+        # state vectors length N+1.
+        n = len(slot_starts_utc)
+        plan = LpPlan(
+            ok=True, status="Optimal", objective_pence=42.0,
+            peak_threshold_pence=18.0, cheap_threshold_pence=8.0,
+        )
+        plan.slot_starts_utc = list(slot_starts_utc)
+        plan.price_pence = list(price_pence)
+        plan.import_kwh = [0.0] * n
+        plan.export_kwh = [0.0] * n
+        plan.battery_charge_kwh = [0.0] * n
+        plan.battery_discharge_kwh = [0.0] * n
+        plan.pv_use_kwh = [0.0] * n
+        plan.pv_curtail_kwh = [0.0] * n
+        plan.dhw_electric_kwh = [0.0] * n
+        plan.space_electric_kwh = [0.0] * n
+        plan.lwt_offset_c = [0.0] * n
+        plan.tank_temp_c = [45.0] * (n + 1)
+        plan.soc_kwh = [5.0] * (n + 1)
+        plan.temp_outdoor_c = [12.0] * n
+        return plan
+
+
+def test_lp_infeasible_with_appliance_retries_without_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First solve Infeasible, second solve Optimal — the second solve must
+    have been called with the appliance kWh removed from ``base_load_kwh``.
+    The optimizer must then proceed down the Optimal path (no held-schedule
+    return) and the strategy_summary must surface the appliance exclusion.
+    """
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+    # Place the washer inside the LP horizon (next 48 h from now=18:00 UTC).
+    _seed_armed_washer(
+        planned_start=datetime(2026, 4, 23, 1, 30, tzinfo=UTC),
+        duration_min=90,
+    )
+
+    solver = _TwoPhaseSolver()
+    monkeypatch.setattr("src.scheduler.lp_optimizer.solve_lp", solver)
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result.get("ok") is True, f"expected Optimal after retry, got {result}"
+    assert len(solver.calls) == 2, (
+        f"expected exactly 2 solve_lp calls (Infeasible + retry), "
+        f"got {len(solver.calls)}"
+    )
+
+    first_total = sum(solver.calls[0])
+    second_total = sum(solver.calls[1])
+    assert first_total > second_total + 1e-6, (
+        f"retry base_load was not reduced: first={first_total:.3f} "
+        f"second={second_total:.3f}"
+    )
+    # Specifically, the difference should match the appliance contribution
+    # (0.5 kW × 0.5 h × 3 slots = 0.75 kWh; the planned window spans 3 half-
+    # hour slots starting at 01:30).
+    delta = first_total - second_total
+    assert 0.6 <= delta <= 0.9, (
+        f"appliance-drop delta out of expected range: {delta:.3f} kWh "
+        f"(expected ~0.75 kWh)"
+    )
+
+    # The strategy_summary on the daily_target row must note the exclusion.
+    target = db.get_daily_target("2026-04-23")
+    if target is None:
+        target = db.get_daily_target("2026-04-22")
+    assert target is not None, "no daily_target row written after retry"
+    assert "appliance" in (target.get("strategy_summary") or "").lower(), (
+        f"strategy_summary missing appliance-exclusion note: "
+        f"{target.get('strategy_summary')!r}"
+    )
+
+
+def test_lp_infeasible_with_appliance_double_fail_falls_through_to_hold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If BOTH the original solve and the appliance-drop retry return
+    Infeasible, the optimizer must fall through to the held-schedule path
+    (no Fox upload) and the audit row must mention that the appliance retry
+    was also Infeasible. This is the "appliance isn't the cause" branch.
+    """
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+    _seed_armed_washer(
+        planned_start=datetime(2026, 4, 23, 1, 30, tzinfo=UTC),
+        duration_min=90,
+    )
+
+    calls: list[list[float]] = []
+
+    def _always_infeasible(
+        *,
+        slot_starts_utc: list[datetime],
+        price_pence: list[float],
+        base_load_kwh: list[float],
+        **_kwargs: Any,
+    ) -> LpPlan:
+        calls.append(list(base_load_kwh))
+        plan = LpPlan(
+            ok=False, status="Infeasible", objective_pence=0.0,
+            peak_threshold_pence=18.0, cheap_threshold_pence=8.0,
+        )
+        plan.slot_starts_utc = list(slot_starts_utc)
+        plan.price_pence = list(price_pence)
+        plan.temp_outdoor_c = [12.0] * len(slot_starts_utc)
+        return plan
+
+    monkeypatch.setattr("src.scheduler.lp_optimizer.solve_lp", _always_infeasible)
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result.get("ok") is False
+    assert result.get("fallback") == "hold_previous_schedule"
+    assert len(calls) == 2, (
+        f"expected 2 solve_lp attempts (original + appliance-drop retry), "
+        f"got {len(calls)}"
+    )
+
+    # And the optimizer_log strategy_summary must surface that the retry
+    # also failed — so the audit script can distinguish "appliance was the
+    # cause" from "something else was the cause".
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT strategy_summary FROM optimizer_log ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert row is not None
+        summary = (row["strategy_summary"] or "").lower()
+        assert "infeasible" in summary
+        assert "appliance-drop retry also infeasible" in summary, (
+            f"strategy_summary doesn't tag the failed appliance retry: "
+            f"{row['strategy_summary']!r}"
+        )
+    finally:
+        conn.close()
+
+
+def test_lp_infeasible_without_appliance_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When there is no armed appliance contributing to base_load, the
+    optimizer must NOT call solve_lp a second time. The retry is a targeted
+    intervention for appliance-induced infeasibility, not a generic re-try
+    loop.
+    """
+    now = datetime(2026, 4, 22, 18, 0, tzinfo=UTC)
+    monkeypatch.setattr(optimizer, "_now_utc", lambda: now)
+    _seed_realistic_day(datetime(2026, 4, 22, 0, 0, tzinfo=UTC))
+    # No appliance seeded — appliance_load_profile_kw returns {}.
+
+    calls: list[int] = []
+
+    def _record_call(
+        *,
+        slot_starts_utc: list[datetime],
+        price_pence: list[float],
+        **_kwargs: Any,
+    ) -> LpPlan:
+        calls.append(1)
+        plan = LpPlan(
+            ok=False, status="Infeasible", objective_pence=0.0,
+            peak_threshold_pence=18.0, cheap_threshold_pence=8.0,
+        )
+        plan.slot_starts_utc = list(slot_starts_utc)
+        plan.price_pence = list(price_pence)
+        plan.temp_outdoor_c = [12.0] * len(slot_starts_utc)
+        return plan
+
+    monkeypatch.setattr("src.scheduler.lp_optimizer.solve_lp", _record_call)
+
+    result = optimizer.run_optimizer(fox=None, daikin=None)
+    assert result.get("ok") is False
+    assert result.get("fallback") == "hold_previous_schedule"
+    assert len(calls) == 1, (
+        f"expected exactly 1 solve_lp call when no appliance was armed, "
+        f"got {len(calls)} (retry should be gated on appliance presence)"
+    )


### PR DESCRIPTION
## Summary

When ``_run_optimizer_lp`` returns Infeasible AND there's a non-zero appliance contribution in ``base_load``, retry once with ``residual_base_load`` (appliance kWh dropped) before falling through to PR #338's held-schedule path. If the retry is Optimal, ship the appliance-blind plan; the APScheduler cron is untouched, so the appliance still fires at its planned time.

## Why

2026-05-19 prod incident at 21:25 BST. SoC was 68 % (way above the 10 % reserve floor — PR #339 territory was not the cause). The previous MPC at 18:55 BST was Optimal. Between those two solves the only material input change was the appliance dispatcher arming a washing machine for Wed 02:00 (+0.75 kWh in base_load across 3 cheap slots). The 21:25 solve returned Infeasible; PR #338 held the previous schedule, so the household lost LP coordination for 2.5 h until the next solve.

The appliance deadline is currently a hard pre-LP filter (``appliance_dispatch.reconcile`` picks the cheapest contiguous window before the deadline and the LP must absorb that load at those exact slots). When the LP can't satisfy everything else with that load locked in, the whole solve fails — there's no way for the LP to slip the appliance by one slot.

## Design choice

Two viable shapes for "soft deadline":

1. **Let the LP pick the appliance slot itself** (add per-slot variables, sum-to-required, slack against deadline). LP-correct, but pulls appliance_dispatch into the LP variable space — bigger refactor (LpPlan needs an appliance plan, write-back to ``appliance_jobs``, cron re-registration).
2. **Retry without the appliance.** ← chosen here. Keeps appliance_dispatch and the LP independent. If the appliance is *the* cause of infeasibility, the second solve clears and ships. If not, falls through to PR #338's defensive path with a tag that surfaces "we tried, it wasn't the appliance" in the daily audit.

(2) is strictly the smaller intervention. It's only an LP-coordination loss during the appliance window itself (~1 h), versus shipping a stale held-schedule for 2-3 h.

## Behaviour matrix

| Original solve | Appliance present | Retry solve | Behaviour | Strategy summary |
|---|---|---|---|---|
| Optimal | any | n/a | unchanged | normal |
| Infeasible | no | n/a | held-schedule (PR #338) | "held previous schedule" |
| Infeasible | yes | Optimal | **ship retry plan** | "...appliance load (+X kWh) excluded..." |
| Infeasible | yes | Infeasible | held-schedule | "...appliance-drop retry also Infeasible..." |

## Test plan

- [x] ``test_lp_infeasible_with_appliance_retries_without_it`` — Two-phase solver (Infeasible → Optimal). Asserts (a) exactly 2 solve_lp calls, (b) the second base_load is ~0.75 kWh smaller, (c) the daily_target strategy_summary surfaces the exclusion.
- [x] ``test_lp_infeasible_with_appliance_double_fail_falls_through_to_hold`` — Always-Infeasible solver. Asserts (a) the retry is still attempted, (b) the optimizer ends in held-schedule, (c) optimizer_log strategy_summary tags the failed retry.
- [x] ``test_lp_infeasible_without_appliance_does_not_retry`` — Infeasible solver, no appliance armed. Asserts exactly 1 solve_lp call — the retry is gated on appliance presence, not a generic re-try loop.
- [x] Full ``tests/scheduler/`` + ``tests/test_heuristic_fallback.py`` + ``tests/test_lp_infeasible_hold.py`` + new file — 57 passed, 1 xfailed (known heuristic-defaults xfail).

## Follow-up

PR-A (#341) lands first to ensure the prod DB starts capturing infeasible snapshots — so we can verify, after this lands, that the appliance-retry actually fires on the next residual-class event with telemetry. The audit script at ``/srv/hem/data/audit_held_schedule.py`` already classifies held events; once both PRs are deployed, the appliance-retry strategy_summary tag will help the script split the held-schedule events into "appliance was the cause / wasn't the cause" buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)