### PR TITLE
feat(ui): SPA container scaffold — nginx + bearer fetch wrapper (B3)

### DIFF
--- a/.github/workflows/ui-publish.yml
+++ b/.github/workflows/ui-publish.yml
@@ -1,0 +1,68 @@
+name: Publish UI image
+
+# Build + push the SPA container to GHCR on every push to main and on tags.
+# Mirrors docker-publish.yml's pattern but builds from the ui/ subdirectory
+# and tags the separate ghcr.io/<owner>/home-energy-manager-ui repo.
+#
+# The SPA image is consumed by deploy/compose.yaml (Story B6) as the
+# hem-ui service. The HEM API image (already published by docker-publish.yml)
+# is independent — these two images can be redeployed separately.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      # Only rebuild when SPA assets actually change. The HEM API image's
+      # publish workflow handles its own paths.
+      - "ui/**"
+      - ".github/workflows/ui-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/home-energy-manager-ui
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=long
+
+      - name: Build + push (linux/arm64 to match prod Hetzner host)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ui
+          file: ./ui/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=ui
+          cache-to: type=gha,mode=max,scope=ui

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,37 @@
+# HEM SPA container — nginx serving the static SPA + reverse-proxying /api → HEM.
+#
+# Built + published by .github/workflows/ui-publish.yml on every push to main:
+#   ghcr.io/albinati/home-energy-manager-ui:<sha>
+#   ghcr.io/albinati/home-energy-manager-ui:main
+#
+# Runtime configuration is via two env vars consumed by ui-entrypoint.sh:
+#   HEM_API_URL  — upstream HEM, e.g. http://hem:8000 (compose) or
+#                  http://127.0.0.1:8000 (host network).
+#   HEM_UI_TOKEN — bearer minted by HEM's lifespan at /srv/hem/data/.hem-ui-token,
+#                  read into the container as a Docker secret or env var. The
+#                  entrypoint substitutes the token into a runtime config file
+#                  the SPA reads on boot (so the token never gets baked into
+#                  the image).
+FROM nginx:1.27-alpine
+
+# gettext provides `envsubst` for the entrypoint
+RUN apk add --no-cache gettext
+
+# Static assets — html/, src/js/, src/css/ map to /usr/share/nginx/html/
+COPY html/        /usr/share/nginx/html/
+COPY src/js/      /usr/share/nginx/html/js/
+COPY src/css/     /usr/share/nginx/html/css/
+
+# nginx config — single template; entrypoint envsubsts HEM_API_URL into it
+COPY conf/nginx.conf.template  /etc/nginx/templates/default.conf.template
+
+# Runtime config — entrypoint writes /usr/share/nginx/html/config.js with
+# the bearer token + API base so the SPA can read window.__HEM_CONFIG__.
+COPY ui-entrypoint.sh /docker-entrypoint.d/40-hem-config.sh
+RUN chmod +x /docker-entrypoint.d/40-hem-config.sh
+
+# Health endpoint — nginx serves /healthz with a static response (no HEM round-trip)
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -q -O /dev/null http://127.0.0.1:80/healthz || exit 1
+
+EXPOSE 80

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,67 @@
+# HEM SPA container
+
+Standalone nginx container serving the Home Energy Manager web UI.
+Decouples the frontend from the Python API container so each can iterate
+independently. Shipped by Epic 13b.
+
+## Layout
+
+```
+ui/
+├── Dockerfile                  nginx:alpine + envsubst for config
+├── README.md                   this file
+├── conf/
+│   └── nginx.conf.template     server config; ${HEM_API_URL} substituted at boot
+├── html/                       static HTML pages (one per route)
+│   └── cockpit.html            placeholder until B4 lifts the real cockpit
+├── src/
+│   ├── css/                    CSS, served from /css/
+│   └── js/
+│       └── _api.js             shared fetch() wrapper (bearer + base URL)
+└── ui-entrypoint.sh            generates /usr/share/nginx/html/config.js at boot
+```
+
+## Build + publish
+
+CI handles it — every push to main that touches `ui/**` triggers
+`.github/workflows/ui-publish.yml`, which pushes
+`ghcr.io/albinati/home-energy-manager-ui:<sha>` (and the `main` tag).
+
+To build locally:
+
+```bash
+docker build -t hem-ui ./ui
+```
+
+## Run
+
+Two required env vars:
+
+| Var | Purpose |
+|---|---|
+| `HEM_API_URL` | Upstream HEM (e.g. `http://hem:8000` in compose, `http://127.0.0.1:8000` on host network). The nginx config envsubsts this into the `/api/` reverse proxy. |
+| `HEM_UI_TOKEN` | Bearer for `/api/v1/*`. Minted by HEM's lifespan at `/srv/hem/data/.hem-ui-token` (Epic 13b/B1). Written into the runtime `/config.js` by the entrypoint so the SPA can read it on boot. |
+
+```bash
+docker run --rm -p 8080:80 \
+  -e HEM_API_URL=http://host.docker.internal:8000 \
+  -e HEM_UI_TOKEN="$(cat data/.hem-ui-token)" \
+  hem-ui
+```
+
+Open <http://localhost:8080/>.
+
+## Story progression
+
+- **B3** (this PR) — scaffold only. Placeholder cockpit page proves
+  routing + bearer injection are wired.
+- **B4** — lift the actual pages from `src/api/templates/` + JS from
+  `src/api/static/js/`. Mechanical copy, per the inventory at
+  [`docs/UI_API_INVENTORY.md`](../docs/UI_API_INVENTORY.md).
+- **B5** — drop the inline templates / Jinja2 from the HEM container.
+- **B6** — wire the `hem-ui` service into `/srv/hem/compose.yaml` and
+  flip `HEM_UI_AUTH_REQUIRED=true` so the new bearer gate enforces.
+
+Until B6 cuts over, the inline UI inside HEM keeps serving traffic —
+this SPA container can be built + pulled in parallel without affecting
+prod.

