### PR TITLE
feat(lp): shower-window tank floor → soft constraint with heavy penalty

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -668,6 +668,14 @@ class Config:
     LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT: float = float(
         os.getenv("LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT", "0.01")
     )
+    # Shower-floor slack penalty (pence per °C-slot of breach). Heavy default
+    # (50 p / K-slot) so the LP only violates when physically forced — see
+    # PR #344. The slack becomes the "by how many K did the tank miss the
+    # shower floor" diagnostic. Lowering it weakens the comfort guarantee;
+    # raising it risks Infeasible if other constraints already strain.
+    LP_SHOWER_LO_PENALTY_PENCE_PER_DEGC_SLOT: float = float(
+        os.getenv("LP_SHOWER_LO_PENALTY_PENCE_PER_DEGC_SLOT", "50.0")
+    )
     # Comma-separated trigger reasons for which scenario LP runs. Other
     # triggers (drift, forecast_revision, hourly cron not in this list)
     # use only the nominal solve to keep latency low.

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -707,10 +707,29 @@ def solve_lp(
     # Skip shower hard constraint in passive mode — the LP can't decide e_dhw
     # to make this happen (firmware controls the tank). Enforcing would make
     # the solve infeasible whenever tank starts low.
+    #
+    # Soft floor with high penalty (PR #344): the previous hard floor
+    # ``tank[i+1] >= t_min_dhw`` on every shower-window slot drove an
+    # infeasibility class observed empirically — 8 of 9 above-reserve
+    # infeasibilities in the 60-day audit fired at the 21:25 BST tier-boundary
+    # MPC trigger where slot 0 lands inside the evening shower window and
+    # the tank is too cold to lift the required °C in a single 30-min slot
+    # (physics floor: ~10 K/slot at max HP draw + COP 2.5, vs. e.g. 45-28
+    # = 17 K required). With a hard constraint these solves returned
+    # Infeasible and PR #338 then held the previous schedule. With this
+    # soft floor + heavy penalty (default 50 p / K-slot, well above any
+    # marginal kWh saving), the LP heats as fast as physically possible
+    # and surfaces the unavoidable deficit as positive slack, instead of
+    # going Infeasible.
+    s_shower_lo: dict[int, pulp.LpVariable] = {}
+    shower_lo_penalty_p = float(
+        getattr(config, "LP_SHOWER_LO_PENALTY_PENCE_PER_DEGC_SLOT", 50.0)
+    )
     if not passive_daikin:
         for i in range(n):
             if shower_mask[i]:
-                prob += tank[i + 1] >= t_min_dhw
+                s_shower_lo[i] = pulp.LpVariable(f"shower_lo_slack_{i}", lowBound=0)
+                prob += tank[i + 1] + s_shower_lo[i] >= t_min_dhw
 
         # Weekly legionella thermal-shock cycle. When ``DHW_LEGIONELLA_DAY``
         # ∈ [0,6] (Mon..Sun, Python weekday convention), force tank ≥ target
@@ -947,6 +966,16 @@ def solve_lp(
     # penalty is needed to prevent gratuitous overshoot.
     tank_hi_slack_p = float(getattr(config, "LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT", 0.01))
     obj_tank_hi = tank_hi_slack_p * pulp.lpSum(s_tank_hi[i] for i in range(n))
+    # PR #344 shower-floor slack penalty. Heavy by default (50 p / K-slot)
+    # so the LP only breaches when physically forced — the slack is the
+    # "we couldn't reach 45 °C in time" diagnostic. Setting the penalty to
+    # zero would degenerate to "ignore shower floor", which is wrong; tune
+    # downward only with care.
+    obj_shower_lo: Any = 0
+    if s_shower_lo:
+        obj_shower_lo = shower_lo_penalty_p * pulp.lpSum(
+            s_shower_lo[i] for i in s_shower_lo
+        )
     # PV-abundance DHW reward: when PV exceeds self-use + battery headroom, every kWh
     # the LP routes into the tank instead of curtailing earns a small reward. Tied to
     # the same per-slot bool used for the ceiling lift above.
@@ -983,7 +1012,10 @@ def solve_lp(
     obj_pv_curt = (
         pv_curt_pen * pulp.lpSum(pv_curt[i] for i in range(n)) if pv_curt_pen > 0 else 0
     )
-    objective = obj_grid + obj_cycle + obj_comfort + obj_tank_hi + obj_pv_curt + obj_pv_abundance_dhw
+    objective = (
+        obj_grid + obj_cycle + obj_comfort + obj_tank_hi
+        + obj_pv_curt + obj_pv_abundance_dhw + obj_shower_lo
+    )
 
     if use_stress and stress_aux:
         # Stress cost is suppressed during negative-price slots: every kWh of

--- a/tests/test_lp_shower_floor_soft.py
+++ b/tests/test_lp_shower_floor_soft.py
@@ -1,0 +1,195 @@
+"""The shower-window tank floor (``tank[i+1] >= t_min_dhw``) is now soft.
+
+Before PR #344 this constraint was HARD on every slot inside a shower window.
+That stacked with the LP firing 5 min before the evening shower window (the
+``tier_boundary`` MPC trigger at 21:25 BST) to drive 8 of 9 above-reserve
+infeasibilities in the 60-day audit window. The pattern: horizon slot 0
+starts at 21:30 BST, which IS the shower window. Tank temperature at the
+solve moment is sometimes too low to lift to 45 °C in a single 30-min slot
+(physics floor: ~10 K of heating per slot at max HP draw and COP 2.5). With
+a hard constraint the solver returned Infeasible. With this PR's soft
+constraint (slack variable + 50 p / K-slot penalty), the LP heats as fast
+as physically possible and surfaces the unavoidable deficit as a quantified
+slack — no Infeasible.
+
+Penalty calibration: each saved kWh of HP electricity costs ~12-35 p (cheap
+to peak Agile). Each K saved on tank temp avoids ~0.1 kWh. So saving 5 K
+saves ~1 p. The default 50 p / K-slot penalty exceeds any conceivable
+saving, ensuring the LP only breaches the floor when physically forced
+(not when it would just be slightly cheaper to skip).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db as _db
+from src.config import config as app_config
+from src.scheduler.lp_optimizer import LpInitialState, solve_lp
+from src.weather import WeatherLpSeries
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    _db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _active_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Match the prod active-mode shape that hits this bug class."""
+    monkeypatch.setattr(app_config, "LP_CBC_TIME_LIMIT_SECONDS", 15)
+    monkeypatch.setattr(app_config, "LP_INVERTER_STRESS_COST_PENCE", 0.0)
+    monkeypatch.setattr(app_config, "LP_HP_MIN_ON_SLOTS", 1)
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr(app_config, "ENERGY_STRATEGY_MODE", "savings_first")
+    monkeypatch.setattr(app_config, "BATTERY_CAPACITY_KWH", 10.36)
+    monkeypatch.setattr(app_config, "MIN_SOC_RESERVE_PERCENT", 10.0)
+    monkeypatch.setattr(app_config, "DAIKIN_MAX_HP_KW", 2.0)
+    monkeypatch.setattr(app_config, "DHW_TANK_LITRES", 200.0)
+    monkeypatch.setattr(app_config, "DHW_DAILY_SHOWER_LITRES", 0.0)  # isolate the floor
+    monkeypatch.setattr(app_config, "LP_PLUNGE_PREP_HOURS", 0)
+    monkeypatch.setattr(app_config, "LP_SOC_FINAL_KWH", 0.0)
+    monkeypatch.setattr(app_config, "LP_PV_SUFFICIENCY_GUARD", False)
+    # Evening shower starts EXACTLY at the horizon slot-0 boundary.
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "21:30-22:30")
+    monkeypatch.setattr(app_config, "LP_SHOWER_MORNING_LOCAL", "")
+    monkeypatch.setattr(app_config, "LP_SHOWER_EVENING_LOCAL", "")
+
+
+def _build(
+    n: int, *, t_out: float = -2.0,
+) -> tuple[list[datetime], WeatherLpSeries, list[float], list[float]]:
+    """Horizon starts at 21:30 BST (20:30 UTC). Slot 0 IS inside the shower
+    window; subsequent slots span overnight then the next day.
+
+    Default ``t_out=-2 °C`` because solve_lp recomputes COP from the
+    Daikin curve (ignoring any cop_dhw / cop_space in WeatherLpSeries),
+    so the actual lift-per-slot is driven by ``cop_at_temperature(t_out)``.
+    At -2 °C the COP is ~2.9 and the per-slot lift cap is ~12 K — meaning
+    a cold tank at 28 °C cannot reach the 45 °C shower floor in one slot.
+    """
+    base = datetime(2026, 5, 19, 20, 30, tzinfo=UTC)
+    starts = [base + i * timedelta(minutes=30) for i in range(n)]
+    weather = WeatherLpSeries(
+        slot_starts_utc=list(starts),
+        temperature_outdoor_c=[t_out] * n,
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[80.0] * n,
+        pv_kwh_per_slot=[0.0] * n,
+        cop_space=[3.0] * n,  # IGNORED — solve_lp recomputes from temp
+        cop_dhw=[2.5] * n,
+    )
+    prices = [12.0] * n
+    base_load = [0.3] * n
+    return starts, weather, prices, base_load
+
+
+def test_cold_tank_in_slot_0_shower_window_is_now_feasible() -> None:
+    """The reproduction of the 8-of-9 above-reserve infeasibility pattern.
+
+    Tank starts at 28 °C (matches 2026-05-14 20:05 + 2026-05-18 19:55 prod
+    incidents — see audit memo). Shower window starts at slot 0. Lifting
+    from 28 → 45 °C requires +17 K thermal in 30 min; max HP electrical
+    is 1 kWh × COP 2.5 = 2.5 kWh thermal = ~3 K with the 200 L tank's
+    heat capacity at this slot length. So slot-0 floor is PHYSICALLY
+    impossible. Pre-#344 this returned Infeasible.
+
+    Post-#344 the LP solves with a positive slack reflecting the
+    unavoidable deficit, and the rest of the horizon plans cleanly.
+    """
+    n = 12
+    starts, w, prices, base_load = _build(n)
+    plan = solve_lp(
+        slot_starts_utc=starts,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=LpInitialState(soc_kwh=5.0, tank_temp_c=28.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, (
+        f"LP should be Optimal with soft shower floor (status={plan.status}). "
+        f"Pre-#344 this exact scenario reproduced the residual-class "
+        f"infeasibility audit."
+    )
+    # The LP should have lifted the tank as fast as physically possible.
+    # tank[1] = tank[0] + lift - loss - draw. With tank[0]=28 and ~3 K max
+    # lift per slot, tank[1] should be ~30-31 °C — short of the 45 °C floor
+    # by 14-15 K. That deficit IS the slack value (the diagnostic signal).
+    assert plan.tank_temp_c[1] < 45.0, (
+        f"Expected tank[1] < 45 (physics floor unreachable in 1 slot from "
+        f"28 °C), got {plan.tank_temp_c[1]}"
+    )
+    # And the LP must have planned DHW heating in slot 0 to lift as much as
+    # possible — verify e_dhw[0] is at or near max_hp_kwh.
+    max_hp_kwh = float(app_config.DAIKIN_MAX_HP_KW) * 0.5
+    assert plan.dhw_electric_kwh[0] >= max_hp_kwh * 0.5, (
+        f"LP should max-out DHW heating in slot 0 to minimize the deficit, "
+        f"got e_dhw[0] = {plan.dhw_electric_kwh[0]:.3f} (max {max_hp_kwh:.3f})"
+    )
+
+
+def test_warm_tank_in_slot_0_shower_window_no_slack() -> None:
+    """When tank starts warm enough to satisfy the shower floor naturally,
+    the slack should be effectively zero (LP doesn't pay the penalty when
+    not forced to).
+    """
+    n = 12
+    starts, w, prices, base_load = _build(n)
+    plan = solve_lp(
+        slot_starts_utc=starts,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        initial=LpInitialState(soc_kwh=5.0, tank_temp_c=47.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, f"LP status: {plan.status}"
+    # Tank starts ABOVE the floor; the LP should keep it there without
+    # paying slack penalty. Tank[1] (end of slot 0) should be ≥ 45.
+    assert plan.tank_temp_c[1] >= 45.0 - 1e-3, (
+        f"warm-tank scenario: tank[1] = {plan.tank_temp_c[1]} should ≥ 45 "
+        f"without using slack"
+    )
+
+
+def test_2026_05_14_replay_now_feasible() -> None:
+    """Synthetic replay of the 2026-05-14 20:05 prod incident:
+    SoC=54 %, tank=**28 °C**, outdoor=**7 °C**, evening shower window
+    starting at 21:30 BST.
+
+    Pre-#344 returned Infeasible (and PR #338 didn't exist yet so the
+    heuristic fallback fired). Post-#344 must solve, possibly with a
+    small slack (at 7 °C the COP is ~4.3, so 28 → 44.3 is feasible —
+    a ~0.7 K deficit). Either way, no Infeasible.
+    """
+    n = 24
+    base = datetime(2026, 5, 14, 19, 5, tzinfo=UTC)  # 20:05 BST
+    starts = [base + i * timedelta(minutes=30) for i in range(n)]
+    w = WeatherLpSeries(
+        slot_starts_utc=list(starts),
+        temperature_outdoor_c=[7.0] * n,  # matches prod telemetry
+        shortwave_radiation_wm2=[0.0] * n,
+        cloud_cover_pct=[80.0] * n,
+        pv_kwh_per_slot=[0.0] * n,
+        cop_space=[3.0] * n,
+        cop_dhw=[2.5] * n,
+    )
+    prices = [18.0] * n
+    base_load = [0.3] * n
+
+    plan = solve_lp(
+        slot_starts_utc=starts,
+        price_pence=prices,
+        base_load_kwh=base_load,
+        weather=w,
+        # SoC 54 % of 10.36 ≈ 5.6 kWh. Tank 28 °C — well below shower floor.
+        initial=LpInitialState(soc_kwh=5.6, tank_temp_c=28.0),
+        tz=ZoneInfo("Europe/London"),
+    )
+    assert plan.ok, (
+        f"2026-05-14 replay returned {plan.status} — the shower-floor soft "
+        f"constraint should rescue this incident class"
+    )


### PR DESCRIPTION
## Summary

Replace the hard ``tank[i+1] >= t_min_dhw`` constraint on shower-window slots with a soft constraint (slack variable + heavy 50 p / K-slot penalty). Closes the actual root-cause of the residual-class above-reserve infeasibilities surfaced by the 60-day audit of `optimizer_log` — **not** the mode-mutex theory that PR #343 set out to address.

## Evidence

60-day audit of `optimizer_log`:

- **50** non-LP-objective runs in window.
- **41** had SoC < 20 % → the below-reserve class **PR #339 closed**.
- **9** had SoC ≥ 20 % → the residual class.
- **8 of 9** fired in the 20:00–20:25 UTC window = **21:00–21:25 BST** = the `tier_boundary` MPC trigger 5 min before the 21:30 BST tariff transition.

The MPC's new horizon starts at 21:30 BST = **the start of the evening shower window**. Slot 0 carries the hard `tank[1] >= 45 °C` constraint. When the live tank reading is too cold (5 of 9 events had tank ≤ 43 °C; two events at 28 °C), the physics floor of ~10 K of DHW heating per slot at max HP draw cannot lift to 45 °C in a single 30-minute slot — the constraint is **physically un-satisfiable**. CBC returns Infeasible.

## The fix

```python
# Before (hard floor, line 713):
if shower_mask[i]:
    prob += tank[i + 1] >= t_min_dhw

# After (soft floor with diagnostic slack):
if shower_mask[i]:
    s_shower_lo[i] = pulp.LpVariable(f"shower_lo_slack_{i}", lowBound=0)
    prob += tank[i + 1] + s_shower_lo[i] >= t_min_dhw

# Objective adds (heavy default 50 p / K-slot):
obj_shower_lo = shower_lo_penalty_p * pulp.lpSum(s_shower_lo[i] for i in s_shower_lo)
```

## Penalty calibration

Each kWh of HP electricity saved costs roughly 12–35 p (cheap to peak Agile). Each K saved on tank requires ~0.1 kWh. So saving 5 K saves ~1 p of electricity. The default 50 p / K-slot penalty exceeds any conceivable saving, so the LP only breaches the floor when **physically forced** — the slack value becomes the "by how many K did tank miss the shower floor" diagnostic.

Setting the penalty to zero degenerates to "ignore shower comfort," which is wrong. Setting it too high risks reintroducing Infeasible if other constraints already strain. 50 p is comfortably in the safe middle.

## Test plan — discriminating tests verified against `main`

- [x] **``test_cold_tank_in_slot_0_shower_window_is_now_feasible``** — tank=28 °C, outdoor=−2 °C, shower starts slot 0. **Pre-#344 returns Infeasible (verified by running this test on main: FAILED). Post-#344 returns Optimal with positive slack.** This is the regression test that proves the fix.
- [x] **``test_warm_tank_in_slot_0_shower_window_no_slack``** — tank=47 °C; LP should NOT use slack when not forced. Asserts ``tank[1] >= 45 °C`` without slack.
- [x] **``test_2026_05_14_replay_now_feasible``** — synthetic replay of the 2026-05-14 20:05 BST prod incident (SoC=54 %, tank=28 °C, outdoor=7 °C). Asserts Optimal.
- [x] Full LP suite (44 tests across test_lp_optimizer, test_lp_optimizer_space_floor, test_lp_dhw_shower_schedule, test_lp_legionella_cycle, test_lp_shower_floor_soft): all green.

## What does NOT change

- ``t_min_dhw`` value (guests/normal preset selection) untouched.
- Legionella floor (separate hard constraint on Sunday cycle slot) untouched.
- Terminal tank floor (last slot in shower window) untouched.
- Tank-hi soft slack untouched (still ``LP_TANK_HI_SLACK_PENCE_PER_DEGC_SLOT``).
- Passive-mode behaviour untouched (the constraint was already skipped in passive — see comment).

## Risk

- LP cost objective gains one penalty term. With penalty=50 p/K-slot and slack only non-zero when physically forced, the objective magnitude is unaffected on already-feasible inputs (regression baseline expectation: identical objective on every existing successful solve).
- Diagnostic value: future runs of ``optimizer_log`` should show zero residual-class Infeasibles AND surface the slack value in the `lp_solution_snapshot` if/when present (a follow-up PR can add it to the snapshot schema).

## Follow-ups (separate)

- Capture ``s_shower_lo[i]`` in ``lp_solution_snapshot`` so the History view shows "shower deficit = N K" — diagnostic value.
- ``LP_HP_MIN_ON_SLOTS=1`` evaluation (audit finding, separate PR).
- LP regression baseline refresh post-merge of the full stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
