### PR TITLE
fix(brief): Mode line reflects hands-off climate (closes #328)

### DIFF
--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -400,14 +400,20 @@ def build_night_payload() -> str:
 def _mode_status_line() -> str:
     """One-line mode status so OpenClaw stops inventing Daikin advice.
 
-    The user runs Daikin in passive mode (telemetry-only — Onecta firmware drives
-    the heat pump on its own weather curve, HEM doesn't touch setpoints). Without
-    this line, the LLM that paraphrases the brief tends to fill in tactical
-    Daikin advice ("preheat tank during cheap window!") that has no basis.
+    Both ``passive`` and ``active`` modes leave SPACE heating to the Daikin
+    firmware's weather curve since PR #321 (climate-strip incident,
+    2026-05-11). The active-mode difference is solely that HEM dispatches
+    the **DHW tank target** based on the LP plan (e.g. cheap-overnight
+    pre-charge, peak-window idle). LWT offset + climate_on are never
+    written to Daikin in either mode now — surface that explicitly so the
+    LLM rendering the brief doesn't invent tactical space-heating advice.
     """
     daikin_mode = (config.DAIKIN_CONTROL_MODE or "passive").strip().lower()
     if daikin_mode == "active":
-        daikin_label = "active (HEM dispatches setpoints/LWT offset per LP plan)"
+        daikin_label = (
+            "active (HEM dispatches DHW tank target per LP plan; firmware "
+            "weather curve owns space heating — HEM does NOT write LWT offset)"
+        )
     else:
         daikin_label = (
             "passive (telemetry-only; Onecta firmware drives autonomously on weather curve — "

--- a/tests/test_brief_mode_line.py
+++ b/tests/test_brief_mode_line.py
@@ -1,0 +1,51 @@
+"""``_mode_status_line`` must accurately reflect what HEM actually writes.
+
+Background: PR #321 (2026-05-11 climate-strip incident) made HEM stop writing
+``lwt_offset`` and ``climate_on`` to Daikin even in active mode. The brief's
+active-mode label still claimed "HEM dispatches setpoints/LWT offset per LP
+plan" — misleading anyone (LLM-renderer or human) reading the brief into
+thinking HEM owns space heating. Issue #328 tracks this; fix is in this PR.
+
+Both modes now correctly explain that the Daikin firmware's weather curve
+owns space heating; the only active-mode difference is DHW tank target
+dispatch.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.analytics import daily_brief
+from src.config import config as app_config
+
+
+def test_active_mode_says_tank_only_and_no_lwt_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Active-mode label must (a) say HEM dispatches DHW tank only,
+    (b) explicitly disclaim LWT offset writes (post-#321 truth)."""
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", False)
+    line = daily_brief._mode_status_line()
+    assert "active" in line
+    assert "DHW tank" in line
+    assert "firmware weather curve" in line
+    assert "does NOT write LWT offset" in line
+    # The old, misleading phrasing must be gone.
+    assert "setpoints/LWT offset per LP plan" not in line
+
+
+def test_passive_mode_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passive label was already correct; regression-pin it."""
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "passive")
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", False)
+    line = daily_brief._mode_status_line()
+    assert "passive" in line
+    assert "telemetry-only" in line
+    assert "does NOT alter setpoints" in line
+
+
+def test_read_only_overrides_fox_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OPENCLAW_READ_ONLY=true short-circuits Fox label regardless of mode."""
+    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr(app_config, "OPENCLAW_READ_ONLY", True)
+    line = daily_brief._mode_status_line()
+    assert "READ_ONLY" in line
+    assert "no hardware writes" in line


### PR DESCRIPTION
## Summary

Updates ``_mode_status_line()`` in ``src/analytics/daily_brief.py`` so the active-mode label accurately describes what HEM actually writes to Daikin since PR #321 (2026-05-11 climate-strip incident).

## Before / after

Before:
> **Mode:** Daikin=**active (HEM dispatches setpoints/LWT offset per LP plan)**; Fox=LP-dispatched

After:
> **Mode:** Daikin=**active (HEM dispatches DHW tank target per LP plan; firmware weather curve owns space heating — HEM does NOT write LWT offset)**; Fox=LP-dispatched

Same shape, accurate content. Passive label unchanged (was already correct).

## Why

Issue #328 documented the staleness. Two reader populations were being misled:
1. **OpenClaw / LLM agents** rendering the brief — would invent tactical space-heating advice ("preheat the radiators!") because the line implied HEM owned that surface.
2. **Future debugging** — anyone reading the brief during an incident would assume HEM had a hand in space heating, wasting investigation time.

## Test plan

- [x] New ``tests/test_brief_mode_line.py`` (3 tests): active-mode wording, passive-mode wording (regression-pin), READ_ONLY override.
- [x] Existing brief test suite (30 tests across 4 files) all green.
- [ ] Verify visually on tonight's 22:00 BST night brief after deploy.

## Closes

Closes #328