--- a/ui/conf/nginx.conf.template
+++ b/ui/conf/nginx.conf.template
@@ -1,0 +1,59 @@
+# nginx config for the HEM SPA container.
+# Runs through `envsubst` at boot — only ${HEM_API_URL} is substituted; other
+# `$variable` references (nginx variables) are NOT in the substitution list.
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index cockpit.html;
+
+    # Hardening — these don't cost anything and tighten the security posture
+    # for an internet-adjacent surface (Tailnet-bound but still).
+    server_tokens off;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Container-level health endpoint — used by docker compose healthcheck.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 'ok\n';
+    }
+
+    # Runtime config — set by ui-entrypoint.sh from env vars. The SPA loads
+    # this BEFORE any other JS so it can read window.__HEM_CONFIG__.
+    location = /config.js {
+        access_log off;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        try_files $uri =404;
+    }
+
+    # Reverse-proxy /api → HEM. The browser sees same-origin, no CORS needed.
+    # The bearer header is injected client-side by the SPA's fetch wrapper.
+    location /api/ {
+        proxy_pass         ${HEM_API_URL};
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    # Static assets — long cache since SPA filenames are versioned by the CI
+    # build (or by image SHA in the URL — every push to main gets a new image).
+    location ~* \.(js|css|woff2?|svg|png|jpg|jpeg|gif|ico)$ {
+        access_log off;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+        try_files $uri =404;
+    }
+
+    # SPA routes — every HTML path falls through to its corresponding file in
+    # html/. Unknown paths fall back to cockpit.html (Single-Page App default).
+    location / {
+        add_header Cache-Control "no-cache" always;
+        try_files $uri $uri/ /cockpit.html;
+    }
+}

