### PR TITLE
docs(skill): document audit + KPI tools (A3)

### DIFF
--- a/skills/home-energy-manager/SKILL.md
+++ b/skills/home-energy-manager/SKILL.md
@@ -211,16 +211,67 @@ Use these to explain past decisions in the user's terms (price + temps + SoC), n
 ### "How did yesterday go?" / "PnL?"
 
 ```
-1. hem__get_energy_metrics()
+1. hem__get_brief_kpis()                 # defaults to yesterday
+     → structured KPI fields shown in the brief: realised_net_cost_gbp,
+       import_kwh, mean_import_rate_p_per_kwh, mtd context (avg/day,
+       weighted rate), strict_savings_forgone, lp_scorecard grade.
+       Lets you compose custom narratives without parsing the markdown.
+2. hem__get_energy_metrics()
      → daily/weekly/monthly delta vs SVT shadow + fixed-tariff shadow,
        VWAP, slippage, arbitrage efficiency, peak-import %, current SoC.
-2. hem__get_attribution_day()    # defaults to yesterday
+3. hem__get_attribution_day()    # defaults to yesterday
      → solar attribution: % of solar to self-use / battery / export.
-3. hem__get_fox_energy_range(start, end)
+4. hem__get_fox_energy_range(start, end)
      → daily totals across a date range for trend comparisons.
 ```
 
 `get_attribution_day` reads `fox_energy_daily`, populated by the nightly rollup — today's row only appears after rollover.
+
+### "Is the LP doing a good job?" / "Audit the last 24h"
+
+```
+1. hem__get_lp_scorecard()               # defaults to yesterday
+     → composite grade A/B/C/D plus three sections:
+       forecast_accuracy (was the LP's input right?),
+       dispatch_accuracy (did the plan execute?),
+       economic_value (did the LP beat naive SelfUse?).
+2. hem__get_audit_report(window_hours=24)
+     → held-schedule events (LP infeasibilities caught by PR #338's
+       fallback) + plan-vs-execution disparities (top-N slots by
+       absolute cost delta) + strict_savings_forgone totals.
+       Same data the 07:30 UTC Telegram cron uses.
+3. hem__explain_dispatch_decisions(run_id="latest")
+     → per-slot lp_kind → dispatched_kind classification and the reason
+       string (e.g. "scenario_filter_downgrade", "strict_savings_hold").
+```
+
+Use these together when the user asks "is the LP working?" — the
+scorecard's grade is the headline, the audit explains the held-schedule
+events, and `explain_dispatch_decisions` answers per-slot "why" questions.
+
+### "What is strict_savings costing us this month?"
+
+```
+1. hem__get_strict_savings_forgone_export(
+        start_date="2026-05-01",        # 1st of current month
+        end_date="2026-05-20",          # today
+   )
+     → totals.pounds = revenue NOT realised over the month because the
+       scenario filter / strict_savings policy held LP-preferred
+       peak_export slots; per-day breakdown shows when it bit.
+2. hem__get_tariff_comparison(period="mtd")
+     → realised cost vs SVT + Fixed shadows for the same window;
+       compose with #1 to extrapolate annual cost of the strategy.
+3. (if the gap is large and sustained)
+   hem__list_settings()   # ENERGY_STRATEGY_MODE row
+     → flip to "savings_first" via set_setting() if the user wants
+       to realise the missed revenue (overrides the user's
+       near-zero-grid-cost preference — confirm first).
+```
+
+The user prefers `strict_savings` for the near-zero grid-cost policy.
+Surface the forgone tally as a *trade-off* number, not a recommendation
+to switch — battery for overnight self-use is the explicit policy.
 
 ### "Mute the daily PnL alert until I'm back from holiday"
 


### PR DESCRIPTION
## Summary

Updates \`skills/home-energy-manager/SKILL.md\` to document the three new MCP tools shipped in #368 and the LP scorecard tool from #365 (which was undocumented). Adds two new worked-composition sections so OpenClaw / Claude pick the right tool chain for these common questions.

Closes #354. Tracked by #351 (completes Epic 13a).

## What changes

| Section | Tools |
|---|---|
| \"How did yesterday go?\" (existing) | + \`get_brief_kpis\` as the structured-fields entry point |
| \"Is the LP doing a good job?\" (new) | \`get_lp_scorecard\` → \`get_audit_report\` → \`explain_dispatch_decisions\` |
| \"What is strict_savings costing us this month?\" (new) | \`get_strict_savings_forgone_export\` → \`get_tariff_comparison(period=mtd)\` |

The strict_savings section is framed as a **trade-off**, not a recommendation to switch — per the user's explicit policy (\`feedback_near_zero_grid_cost_policy\`): battery for overnight self-use is intentional, the forgone-export tally is just visibility into what it costs.

## Why now

Without this update OpenClaw won't know the new tools exist — SKILL.md is the discovery surface. Skill catalog drift was the core motivation for Story A3.

## Deploy

Docs-only. SKILL.md is loaded as an extra skill dir by OpenClaw at \`/srv/hem/skills/home-energy-manager/SKILL.md\` (synced from this repo). Update lands on next OpenClaw skill-dir refresh — no service restart needed on the HEM side.

## Test plan

- [x] Diff reviewed; +54 lines, -3 lines (only the existing \"How did yesterday go?\" section was edited, two new sections appended)
- [ ] After merge: confirm OpenClaw picks up the SKILL.md update on its next skill-dir scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)