### PR TITLE
feat(mcp): expose audit + forgone-export + brief KPI tools (A2)

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2029,6 +2029,264 @@ def build_mcp() -> FastMCP:
         return {"ok": True, "scorecard": scorecard}
 
     @mcp.tool(
+        name="get_audit_report",
+        description=(
+            "Daily audit — held-schedule events + plan-vs-execution + "
+            "strict_savings forgone-export, all over a configurable trailing "
+            "window. Returns the same structured dict the prod 07:30 UTC cron "
+            "consumes to decide whether to push to Telegram. Three sections:\n"
+            "  * held_schedule — LP infeasibilities caught by PR #338's "
+            "defensive fallback, each annotated with closest SoC and tank "
+            "temp + classified below_reserve (harmless post-#339) vs "
+            "above_reserve (the residual class, shower-floor-in-slot-0)\n"
+            "  * plan_vs_execution — LP-run → Fox-upload coverage %, totals "
+            "(import + export kWh, cost in pence), top-N per-slot disparities "
+            "by absolute cost delta\n"
+            "  * strict_savings_forgone — kWh + pence the household didn't "
+            "earn because the scenario filter / strict_savings policy "
+            "downgraded LP-preferred peak_export slots\n"
+            "Pure read over DB; no Daikin API, no LP solve. Safe to call "
+            "mid-day. Default window = 24h."
+        ),
+    )
+    def get_audit_report(window_hours: int = 24) -> dict[str, Any]:
+        from .analytics.audit_report import build_audit_report
+
+        try:
+            window = int(window_hours)
+        except (TypeError, ValueError):
+            return {"ok": False, "error": f"invalid window_hours {window_hours!r}"}
+        if window <= 0 or window > 168:
+            return {"ok": False, "error": "window_hours must be in (0, 168]"}
+        try:
+            report = build_audit_report(window_hours=window)
+        except Exception as e:
+            logger.exception("get_audit_report failed")
+            return {"ok": False, "error": str(e)}
+        return {"ok": True, "report": report}
+
+    @mcp.tool(
+        name="get_strict_savings_forgone_export",
+        description=(
+            "Counterfactual revenue NOT realised because the strict_savings "
+            "policy / scenario filter downgraded LP-preferred peak_export "
+            "slots to standard. For each day in [start_date, end_date] "
+            "(inclusive, YYYY-MM-DD local), returns per-slot detail + a "
+            "totals roll-up:\n"
+            "  - kwh: total forgone export kWh\n"
+            "  - pence / pounds: total forgone revenue\n"
+            "  - slot_count: number of downgraded slots\n"
+            "  - daily: list of {date, kwh, pence, slot_count}\n"
+            "Lets OpenClaw answer 'what is strict_savings costing us this "
+            "month?' composably (set start_date=YYYY-MM-01, end_date=today). "
+            "Pure read; no Daikin / Fox / Octopus calls. Range capped at "
+            "367 days."
+        ),
+    )
+    def get_strict_savings_forgone_export(
+        start_date: str,
+        end_date: str,
+    ) -> dict[str, Any]:
+        from datetime import date as _date
+        from datetime import timedelta as _td
+
+        try:
+            start_d = _date.fromisoformat(start_date)
+            end_d = _date.fromisoformat(end_date)
+        except (TypeError, ValueError) as e:
+            return {"ok": False, "error": f"invalid date: {e}"}
+        if end_d < start_d:
+            return {"ok": False, "error": "end_date must be >= start_date"}
+        if (end_d - start_d).days > 367:
+            return {"ok": False, "error": "range capped at 367 days"}
+
+        try:
+            from . import db as _db
+            total_kwh = 0.0
+            total_p = 0.0
+            total_slots = 0
+            daily: list[dict[str, Any]] = []
+            d = start_d
+            while d <= end_d:
+                rows = _db.list_strict_savings_forgone_export_for_day(d.isoformat())
+                day_kwh = sum(float(r.get("export_kwh") or 0) for r in rows)
+                day_p = sum(
+                    float(r.get("export_kwh") or 0)
+                    * float(r.get("export_price_p_kwh") or 0)
+                    for r in rows
+                )
+                daily.append({
+                    "date": d.isoformat(),
+                    "kwh": round(day_kwh, 3),
+                    "pence": round(day_p, 1),
+                    "slot_count": len(rows),
+                })
+                total_kwh += day_kwh
+                total_p += day_p
+                total_slots += len(rows)
+                d += _td(days=1)
+        except Exception as e:
+            logger.exception("get_strict_savings_forgone_export failed")
+            return {"ok": False, "error": str(e)}
+
+        return {
+            "ok": True,
+            "start_date": start_d.isoformat(),
+            "end_date": end_d.isoformat(),
+            "n_days": (end_d - start_d).days + 1,
+            "totals": {
+                "kwh": round(total_kwh, 3),
+                "pence": round(total_p, 1),
+                "pounds": round(total_p / 100.0, 2),
+                "slot_count": total_slots,
+            },
+            "daily": daily,
+        }
+
+    @mcp.tool(
+        name="get_brief_kpis",
+        description=(
+            "Structured KPI fields shown in the daily brief — composable for "
+            "dashboards / agents that want to compose their own narrative "
+            "instead of parsing the markdown the brief renders. Defaults to "
+            "yesterday (the brief's anchor). Returns:\n"
+            "  * realised_net_cost_gbp — what we actually paid net of exports "
+            "(includes standing charge)\n"
+            "  * import_kwh + import_cost_gbp — energy-import side only\n"
+            "  * mean_import_rate_p_per_kwh — import-weighted mean Agile rate "
+            "today (NOT 24h-time-average — what we actually paid per kWh)\n"
+            "  * mtd: {n_days, avg_per_day_gbp, mean_import_rate_p_per_kwh} — "
+            "month-to-date context (EXCLUDES today)\n"
+            "  * strict_savings_forgone: {kwh, pence, slot_count} for today\n"
+            "  * lp_scorecard: {grade, lp_avoided_cost_p, dispatch_accuracy_pct}\n"
+            "Pure read; no Daikin API call."
+        ),
+    )
+    def get_brief_kpis(date: str | None = None) -> dict[str, Any]:
+        from datetime import date as _date
+        from datetime import datetime as _dt
+        from datetime import timedelta as _td
+        from zoneinfo import ZoneInfo
+
+        from . import db as _db
+        from .analytics.lp_scorecard import build_lp_scorecard
+        from .analytics.pnl import compute_daily_pnl, compute_period_pnl
+
+        tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+        if date is None:
+            target = _dt.now(tz).date() - _td(days=1)
+        else:
+            try:
+                target = _date.fromisoformat(date)
+            except ValueError:
+                return {"ok": False, "error": f"invalid date {date!r} (expected YYYY-MM-DD)"}
+
+        try:
+            pnl = compute_daily_pnl(target)
+        except Exception as e:
+            logger.exception("get_brief_kpis: compute_daily_pnl failed")
+            return {"ok": False, "error": f"daily pnl: {e}"}
+
+        # MTD aggregate (1st of month → target-1, excluding target itself).
+        mtd_block: dict[str, Any] | None = None
+        if target.day > 1:
+            try:
+                mtd_summary = compute_period_pnl(
+                    target.replace(day=1), target - _td(days=1),
+                    label=f"MTD to {(target - _td(days=1)).isoformat()}",
+                )
+                n_days = int(mtd_summary.get("n_days") or 0)
+                if n_days > 0:
+                    mtd_net = mtd_summary.get("realised_net_cost_gbp")
+                    if mtd_net is None:
+                        mtd_net = mtd_summary.get("realised_cost_gbp")
+                    m_kwh = mtd_summary.get("import_kwh")
+                    m_gbp = mtd_summary.get("import_cost_gbp")
+                    mtd_mean_p = (
+                        (m_gbp * 100.0) / m_kwh
+                        if (m_kwh and m_gbp is not None and m_kwh > 0)
+                        else None
+                    )
+                    mtd_block = {
+                        "n_days": n_days,
+                        "avg_per_day_gbp": (
+                            round(mtd_net / n_days, 2)
+                            if mtd_net is not None else None
+                        ),
+                        "mean_import_rate_p_per_kwh": (
+                            round(mtd_mean_p, 2) if mtd_mean_p is not None else None
+                        ),
+                    }
+            except Exception:
+                logger.exception("get_brief_kpis: MTD compute failed (continuing)")
+
+        imp_kwh = pnl.get("import_kwh")
+        imp_gbp = pnl.get("import_cost_gbp")
+        today_mean_p = (
+            (imp_gbp * 100.0) / imp_kwh
+            if (imp_kwh and imp_gbp is not None and imp_kwh > 0)
+            else None
+        )
+
+        forgone_rows = _db.list_strict_savings_forgone_export_for_day(target.isoformat())
+        forgone_kwh = sum(float(r.get("export_kwh") or 0) for r in forgone_rows)
+        forgone_p = sum(
+            float(r.get("export_kwh") or 0) * float(r.get("export_price_p_kwh") or 0)
+            for r in forgone_rows
+        )
+
+        lp_block: dict[str, Any] = {"grade": "N/A", "lp_avoided_cost_p": None,
+                                     "dispatch_accuracy_pct": None}
+        try:
+            card = build_lp_scorecard(target)
+            grade = card.get("grade")
+            econ = card.get("economic_value") or {}
+            disp = card.get("dispatch_accuracy") or {}
+            pcts = [
+                disp.get(k) for k in
+                ("import_accuracy_pct", "export_accuracy_pct", "charge_accuracy_pct")
+                if disp.get(k) is not None
+            ]
+            avg_acc = sum(pcts) / len(pcts) if pcts else None
+            lp_block = {
+                "grade": grade,
+                "lp_avoided_cost_p": econ.get("lp_avoided_cost_p"),
+                "dispatch_accuracy_pct": (
+                    round(avg_acc, 1) if avg_acc is not None else None
+                ),
+            }
+        except Exception:
+            logger.exception("get_brief_kpis: scorecard compute failed (continuing)")
+
+        net_cost = pnl.get("realised_net_cost_gbp")
+        if net_cost is None:
+            net_cost = pnl.get("realised_cost_gbp")
+
+        return {
+            "ok": True,
+            "date": target.isoformat(),
+            "realised_net_cost_gbp": (
+                round(float(net_cost), 2) if net_cost is not None else None
+            ),
+            "import_kwh": (
+                round(float(imp_kwh), 2) if imp_kwh is not None else None
+            ),
+            "import_cost_gbp": (
+                round(float(imp_gbp), 2) if imp_gbp is not None else None
+            ),
+            "mean_import_rate_p_per_kwh": (
+                round(today_mean_p, 2) if today_mean_p is not None else None
+            ),
+            "mtd": mtd_block,
+            "strict_savings_forgone": {
+                "kwh": round(forgone_kwh, 3),
+                "pence": round(forgone_p, 1),
+                "slot_count": len(forgone_rows),
+            },
+            "lp_scorecard": lp_block,
+        }
+
+    @mcp.tool(
         name="get_tariff_comparison",
         description=(
             "Apples-to-apples cost comparison across every configured tariff: realised "

--- a/tests/test_mcp_audit_tools.py
+++ b/tests/test_mcp_audit_tools.py
@@ -1,0 +1,304 @@
+"""Tests for the three audit MCP tools added in Story A2 of Epic 13a:
+
+* ``get_audit_report``                — thin wrapper over build_audit_report
+* ``get_strict_savings_forgone_export`` — multi-day forgone-export aggregate
+* ``get_brief_kpis``                  — structured KPI fields from the brief
+
+Tests exercise each tool via ``mcp.call_tool(...)`` (the same path OpenClaw
+takes over HTTP), monkeypatching ``config.DB_PATH`` so the queries hit a
+tmp DB with controlled seed data. No live Daikin / Fox / Octopus calls.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import sqlite3
+import unittest
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp", reason="Install the `mcp` package to run MCP server tests.")
+
+
+def _make_tmp_db(tmp_path: Path) -> Path:
+    """Tmp DB with the same minimal schema slice used by audit_report tests."""
+    db_path = tmp_path / "mcp.db"
+    db = sqlite3.connect(str(db_path))
+    db.executescript(
+        """
+        CREATE TABLE optimizer_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_at TEXT NOT NULL,
+            strategy_summary TEXT
+        );
+        CREATE TABLE pv_realtime_history (
+            captured_at TEXT PRIMARY KEY,
+            solar_power_kw REAL, soc_pct REAL,
+            load_power_kw REAL, grid_import_kw REAL, grid_export_kw REAL,
+            battery_charge_kw REAL, battery_discharge_kw REAL,
+            source TEXT NOT NULL DEFAULT 'test'
+        );
+        CREATE TABLE daikin_telemetry (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            fetched_at REAL NOT NULL, source TEXT NOT NULL, tank_temp_c REAL
+        );
+        CREATE TABLE lp_inputs_snapshot (
+            run_id INTEGER PRIMARY KEY, run_at_utc TEXT NOT NULL
+        );
+        CREATE TABLE lp_solution_snapshot (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL, slot_index INTEGER NOT NULL,
+            slot_time_utc TEXT NOT NULL,
+            import_kwh REAL, export_kwh REAL, charge_kwh REAL,
+            discharge_kwh REAL, pv_use_kwh REAL, dhw_kwh REAL, space_kwh REAL
+        );
+        CREATE TABLE dispatch_decisions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL, slot_time_utc TEXT NOT NULL,
+            lp_kind TEXT NOT NULL, dispatched_kind TEXT NOT NULL,
+            export_price_p_kwh REAL, reason TEXT,
+            UNIQUE(run_id, slot_time_utc)
+        );
+        CREATE TABLE fox_schedule_state (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, uploaded_at TEXT NOT NULL
+        );
+        CREATE TABLE agile_rates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            valid_from TEXT NOT NULL, value_inc_vat REAL NOT NULL
+        );
+        CREATE TABLE agile_export_rates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            valid_from TEXT NOT NULL, value_inc_vat REAL NOT NULL
+        );
+        """
+    )
+    db.commit()
+    db.close()
+    return db_path
+
+
+class TestGetAuditReport(unittest.IsolatedAsyncioTestCase):
+    """Exercise ``get_audit_report`` end-to-end via mcp.call_tool."""
+
+    async def asyncSetUp(self) -> None:
+        self._tmp_dir = Path(__import__("tempfile").mkdtemp())
+        self._db = _make_tmp_db(self._tmp_dir)
+
+    async def asyncTearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+
+    async def test_returns_structured_report_on_empty_db(self) -> None:
+        from unittest.mock import patch
+
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        with patch("src.analytics.audit_report.config") as cfg:
+            cfg.DB_PATH = str(self._db)
+            cfg.BATTERY_CAPACITY_KWH = 10.0
+            cfg.MIN_SOC_RESERVE_PERCENT = 15.0
+            _blocks, out = await mcp.call_tool("get_audit_report", {})
+        assert out["ok"] is True
+        rep = out["report"]
+        assert rep["window_hours"] == 24
+        assert rep["held_schedule"]["total"] == 0
+        assert rep["plan_vs_execution"]["lp_runs"] == 0
+        assert rep["strict_savings_forgone"]["slot_count"] == 0
+
+    async def test_rejects_out_of_range_window(self) -> None:
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool("get_audit_report", {"window_hours": 0})
+        assert out["ok"] is False
+        assert "window_hours" in out["error"]
+        _blocks, out = await mcp.call_tool("get_audit_report", {"window_hours": 999})
+        assert out["ok"] is False
+
+    async def test_custom_window_passes_through(self) -> None:
+        """Non-default window_hours is honoured by the underlying call."""
+        from unittest.mock import patch
+
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        with patch("src.analytics.audit_report.config") as cfg:
+            cfg.DB_PATH = str(self._db)
+            cfg.BATTERY_CAPACITY_KWH = 10.0
+            cfg.MIN_SOC_RESERVE_PERCENT = 15.0
+            _blocks, out = await mcp.call_tool("get_audit_report", {"window_hours": 48})
+        assert out["ok"] is True
+        assert out["report"]["window_hours"] == 48
+
+
+class TestGetStrictSavingsForgoneExport(unittest.IsolatedAsyncioTestCase):
+    """Exercise ``get_strict_savings_forgone_export`` for a small range."""
+
+    async def asyncSetUp(self) -> None:
+        from src import db as _db
+        _db.init_db()
+
+    async def test_empty_range_returns_zero_totals(self) -> None:
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_strict_savings_forgone_export",
+            {"start_date": "2026-05-01", "end_date": "2026-05-03"},
+        )
+        assert out["ok"] is True
+        assert out["n_days"] == 3
+        assert out["totals"]["slot_count"] == 0
+        assert out["totals"]["kwh"] == 0.0
+        assert out["totals"]["pence"] == 0.0
+        assert out["totals"]["pounds"] == 0.0
+        assert len(out["daily"]) == 3
+        # Each day enumerated with explicit ISO date string
+        assert [d["date"] for d in out["daily"]] == [
+            "2026-05-01", "2026-05-02", "2026-05-03",
+        ]
+
+    async def test_invalid_date_returns_error(self) -> None:
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_strict_savings_forgone_export",
+            {"start_date": "not-a-date", "end_date": "2026-05-01"},
+        )
+        assert out["ok"] is False
+        assert "invalid date" in out["error"].lower()
+
+    async def test_inverted_range_rejected(self) -> None:
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_strict_savings_forgone_export",
+            {"start_date": "2026-05-10", "end_date": "2026-05-01"},
+        )
+        assert out["ok"] is False
+        assert ">=" in out["error"]
+
+    async def test_range_cap_enforced(self) -> None:
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_strict_savings_forgone_export",
+            {"start_date": "2024-01-01", "end_date": "2026-01-02"},
+        )
+        assert out["ok"] is False
+        assert "367" in out["error"]
+
+    async def test_aggregates_real_seeded_data(self) -> None:
+        """Seed two days with one forgone-export slot each, verify totals."""
+        from src import db as _db
+
+        # PR #350's helper reads dispatch_decisions + lp_solution_snapshot;
+        # seed one downgrade slot per day at different export prices.
+        conn = sqlite3.connect(_db.config.DB_PATH)
+        try:
+            for day, slot_iso, export_p in (
+                ("2026-05-01", "2026-05-01T13:00:00+00:00", 25.0),
+                ("2026-05-02", "2026-05-02T13:00:00+00:00", 30.0),
+            ):
+                conn.execute(
+                    "INSERT INTO lp_inputs_snapshot (run_id, run_at_utc) "
+                    "VALUES (?, ?)",
+                    (int(day.replace("-", "")), slot_iso),
+                )
+                conn.execute(
+                    "INSERT INTO lp_solution_snapshot "
+                    "(run_id, slot_index, slot_time_utc, export_kwh, import_kwh) "
+                    "VALUES (?, 0, ?, 1.0, 0.0)",
+                    (int(day.replace("-", "")), slot_iso),
+                )
+                conn.execute(
+                    "INSERT INTO dispatch_decisions "
+                    "(run_id, slot_time_utc, lp_kind, dispatched_kind, "
+                    "committed, reason, export_price_p_kwh, created_at) "
+                    "VALUES (?, ?, 'peak_export', 'standard', 1, "
+                    "'strict_savings_downgrade', ?, ?)",
+                    (int(day.replace("-", "")), slot_iso, export_p, slot_iso),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        from src.mcp_server import build_mcp
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_strict_savings_forgone_export",
+            {"start_date": "2026-05-01", "end_date": "2026-05-02"},
+        )
+        assert out["ok"] is True
+        assert out["totals"]["slot_count"] == 2
+        assert out["totals"]["kwh"] == pytest.approx(2.0, abs=0.05)
+        # 1 kWh × 25p + 1 kWh × 30p = 55p
+        assert out["totals"]["pence"] == pytest.approx(55.0, abs=1.0)
+        assert out["totals"]["pounds"] == pytest.approx(0.55, abs=0.02)
+
+
+class TestGetBriefKpis(unittest.IsolatedAsyncioTestCase):
+    """Exercise ``get_brief_kpis`` for default + explicit date arguments."""
+
+    async def asyncSetUp(self) -> None:
+        from src import db as _db
+        _db.init_db()
+
+    async def test_handles_empty_db_gracefully(self) -> None:
+        """Empty DB → all KPI numeric fields are None or zero; tool stays ``ok=True``."""
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_brief_kpis", {"date": "2026-05-15"}
+        )
+        assert out["ok"] is True
+        assert out["date"] == "2026-05-15"
+        # MTD requires day > 1 — 2026-05-15 qualifies but DB is empty
+        # so the block may be present but with zeros / Nones, or None.
+        assert "mtd" in out
+        assert out["strict_savings_forgone"] == {
+            "kwh": 0.0, "pence": 0.0, "slot_count": 0,
+        }
+        # Scorecard on empty DB renders N/A grade
+        assert out["lp_scorecard"]["grade"] == "N/A"
+
+    async def test_first_of_month_skips_mtd_block(self) -> None:
+        """On the 1st of the month there's no previous-days MTD window —
+        the helper returns None instead of fabricating empty stats."""
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_brief_kpis", {"date": "2026-05-01"}
+        )
+        assert out["ok"] is True
+        assert out["mtd"] is None
+
+    async def test_invalid_date_returns_error(self) -> None:
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        _blocks, out = await mcp.call_tool(
+            "get_brief_kpis", {"date": "not-a-date"}
+        )
+        assert out["ok"] is False
+        assert "invalid date" in out["error"].lower()
+
+
+class TestNewToolsRegistered(unittest.IsolatedAsyncioTestCase):
+    """Sanity check that all three new tools appear in tools/list."""
+
+    async def test_all_three_audit_tools_registered(self) -> None:
+        from src.mcp_server import build_mcp
+
+        mcp = build_mcp()
+        tools = await mcp.list_tools()
+        names = {t.name for t in tools}
+        assert "get_audit_report" in names
+        assert "get_strict_savings_forgone_export" in names
+        assert "get_brief_kpis" in names


### PR DESCRIPTION
## Summary

Three new MCP tools that surface the structured audit data (from #367's A1 module) so OpenClaw / Claude / dashboards can query mid-day without parsing markdown or waiting for the 07:30 UTC Telegram pulse.

Closes #353. Tracked by #351 (Epic 13a).

## Tools

| Tool | Purpose |
|---|---|
| \`get_audit_report(window_hours=24)\` | Full structured audit (held-schedule + plan-vs-execution + strict_savings forgone). 24h default, capped 168. |
| \`get_strict_savings_forgone_export(start_date, end_date)\` | Multi-day counterfactual aggregate. Daily breakdown + totals (kwh/pence/pounds/slot_count). Capped at 367 days. |
| \`get_brief_kpis(date=None)\` | Structured fields shown in the daily brief — net cost, mean import rate, MTD context, forgone export, LP scorecard grade. |

All three are read-only (no Daikin API, no LP solve, no live Fox poll), follow the existing tool idiom (typed dict return, \`ok: bool\`, graceful empty-DB handling), and mount under the existing bearer-guarded \`/mcp\` namespace.

## Composability example

Answer \"what is strict_savings costing us this month?\":
\`\`\`json
get_strict_savings_forgone_export(start_date=\"2026-05-01\", end_date=\"2026-05-20\")
→ { totals: { pounds: 7.42, slot_count: 24, ... } }
\`\`\`

Combine with \`get_tariff_comparison(period=\"mtd\")\` for the full picture.

## Tests

12 new tests in \`tests/test_mcp_audit_tools.py\`:
- Each tool exercised via real \`mcp.call_tool()\` (same path OpenClaw uses over HTTP)
- Empty-DB shape (\`ok: true\` with zero counts, not an error)
- Validation: invalid date, inverted range, range cap, out-of-range window
- Real-data aggregation: 2 forgone slots @ 25p + 30p → totals.pence = 55.0
- Registration sanity: all three appear in \`tools/list\`

CI ran the existing 1161-test suite with no regressions.

## Deploy

Code-only change. Tools appear in \`tools/list\` after the next image build + container restart on prod. No \`.env\` change.

## Test plan

- [x] \`pytest tests/test_mcp_audit_tools.py\` — 12 pass
- [x] Rebased clean onto main (post-#367 merge)
- [ ] After deploy: \`docker exec hem python -c \"from src.mcp_server import build_mcp; m=build_mcp(); ...\"\` confirms tool count went 76 → 79

🤖 Generated with [Claude Code](https://claude.com/claude-code)