--- a/ui/html/cockpit.html
+++ b/ui/html/cockpit.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HEM SPA · scaffold</title>
+  <script src="/config.js"></script>
+  <script src="/js/_api.js"></script>
+  <style>
+    body { font-family: ui-sans-serif, system-ui; background: #0b0f17; color: #e8eef6; padding: 2rem; }
+    .ok { color: #6fffa1; }
+    .err { color: #ff7070; }
+    pre { background: #131a26; padding: 1rem; border-radius: 8px; overflow: auto; }
+  </style>
+</head>
+<body>
+  <h1>HEM SPA — Story B3 scaffold</h1>
+  <p>
+    This is the placeholder page shipped by Story B3 of Epic 13b. Story B4
+    replaces this with the migrated cockpit (plus history, forecast,
+    insights, workbench, settings). The page below confirms the nginx
+    config, runtime <code>config.js</code>, and bearer-injecting fetch
+    wrapper are wired correctly end-to-end.
+  </p>
+
+  <h2>Health probe</h2>
+  <pre id="health">checking …</pre>
+
+  <h2>Runtime config (from <code>/config.js</code>)</h2>
+  <pre id="config"></pre>
+
+  <script>
+    document.getElementById("config").textContent = JSON.stringify(
+      window.__HEM_CONFIG__ || {}, null, 2
+    );
+
+    hemGetJson("/health")
+      .then(j => {
+        const el = document.getElementById("health");
+        el.classList.add("ok");
+        el.textContent = JSON.stringify(j, null, 2);
+      })
+      .catch(err => {
+        const el = document.getElementById("health");
+        el.classList.add("err");
+        el.textContent = err.message + (err.body ? "\n\n" + err.body : "");
+      });
+  </script>
+</body>
+</html>

--- a/ui/src/js/_api.js
+++ b/ui/src/js/_api.js
@@ -1,0 +1,67 @@
+// Shared API wrapper for the HEM SPA.
+//
+// Wraps fetch() to:
+//   1. prepend the API base (/api/v1) so callers can write fetch('/cockpit/now')
+//      and not care about the prefix.
+//   2. inject `Authorization: Bearer ${window.__HEM_CONFIG__.bearer}` when the
+//      bearer is present in the runtime config (set by ui-entrypoint.sh).
+//   3. throw on non-2xx so callers can `.catch(e => ...)` instead of every
+//      callsite re-checking response.ok.
+//
+// The shape is intentionally minimal — no axios, no class hierarchy. Callsites
+// migrated from src/api/static/js/ can switch fetch('/api/v1/foo') →
+// hemFetch('/foo') with no behaviour change.
+
+(function (global) {
+  "use strict";
+
+  function _config() {
+    return global.__HEM_CONFIG__ || { apiBase: "/api/v1", bearer: null };
+  }
+
+  function _join(base, path) {
+    if (!path.startsWith("/")) path = "/" + path;
+    return base.replace(/\/$/, "") + path;
+  }
+
+  function _withAuth(init) {
+    const cfg = _config();
+    const headers = new Headers((init && init.headers) || {});
+    if (cfg.bearer && !headers.has("Authorization")) {
+      headers.set("Authorization", "Bearer " + cfg.bearer);
+    }
+    return Object.assign({}, init || {}, { headers });
+  }
+
+  async function hemFetch(path, init) {
+    const url = _join(_config().apiBase, path);
+    const resp = await fetch(url, _withAuth(init));
+    if (!resp.ok) {
+      const err = new Error("hem-api " + resp.status + " " + resp.statusText);
+      err.status = resp.status;
+      try { err.body = await resp.text(); } catch (_) { err.body = ""; }
+      throw err;
+    }
+    return resp;
+  }
+
+  // Convenience JSON helpers — the dominant shape across the existing JS files.
+  async function hemGetJson(path, init) {
+    const r = await hemFetch(path, init);
+    return r.json();
+  }
+
+  async function hemPostJson(path, body, init) {
+    const merged = Object.assign({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    }, init || {});
+    const r = await hemFetch(path, merged);
+    return r.json();
+  }
+
+  global.hemFetch    = hemFetch;
+  global.hemGetJson  = hemGetJson;
+  global.hemPostJson = hemPostJson;
+})(window);

--- a/ui/ui-entrypoint.sh
+++ b/ui/ui-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Drop-in entrypoint (nginx's image runs /docker-entrypoint.d/*.sh before
+# launching nginx itself). We use this hook for two things:
+#
+# 1. Generate /usr/share/nginx/html/config.js so the SPA reads its bearer
+#    token + API base from window.__HEM_CONFIG__ on boot. The token is
+#    NEVER baked into the image — it comes in via the runtime env at
+#    container start, lifted from /srv/hem/data/.hem-ui-token by the
+#    compose deploy.
+#
+# 2. Validate that HEM_API_URL is set (the nginx template envsubst step
+#    needs it). If not set we exit 1 so the container fails fast rather
+#    than serving a broken /api proxy.
+set -eu
+
+: "${HEM_API_URL:?HEM_API_URL must be set (e.g. http://hem:8000)}"
+
+CONFIG_PATH=/usr/share/nginx/html/config.js
+TOKEN="${HEM_UI_TOKEN:-}"
+
+cat > "$CONFIG_PATH" <<EOF
+// Generated at container start by ui-entrypoint.sh — DO NOT EDIT.
+// Cached:no-store via nginx config.
+window.__HEM_CONFIG__ = {
+  apiBase: "/api/v1",
+  bearer:  ${TOKEN:+\"$TOKEN\"}${TOKEN:-null},
+  buildSha: "${BUILD_SHA:-unknown}"
+};
+EOF
+
+# Without HEM_UI_TOKEN the SPA still loads but write actions fail with 401
+# (once HEM_UI_AUTH_REQUIRED=true on the API side). Surface the absence in
+# the container log so it's obvious in journalctl.
+if [ -z "$TOKEN" ]; then
+  echo "ui-entrypoint: WARNING — HEM_UI_TOKEN not set; SPA will only succeed on read paths until token is provided" >&2
+fi


### PR DESCRIPTION
## Summary

Standalone nginx container scaffolding for the HEM SPA. Story B3 of Epic 13b — sets up the build pipeline and runtime contract; Story B4 lifts the actual pages.

Closes #358. Tracked by #355.

## What ships

\`\`\`
ui/
├── Dockerfile                  nginx:1.27-alpine + gettext for envsubst
├── README.md                   container-level docs
├── conf/nginx.conf.template    reverse-proxy /api → \${HEM_API_URL}; SPA fallback
├── html/cockpit.html           placeholder; B4 replaces with real cockpit
├── src/js/_api.js              shared fetch() wrapper (bearer + base URL)
└── ui-entrypoint.sh            writes /config.js with bearer + apiBase at boot
\`\`\`

Plus \`.github/workflows/ui-publish.yml\` — pushes \`ghcr.io/<owner>/home-energy-manager-ui:<sha>\` on every change to \`ui/**\` (paths-scoped so HEM-only changes don't rebuild).

## Runtime contract

| Env | Purpose |
|---|---|
| \`HEM_API_URL\` | Upstream HEM. nginx envsubsts into the \`/api/\` reverse proxy. |
| \`HEM_UI_TOKEN\` | Bearer minted by HEM lifespan (B1, #370). Entrypoint writes it into \`/config.js\` so the SPA reads \`window.__HEM_CONFIG__.bearer\`. Never baked into the image. |

## How the bearer flows

1. HEM container boots → lifespan mints \`/srv/hem/data/.hem-ui-token\` (B1).
2. B6 compose: \`HEM_UI_TOKEN=\$(cat /srv/hem/data/.hem-ui-token)\` env-injected into \`hem-ui\` service.
3. nginx entrypoint writes the token into \`/usr/share/nginx/html/config.js\` (no-store cached).
4. SPA reads \`window.__HEM_CONFIG__.bearer\`, fetch wrapper attaches \`Authorization: Bearer …\` to every \`/api/\` call.
5. HEM's \`ApiV1BearerAuth\` (B1) accepts the token.

## Why minimal

\`html/cockpit.html\` is a deliberate placeholder — pings \`/api/v1/health\`, renders the runtime config, proves end-to-end wiring. The real pages land in B4 (mechanical lift from \`src/api/templates/\` + \`src/api/static/js/\`).

## Test plan

- [x] \`docker build ./ui\` succeeds (verified locally; \`hadolint\` warnings would be CI's job)
- [x] CI workflow YAML lints
- [ ] After merge: image appears at \`ghcr.io/albinati/home-energy-manager-ui:main\`
- [ ] Optional smoke: \`docker run --rm -p 8080:80 -e HEM_API_URL=http://host.docker.internal:8000 -e HEM_UI_TOKEN=... hem-ui\` → open \`http://localhost:8080/\` and see the placeholder

## Notes

- Image is **not** wired into prod compose yet — that's B6.
- The inline UI inside HEM keeps serving until B5 decommissions it. Until then both can coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)