### PR TITLE
feat(notify): fan appliance lifecycle pings out to extra Telegram chats

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -148,6 +148,14 @@ class Config:
         os.getenv("TELEGRAM_API_BASE_URL") or "https://api.telegram.org"
     ).strip().rstrip("/")
     TELEGRAM_TIMEOUT_SECONDS: int = int(os.getenv("TELEGRAM_TIMEOUT_SECONDS", "10"))
+    # Extra Telegram chat IDs (CSV) that receive a copy of every appliance
+    # lifecycle notification (armed / starting / finished / cancelled). The
+    # primary chat at TELEGRAM_CHAT_ID always gets the message; entries here
+    # are fanned out *in addition*. De-duplicated against the primary chat
+    # so listing the same ID twice is harmless. Empty = no fanout.
+    TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS: str = (
+        os.getenv("TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS") or ""
+    ).strip()
 
     # ── Google Family Calendar publisher (Octopus rate windows) ─────────────
     # Side feature: after every Octopus fetch, classify each 30-min slot into

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -103,6 +103,41 @@ def _telegram_header_for(alert_key: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Appliance fanout — additional Telegram chats for lifecycle events
+# ---------------------------------------------------------------------------
+
+_APPLIANCE_FANOUT_ALERT_KEYS: frozenset[str] = frozenset({
+    AlertType.APPLIANCE_ARMED.value,
+    AlertType.APPLIANCE_STARTING.value,
+    AlertType.APPLIANCE_FINISHED.value,
+    AlertType.APPLIANCE_CANCELLED.value,
+})
+
+
+def _appliance_fanout_chat_ids() -> list[str]:
+    """Return extra Telegram chat IDs to fan appliance notifications out to.
+
+    Reads CSV from ``config.TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS``. Empty
+    strings are filtered; the primary ``TELEGRAM_CHAT_ID`` is removed so
+    listing it here doesn't cause a duplicate send. Order is preserved
+    so the user can predict delivery order from the CSV.
+    """
+    raw = (getattr(config, "TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS", "") or "").strip()
+    if not raw:
+        return []
+    primary = (getattr(config, "TELEGRAM_CHAT_ID", "") or "").strip()
+    seen: set[str] = {primary} if primary else set()
+    out: list[str] = []
+    for chunk in raw.split(","):
+        cid = chunk.strip()
+        if not cid or cid in seen:
+            continue
+        seen.add(cid)
+        out.append(cid)
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Route resolution (SQLite → env fallback)
 # ---------------------------------------------------------------------------
 
@@ -498,6 +533,13 @@ def _dispatch(
             header_override=telegram_header_override,
         )
         telegram_transport.send_message(body, silent=silent)
+        # Appliance lifecycle events fan out to optional secondary chats so
+        # household members get the same message (washing-machine armed /
+        # starting / finished / cancelled). Failures are swallowed by the
+        # transport — one chat being unreachable must not block the others.
+        if kind.value in _APPLIANCE_FANOUT_ALERT_KEYS:
+            for cid in _appliance_fanout_chat_ids():
+                telegram_transport.send_message(body, silent=silent, chat_id_override=cid)
         return
 
     if not _hooks_credentials_configured():

--- a/src/telegram_transport.py
+++ b/src/telegram_transport.py
@@ -73,10 +73,11 @@ def send_message(
     silent: bool = False,
     convert_markdown: bool = True,
     parse_mode: str = "HTML",
+    chat_id_override: str | None = None,
 ) -> bool:
     """POST to Bot API ``sendMessage``. Returns True on HTTP 2xx.
 
-    Two flags, intentionally orthogonal:
+    Three flags, intentionally orthogonal:
 
     * ``convert_markdown`` — when True (default), HEM-style Markdown
       (``**bold**``, `` `code` ``) is HTML-escaped and promoted to Telegram
@@ -85,6 +86,11 @@ def send_message(
       pass ``False`` to keep their tags intact.
     * ``parse_mode`` — Telegram parse mode header. Defaults to ``"HTML"``;
       set to ``""`` to send literal text with no formatting.
+    * ``chat_id_override`` — when set (non-empty), POST to that chat ID
+      instead of ``config.TELEGRAM_CHAT_ID``. Used by the appliance fanout
+      path in ``notifier`` to deliver the same body to a secondary chat
+      (e.g. a household member). The bot token still comes from config —
+      both chats must have already started a conversation with the bot.
 
     Failures are logged and swallowed — a Telegram outage must never abort
     the LP solver, scheduler tick, or appliance dispatcher. stdout +
@@ -93,7 +99,9 @@ def send_message(
     if not is_configured():
         return False
     token = config.TELEGRAM_BOT_TOKEN.strip()
-    chat_id = config.TELEGRAM_CHAT_ID.strip()
+    chat_id = (chat_id_override or config.TELEGRAM_CHAT_ID).strip()
+    if not chat_id:
+        return False
     base = (
         getattr(config, "TELEGRAM_API_BASE_URL", "https://api.telegram.org") or ""
     ).rstrip("/") or "https://api.telegram.org"

--- a/tests/test_appliance_notifications.py
+++ b/tests/test_appliance_notifications.py
@@ -219,6 +219,154 @@ def test_notify_appliance_cancelled_omits_planned_start_when_unknown() -> None:
     assert "planned_start_local" not in kwargs["extra"]
 
 
+# ---------- Telegram fanout to secondary household chats ----------
+
+
+def _force_telegram_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the dispatcher so it always takes the direct-Telegram path with
+    delivery enabled. Tests below own the rest of the path via patches."""
+    monkeypatch.setattr(app_config, "OPENCLAW_NOTIFY_ENABLED", True, raising=False)
+    monkeypatch.setattr(app_config, "OPENCLAW_NOTIFY_TARGET", "fake-target", raising=False)
+    monkeypatch.setattr(app_config, "OPENCLAW_NOTIFY_CHANNEL", "fake-channel", raising=False)
+    monkeypatch.setattr(app_config, "TELEGRAM_BOT_TOKEN", "stub-token", raising=False)
+    monkeypatch.setattr(app_config, "TELEGRAM_CHAT_ID", "100", raising=False)
+
+
+def test_appliance_armed_fans_out_to_extra_chat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS is set, the appliance_armed
+    notification is sent both to the primary chat and to each extra ID."""
+    _force_telegram_route(monkeypatch)
+    monkeypatch.setattr(
+        app_config, "TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS", "200,300", raising=False
+    )
+    with patch("src.notifier.telegram_transport.send_message") as mock_send:
+        mock_send.return_value = True
+        notify_appliance_armed(
+            appliance_name="Washer",
+            planned_start_local="Sat 01:00",
+            planned_end_local="03:15",
+            deadline_local="07:00",
+            duration_minutes=135,
+            avg_price_pence=4.5,
+        )
+    # One primary send (no override) + two fanout sends with explicit chat_id
+    assert mock_send.call_count == 3
+    primary_call, fan_a, fan_b = mock_send.call_args_list
+    assert primary_call.kwargs.get("chat_id_override") is None
+    assert fan_a.kwargs["chat_id_override"] == "200"
+    assert fan_b.kwargs["chat_id_override"] == "300"
+    # All three deliveries carry the SAME body text — same message, different chats.
+    assert primary_call.args[0] == fan_a.args[0] == fan_b.args[0]
+
+
+def test_appliance_cancelled_fans_out_to_extra_chat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cancellation is the other event the user explicitly wanted Karol to
+    receive — verify the fanout fires for it too."""
+    _force_telegram_route(monkeypatch)
+    monkeypatch.setattr(
+        app_config, "TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS", "200", raising=False
+    )
+    with patch("src.notifier.telegram_transport.send_message") as mock_send:
+        mock_send.return_value = True
+        notify_appliance_cancelled(
+            appliance_name="Washer",
+            reason="remote_mode_dropped",
+            planned_start_local="Sat 01:00",
+        )
+    assert mock_send.call_count == 2
+    assert mock_send.call_args_list[1].kwargs["chat_id_override"] == "200"
+
+
+def test_appliance_starting_and_finished_also_fan_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Full lifecycle: ARMED + STARTING + FINISHED + CANCELLED all fan out
+    (the user opted for all four events to Karol)."""
+    _force_telegram_route(monkeypatch)
+    monkeypatch.setattr(
+        app_config, "TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS", "200", raising=False
+    )
+    with patch("src.notifier.telegram_transport.send_message") as mock_send:
+        mock_send.return_value = True
+        notify_appliance_starting(
+            appliance_name="Washer",
+            planned_start_local="Sat 04:30",
+            deadline_local="Sun 06:00",
+            avg_price_pence=3.7,
+            duration_minutes=77,
+        )
+        notify_appliance_finished(
+            appliance_name="Washer",
+            started_local="04:30",
+            ended_local="05:47",
+            duration_minutes=77,
+            avg_price_pence=3.7,
+        )
+    # 2 events × (primary + 1 fanout) = 4 sends
+    assert mock_send.call_count == 4
+    fanout_calls = [c for c in mock_send.call_args_list
+                    if c.kwargs.get("chat_id_override") == "200"]
+    assert len(fanout_calls) == 2
+
+
+def test_non_appliance_alerts_do_not_fan_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Briefs, risks, tier-boundary pings stay on the primary chat only —
+    the secondary chat ID is *only* for appliance lifecycle events.
+
+    Imported lazily so the existing top-level imports stay minimal.
+    """
+    from src.notifier import notify_morning_report
+    _force_telegram_route(monkeypatch)
+    monkeypatch.setattr(
+        app_config, "TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS", "200,300", raising=False
+    )
+    with patch("src.notifier.telegram_transport.send_message") as mock_send:
+        mock_send.return_value = True
+        notify_morning_report("Test morning report body")
+    assert mock_send.call_count == 1
+    assert mock_send.call_args_list[0].kwargs.get("chat_id_override") is None
+
+
+def test_fanout_skips_primary_chat_to_avoid_duplicates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the user accidentally lists the primary chat ID in the fanout CSV,
+    it must NOT trigger a duplicate send to the same chat."""
+    _force_telegram_route(monkeypatch)
+    monkeypatch.setattr(
+        app_config, "TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS", "100,200", raising=False
+    )
+    with patch("src.notifier.telegram_transport.send_message") as mock_send:
+        mock_send.return_value = True
+        notify_appliance_armed(
+            appliance_name="Washer",
+            planned_start_local="Sat 01:00",
+            planned_end_local="03:15",
+            deadline_local="07:00",
+            duration_minutes=135,
+            avg_price_pence=4.5,
+        )
+    # Primary chat is "100" — fanout CSV's "100" entry must be filtered out.
+    assert mock_send.call_count == 2
+    fanout_call = mock_send.call_args_list[1]
+    assert fanout_call.kwargs["chat_id_override"] == "200"
+
+
+def test_empty_fanout_csv_keeps_single_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default config (empty CSV) = no behavioural change vs pre-feature."""
+    _force_telegram_route(monkeypatch)
+    monkeypatch.setattr(
+        app_config, "TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS", "", raising=False
+    )
+    with patch("src.notifier.telegram_transport.send_message") as mock_send:
+        mock_send.return_value = True
+        notify_appliance_armed(
+            appliance_name="Washer",
+            planned_start_local="Sat 01:00",
+            planned_end_local="03:15",
+            deadline_local="07:00",
+            duration_minutes=135,
+            avg_price_pence=4.5,
+        )
+    assert mock_send.call_count == 1
+
+
 # ---------- Completion poll ----------
 
 def _seed_running_job(


### PR DESCRIPTION
## Summary

Adds \`TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS\` (CSV) so secondary household members receive washer/dryer/dishwasher notifications alongside the primary user. Same body, same render path, no LLM in the loop.

## Why

Karol needs the same lifecycle pings — \"laundry armed for 01:00\", \"done at 05:47\" — so she can plan around the wash cycle without me forwarding from Telegram. The existing direct-Telegram transport only knows one chat ID.

## What ships

| Surface | Change |
|---|---|
| \`config.py\` | New \`TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS\` (CSV string, default empty) |
| \`telegram_transport.send_message\` | New \`chat_id_override\` kwarg — overrides config chat ID for a single send |
| \`notifier._dispatch\` | After the primary send, if \`kind.value\` is one of the four \`APPLIANCE_*\` AlertTypes, iterate the fanout list and re-send the same body |
| Tests | 6 new tests in \`tests/test_appliance_notifications.py\` (armed/cancelled/starting/finished fanout, non-appliance isolation, primary-chat dedup, empty-CSV no-op) |

## Scope (deliberately narrow)

- **Only** the four \`APPLIANCE_*\` events fan out (armed / starting / finished / cancelled). Briefs, risks, plan_proposed, tier-boundary pings stay on the primary chat.
- Same body text — single render, multiple sends. No per-chat formatting.
- One bot token, multiple chat IDs. Each recipient must have started a conversation with the bot at least once.
- De-duplication: listing the primary chat in the fanout CSV is a no-op, not a duplicate.
- Failure isolation: \`send_message\` already swallows non-2xx + \`RequestException\`. One unreachable chat does not block the others or the LP solver.

## Deploy

\`\`\`
echo 'TELEGRAM_APPLIANCE_FANOUT_CHAT_IDS=<karol-id>' >> /srv/hem/.env
chmod 640 /srv/hem/.env  # perms must stay 640 root:gid1001
systemctl restart hem
\`\`\`

## Test plan

- [x] \`pytest tests/test_appliance_notifications.py\` — 20/20 pass (6 new)
- [ ] After deploy: trigger a smoke test from MCP \`schedule_appliance_run\` to verify both chats receive the armed ping
- [ ] Karol confirms first message lands (she may need to message the bot first to enable delivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)