### PR TITLE
fix(lp): tank_idle_overnight on horizons starting mid-idle window (closes #323)

### DIFF
--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -180,6 +180,29 @@ def lp_plan_to_slots(plan: LpPlan) -> list[HalfHourSlot]:
             shower_mask = [False] * n
 
         seen_shower_in_window = False
+        # Bug fix (#323): when the LP horizon's first slot starts INSIDE an
+        # in-progress idle window (i.e. AFTER the last shower of the day
+        # already ended), the loop below would never see a shower slot —
+        # so it never flipped seen_shower_in_window to True — so the
+        # remaining slots stayed ``standard`` instead of becoming
+        # ``tank_idle_overnight``. Pre-arm the flag based on slot 0's local
+        # clock position relative to the shower schedule's wraparound idle
+        # window: from latest_shower_end through to next-day earliest start.
+        if shower_windows and plan.slot_starts_utc:
+            first_slot_mid = (
+                plan.slot_starts_utc[0] + timedelta(minutes=15)
+            ).astimezone(TZ())
+            first_min = first_slot_mid.hour * 60 + first_slot_mid.minute
+            latest_end = max(e for _, e in shower_windows)
+            earliest_start = min(s for s, _ in shower_windows)
+            if latest_end > earliest_start:
+                # Wraparound idle window: post-latest-end OR pre-earliest-start.
+                in_idle_window = first_min >= latest_end or first_min < earliest_start
+            else:
+                # Clean range, no wraparound (e.g. morning-only schedule).
+                in_idle_window = latest_end <= first_min < earliest_start
+            if in_idle_window:
+                seen_shower_in_window = True
         # Reset overnight tracker ONLY on solar_charge (PV abundance kicks in)
         # or negative-price slots (grid pays us — tank-heat free). NOT on
         # cheap-grid battery-charging slots: a 02:30 cheap-charge slot for

--- a/tests/test_lp_dispatch_gap_bridge.py
+++ b/tests/test_lp_dispatch_gap_bridge.py
@@ -39,9 +39,25 @@ def _four_slot_plan_with_standard_gap() -> LpPlan:
 
 
 def test_lp_dispatch_slots_match_lp_plan_no_gap_bridge_promotion() -> None:
+    """The original intent: gap slots between cheap slots must NOT be
+    promoted to ``cheap`` (which would ForceCharge through the gap and
+    override the MILP). Slots 1+2 are between cheap slot 0 and cheap
+    slot 3 — they must end up as anything BUT cheap.
+
+    Updated 2026-05-20 (#323): with the default ``DHW_SHOWER_SCHEDULE``
+    of ``19:00-22:00`` and the synthetic plan running 01:00-03:00 BST
+    (post-shower idle window), the second-pass overnight-tank-idle
+    classifier now correctly marks slots 1+2 as ``tank_idle_overnight``
+    rather than leaving them ``standard`` — same gap-bridge guarantee
+    (not promoted to cheap), more accurate kind. The dispatch surface
+    must mirror the raw classifier output exactly."""
     plan = _four_slot_plan_with_standard_gap()
     raw = lp_plan_to_slots(plan)
-    assert [s.kind for s in raw] == ["cheap", "standard", "standard", "cheap"]
+    kinds = [s.kind for s in raw]
+    assert kinds[0] == "cheap" and kinds[3] == "cheap"
+    # The non-cheap-promotion guarantee: slots 1+2 are NOT cheap.
+    assert kinds[1] != "cheap"
+    assert kinds[2] != "cheap"
 
     dispatched = lp_dispatch_slots_for_hardware(plan)
     assert [s.kind for s in dispatched] == [s.kind for s in raw]

--- a/tests/test_lp_tank_idle_resolve_during_window.py
+++ b/tests/test_lp_tank_idle_resolve_during_window.py
@@ -1,0 +1,181 @@
+"""``tank_idle_overnight`` classification must survive an LP re-solve that
+fires AFTER the day's last shower window has already ended.
+
+Issue #323: when the LP runs ``lp_plan_to_slots`` on a horizon whose FIRST
+slot starts past the latest shower-window end of the day, the
+``seen_shower_in_window`` tracker never flipped True (no shower slot in
+the horizon to trigger it), so the post-shower overnight slots stayed
+``standard`` and the dispatcher emitted no ``tank_idle_overnight`` action.
+Result: tank held whatever the previous restore left (~45 °C) all night,
+foregoing the modest standing-loss saving the idle setback provides.
+
+This file pins the fix: pre-arm ``seen_shower_in_window`` when slot 0's
+local clock position falls inside the wraparound idle window between the
+schedule's latest shower-end and earliest next-day shower-start.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db as _db
+from src.config import config as app_config
+from src.scheduler.lp_dispatch import lp_plan_to_slots
+from src.scheduler.lp_optimizer import LpPlan
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    _db.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _idle_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_config, "BULLETPROOF_TIMEZONE", "Europe/London")
+    monkeypatch.setattr(app_config, "DHW_TANK_OVERNIGHT_IDLE_ENABLED", "true")
+    # Two-shower schedule: morning + evening (the prod default shape).
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "06:00-07:30,21:30-22:30")
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE_GUESTS", "")
+    monkeypatch.setattr(app_config, "OPTIMIZATION_PRESET", "normal")
+    monkeypatch.setattr(app_config, "ENERGY_STRATEGY_MODE", "savings_first")
+
+
+def _build_plan(
+    base_utc: datetime,
+    *,
+    n_slots: int,
+    kind_overrides: dict[int, str] | None = None,
+) -> LpPlan:
+    """Build an LpPlan with all-standard slots; kind classification is
+    derived by ``lp_plan_to_slots`` from prices + chg/dis/exp. Default
+    here: price=12 (standard), no charge / discharge / export."""
+    starts = [base_utc + i * timedelta(minutes=30) for i in range(n_slots)]
+    plan = LpPlan(
+        ok=True, status="Optimal", objective_pence=0.0,
+        peak_threshold_pence=18.0, cheap_threshold_pence=8.0,
+    )
+    plan.slot_starts_utc = list(starts)
+    plan.price_pence = [12.0] * n_slots
+    plan.import_kwh = [0.3] * n_slots
+    plan.export_kwh = [0.0] * n_slots
+    plan.battery_charge_kwh = [0.0] * n_slots
+    plan.battery_discharge_kwh = [0.0] * n_slots
+    plan.pv_use_kwh = [0.0] * n_slots
+    plan.pv_curtail_kwh = [0.0] * n_slots
+    plan.dhw_electric_kwh = [0.0] * n_slots
+    plan.space_electric_kwh = [0.0] * n_slots
+    plan.lwt_offset_c = [0.0] * n_slots
+    plan.tank_temp_c = [45.0] * (n_slots + 1)
+    plan.soc_kwh = [5.0] * (n_slots + 1)
+    plan.temp_outdoor_c = [10.0] * n_slots
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# THE BUG: solve fires after evening shower ended; first slot starts mid-idle.
+# ---------------------------------------------------------------------------
+
+def test_horizon_starting_after_evening_shower_marks_idle() -> None:
+    """Bug reproducer: LP solves at 21:25 BST (mid-idle window since shower
+    ended at 21:30 BST is now in the past — wait, 21:30 BST is the START so
+    the END is 22:30 BST). Solve at 22:25 BST → horizon starts 22:30 BST
+    (= 21:30 UTC). Slot 0 midpoint 22:45 BST = 1365 min, past the
+    1350-min (22:30 BST) shower end. Must mark slots tank_idle_overnight."""
+    # Slot 0 starts at 21:30 UTC = 22:30 BST. Two-shower schedule has
+    # evening 21:30-22:30 BST = 20:30-21:30 UTC.
+    base = datetime(2026, 5, 19, 21, 30, tzinfo=UTC)  # 22:30 BST
+    plan = _build_plan(base, n_slots=10)  # 5 h window, 22:30-03:30 BST
+
+    slots = lp_plan_to_slots(plan)
+    assert slots, "no slots returned"
+
+    # Every slot in this horizon should be marked tank_idle_overnight
+    # (post-shower, no productive reset hit, all standard kind).
+    kinds = [s.kind for s in slots]
+    assert all(k == "tank_idle_overnight" for k in kinds), (
+        f"expected all slots tank_idle_overnight, got: {kinds}"
+    )
+
+
+def test_horizon_starting_in_post_midnight_idle_marks_idle() -> None:
+    """Edge case: solve at 02:00 BST. Idle window wraps midnight (yesterday's
+    22:30 → today's 06:00). Slot 0 midpoint 02:15 BST = 135 min, BEFORE
+    today's morning shower start (06:00 = 360 min). Must mark idle."""
+    base = datetime(2026, 5, 20, 1, 0, tzinfo=UTC)  # 02:00 BST
+    plan = _build_plan(base, n_slots=6)  # 02:00-05:00 BST
+
+    slots = lp_plan_to_slots(plan)
+    kinds = [s.kind for s in slots]
+    assert all(k == "tank_idle_overnight" for k in kinds), (
+        f"expected all idle (pre-morning-shower wraparound), got: {kinds}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavior preservation: pre-fix correctness for cases that already worked.
+# ---------------------------------------------------------------------------
+
+def test_horizon_starting_before_evening_shower_no_pre_arm() -> None:
+    """Solve at 18:00 BST (= 17:00 UTC). Slot 0 midpoint 18:15 BST = 1095
+    min, before the evening shower (1290 min). Pre-arm must NOT fire;
+    slots stay standard until the shower slot is reached in the loop."""
+    base = datetime(2026, 5, 19, 17, 0, tzinfo=UTC)  # 18:00 BST
+    plan = _build_plan(base, n_slots=4)  # 18:00-20:00 BST (no shower in horizon)
+
+    slots = lp_plan_to_slots(plan)
+    kinds = [s.kind for s in slots]
+    assert all(k == "standard" for k in kinds), (
+        f"expected all standard (before evening shower), got: {kinds}"
+    )
+
+
+def test_horizon_spans_evening_shower_then_idle_then_morning() -> None:
+    """Full overnight: starts 19:00 BST, spans evening shower (21:30-22:30),
+    then idle through to morning shower (06:00-07:30). Loop should mark
+    pre-shower slots standard, shower slots not-marked (default), and
+    post-shower-pre-morning-shower slots idle."""
+    base = datetime(2026, 5, 19, 18, 0, tzinfo=UTC)  # 19:00 BST
+    # n=22 ends at 06:00 BST exactly (just before morning shower starts).
+    plan = _build_plan(base, n_slots=22)  # 11 h, 19:00 → 06:00 BST
+
+    slots = lp_plan_to_slots(plan)
+    kinds = [s.kind for s in slots]
+    # First few slots (19:00-21:30): no pre-arm + no shower yet → standard.
+    assert kinds[0] == "standard"
+    assert kinds[1] == "standard"
+    # Slots covering shower window (around index 5-6 = 21:30-22:30 BST):
+    # the shower_mask filter skips them in the idle-marking loop, so they
+    # keep their default classification (standard) — but the FLAG flips
+    # for subsequent slots.
+    # Subsequent slots (after evening shower) should be tank_idle_overnight.
+    # Slot 8 = 23:00 BST midpoint 23:15 — definitely post-shower.
+    assert kinds[8] == "tank_idle_overnight", f"slot 8 (23:00 BST): {kinds[8]}"
+    # Final pre-morning-shower slot (~05:30 BST): still idle.
+    assert kinds[-1] == "tank_idle_overnight", f"last slot: {kinds[-1]}"
+
+
+def test_idle_disabled_returns_all_standard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``DHW_TANK_OVERNIGHT_IDLE_ENABLED=false`` short-circuits the whole pass."""
+    monkeypatch.setattr(app_config, "DHW_TANK_OVERNIGHT_IDLE_ENABLED", "false")
+    base = datetime(2026, 5, 19, 21, 30, tzinfo=UTC)
+    plan = _build_plan(base, n_slots=6)
+    slots = lp_plan_to_slots(plan)
+    assert all(s.kind == "standard" for s in slots)
+
+
+def test_morning_only_schedule_no_wraparound(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Schedule with only a morning shower (no evening). After morning
+    shower the tank idles all day until productive slot. Pre-arm should
+    fire if slot 0 is post-morning-shower without wraparound."""
+    monkeypatch.setattr(app_config, "DHW_SHOWER_SCHEDULE", "06:00-07:30")
+    # Slot 0 at 10:00 BST (post morning shower).
+    base = datetime(2026, 5, 19, 9, 0, tzinfo=UTC)  # 10:00 BST
+    plan = _build_plan(base, n_slots=4)
+    slots = lp_plan_to_slots(plan)
+    # With latest_end (450) > earliest_start (360) it's a wraparound case.
+    # Slot 0 mid = 615 → >= 450 → in_idle → pre-arm. Idle.
+    assert all(s.kind == "tank_idle_overnight" for s in slots), (
+        f"morning-only schedule, post-shower slot must be idle: {[s.kind for s in slots]}"
+    )


### PR DESCRIPTION
## Summary

Fixes the bug documented in #323: when the LP re-solves AFTER the day's last shower window has already ended (e.g., a ``tier_boundary`` MPC fire at 22:25 BST → horizon starts 22:30 BST), the post-shower idle slots stayed ``standard`` instead of being marked ``tank_idle_overnight``, so no LP-emitted overnight tank action shipped and the firmware held the prior restore (~45 °C) all night.

## Root cause

``lp_plan_to_slots`` initialised ``seen_shower_in_window = False`` and only flipped it True when it encountered a shower slot in the current LP horizon. A horizon that STARTS post-shower never flipped the flag.

## Fix

Pre-arm the flag based on slot 0's local clock position relative to the schedule's wraparound idle window (latest shower-end → next-day earliest shower-start). Handles both wraparound schedules (typical evening 22:30 → next morning 06:00) and clean ranges (morning-only).

```python
if shower_windows and plan.slot_starts_utc:
    first_slot_mid = (plan.slot_starts_utc[0] + timedelta(minutes=15)).astimezone(TZ())
    first_min = first_slot_mid.hour * 60 + first_slot_mid.minute
    latest_end = max(e for _, e in shower_windows)
    earliest_start = min(s for s, _ in shower_windows)
    if latest_end > earliest_start:
        in_idle_window = first_min >= latest_end or first_min < earliest_start
    else:
        in_idle_window = latest_end <= first_min < earliest_start
    if in_idle_window:
        seen_shower_in_window = True
```

## Test plan

- [x] **New** ``tests/test_lp_tank_idle_resolve_during_window.py`` — 6 tests covering bug reproducer, wraparound post-midnight, before-shower preservation, full-overnight span, idle-disabled, morning-only schedule.
- [x] **Updated** ``tests/test_lp_dispatch_gap_bridge.py`` to assert the real gap-bridge invariant (slot 1+2 NOT promoted to cheap) without hardcoding the old "standard" kind — those synthetic 01:00-03:00 BST slots are now correctly idle.
- [x] **Full LP dispatch suite (37 tests)**: green.
- [ ] **Wider repo suite**: in flight.

## Operational impact

Modest cost recovery: standing loss of overnight 45 °C → 37 °C is ~£0.05/night. More importantly: closes a correctness gap that would matter more in colder months with pricier off-peak.

## Closes

Closes #323