### PR TITLE
feat(analytics): lift daily audit into src/analytics/audit_report.py (A1)

### DIFF
--- a/deploy/audit_held_schedule.py
+++ b/deploy/audit_held_schedule.py
@@ -1,0 +1,43 @@
+"""Daily prod audit shim — calls ``audit_report.build_audit_report`` + posts
+the rendered markdown to Telegram when there's something to report.
+
+Lives on the prod host at ``/srv/hem/data/audit_held_schedule.py`` and is
+invoked daily at 07:30 UTC by ``hem-audit-held-schedule.timer``. Runs
+inside the hem container via ``docker exec``.
+
+The previous 415-line in-data script was lifted into the repo at
+``src/analytics/audit_report.py`` (Story A1, Epic 13a). This shim keeps
+the on-host behaviour identical (silent on quiet days, single Telegram
+push when there's news) while making the analytics testable and reusable
+by MCP tools / briefs.
+
+Deploy: ``scp deploy/audit_held_schedule.py
+root@<prod>:/srv/hem/data/audit_held_schedule.py``. No restart needed —
+the cron timer re-reads the file on every fire.
+"""
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, "/app")
+
+from src.analytics.audit_report import (  # noqa: E402
+    build_audit_report,
+    render_audit_markdown,
+)
+from src.telegram_transport import send_message  # noqa: E402
+
+
+def main() -> int:
+    report = build_audit_report(window_hours=24)
+    body = render_audit_markdown(report)
+    if body is None:
+        print("Nothing notable to report — Telegram silent.")
+        return 0
+    sent = send_message(body, convert_markdown=False)
+    print(f"Audit posted to Telegram (ok={sent}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/analytics/__init__.py
+++ b/src/analytics/__init__.py
@@ -1,4 +1,4 @@
-"""Analytics: PnL, shadow pricing, SLA, daily brief."""
-from . import daily_brief, pnl, shadow_pricing, sla
+"""Analytics: PnL, shadow pricing, SLA, daily brief, audit report."""
+from . import audit_report, daily_brief, pnl, shadow_pricing, sla
 
-__all__ = ["pnl", "shadow_pricing", "sla", "daily_brief"]
+__all__ = ["pnl", "shadow_pricing", "sla", "daily_brief", "audit_report"]

--- a/src/analytics/audit_report.py
+++ b/src/analytics/audit_report.py
@@ -1,0 +1,512 @@
+"""Structured daily audit — held-schedule events + plan-vs-execution.
+
+Originally lived as ``/srv/hem/data/audit_held_schedule.py`` (host-side, not
+in repo, Telegram-only). Story A1 of Epic 13a (#352) lifts the analytics
+into this module so:
+
+* MCP tools and briefs can pull the same data structurally (A2).
+* The prod-side script becomes a thin markdown shim around
+  :func:`build_audit_report` — behavioural diff zero.
+* The logic gets test coverage instead of relying on prod data + grepping
+  Telegram history to verify.
+
+Two sections, both returned as plain ``dict`` (no markdown, no I/O beyond
+SQLite):
+
+A) **Held-schedule events** — LP runs that returned ``Infeasible`` and the
+   defensive fallback from PR #338 kept the previously-uploaded schedule
+   running. Each event is annotated with the closest pv_realtime + Daikin
+   tank temperature so callers can split "SoC below reserve" (harmless,
+   soft-handled by #339) from "SoC at/above reserve" (the residual class,
+   typically shower-floor-in-slot-0 — fixed in PR #344).
+
+B) **Plan vs execution** — for every 30 min slot in the trailing window:
+   the *operative* LP plan (latest snapshot whose parent run was before
+   the slot started) vs the realised pv_realtime per-slot binning. The
+   audit reports coverage (LP runs → Fox uploads), totals (kWh + cost),
+   and the top-N per-slot disparities by absolute cost delta. A
+   strict_savings forgone-export sub-section tallies what the household
+   would have earned by selling instead of holding battery for self-use.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sqlite3
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+from ..config import config
+
+DISPARITY_TOP_N = 4
+DISPARITY_MIN_PENCE = 5.0
+COVERAGE_MIN_PCT = 90.0
+HELD_BASELINE_PER_DAY = 110.0 / 30.0  # ≈3.67/day pre-PR #338 measured rate
+
+
+# ---------------------------------------------------------------------------
+# Slot helpers
+# ---------------------------------------------------------------------------
+
+def _parse_utc(s: str) -> dt.datetime:
+    s = s.replace("Z", "+00:00")
+    d = dt.datetime.fromisoformat(s)
+    if d.tzinfo is None:
+        d = d.replace(tzinfo=dt.timezone.utc)
+    return d.astimezone(dt.timezone.utc)
+
+
+def _slot_floor(t: dt.datetime) -> dt.datetime:
+    """Round *t* down to the half-hour boundary (00 or 30)."""
+    minute = 0 if t.minute < 30 else 30
+    return t.replace(minute=minute, second=0, microsecond=0)
+
+
+# ---------------------------------------------------------------------------
+# Plan & realised window builders
+# ---------------------------------------------------------------------------
+
+def _operative_plan_for_window(
+    db: sqlite3.Connection,
+    start_utc: dt.datetime,
+    end_utc: dt.datetime,
+) -> dict[dt.datetime, dict[str, Any]]:
+    """For each 30-min slot in ``[start_utc, end_utc)``, find the latest LP
+    solution whose parent run was *before* the slot start — that's the plan
+    actually live when the slot was dispatched. Joined to
+    ``dispatch_decisions`` so callers can distinguish the LP variable's raw
+    ``export_kwh`` from the EFFECTIVE export the strict_savings classifier
+    + scenario filter actually allowed onto Fox V3."""
+    out: dict[dt.datetime, dict[str, Any]] = {}
+    t = start_utc
+    while t < end_utc:
+        row = db.execute(
+            """
+            SELECT s.run_id, s.import_kwh, s.export_kwh, s.charge_kwh, s.discharge_kwh,
+                   s.pv_use_kwh, s.dhw_kwh, s.space_kwh, i.run_at_utc,
+                   dd.lp_kind, dd.dispatched_kind, dd.reason
+            FROM lp_solution_snapshot s
+            JOIN lp_inputs_snapshot i ON i.run_id = s.run_id
+            LEFT JOIN dispatch_decisions dd
+              ON dd.run_id = s.run_id AND dd.slot_time_utc = s.slot_time_utc
+            WHERE s.slot_time_utc = ? AND i.run_at_utc < ?
+            ORDER BY i.run_at_utc DESC LIMIT 1
+            """,
+            (t.isoformat(), t.isoformat()),
+        ).fetchone()
+        if row:
+            out[t] = dict(row)
+        t += dt.timedelta(minutes=30)
+    return out
+
+
+def _effective_plan_export_kwh(plan_slot: dict[str, Any]) -> float:
+    """Export kWh that ACTUALLY shipped to Fox V3 — 0 if the slot was
+    classified ``standard`` (strict_savings policy or scenario filter
+    downgrade). The raw ``export_kwh`` column is the LP variable's value,
+    not the dispatched amount."""
+    if (plan_slot.get("dispatched_kind") or "").strip() == "peak_export":
+        return float(plan_slot.get("export_kwh") or 0)
+    return 0.0
+
+
+def _forgone_export_kwh(plan_slot: dict[str, Any]) -> float:
+    """How much the LP would have exported had strict_savings / scenario
+    filter not downgraded the slot. Zero on slots that shipped as
+    peak_export (no forgone revenue) or where the LP didn't plan export."""
+    if (plan_slot.get("dispatched_kind") or "").strip() == "peak_export":
+        return 0.0
+    return float(plan_slot.get("export_kwh") or 0)
+
+
+def _realised_for_window(
+    db: sqlite3.Connection,
+    start_utc: dt.datetime,
+    end_utc: dt.datetime,
+) -> dict[dt.datetime, dict[str, float]]:
+    """Bin ``pv_realtime_history`` rows into 30-min slots (mean power × 0.5 h
+    → kWh) for each channel."""
+    rows = db.execute(
+        "SELECT captured_at, solar_power_kw, load_power_kw, grid_import_kw, "
+        "grid_export_kw, battery_charge_kw, battery_discharge_kw "
+        "FROM pv_realtime_history WHERE captured_at >= ? AND captured_at < ? "
+        "ORDER BY captured_at",
+        (start_utc.isoformat(), end_utc.isoformat()),
+    ).fetchall()
+    bins: dict[dt.datetime, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for r in rows:
+        b = _slot_floor(_parse_utc(r["captured_at"]))
+        for k in (
+            "solar_power_kw", "load_power_kw", "grid_import_kw",
+            "grid_export_kw", "battery_charge_kw", "battery_discharge_kw",
+        ):
+            v = r[k]
+            if v is not None:
+                bins[b][k].append(v)
+    out: dict[dt.datetime, dict[str, float]] = {}
+    for b, d in bins.items():
+        out[b] = {
+            (k.replace("_kw", "_kwh")): mean(v) * 0.5
+            for k, v in d.items() if v
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Section A — held-schedule
+# ---------------------------------------------------------------------------
+
+def _build_held_schedule_section(
+    db: sqlite3.Connection,
+    *,
+    now_utc: dt.datetime,
+    window_hours: int,
+    cap_kwh: float,
+    reserve_pct: float,
+) -> dict[str, Any]:
+    soc_reserve_kwh = cap_kwh * reserve_pct / 100.0
+    cutoff = now_utc - dt.timedelta(hours=window_hours)
+
+    held_rows = db.execute(
+        """
+        SELECT id, run_at, strategy_summary
+        FROM optimizer_log
+        WHERE run_at >= ?
+          AND strategy_summary LIKE '%held previous schedule%'
+        ORDER BY run_at
+        """,
+        (cutoff.isoformat(),),
+    ).fetchall()
+
+    events: list[dict[str, Any]] = []
+    for r in held_rows:
+        run_at_iso = r["run_at"]
+        soc_row = db.execute(
+            "SELECT soc_pct FROM pv_realtime_history WHERE captured_at >= ? "
+            "ORDER BY captured_at LIMIT 1",
+            (run_at_iso,),
+        ).fetchone()
+        try:
+            ts = dt.datetime.fromisoformat(run_at_iso.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            ts = None
+        tank_row = None
+        if ts is not None:
+            tank_row = db.execute(
+                "SELECT fetched_at, tank_temp_c FROM daikin_telemetry "
+                "WHERE fetched_at < ? ORDER BY fetched_at DESC LIMIT 1",
+                (ts,),
+            ).fetchone()
+        soc_pct = soc_row["soc_pct"] if soc_row else None
+        soc_kwh = (soc_pct / 100.0 * cap_kwh) if soc_pct is not None else None
+        below = (soc_kwh is not None) and (soc_kwh < soc_reserve_kwh - 1e-3)
+        events.append({
+            "run_at": run_at_iso,
+            "soc_pct": soc_pct,
+            "soc_kwh": soc_kwh,
+            "tank_temp_c": tank_row["tank_temp_c"] if tank_row else None,
+            "below_reserve": below,
+        })
+
+    n_below = sum(1 for e in events if e["below_reserve"])
+    n_above = sum(
+        1 for e in events
+        if not e["below_reserve"] and e["soc_pct"] is not None
+    )
+    n_unknown = sum(1 for e in events if e["soc_pct"] is None)
+
+    return {
+        "events": events,
+        "total": len(events),
+        "soc_below_reserve": n_below,
+        "soc_above_reserve": n_above,
+        "soc_unknown": n_unknown,
+        "reserve_pct": reserve_pct,
+        "soc_reserve_kwh": round(soc_reserve_kwh, 3),
+        "battery_capacity_kwh": cap_kwh,
+        "baseline_per_day": round(HELD_BASELINE_PER_DAY, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Section B — plan vs execution + strict_savings forgone-export
+# ---------------------------------------------------------------------------
+
+def _build_plan_vs_execution_section(
+    db: sqlite3.Connection,
+    *,
+    now_utc: dt.datetime,
+    window_hours: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Returns ``(plan_vs_execution_section, strict_savings_forgone_section)``.
+
+    They share the same SQL pass, so we build both at once to avoid a
+    duplicate plan-window scan."""
+    window_start = _slot_floor(now_utc - dt.timedelta(hours=window_hours))
+    plan_end = _slot_floor(now_utc)  # exclusive — only past slots scored
+
+    # Coverage: every LP run should be paired with a Fox upload within 1 min.
+    lp_runs = db.execute(
+        "SELECT run_id, run_at_utc FROM lp_inputs_snapshot "
+        "WHERE run_at_utc >= ? ORDER BY run_at_utc",
+        (window_start.isoformat(),),
+    ).fetchall()
+    n_lp = len(lp_runs)
+    n_paired = 0
+    for r in lp_runs:
+        fu = db.execute(
+            "SELECT id FROM fox_schedule_state "
+            "WHERE julianday(uploaded_at) BETWEEN julianday(?) - 0.0007 "
+            "                                AND julianday(?) + 0.0007 "
+            "LIMIT 1",
+            (r["run_at_utc"], r["run_at_utc"]),
+        ).fetchone()
+        if fu:
+            n_paired += 1
+    coverage_pct = (100.0 * n_paired / n_lp) if n_lp else 100.0
+
+    plan = _operative_plan_for_window(db, window_start, plan_end)
+    real = _realised_for_window(db, window_start, plan_end)
+
+    rate_rows = db.execute(
+        "SELECT valid_from, value_inc_vat FROM agile_rates "
+        "WHERE valid_from >= ? AND valid_from < ?",
+        (window_start.isoformat(), plan_end.isoformat()),
+    ).fetchall()
+    import_p_by_slot = {_parse_utc(r["valid_from"]): r["value_inc_vat"] for r in rate_rows}
+    exp_rate_rows = db.execute(
+        "SELECT valid_from, value_inc_vat FROM agile_export_rates "
+        "WHERE valid_from >= ? AND valid_from < ?",
+        (window_start.isoformat(), plan_end.isoformat()),
+    ).fetchall()
+    export_p_by_slot = {_parse_utc(r["valid_from"]): r["value_inc_vat"] for r in exp_rate_rows}
+
+    plan_imp = sum((d.get("import_kwh") or 0) for d in plan.values())
+    plan_exp = sum(_effective_plan_export_kwh(d) for d in plan.values())
+    real_imp = sum((d.get("grid_import_kwh") or 0) for d in real.values())
+    real_exp = sum((d.get("grid_export_kwh") or 0) for d in real.values())
+
+    plan_cost_p = sum(
+        (plan[t].get("import_kwh") or 0) * (import_p_by_slot.get(t) or 0)
+        - _effective_plan_export_kwh(plan[t]) * (export_p_by_slot.get(t) or 0)
+        for t in plan if t in import_p_by_slot
+    )
+    real_cost_p = sum(
+        (real[t].get("grid_import_kwh") or 0) * (import_p_by_slot.get(t) or 0)
+        - (real[t].get("grid_export_kwh") or 0) * (export_p_by_slot.get(t) or 0)
+        for t in real if t in import_p_by_slot
+    )
+    cost_delta_p = real_cost_p - plan_cost_p
+
+    forgone_kwh = 0.0
+    forgone_p = 0.0
+    forgone_slots = 0
+    for t, slot in plan.items():
+        f_kwh = _forgone_export_kwh(slot)
+        if f_kwh <= 0:
+            continue
+        ep = export_p_by_slot.get(t) or 0
+        forgone_kwh += f_kwh
+        forgone_p += f_kwh * ep
+        forgone_slots += 1
+
+    disparities: list[dict[str, Any]] = []
+    for t in plan:
+        if t not in real or t not in import_p_by_slot:
+            continue
+        p = plan[t]
+        r = real[t]
+        ip = import_p_by_slot[t]
+        ep = export_p_by_slot.get(t, 0) or 0
+        eff_exp = _effective_plan_export_kwh(p)
+        d_imp = (r.get("grid_import_kwh") or 0) - (p.get("import_kwh") or 0)
+        d_exp = (r.get("grid_export_kwh") or 0) - eff_exp
+        d_cost = d_imp * ip - d_exp * ep
+        if abs(d_cost) < DISPARITY_MIN_PENCE:
+            continue
+        disparities.append({
+            "slot_time_utc": t.isoformat(),
+            "delta_cost_p": round(d_cost, 2),
+            "delta_import_kwh": round(d_imp, 3),
+            "delta_export_kwh": round(d_exp, 3),
+            "import_price_p": round(float(ip), 2),
+            "export_price_p": round(float(ep), 2),
+            "plan_import_kwh": round(float(p.get("import_kwh") or 0), 3),
+            "real_import_kwh": round(float(r.get("grid_import_kwh") or 0), 3),
+            "plan_charge_kwh": round(float(p.get("charge_kwh") or 0), 3),
+            "real_charge_kwh": round(float(r.get("battery_charge_kwh") or 0), 3),
+        })
+    disparities.sort(key=lambda d: abs(d["delta_cost_p"]), reverse=True)
+
+    pve = {
+        "lp_runs": n_lp,
+        "paired_uploads": n_paired,
+        "coverage_pct": round(coverage_pct, 1),
+        "coverage_threshold_pct": COVERAGE_MIN_PCT,
+        "plan_kwh": {
+            "import": round(plan_imp, 2),
+            "export_effective": round(plan_exp, 2),
+        },
+        "real_kwh": {
+            "import": round(real_imp, 2),
+            "export": round(real_exp, 2),
+        },
+        "plan_cost_p": round(plan_cost_p, 1),
+        "real_cost_p": round(real_cost_p, 1),
+        "cost_delta_p": round(cost_delta_p, 1),
+        "disparities": disparities[:DISPARITY_TOP_N],
+        "disparity_count_total": len(disparities),
+        "disparity_min_pence": DISPARITY_MIN_PENCE,
+        "window_start_utc": window_start.isoformat(),
+        "window_end_utc": plan_end.isoformat(),
+    }
+    forgone = {
+        "kwh": round(forgone_kwh, 2),
+        "pence": round(forgone_p, 1),
+        "slot_count": forgone_slots,
+    }
+    return pve, forgone
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_audit_report(
+    window_hours: int = 24,
+    *,
+    now_utc: dt.datetime | None = None,
+    db_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build the structured audit report.
+
+    ``now_utc`` defaults to wall-clock UTC; tests inject a fixed timestamp.
+    ``db_path`` defaults to ``config.DB_PATH``; tests point at a tmp DB.
+    Returns a dict with sections ``held_schedule``, ``plan_vs_execution``,
+    and ``strict_savings_forgone`` — plus ``window_hours`` and ``now_utc``
+    on the top level so consumers can attribute the snapshot.
+    """
+    if now_utc is None:
+        now_utc = dt.datetime.now(dt.timezone.utc)
+    if db_path is None:
+        db_path = config.DB_PATH
+    cap_kwh = float(config.BATTERY_CAPACITY_KWH)
+    reserve_pct = float(config.MIN_SOC_RESERVE_PERCENT)
+
+    db = sqlite3.connect(str(db_path))
+    db.row_factory = sqlite3.Row
+    try:
+        held = _build_held_schedule_section(
+            db, now_utc=now_utc, window_hours=window_hours,
+            cap_kwh=cap_kwh, reserve_pct=reserve_pct,
+        )
+        pve, forgone = _build_plan_vs_execution_section(
+            db, now_utc=now_utc, window_hours=window_hours,
+        )
+    finally:
+        db.close()
+
+    return {
+        "window_hours": window_hours,
+        "now_utc": now_utc.isoformat(),
+        "held_schedule": held,
+        "plan_vs_execution": pve,
+        "strict_savings_forgone": forgone,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown renderer (for the Telegram-shim path)
+# ---------------------------------------------------------------------------
+
+def render_audit_markdown(
+    report: dict[str, Any],
+    *,
+    silent_cost_delta_threshold_p: float = 30.0,
+) -> str | None:
+    """Render *report* as the Telegram HTML body, or ``None`` if nothing
+    is notable enough to warrant a push.
+
+    The prod cron at 07:30 UTC was deliberately silent on quiet days:
+    no held-schedule events AND a small |cost delta| AND coverage above
+    threshold = no message. Preserved here so the shim's behavioural
+    diff vs the prior in-tree script stays zero.
+    """
+    held = report["held_schedule"]
+    pve = report["plan_vs_execution"]
+    forgone = report["strict_savings_forgone"]
+
+    coverage_warn = pve["coverage_pct"] < pve["coverage_threshold_pct"] and pve["lp_runs"]
+    silent_b = (
+        abs(float(pve["cost_delta_p"])) < silent_cost_delta_threshold_p
+        and not coverage_warn
+    )
+    if held["total"] == 0 and silent_b:
+        return None
+
+    parts: list[str] = ["<b>📊 HEM daily audit (last 24 h)</b>", ""]
+
+    if held["total"] > 0:
+        baseline = held["baseline_per_day"]
+        parts.extend([
+            "<b>A) Held-schedule events (24 h)</b>",
+            f"  total: <b>{held['total']}</b>  (baseline ≈ {baseline:.1f}/day pre-#338)",
+            f"  reserve: {held['reserve_pct']:.0f}% = {held['soc_reserve_kwh']:.2f} kWh",
+            f"  SoC&lt;reserve: <b>{held['soc_below_reserve']}</b>  <i>(harmless post-#339)</i>",
+            f"  SoC≥reserve: <b>{held['soc_above_reserve']}</b>  <i>(follow-up — legionella/shower suspect)</i>",
+        ])
+        if held["soc_unknown"]:
+            parts.append(f"  SoC unknown: {held['soc_unknown']}")
+        for e in held["events"][:6]:
+            ts_short = e["run_at"][:16].replace("T", " ") + "Z"
+            soc_s = f"{e['soc_pct']:5.1f}%" if e["soc_pct"] is not None else " --- "
+            tank_s = f"{e['tank_temp_c']:4.1f}°C" if e["tank_temp_c"] is not None else "---"
+            flag = "⬇" if e["below_reserve"] else ("⬆" if e["soc_pct"] is not None else "?")
+            parts.append(f"  {flag} {ts_short}  SoC={soc_s}  tank={tank_s}")
+        if held["total"] > 6:
+            parts.append(f"  ... and {held['total'] - 6} more")
+        parts.append("")
+
+    parts.append("<b>B) Plan vs execution (24 h)</b>")
+    cov_flag = " ⚠️" if coverage_warn else ""
+    parts.append(
+        f"  LP runs: {pve['lp_runs']}  →  paired uploads: {pve['paired_uploads']}  "
+        f"({pve['coverage_pct']:.0f}% coverage{cov_flag})"
+    )
+    parts.append(
+        f"  plan kWh:  imp={pve['plan_kwh']['import']:5.1f}  "
+        f"exp={pve['plan_kwh']['export_effective']:5.1f}  (effective, post-filter)"
+    )
+    d_imp = pve["real_kwh"]["import"] - pve["plan_kwh"]["import"]
+    d_exp = pve["real_kwh"]["export"] - pve["plan_kwh"]["export_effective"]
+    parts.append(
+        f"  real kWh:  imp={pve['real_kwh']['import']:5.1f}  "
+        f"exp={pve['real_kwh']['export']:5.1f}  "
+        f"(Δimp={d_imp:+.1f}, Δexp={d_exp:+.1f})"
+    )
+    parts.append(
+        f"  cost (excl standing): plan={pve['plan_cost_p']:6.1f}p  "
+        f"real={pve['real_cost_p']:6.1f}p  <b>Δ={pve['cost_delta_p']:+6.1f}p</b>"
+    )
+    if forgone["slot_count"] > 0:
+        parts.append(
+            f"  strict_savings forgone export: "
+            f"~£{forgone['pence'] / 100.0:.2f} ({forgone['kwh']:.1f} kWh over "
+            f"{forgone['slot_count']} slot{'s' if forgone['slot_count'] != 1 else ''}) "
+            f"— set <code>ENERGY_STRATEGY_MODE=savings_first</code> to realise"
+        )
+    if pve["disparities"]:
+        parts.append(
+            f"  Top {len(pve['disparities'])} slot disparities "
+            f"(|Δcost|≥{pve['disparity_min_pence']:.0f}p):"
+        )
+        for d in pve["disparities"]:
+            t = _parse_utc(d["slot_time_utc"])
+            hh = t.strftime("%H:%M")
+            parts.append(
+                f"    {hh}Z (ip={d['import_price_p']:5.1f}p)  Δ={d['delta_cost_p']:+5.1f}p  "
+                f"imp p={d['plan_import_kwh']:.2f}/r={d['real_import_kwh']:.2f}  "
+                f"chg p={d['plan_charge_kwh']:.2f}/r={d['real_charge_kwh']:.2f}"
+            )
+    return "\n".join(parts)

--- a/tests/analytics/test_audit_report.py
+++ b/tests/analytics/test_audit_report.py
@@ -1,0 +1,431 @@
+"""Tests for ``src/analytics/audit_report.py`` (Story A1, Epic 13a).
+
+Verifies the structured shape, classification logic, and rendering rules
+of the lifted audit module. The prod-side script at
+``/srv/hem/data/audit_held_schedule.py`` becomes a thin shim around
+:func:`build_audit_report` + :func:`render_audit_markdown` once A1 lands.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.analytics import audit_report
+
+
+# ---------------------------------------------------------------------------
+# Schema bootstrap — minimal DDL covering only the columns the audit reads
+# ---------------------------------------------------------------------------
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a tmp sqlite DB with the schema slice the audit touches."""
+    db_path = tmp_path / "audit.db"
+    db = sqlite3.connect(str(db_path))
+    db.executescript(
+        """
+        CREATE TABLE optimizer_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_at TEXT NOT NULL,
+            strategy_summary TEXT
+        );
+        CREATE TABLE pv_realtime_history (
+            captured_at TEXT PRIMARY KEY,
+            solar_power_kw REAL,
+            soc_pct REAL,
+            load_power_kw REAL,
+            grid_import_kw REAL,
+            grid_export_kw REAL,
+            battery_charge_kw REAL,
+            battery_discharge_kw REAL,
+            source TEXT NOT NULL DEFAULT 'test'
+        );
+        CREATE TABLE daikin_telemetry (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            fetched_at REAL NOT NULL,
+            source TEXT NOT NULL,
+            tank_temp_c REAL
+        );
+        CREATE TABLE lp_inputs_snapshot (
+            run_id INTEGER PRIMARY KEY,
+            run_at_utc TEXT NOT NULL
+        );
+        CREATE TABLE lp_solution_snapshot (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL,
+            slot_index INTEGER NOT NULL,
+            slot_time_utc TEXT NOT NULL,
+            import_kwh REAL,
+            export_kwh REAL,
+            charge_kwh REAL,
+            discharge_kwh REAL,
+            pv_use_kwh REAL,
+            dhw_kwh REAL,
+            space_kwh REAL
+        );
+        CREATE TABLE dispatch_decisions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL,
+            slot_time_utc TEXT NOT NULL,
+            lp_kind TEXT NOT NULL,
+            dispatched_kind TEXT NOT NULL,
+            reason TEXT
+        );
+        CREATE TABLE fox_schedule_state (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            uploaded_at TEXT NOT NULL
+        );
+        CREATE TABLE agile_rates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            valid_from TEXT NOT NULL,
+            value_inc_vat REAL NOT NULL
+        );
+        CREATE TABLE agile_export_rates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            valid_from TEXT NOT NULL,
+            value_inc_vat REAL NOT NULL
+        );
+        """
+    )
+    db.commit()
+    db.close()
+    return db_path
+
+
+def _now() -> dt.datetime:
+    """Fixed anchor — 2026-05-20 10:00 UTC. Audit window = preceding 24 h
+    (2026-05-19 10:00 → 2026-05-20 10:00 UTC)."""
+    return dt.datetime(2026, 5, 20, 10, 0, 0, tzinfo=dt.timezone.utc)
+
+
+def _ago(hours: float) -> str:
+    """ISO timestamp for the half-hour slot floor of (now - *hours*).
+
+    Stays inside the audit window for ``0 < hours < 24``. Floor to the
+    30-min grid so slot_time_utc strings round-trip exactly against the
+    audit's slot-iterator."""
+    t = _now() - dt.timedelta(hours=hours)
+    minute = 0 if t.minute < 30 else 30
+    return t.replace(minute=minute, second=0, microsecond=0).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Shape / empty-DB
+# ---------------------------------------------------------------------------
+
+def test_build_audit_report_returns_complete_shape_on_empty_db(tmp_path: Path) -> None:
+    db = _make_db(tmp_path)
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+
+    assert report["window_hours"] == 24
+    assert report["now_utc"] == _now().isoformat()
+
+    held = report["held_schedule"]
+    assert held["total"] == 0
+    assert held["soc_below_reserve"] == 0
+    assert held["soc_above_reserve"] == 0
+    assert held["soc_unknown"] == 0
+    assert held["events"] == []
+
+    pve = report["plan_vs_execution"]
+    assert pve["lp_runs"] == 0
+    assert pve["paired_uploads"] == 0
+    assert pve["coverage_pct"] == 100.0
+    assert pve["plan_kwh"] == {"import": 0.0, "export_effective": 0.0}
+    assert pve["real_kwh"] == {"import": 0.0, "export": 0.0}
+    assert pve["cost_delta_p"] == 0.0
+    assert pve["disparities"] == []
+
+    forgone = report["strict_savings_forgone"]
+    assert forgone == {"kwh": 0.0, "pence": 0.0, "slot_count": 0}
+
+
+def test_empty_audit_renders_silent(tmp_path: Path) -> None:
+    """No held events + small cost delta + 100% coverage → markdown is None."""
+    db = _make_db(tmp_path)
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    assert audit_report.render_audit_markdown(report) is None
+
+
+# ---------------------------------------------------------------------------
+# Section A — held-schedule classification
+# ---------------------------------------------------------------------------
+
+def _seed_held_event(
+    db_path: Path,
+    *,
+    run_at: str,
+    soc_pct: float | None,
+    tank_temp_c: float | None = None,
+) -> None:
+    db = sqlite3.connect(str(db_path))
+    db.execute(
+        "INSERT INTO optimizer_log (run_at, strategy_summary) VALUES (?, ?)",
+        (run_at, "Infeasible — held previous schedule"),
+    )
+    if soc_pct is not None:
+        # Insert one realtime row whose timestamp is >= run_at so the lookup
+        # ``captured_at >= run_at ORDER BY captured_at LIMIT 1`` finds it.
+        db.execute(
+            "INSERT INTO pv_realtime_history (captured_at, soc_pct, source) VALUES (?, ?, 'test')",
+            (run_at, soc_pct),
+        )
+    if tank_temp_c is not None:
+        # Daikin uses unix-epoch seconds; pick a value slightly BEFORE the
+        # run_at timestamp so the < cutoff lookup picks it up.
+        ts = dt.datetime.fromisoformat(run_at.replace("Z", "+00:00")).timestamp() - 60
+        db.execute(
+            "INSERT INTO daikin_telemetry (fetched_at, source, tank_temp_c) VALUES (?, 'test', ?)",
+            (ts, tank_temp_c),
+        )
+    db.commit()
+    db.close()
+
+
+def test_held_event_classified_below_reserve(tmp_path: Path) -> None:
+    """SoC at 5% on a 10 kWh battery with 15% reserve → below_reserve True."""
+    db = _make_db(tmp_path)
+    _seed_held_event(db, run_at=_ago(3), soc_pct=5.0, tank_temp_c=42.5)
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    held = report["held_schedule"]
+    assert held["total"] == 1
+    assert held["soc_below_reserve"] == 1
+    assert held["soc_above_reserve"] == 0
+    e = held["events"][0]
+    assert e["soc_pct"] == 5.0
+    assert e["tank_temp_c"] == 42.5
+    assert e["below_reserve"] is True
+
+
+def test_held_event_classified_above_reserve(tmp_path: Path) -> None:
+    """SoC at 55% → comfortably above the 15% reserve → goes to follow-up class."""
+    db = _make_db(tmp_path)
+    _seed_held_event(db, run_at=_ago(12), soc_pct=55.0, tank_temp_c=40.0)
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    held = report["held_schedule"]
+    assert held["soc_below_reserve"] == 0
+    assert held["soc_above_reserve"] == 1
+    assert held["events"][0]["below_reserve"] is False
+
+
+def test_held_event_with_unknown_soc_counted_separately(tmp_path: Path) -> None:
+    db = _make_db(tmp_path)
+    _seed_held_event(db, run_at=_ago(5), soc_pct=None)
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    held = report["held_schedule"]
+    assert held["soc_unknown"] == 1
+    assert held["soc_below_reserve"] == 0
+    assert held["soc_above_reserve"] == 0
+
+
+def test_event_outside_window_not_included(tmp_path: Path) -> None:
+    """A held event 36 h ago is older than the 24 h window — must be excluded."""
+    db = _make_db(tmp_path)
+    _seed_held_event(db, run_at=_ago(36), soc_pct=10.0)
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    assert report["held_schedule"]["total"] == 0
+
+
+def test_held_events_render_into_markdown(tmp_path: Path) -> None:
+    """Any held event forces a Telegram render regardless of cost delta."""
+    db = _make_db(tmp_path)
+    _seed_held_event(db, run_at=_ago(12), soc_pct=55.0, tank_temp_c=39.5)
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    md = audit_report.render_audit_markdown(report)
+    assert md is not None
+    assert "Held-schedule events" in md
+    assert "55.0%" in md
+    assert "39.5" in md   # tank temperature value (no degree sign assertion — encoding)
+
+
+# ---------------------------------------------------------------------------
+# Section B — plan vs execution + forgone export
+# ---------------------------------------------------------------------------
+
+def _seed_lp_pair(
+    db_path: Path,
+    *,
+    run_id: int,
+    run_at_utc: str,
+    slot_time_utc: str,
+    plan_import_kwh: float = 0.0,
+    plan_export_kwh: float = 0.0,
+    dispatched_kind: str = "standard",
+) -> None:
+    db = sqlite3.connect(str(db_path))
+    db.execute(
+        "INSERT INTO lp_inputs_snapshot (run_id, run_at_utc) VALUES (?, ?)",
+        (run_id, run_at_utc),
+    )
+    db.execute(
+        "INSERT INTO lp_solution_snapshot "
+        "(run_id, slot_index, slot_time_utc, import_kwh, export_kwh) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (run_id, 0, slot_time_utc, plan_import_kwh, plan_export_kwh),
+    )
+    db.execute(
+        "INSERT INTO dispatch_decisions (run_id, slot_time_utc, lp_kind, dispatched_kind) "
+        "VALUES (?, ?, ?, ?)",
+        (run_id, slot_time_utc, "standard", dispatched_kind),
+    )
+    db.commit()
+    db.close()
+
+
+def _seed_realised(
+    db_path: Path, *, captured_at: str, grid_import_kw: float, grid_export_kw: float = 0.0
+) -> None:
+    db = sqlite3.connect(str(db_path))
+    db.execute(
+        "INSERT INTO pv_realtime_history "
+        "(captured_at, grid_import_kw, grid_export_kw, source) VALUES (?, ?, ?, 'test')",
+        (captured_at, grid_import_kw, grid_export_kw),
+    )
+    db.commit()
+    db.close()
+
+
+def _seed_rate(db_path: Path, *, valid_from: str, import_p: float, export_p: float = 5.0) -> None:
+    db = sqlite3.connect(str(db_path))
+    db.execute(
+        "INSERT INTO agile_rates (valid_from, value_inc_vat) VALUES (?, ?)",
+        (valid_from, import_p),
+    )
+    db.execute(
+        "INSERT INTO agile_export_rates (valid_from, value_inc_vat) VALUES (?, ?)",
+        (valid_from, export_p),
+    )
+    db.commit()
+    db.close()
+
+
+def test_disparity_surfaces_when_real_imports_above_plan(tmp_path: Path) -> None:
+    """LP planned 0 import @ 20p/kWh; realised mean 2 kW × 0.5 h = 1 kWh
+    imported. Δcost ≈ +20p — surfaces in the per-slot disparities list."""
+    db = _make_db(tmp_path)
+    slot = _ago(4)
+    _seed_lp_pair(db, run_id=1, run_at_utc=_ago(4.5), slot_time_utc=slot,
+                  plan_import_kwh=0.0)
+    # One heartbeat sample inside the slot — mean is the value itself.
+    _seed_realised(db, captured_at=slot, grid_import_kw=2.0)
+    _seed_rate(db, valid_from=slot, import_p=20.0)
+
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    pve = report["plan_vs_execution"]
+    assert pve["plan_kwh"]["import"] == 0.0
+    assert pve["real_kwh"]["import"] == 1.0
+    assert pve["cost_delta_p"] == pytest.approx(20.0, abs=0.5)
+    assert len(pve["disparities"]) == 1
+    d = pve["disparities"][0]
+    assert d["delta_cost_p"] == pytest.approx(20.0, abs=0.5)
+    assert d["plan_import_kwh"] == 0.0
+    assert d["real_import_kwh"] == 1.0
+
+
+def test_strict_savings_forgone_export_counted(tmp_path: Path) -> None:
+    """LP wanted to export 1 kWh @ 25p but dispatched_kind=standard
+    (strict_savings policy held the battery) → forgone tally captures it."""
+    db = _make_db(tmp_path)
+    slot = _ago(21)
+    _seed_lp_pair(
+        db, run_id=1, run_at_utc=_ago(21.2), slot_time_utc=slot,
+        plan_import_kwh=0.0, plan_export_kwh=1.0, dispatched_kind="standard",
+    )
+    _seed_rate(db, valid_from=slot, import_p=15.0, export_p=25.0)
+
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    forgone = report["strict_savings_forgone"]
+    assert forgone["slot_count"] == 1
+    assert forgone["kwh"] == 1.0
+    assert forgone["pence"] == pytest.approx(25.0, abs=0.5)
+
+
+def test_peak_export_dispatch_does_not_count_as_forgone(tmp_path: Path) -> None:
+    """When dispatched_kind=peak_export, the export was honoured → 0 forgone."""
+    db = _make_db(tmp_path)
+    slot = _ago(21)
+    _seed_lp_pair(
+        db, run_id=1, run_at_utc=_ago(21.2), slot_time_utc=slot,
+        plan_export_kwh=1.0, dispatched_kind="peak_export",
+    )
+    _seed_rate(db, valid_from=slot, import_p=15.0, export_p=25.0)
+
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    assert report["strict_savings_forgone"]["slot_count"] == 0
+    # And plan_kwh.export_effective DOES include this 1 kWh (it shipped).
+    assert report["plan_vs_execution"]["plan_kwh"]["export_effective"] == 1.0
+
+
+def test_strict_savings_downgrade_excluded_from_effective_plan_export(tmp_path: Path) -> None:
+    """Same LP export, but downgraded to standard → effective plan export = 0,
+    so it can NOT contribute a false-positive disparity vs zero real export."""
+    db = _make_db(tmp_path)
+    slot = _ago(21)
+    _seed_lp_pair(
+        db, run_id=1, run_at_utc=_ago(21.2), slot_time_utc=slot,
+        plan_export_kwh=1.0, dispatched_kind="standard",
+    )
+    _seed_rate(db, valid_from=slot, import_p=15.0, export_p=25.0)
+
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    assert report["plan_vs_execution"]["plan_kwh"]["export_effective"] == 0.0
+    # The strict_savings downgrade should not generate a disparity row by
+    # itself — real export is 0, effective plan export is 0, Δ = 0.
+    no_export_disp = [
+        d for d in report["plan_vs_execution"]["disparities"]
+        if abs(d["delta_export_kwh"]) > 0
+    ]
+    assert no_export_disp == []
+
+
+def test_coverage_pct_reflects_lp_run_to_upload_pairing(tmp_path: Path) -> None:
+    """2 LP runs, 1 paired upload → 50% coverage."""
+    db = _make_db(tmp_path)
+    run_at_1 = _ago(4)
+    run_at_2 = _ago(3)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO lp_inputs_snapshot (run_id, run_at_utc) VALUES (1, ?)", (run_at_1,)
+    )
+    conn.execute(
+        "INSERT INTO lp_inputs_snapshot (run_id, run_at_utc) VALUES (2, ?)", (run_at_2,)
+    )
+    conn.execute(
+        "INSERT INTO fox_schedule_state (uploaded_at) VALUES (?)", (run_at_1,)
+    )
+    conn.commit()
+    conn.close()
+
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    pve = report["plan_vs_execution"]
+    assert pve["lp_runs"] == 2
+    assert pve["paired_uploads"] == 1
+    assert pve["coverage_pct"] == 50.0
+
+
+def test_render_flags_coverage_when_below_threshold(tmp_path: Path) -> None:
+    """Coverage 50% < 90% threshold → render emits the ⚠️ flag (forces a push
+    even on a 0p cost-delta day)."""
+    db = _make_db(tmp_path)
+    run_at_1 = _ago(4)
+    run_at_2 = _ago(3)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO lp_inputs_snapshot (run_id, run_at_utc) VALUES (1, ?)", (run_at_1,)
+    )
+    conn.execute(
+        "INSERT INTO lp_inputs_snapshot (run_id, run_at_utc) VALUES (2, ?)", (run_at_2,)
+    )
+    conn.execute(
+        "INSERT INTO fox_schedule_state (uploaded_at) VALUES (?)", (run_at_1,)
+    )
+    conn.commit()
+    conn.close()
+
+    report = audit_report.build_audit_report(now_utc=_now(), db_path=db)
+    md = audit_report.render_audit_markdown(report)
+    assert md is not None  # coverage warn forces a push
+    assert "50% coverage" in md
+    assert "⚠️" in md


### PR DESCRIPTION
## Summary

Lifts the daily audit logic out of \`/srv/hem/data/audit_held_schedule.py\` (host-side, not in repo, Telegram-only) into a testable, reusable module. Story A1 of Epic 13a (#351) — unblocks A2's three new MCP tools by giving them a structured \`dict\` return shape to work from.

Closes #352. Tracked by #351.

## What ships

**New module**: \`src/analytics/audit_report.py\`

\`\`\`python
build_audit_report(window_hours=24, *, now_utc=None, db_path=None) -> dict
render_audit_markdown(report, *, silent_cost_delta_threshold_p=30.0) -> str | None
\`\`\`

Three sections in the dict — \`held_schedule\`, \`plan_vs_execution\`, \`strict_savings_forgone\` — so MCP tools and briefs can compose their own narratives without re-parsing the Telegram markdown.

**Strict_savings filter awareness preserved**:
- \`_effective_plan_export_kwh()\` zeros out a slot's \`export_kwh\` when the dispatch classifier downgraded it from \`peak_export\` → \`standard\`. Keeps the disparity report from false-positive flagging working-as-designed scenario-filter downgrades.
- \`_forgone_export_kwh()\` captures the same slots as the counterfactual \"what we would have earned\" tally.

**Prod-side shim**: \`deploy/audit_held_schedule.py\` replaces the prior 415-line in-data script with a 30-line wrapper. Same silent-on-quiet-days contract, same markdown body shape, same coverage warning threshold.

## Tests

13 new tests in \`tests/analytics/test_audit_report.py\`:
- Empty DB → all-zero shape, silent render
- Held events: SoC below / above / unknown / outside-24h-window
- Per-slot disparity surfacing when realised diverges from plan
- Strict_savings forgone counting + the peak_export false-positive guard
- LP-run → Fox-upload coverage percentage
- Render flags coverage warning when below 90%, emits None on quiet days

Full suite: 1161 passed (the 1 xfail is unrelated #254 MCP singleton).

## Deploy

After merge:
\`\`\`bash
scp deploy/audit_held_schedule.py root@<prod>:/srv/hem/data/audit_held_schedule.py
\`\`\`
No \`systemctl restart hem\` needed — the timer re-reads the file on every fire (07:30 UTC daily). Behavioural diff vs the current prod script: zero.

## Test plan

- [x] \`pytest tests/analytics/test_audit_report.py\` — 13 pass
- [x] Full suite \`pytest --ignore=tests/test_mcp_singleton.py\` — 1161 pass
- [ ] After deploy: tomorrow's 07:30 UTC fire produces the same markdown shape as today's

🤖 Generated with [Claude Code](https://claude.com/claude-code)