### PR TITLE
feat(ui): lift cockpit + history + forecast + insights + workbench + settings (B4)

### DIFF
--- a/ui/html/cockpit.html
+++ b/ui/html/cockpit.html
@@ -2,49 +2,398 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>HEM SPA · scaffold</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0f17">
+  <title>Cockpit · Home Energy</title>
+  <link rel="stylesheet" href="/css/cockpit.css">
   <script src="/config.js"></script>
   <script src="/js/_api.js"></script>
-  <style>
-    body { font-family: ui-sans-serif, system-ui; background: #0b0f17; color: #e8eef6; padding: 2rem; }
-    .ok { color: #6fffa1; }
-    .err { color: #ff7070; }
-    pre { background: #131a26; padding: 1rem; border-radius: 8px; overflow: auto; }
-  </style>
 </head>
 <body>
-  <h1>HEM SPA — Story B3 scaffold</h1>
-  <p>
-    This is the placeholder page shipped by Story B3 of Epic 13b. Story B4
-    replaces this with the migrated cockpit (plus history, forecast,
-    insights, workbench, settings). The page below confirms the nginx
-    config, runtime <code>config.js</code>, and bearer-injecting fetch
-    wrapper are wired correctly end-to-end.
-  </p>
+<header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">⚡ Home Energy</div>
+            <button id="modeBadge"
+                    class="mode-badge"
+                    type="button"
+                    data-daikin="passive"
+                    data-require-sim="false"
+                    title="Daikin control + simulate-id enforcement. Passive = heat pump runs on its own curve (normal). Active = the LP schedules tank + LWT.">
+                <span class="mode-dot"></span>
+                <span class="mode-label">Daikin:</span>
+                <span class="mode-value">passive</span>
+            </button>
+            <nav class="tabs" aria-label="Pages">
+                <a href="/" class="tab">Cockpit</a>
+                <a href="/forecast" class="tab">Forecast</a>
+                <a href="/history" class="tab">History</a>
+                <a href="/insights" class="tab">Insights</a>
+                <a href="/workbench" class="tab">Workbench</a>
+                <a href="/settings" class="tab">Settings</a>
+            </nav>
+            <div class="quota-pills" id="quotaPills">
+                <span class="pill" id="quotaDaikin" title="Daikin Onecta API requests today">D —/180</span>
+                <span class="pill" id="quotaFox" title="Fox ESS API requests today">F —/1200</span>
+            </div>
+            <span class="pill tz-pill" id="tzBadge"
+                  title="Planning + cockpit use this timezone. The nightly plan-push cron is UTC-anchored so each new day&apos;s first dispatches land on a fresh Daikin quota day.">
+                🕒 —
+            </span>
+        </div>
+    </header>
 
-  <h2>Health probe</h2>
-  <pre id="health">checking …</pre>
+<main class="page">
+<!-- Phase 2: "NOW" hero panel — one coherent snapshot from /api/v1/cockpit/now -->
+<section class="card cockpit-hero">
+    <div class="hero-main">
+        <div class="hero-now">
+            <span class="hero-kicker">Current slot</span>
+            <div class="hero-slot-line">
+                <span class="hero-slot-time" id="heroSlotTime">—</span>
+                <span class="hero-slot-kind" id="heroSlotKind">—</span>
+                <span class="hero-slot-price" id="heroSlotPrice">—</span>
+            </div>
+            <div class="hero-state-grid">
+                <div class="hero-kpi"><span class="hero-kpi-label">SoC</span><span class="hero-kpi-value" id="heroSoc">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Solar</span><span class="hero-kpi-value" id="heroSolar">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Load</span><span class="hero-kpi-value" id="heroLoad">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Grid</span><span class="hero-kpi-value" id="heroGrid">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Tank</span><span class="hero-kpi-value" id="heroTank">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Indoor</span><span class="hero-kpi-value" id="heroIndoor">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Outdoor</span><span class="hero-kpi-value" id="heroOutdoor">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">LWT</span><span class="hero-kpi-value" id="heroLwt">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Fox mode</span><span class="hero-kpi-value" id="heroFoxMode">—</span></div>
+                <div class="hero-kpi"><span class="hero-kpi-label">Daikin</span><span class="hero-kpi-value" id="heroDaikinMode">—</span></div>
+            </div>
+        </div>
+        <aside class="hero-next">
+            <span class="hero-kicker">Next transition</span>
+            <div class="hero-next-count" id="heroNextCountdown">—</div>
+            <div class="hero-next-label" id="heroNextLabel">—</div>
+        </aside>
+    </div>
+    <div class="freshness-ribbon" id="freshnessRibbon" title="Click a chip to refresh just that source">
+        <button class="fresh-chip" type="button" data-source="agile">
+            <span class="fresh-chip-name">Agile</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
+        <button class="fresh-chip" type="button" data-source="fox">
+            <span class="fresh-chip-name">Fox</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
+        <button class="fresh-chip" type="button" data-source="daikin">
+            <span class="fresh-chip-name">Daikin</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
+        <button class="fresh-chip" type="button" data-source="plan">
+            <span class="fresh-chip-name">Plan</span>
+            <span class="fresh-chip-age" data-age>—</span>
+            <span class="fresh-chip-refresh" aria-label="Refresh">⟳</span>
+        </button>
+        <button class="fresh-chip fresh-chip-settings" type="button" id="btnSettingsDrawer"
+                title="Open settings drawer — comfort targets, strategy, schedule cadence">
+            <span class="fresh-chip-name">⚙ Settings</span>
+        </button>
+    </div>
+    <!-- Recent manual/scheduler triggers with duration. Fed by
+         /api/v1/recent-triggers, reloaded after any wrapAction() apply so
+         a user-fired change (propose, Fox mode, tank temp) appears in the
+         strip within seconds. -->
+    <div class="recent-triggers" id="recentTriggers">
+        <span class="recent-triggers-head">Recent</span>
+        <span class="recent-triggers-list" id="recentTriggersList">—</span>
+    </div>
+</section>
 
-  <h2>Runtime config (from <code>/config.js</code>)</h2>
-  <pre id="config"></pre>
+<!-- Settings drawer — opens from the ⚙ chip. Same form as the /settings page
+     (container IDs match so settings.js populates both automatically). -->
+<div class="drawer-backdrop" id="settingsDrawerBackdrop" hidden>
+    <aside class="drawer" role="dialog" aria-modal="true" aria-labelledby="settingsDrawerTitle">
+        <header class="drawer-header">
+            <h2 id="settingsDrawerTitle">Settings</h2>
+            <a href="/settings" class="btn btn-sm btn-secondary" title="Open full settings page">Full page →</a>
+            <button class="drawer-close" id="btnSettingsDrawerClose" type="button" aria-label="Close">&times;</button>
+        </header>
+        <div class="drawer-body">
+            <p class="text-dim" style="font-size:0.78rem;margin:0 0 0.85rem 0;">
+                Quick tuning for comfort, strategy, and schedule. Every change simulates first.
+            </p>
+            <section class="drawer-card">
+                <h3 class="drawer-card-title">Comfort targets</h3>
+                <div id="settingsComfort"></div>
+            </section>
+            <section class="drawer-card">
+                <h3 class="drawer-card-title">Optimization strategy</h3>
+                <div id="settingsStrategy"></div>
+            </section>
+            <section class="drawer-card">
+                <h3 class="drawer-card-title">Schedule cadence</h3>
+                <div id="settingsSchedule"></div>
+            </section>
+        </div>
+    </aside>
+</div>
 
-  <script>
-    document.getElementById("config").textContent = JSON.stringify(
-      window.__HEM_CONFIG__ || {}, null, 2
-    );
+<section class="card">
+    <h2 class="card-title">House load breakdown</h2>
+    <div class="load-breakdown">
+        <div class="load-row is-total">
+            <span>House total</span>
+            <span class="value" data-load-total>—</span>
+        </div>
+        <div class="load-row is-sub">
+            <span>Daikin (heat pump, est.)</span>
+            <span class="value" data-load-daikin>—</span>
+        </div>
+        <div class="load-row is-sub">
+            <span>Residual (everything else)</span>
+            <span class="value" data-load-residual>—</span>
+        </div>
+    </div>
+    <p class="text-mute" style="font-size:0.75rem;margin:0.5rem 0 0 0;" data-load-source>—</p>
+</section>
 
-    hemGetJson("/health")
-      .then(j => {
-        const el = document.getElementById("health");
-        el.classList.add("ok");
-        el.textContent = JSON.stringify(j, null, 2);
-      })
-      .catch(err => {
-        const el = document.getElementById("health");
-        el.classList.add("err");
-        el.textContent = err.message + (err.body ? "\n\n" + err.body : "");
-      });
-  </script>
+<section class="card">
+    <h2 class="card-title">
+        24-hour timeline
+        <span class="card-actions">
+            <button class="btn btn-sm btn-primary" id="btnSimulateRePlanCockpit"
+                    title="Run a fresh LP simulation, review the diff in a modal, then choose to apply">
+                Re-plan
+            </button>
+        </span>
+    </h2>
+    <p class="timeline-summary" id="timelineSummary">—</p>
+
+    <!-- Merged tariff+plan strip (replaces the old three stacked strips).
+         Each of the 48 cells has two layers:
+           • background = price kind (negative / cheap / standard / peak)
+           • accent bar at the bottom = Fox mode decided by the LP
+         A vertical "now" cursor overlays the whole strip. Click any cell
+         for the full slot detail (price, mode, LP import/charge/discharge). -->
+    <div class="timeline-wrap">
+        <div class="timeline-axis-top">
+            <span class="threshold-marker" id="thrPeak">peak —</span>
+            <span class="threshold-marker" id="thrCheap">cheap —</span>
+        </div>
+        <div class="timeline-strip" id="timelineStrip" title="Click a slot for detail"></div>
+        <div class="timeline-cursor" id="timelineCursor" style="display:none"></div>
+        <div class="timeline-axis">
+            <span>00</span><span>03</span><span>06</span><span>09</span>
+            <span>12</span><span>15</span><span>18</span><span>21</span><span>24</span>
+        </div>
+        <div class="timeline-export-wrap" id="timelineExportWrap">
+            <span class="timeline-export-label">export</span>
+            <div class="timeline-export" id="timelineExport"></div>
+        </div>
+    </div>
+
+    <div class="timeline-legend">
+        <span class="leg-group">
+            <span class="leg-head">Price</span>
+            <span><span class="legend-swatch" style="background:var(--neg-price)"></span>negative</span>
+            <span><span class="legend-swatch" style="background:var(--cheap)"></span>cheap</span>
+            <span><span class="legend-swatch" style="background:var(--standard)"></span>standard</span>
+            <span><span class="legend-swatch" style="background:var(--peak)"></span>peak</span>
+        </span>
+        <span class="leg-group">
+            <span class="leg-head">Fox mode</span>
+            <span><span class="legend-mode mode-force-charge"></span>ForceCharge</span>
+            <span><span class="legend-mode mode-feed-in"></span>Feed-in</span>
+            <span><span class="legend-mode mode-force-discharge"></span>ForceDischarge</span>
+            <span><span class="legend-mode mode-backup"></span>Backup</span>
+            <span><span class="legend-mode mode-self-use"></span>SelfUse</span>
+        </span>
+    </div>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        Every action on this page runs as a simulation first; you confirm in a modal before anything writes.
+    </p>
+</section>
+
+<!-- Slot-detail modal (shared element, populated on click). -->
+<div class="drawer-backdrop" id="slotDetailBackdrop" hidden>
+    <div class="slot-detail" role="dialog" aria-modal="true" aria-labelledby="slotDetailTitle">
+        <header class="slot-detail-head">
+            <h3 id="slotDetailTitle">Slot</h3>
+            <button class="drawer-close" id="btnSlotDetailClose" type="button" aria-label="Close">&times;</button>
+        </header>
+        <div class="slot-detail-body" id="slotDetailBody"></div>
+    </div>
+</div>
+
+<section class="override-section">
+    <button class="override-toggle" id="overrideToggle" aria-expanded="false">
+        <span class="override-toggle-left">
+            <span class="override-toggle-icon" aria-hidden="true">▸</span>
+            <span class="override-toggle-title">Controls</span>
+        </span>
+        <span class="override-toggle-right text-dim">Fox mode · Plan · Daikin — preview &amp; confirm</span>
+    </button>
+    <div class="override-body" id="overrideBody" hidden>
+        <div class="override-tabs" role="tablist">
+            <button class="override-tab is-active" data-tab-target="ovFox" role="tab">Fox mode</button>
+            <button class="override-tab" data-tab-target="ovPlan" role="tab">Plan</button>
+            <button class="override-tab" data-tab-target="ovDaikin" role="tab">Daikin</button>
+        </div>
+
+        <div class="override-tab-panel" id="ovFox">
+            <p class="text-dim" style="font-size:0.85rem;margin:0;">Switch the Fox ESS work mode now. The next optimizer run will overwrite this.</p>
+            <div class="control" style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                <button class="btn btn-sm btn-secondary" data-fox-mode="Self Use">Self Use</button>
+                <button class="btn btn-sm btn-secondary" data-fox-mode="Feed-in Priority">Feed-in</button>
+                <button class="btn btn-sm btn-secondary" data-fox-mode="Back Up">Back Up</button>
+                <button class="btn btn-sm btn-secondary" data-fox-mode="Force charge">Force charge</button>
+                <button class="btn btn-sm btn-secondary" data-fox-mode="Force discharge">Force discharge</button>
+            </div>
+        </div>
+
+        <div class="override-tab-panel" id="ovPlan" hidden>
+            <p class="text-dim" style="font-size:0.85rem;margin:0;">Re-solve the LP and propose a fresh plan now.</p>
+            <button class="btn btn-secondary" id="btnProposeNow">Propose new plan now</button>
+        </div>
+
+        <div class="override-tab-panel" id="ovDaikin" hidden>
+            <p class="text-dim" style="font-size:0.85rem;margin:0;" id="daikinOverrideHint">
+                Daikin is in <code data-daikin-mode-text>—</code> mode.
+            </p>
+            <!-- Phase 6: passive-mode gating grey-out (not hidden) + tooltip
+                 so the user sees *why* the controls are disabled rather than
+                 having them silently disappear. -->
+            <div id="daikinOverridePassiveNote" class="text-warn" style="font-size:0.85rem;" hidden>
+                In passive mode the service never writes to Daikin.
+                Flip <code>DAIKIN_CONTROL_MODE</code> to <code>active</code> via the top-bar mode badge to enable manual overrides.
+            </div>
+            <div id="daikinOverrideActive"
+                 class="daikin-controls"
+                 title="Daikin is in passive mode. Switch to active (topbar mode badge) to enable these controls.">
+                <div class="field">
+                    <label>Tank target (°C)</label>
+                    <input type="number" min="30" max="65" step="0.5" id="daikinTankInput" value="48">
+                    <button class="btn btn-secondary btn-sm" id="btnDaikinTank">Set tank target</button>
+                </div>
+                <div class="field">
+                    <label>LWT offset (-10 to +10)</label>
+                    <input type="number" min="-10" max="10" step="0.5" id="daikinLwtInput" value="0">
+                    <button class="btn btn-secondary btn-sm" id="btnDaikinLwt">Set LWT offset</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+</main>
+
+<div class="modal-backdrop" id="modalBackdrop" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <header class="modal-header">
+            <h2 id="modalTitle">Confirm action</h2>
+            <button class="modal-close" type="button" id="modalCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body" id="modalBody">
+            <p class="modal-summary" id="modalSummary"></p>
+
+            <div class="modal-section" id="modalBatchSection" hidden>
+                <h3>Changes</h3>
+                <div class="modal-batch-table-wrap">
+                    <table class="modal-batch-table">
+                        <thead>
+                            <tr><th>Key</th><th>Before</th><th>After</th><th>Safety</th></tr>
+                        </thead>
+                        <tbody id="modalBatchBody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="modal-section" id="modalBeforeSection">
+                <h3>Before</h3>
+                <pre class="kv-block" id="modalBefore"></pre>
+            </div>
+
+            <div class="modal-section" id="modalAfterSection">
+                <h3>After</h3>
+                <pre class="kv-block" id="modalAfter"></pre>
+            </div>
+
+            <div class="modal-section" id="modalImpact" hidden>
+                <h3>Impact</h3>
+                <p id="modalImpactBody"></p>
+            </div>
+
+            <div class="modal-section flags-section" id="modalFlagsSection" hidden>
+                <h3 class="flags-heading">⚠ Safety flags</h3>
+                <ul class="flags-list" id="modalFlags"></ul>
+                <label class="flags-confirm" id="modalFlagsConfirmLabel" hidden>
+                    Type <code id="modalFlagsConfirmWord"></code> to confirm:
+                    <input type="text" id="modalFlagsConfirmInput" autocomplete="off">
+                </label>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modalCancelBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modalApplyBtn">Confirm &amp; apply</button>
+        </footer>
+    </div>
+</div>
+<div class="mode-switcher-backdrop" id="modeSwitcherBackdrop" hidden>
+    <div class="mode-switcher" role="dialog" aria-modal="true" aria-labelledby="modeSwitcherTitle">
+        <header class="modal-header">
+            <h2 id="modeSwitcherTitle">System mode</h2>
+            <button class="modal-close" type="button" id="modeSwitcherCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body">
+            <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
+                Stage one or more toggles, then <strong>Review changes</strong> opens a single
+                preview → modal → confirm — all applied as one batch.
+            </p>
+
+            <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Daikin control</h3>
+                    <span class="status-badge" id="msDaikinBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
+                    <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
+                </p>
+                <div class="mode-row-toggle" data-pending-key="DAIKIN_CONTROL_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="passive">passive</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="active">active</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="REQUIRE_SIMULATION_ID">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Require simulation-id for writes</h3>
+                    <span class="status-badge" id="msRequireSimBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    When ON, every state-changing API call must first go through its <code>/simulate</code> endpoint
+                    and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
+                    scripts and accidental writes — the cockpit always uses this flow regardless.
+                </p>
+                <div class="mode-row-toggle" data-pending-key="REQUIRE_SIMULATION_ID">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="false">off</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="true">on</button>
+                </div>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modeSwitcherReviewBtn" disabled>Review changes</button>
+        </footer>
+    </div>
+</div>
+
+<div class="toast-stack" id="toastStack" aria-live="polite"></div>
+
+<script src="/js/modal.js"></script>
+<script src="/js/tz.js"></script>
+<script src="/js/quota.js"></script>
+<script src="/js/mode_switcher.js"></script>
+<script src="/js/_chrome.js"></script>
+<script src="/js/cockpit.js"></script>
+<script src="/js/settings.js"></script>
 </body>
 </html>

--- a/ui/html/forecast.html
+++ b/ui/html/forecast.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0f17">
+  <title>Forecast · Home Energy</title>
+  <link rel="stylesheet" href="/css/cockpit.css">
+  <script src="/config.js"></script>
+  <script src="/js/_api.js"></script>
+</head>
+<body>
+<header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">⚡ Home Energy</div>
+            <button id="modeBadge"
+                    class="mode-badge"
+                    type="button"
+                    data-daikin="passive"
+                    data-require-sim="false"
+                    title="Daikin control + simulate-id enforcement. Passive = heat pump runs on its own curve (normal). Active = the LP schedules tank + LWT.">
+                <span class="mode-dot"></span>
+                <span class="mode-label">Daikin:</span>
+                <span class="mode-value">passive</span>
+            </button>
+            <nav class="tabs" aria-label="Pages">
+                <a href="/" class="tab">Cockpit</a>
+                <a href="/forecast" class="tab">Forecast</a>
+                <a href="/history" class="tab">History</a>
+                <a href="/insights" class="tab">Insights</a>
+                <a href="/workbench" class="tab">Workbench</a>
+                <a href="/settings" class="tab">Settings</a>
+            </nav>
+            <div class="quota-pills" id="quotaPills">
+                <span class="pill" id="quotaDaikin" title="Daikin Onecta API requests today">D —/180</span>
+                <span class="pill" id="quotaFox" title="Fox ESS API requests today">F —/1200</span>
+            </div>
+            <span class="pill tz-pill" id="tzBadge"
+                  title="Planning + cockpit use this timezone. The nightly plan-push cron is UTC-anchored so each new day&apos;s first dispatches land on a fresh Daikin quota day.">
+                🕒 —
+            </span>
+        </div>
+    </header>
+
+<main class="page">
+<section class="card">
+    <h2 class="card-title">
+        LP inputs
+        <span class="card-actions">
+            <button class="btn btn-sm btn-secondary" id="btnForecastReload" title="Reload the cached inputs (no cloud calls)">Reload</button>
+            <button class="btn btn-sm btn-primary" id="btnForecastReplan" title="Fetch fresh Octopus + weather and re-solve">
+                Refresh data &amp; re-plan
+            </button>
+        </span>
+    </h2>
+    <p class="text-mute" style="font-size:0.78rem;margin:0 0 0.75rem 0;">
+        Everything the next LP solve will see, read from caches and the
+        <code>meteo_forecast</code> / <code>agile_rates</code> tables. No cloud calls are
+        triggered by opening this page.
+    </p>
+    <div class="forecast-summary" id="forecastSummary">
+        <div class="fcs-kpi"><span class="fcs-k">Horizon</span><span class="fcs-v" id="fcHorizon">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Planner tz</span><span class="fcs-v" id="fcTz">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Tomorrow rates</span><span class="fcs-v" id="fcTomorrow">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Cheap &lt;</span><span class="fcs-v" id="fcCheap">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Peak &gt;</span><span class="fcs-v" id="fcPeak">—</span></div>
+        <div class="fcs-kpi"><span class="fcs-k">Micro-climate Δ</span><span class="fcs-v" id="fcMicro">—</span></div>
+    </div>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Initial state (what the LP reads at solve time)</h3>
+    <table class="fc-kv-table">
+        <tbody>
+            <tr><th>SoC</th><td id="fcInitSoc">—</td><td class="text-dim" id="fcInitSocSrc">—</td></tr>
+            <tr><th>Tank</th><td id="fcInitTank">—</td><td class="text-dim" id="fcInitTankSrc">—</td></tr>
+            <tr><th>Indoor</th><td id="fcInitIndoor">—</td><td class="text-dim" id="fcInitIndoorSrc">—</td></tr>
+        </tbody>
+    </table>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        Source labels: <code>fox_realtime_cache</code> / <code>db_realtime_snapshot</code> (SoC);
+        <code>daikin_live</code> / <code>daikin_cache</code> / <code>daikin_estimate</code> (tank &amp; indoor);
+        <code>default</code> means config fallback.
+    </p>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Config snapshot</h3>
+    <div class="fc-chip-row" id="fcConfigChips">—</div>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        These are the knobs the LP will read on its next solve. Historical values live in the
+        <code>config_audit</code> table (tuning changes are logged there).
+    </p>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Per-slot inputs (next horizon)</h3>
+    <div class="fc-spark-grid">
+        <div>
+            <div class="fc-spark-label">Import price (p/kWh)</div>
+            <div class="fc-spark" id="fcSparkPrice"></div>
+        </div>
+        <div>
+            <div class="fc-spark-label">Outdoor temp (°C)</div>
+            <div class="fc-spark" id="fcSparkTemp"></div>
+        </div>
+        <div>
+            <div class="fc-spark-label">Solar W/m²</div>
+            <div class="fc-spark" id="fcSparkSolar"></div>
+        </div>
+        <div>
+            <div class="fc-spark-label">Base load (kWh/slot)</div>
+            <div class="fc-spark" id="fcSparkLoad"></div>
+        </div>
+    </div>
+    <div class="fc-slot-table-wrap">
+        <table class="fc-slot-table" id="fcSlotTable">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th class="num">Import p</th>
+                    <th class="num">Export p</th>
+                    <th class="num">Temp °C</th>
+                    <th class="num">Solar W/m²</th>
+                    <th class="num">Base load kWh</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</section>
+</main>
+
+<div class="modal-backdrop" id="modalBackdrop" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <header class="modal-header">
+            <h2 id="modalTitle">Confirm action</h2>
+            <button class="modal-close" type="button" id="modalCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body" id="modalBody">
+            <p class="modal-summary" id="modalSummary"></p>
+
+            <div class="modal-section" id="modalBatchSection" hidden>
+                <h3>Changes</h3>
+                <div class="modal-batch-table-wrap">
+                    <table class="modal-batch-table">
+                        <thead>
+                            <tr><th>Key</th><th>Before</th><th>After</th><th>Safety</th></tr>
+                        </thead>
+                        <tbody id="modalBatchBody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="modal-section" id="modalBeforeSection">
+                <h3>Before</h3>
+                <pre class="kv-block" id="modalBefore"></pre>
+            </div>
+
+            <div class="modal-section" id="modalAfterSection">
+                <h3>After</h3>
+                <pre class="kv-block" id="modalAfter"></pre>
+            </div>
+
+            <div class="modal-section" id="modalImpact" hidden>
+                <h3>Impact</h3>
+                <p id="modalImpactBody"></p>
+            </div>
+
+            <div class="modal-section flags-section" id="modalFlagsSection" hidden>
+                <h3 class="flags-heading">⚠ Safety flags</h3>
+                <ul class="flags-list" id="modalFlags"></ul>
+                <label class="flags-confirm" id="modalFlagsConfirmLabel" hidden>
+                    Type <code id="modalFlagsConfirmWord"></code> to confirm:
+                    <input type="text" id="modalFlagsConfirmInput" autocomplete="off">
+                </label>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modalCancelBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modalApplyBtn">Confirm &amp; apply</button>
+        </footer>
+    </div>
+</div>
+<div class="mode-switcher-backdrop" id="modeSwitcherBackdrop" hidden>
+    <div class="mode-switcher" role="dialog" aria-modal="true" aria-labelledby="modeSwitcherTitle">
+        <header class="modal-header">
+            <h2 id="modeSwitcherTitle">System mode</h2>
+            <button class="modal-close" type="button" id="modeSwitcherCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body">
+            <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
+                Stage one or more toggles, then <strong>Review changes</strong> opens a single
+                preview → modal → confirm — all applied as one batch.
+            </p>
+
+            <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Daikin control</h3>
+                    <span class="status-badge" id="msDaikinBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
+                    <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
+                </p>
+                <div class="mode-row-toggle" data-pending-key="DAIKIN_CONTROL_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="passive">passive</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="active">active</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="REQUIRE_SIMULATION_ID">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Require simulation-id for writes</h3>
+                    <span class="status-badge" id="msRequireSimBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    When ON, every state-changing API call must first go through its <code>/simulate</code> endpoint
+                    and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
+                    scripts and accidental writes — the cockpit always uses this flow regardless.
+                </p>
+                <div class="mode-row-toggle" data-pending-key="REQUIRE_SIMULATION_ID">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="false">off</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="true">on</button>
+                </div>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modeSwitcherReviewBtn" disabled>Review changes</button>
+        </footer>
+    </div>
+</div>
+
+<div class="toast-stack" id="toastStack" aria-live="polite"></div>
+
+<script src="/js/modal.js"></script>
+<script src="/js/tz.js"></script>
+<script src="/js/quota.js"></script>
+<script src="/js/mode_switcher.js"></script>
+<script src="/js/_chrome.js"></script>
+<script src="/js/forecast.js"></script>
+</body>
+</html>

--- a/ui/html/history.html
+++ b/ui/html/history.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0f17">
+  <title>History · Home Energy</title>
+  <link rel="stylesheet" href="/css/cockpit.css">
+  <script src="/config.js"></script>
+  <script src="/js/_api.js"></script>
+</head>
+<body>
+<header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">⚡ Home Energy</div>
+            <button id="modeBadge"
+                    class="mode-badge"
+                    type="button"
+                    data-daikin="passive"
+                    data-require-sim="false"
+                    title="Daikin control + simulate-id enforcement. Passive = heat pump runs on its own curve (normal). Active = the LP schedules tank + LWT.">
+                <span class="mode-dot"></span>
+                <span class="mode-label">Daikin:</span>
+                <span class="mode-value">passive</span>
+            </button>
+            <nav class="tabs" aria-label="Pages">
+                <a href="/" class="tab">Cockpit</a>
+                <a href="/forecast" class="tab">Forecast</a>
+                <a href="/history" class="tab">History</a>
+                <a href="/insights" class="tab">Insights</a>
+                <a href="/workbench" class="tab">Workbench</a>
+                <a href="/settings" class="tab">Settings</a>
+            </nav>
+            <div class="quota-pills" id="quotaPills">
+                <span class="pill" id="quotaDaikin" title="Daikin Onecta API requests today">D —/180</span>
+                <span class="pill" id="quotaFox" title="Fox ESS API requests today">F —/1200</span>
+            </div>
+            <span class="pill tz-pill" id="tzBadge"
+                  title="Planning + cockpit use this timezone. The nightly plan-push cron is UTC-anchored so each new day&apos;s first dispatches land on a fresh Daikin quota day.">
+                🕒 —
+            </span>
+        </div>
+    </header>
+
+<main class="page">
+<section class="card">
+    <h2 class="card-title">
+        Replay a past moment
+        <span class="card-actions">
+            <input type="datetime-local" id="historyWhen" class="history-picker" />
+            <button class="btn btn-sm btn-secondary" id="btnHistoryJump" title="Replay the snapshot at the chosen moment">Replay</button>
+            <button class="btn btn-sm btn-secondary" id="btnHistoryNow" title="Jump to the latest run">Latest run</button>
+        </span>
+    </h2>
+    <p class="text-mute" style="font-size:0.78rem;margin:0 0 0.75rem 0;">
+        Reads from the LP snapshot tables — the same layout as the Cockpit NOW panel, frozen at the chosen moment.
+        Source labels below show exactly which <code>optimizer_log</code> run and which <code>execution_log</code>
+        row the data came from.
+    </p>
+    <div class="history-source" id="historySource">—</div>
+</section>
+
+<section class="card">
+    <h3 class="card-title">State at that moment</h3>
+    <div class="hero-state-grid">
+        <div class="hero-kpi"><span class="hero-kpi-label">SoC</span><span class="hero-kpi-value" id="hSoc">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Load</span><span class="hero-kpi-value" id="hLoad">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Fox mode</span><span class="hero-kpi-value" id="hFoxMode">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Tank</span><span class="hero-kpi-value" id="hTank">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Indoor</span><span class="hero-kpi-value" id="hIndoor">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Outdoor</span><span class="hero-kpi-value" id="hOutdoor">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">LWT</span><span class="hero-kpi-value" id="hLwt">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Slot kind</span><span class="hero-kpi-value" id="hKind">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Import p</span><span class="hero-kpi-value" id="hPriceImp">—</span></div>
+        <div class="hero-kpi"><span class="hero-kpi-label">Export p</span><span class="hero-kpi-value" id="hPriceExp">—</span></div>
+    </div>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Plan vs Actual (this slot)</h3>
+    <table class="fc-kv-table" id="histPlanActual">
+        <thead>
+            <tr><th>Metric</th><th>Plan</th><th>Actual</th></tr>
+        </thead>
+        <tbody>
+            <tr><th>Import kWh</th><td id="paPlanImport">—</td><td id="paActImport">—</td></tr>
+            <tr><th>Battery charge kWh</th><td id="paPlanChg">—</td><td class="text-dim">—</td></tr>
+            <tr><th>Battery discharge kWh</th><td id="paPlanDis">—</td><td class="text-dim">—</td></tr>
+            <tr><th>DHW kWh</th><td id="paPlanDhw">—</td><td class="text-dim">—</td></tr>
+            <tr><th>Space heat kWh</th><td id="paPlanSpace">—</td><td class="text-dim">—</td></tr>
+            <tr><th>Tank end °C</th><td id="paPlanTank">—</td><td id="paActTank">—</td></tr>
+            <tr><th>Indoor end °C</th><td id="paPlanIndoor">—</td><td id="paActIndoor">—</td></tr>
+            <tr><th>SoC end kWh</th><td id="paPlanSoc">—</td><td id="paActSoc">—</td></tr>
+        </tbody>
+    </table>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        Plan columns come from <code>lp_solution_snapshot</code> (the LP's per-slot decision at solve time).
+        Actual comes from <code>execution_log</code>. A row of dashes means we have no actual telemetry
+        for that metric (e.g. per-slot battery charge isn't logged yet).
+    </p>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Solar attribution (day of replay)</h3>
+    <div class="attribution-block" id="attributionBlock">
+        <div class="attribution-donut" id="attributionDonut" aria-hidden="true"></div>
+        <div class="attribution-legend" id="attributionLegend">—</div>
+    </div>
+    <p class="text-mute" style="font-size:0.72rem;margin:0.5rem 0 0 0;">
+        Where today's solar went: self-used, stored in battery, or exported. Historical-only — today's running totals appear once the nightly Fox rollup fires.
+    </p>
+</section>
+
+<section class="card">
+    <h3 class="card-title">LP inputs at solve time</h3>
+    <table class="fc-kv-table">
+        <tbody>
+            <tr><th>Run at</th><td id="liRunAt">—</td></tr>
+            <tr><th>Plan date</th><td id="liPlanDate">—</td></tr>
+            <tr><th>Horizon</th><td id="liHorizon">—</td></tr>
+            <tr><th>Initial SoC</th><td id="liSoc">—</td></tr>
+            <tr><th>Initial tank</th><td id="liTank">—</td></tr>
+            <tr><th>Initial indoor</th><td id="liIndoor">—</td></tr>
+            <tr><th>Micro-climate Δ</th><td id="liMicro">—</td></tr>
+            <tr><th>Cheap threshold</th><td id="liCheap">—</td></tr>
+            <tr><th>Peak threshold</th><td id="liPeak">—</td></tr>
+            <tr><th>Daikin mode</th><td id="liDkMode">—</td></tr>
+            <tr><th>Preset</th><td id="liPreset">—</td></tr>
+        </tbody>
+    </table>
+</section>
+
+<section class="card">
+    <h3 class="card-title">LP exogenous build</h3>
+    <table class="fc-kv-table">
+        <tbody>
+            <tr><th>Residual base load</th><td id="lxResidual">—</td></tr>
+            <tr><th>Appliance-added load</th><td id="lxAppliance">—</td></tr>
+            <tr><th>Flat fallback</th><td id="lxFlat">—</td></tr>
+            <tr><th>Fox mean / slot</th><td id="lxFoxMean">—</td></tr>
+            <tr><th>Load buckets</th><td id="lxBuckets">—</td></tr>
+            <tr><th>Forecast fetch</th><td id="lxFetch">—</td></tr>
+            <tr><th>PV adjust</th><td id="lxPvAdjust">—</td></tr>
+            <tr><th>Export pricing</th><td id="lxExport">—</td></tr>
+        </tbody>
+    </table>
+</section>
+
+<section class="card">
+    <h3 class="card-title">Why This Slot</h3>
+    <div id="historyWhy" class="text-mute">—</div>
+</section>
+</main>
+
+<div class="modal-backdrop" id="modalBackdrop" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <header class="modal-header">
+            <h2 id="modalTitle">Confirm action</h2>
+            <button class="modal-close" type="button" id="modalCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body" id="modalBody">
+            <p class="modal-summary" id="modalSummary"></p>
+
+            <div class="modal-section" id="modalBatchSection" hidden>
+                <h3>Changes</h3>
+                <div class="modal-batch-table-wrap">
+                    <table class="modal-batch-table">
+                        <thead>
+                            <tr><th>Key</th><th>Before</th><th>After</th><th>Safety</th></tr>
+                        </thead>
+                        <tbody id="modalBatchBody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="modal-section" id="modalBeforeSection">
+                <h3>Before</h3>
+                <pre class="kv-block" id="modalBefore"></pre>
+            </div>
+
+            <div class="modal-section" id="modalAfterSection">
+                <h3>After</h3>
+                <pre class="kv-block" id="modalAfter"></pre>
+            </div>
+
+            <div class="modal-section" id="modalImpact" hidden>
+                <h3>Impact</h3>
+                <p id="modalImpactBody"></p>
+            </div>
+
+            <div class="modal-section flags-section" id="modalFlagsSection" hidden>
+                <h3 class="flags-heading">⚠ Safety flags</h3>
+                <ul class="flags-list" id="modalFlags"></ul>
+                <label class="flags-confirm" id="modalFlagsConfirmLabel" hidden>
+                    Type <code id="modalFlagsConfirmWord"></code> to confirm:
+                    <input type="text" id="modalFlagsConfirmInput" autocomplete="off">
+                </label>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modalCancelBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modalApplyBtn">Confirm &amp; apply</button>
+        </footer>
+    </div>
+</div>
+<div class="mode-switcher-backdrop" id="modeSwitcherBackdrop" hidden>
+    <div class="mode-switcher" role="dialog" aria-modal="true" aria-labelledby="modeSwitcherTitle">
+        <header class="modal-header">
+            <h2 id="modeSwitcherTitle">System mode</h2>
+            <button class="modal-close" type="button" id="modeSwitcherCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body">
+            <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
+                Stage one or more toggles, then <strong>Review changes</strong> opens a single
+                preview → modal → confirm — all applied as one batch.
+            </p>
+
+            <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Daikin control</h3>
+                    <span class="status-badge" id="msDaikinBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
+                    <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
+                </p>
+                <div class="mode-row-toggle" data-pending-key="DAIKIN_CONTROL_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="passive">passive</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="active">active</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="REQUIRE_SIMULATION_ID">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Require simulation-id for writes</h3>
+                    <span class="status-badge" id="msRequireSimBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    When ON, every state-changing API call must first go through its <code>/simulate</code> endpoint
+                    and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
+                    scripts and accidental writes — the cockpit always uses this flow regardless.
+                </p>
+                <div class="mode-row-toggle" data-pending-key="REQUIRE_SIMULATION_ID">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="false">off</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="true">on</button>
+                </div>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modeSwitcherReviewBtn" disabled>Review changes</button>
+        </footer>
+    </div>
+</div>
+
+<div class="toast-stack" id="toastStack" aria-live="polite"></div>
+
+<script src="/js/modal.js"></script>
+<script src="/js/tz.js"></script>
+<script src="/js/quota.js"></script>
+<script src="/js/mode_switcher.js"></script>
+<script src="/js/_chrome.js"></script>
+<script src="/js/history.js"></script>
+</body>
+</html>

--- a/ui/html/insights.html
+++ b/ui/html/insights.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0f17">
+  <title>Insights · Home Energy</title>
+  <link rel="stylesheet" href="/css/cockpit.css">
+  <script src="/config.js"></script>
+  <script src="/js/_api.js"></script>
+</head>
+<body>
+<header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">⚡ Home Energy</div>
+            <button id="modeBadge"
+                    class="mode-badge"
+                    type="button"
+                    data-daikin="passive"
+                    data-require-sim="false"
+                    title="Daikin control + simulate-id enforcement. Passive = heat pump runs on its own curve (normal). Active = the LP schedules tank + LWT.">
+                <span class="mode-dot"></span>
+                <span class="mode-label">Daikin:</span>
+                <span class="mode-value">passive</span>
+            </button>
+            <nav class="tabs" aria-label="Pages">
+                <a href="/" class="tab">Cockpit</a>
+                <a href="/forecast" class="tab">Forecast</a>
+                <a href="/history" class="tab">History</a>
+                <a href="/insights" class="tab">Insights</a>
+                <a href="/workbench" class="tab">Workbench</a>
+                <a href="/settings" class="tab">Settings</a>
+            </nav>
+            <div class="quota-pills" id="quotaPills">
+                <span class="pill" id="quotaDaikin" title="Daikin Onecta API requests today">D —/180</span>
+                <span class="pill" id="quotaFox" title="Fox ESS API requests today">F —/1200</span>
+            </div>
+            <span class="pill tz-pill" id="tzBadge"
+                  title="Planning + cockpit use this timezone. The nightly plan-push cron is UTC-anchored so each new day&apos;s first dispatches land on a fresh Daikin quota day.">
+                🕒 —
+            </span>
+        </div>
+    </header>
+
+<main class="page">
+<section class="card">
+    <div class="period-bar">
+        <div class="period-nav">
+            <button class="btn btn-sm btn-secondary period-nav-btn" data-nav="prev" aria-label="Previous period">‹</button>
+            <span class="period-nav-label" id="insightPeriodLabel">Loading…</span>
+            <button class="btn btn-sm btn-secondary period-nav-btn" data-nav="next" aria-label="Next period">›</button>
+            <button class="btn btn-sm btn-secondary period-nav-btn" data-nav="today" id="insightTodayBtn" title="Jump to today">Today</button>
+        </div>
+        <div class="period-tabs">
+            <button class="btn btn-sm btn-secondary insights-period-btn" data-period="day">Day</button>
+            <button class="btn btn-sm btn-secondary insights-period-btn" data-period="week">Week</button>
+            <button class="btn btn-sm btn-primary insights-period-btn" data-period="month">Month</button>
+            <button class="btn btn-sm btn-secondary insights-period-btn" data-period="year">Year</button>
+        </div>
+    </div>
+    <p class="text-mute" id="insightFreshnessLine" style="font-size:0.75rem;margin:0.5rem 0 0 0;"></p>
+</section>
+
+<details class="card insights-section" open>
+    <summary class="card-title">Economics</summary>
+    <div class="insights-summary">
+        <div class="insight-tile"><div class="label">Net cost</div><div class="value" id="ecoNet">—</div></div>
+        <div class="insight-tile"><div class="label">Imported</div><div class="value" id="ecoImport">—</div></div>
+        <div class="insight-tile"><div class="label">Export earnings</div><div class="value text-ok" id="ecoExport">—</div></div>
+        <div class="insight-tile"><div class="label">Standing charge</div><div class="value text-mute" id="ecoStanding">—</div></div>
+    </div>
+    <div class="insights-summary" style="margin-top:0.5rem;">
+        <div class="insight-tile"><div class="label">Import kWh</div><div class="value" id="ecoImpKwh">—</div></div>
+        <div class="insight-tile"><div class="label">Solar kWh</div><div class="value" id="ecoSolarKwh">—</div></div>
+        <div class="insight-tile"><div class="label">Load kWh</div><div class="value" id="ecoLoadKwh">—</div></div>
+        <div class="insight-tile"><div class="label">Export kWh</div><div class="value" id="ecoExpKwh">—</div></div>
+    </div>
+</details>
+
+<details class="card insights-section" id="dayViewSection" hidden>
+    <summary class="card-title">Tariff &amp; cost · slot-by-slot</summary>
+    <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
+        One cell per 30-min Octopus slot, colour-coded cheap → peak. The table below maps each slot's actual consumption against the SVT shadow price.
+    </p>
+    <div class="tariff-day-strip" id="tariffStrip"></div>
+    <p class="data-quality-note" id="dayDataQualityNote" hidden></p>
+    <div class="insights-summary" id="dayTotals">
+        <div class="insight-tile"><div class="label">Cost</div><div class="value" data-tot="cost">—</div></div>
+        <div class="insight-tile"><div class="label">vs SVT</div><div class="value" data-tot="delta">—</div></div>
+        <div class="insight-tile"><div class="label">Daikin share</div><div class="value" data-tot="daikin_share">—</div></div>
+        <div class="insight-tile"><div class="label">Load</div><div class="value" data-tot="load">—</div></div>
+    </div>
+    <div style="overflow-x:auto;">
+        <table class="plan-table" id="daySlotTable">
+            <thead><tr>
+                <th>Slot</th>
+                <th>Strategy</th>
+                <th class="num">Tariff</th>
+                <th class="num">kWh</th>
+                <th class="num">Cost</th>
+                <th class="num">Daikin</th>
+                <th class="num">Residual</th>
+                <th class="num">SVT</th>
+                <th class="num">Δ</th>
+            </tr></thead>
+            <tbody><tr><td colspan="9" class="text-mute">Loading…</td></tr></tbody>
+        </table>
+    </div>
+</details>
+
+<details class="card insights-section">
+    <summary class="card-title">Daikin (heat pump)</summary>
+    <div class="insights-summary">
+        <div class="insight-tile"><div class="label">Heating energy</div><div class="value" id="daikinKwh">—</div></div>
+        <div class="insight-tile"><div class="label">Heating cost</div><div class="value" id="daikinCost">—</div></div>
+        <div class="insight-tile"><div class="label">% of total cost</div><div class="value" id="daikinPctCost">—</div></div>
+        <div class="insight-tile"><div class="label">% of consumption</div><div class="value" id="daikinPctKwh">—</div></div>
+    </div>
+    <p class="text-mute" style="font-size:0.78rem;margin:0.5rem 0 0 0;">
+        Heating estimate from physics (climate curve × outdoor temp). Refined by the daily Daikin cache (E1) where available.
+    </p>
+</details>
+
+<details class="card insights-section" id="gasCompareCard" hidden>
+    <summary class="card-title">vs gas boiler</summary>
+    <div class="insights-summary">
+        <div class="insight-tile"><div class="label">Equivalent gas cost</div><div class="value" id="gasCost">—</div></div>
+        <div class="insight-tile"><div class="label">Heat pump advantage</div><div class="value text-ok" id="gasAdvantage">—</div></div>
+    </div>
+</details>
+
+<details class="card insights-section" id="patternsSection">
+    <summary class="card-title">Patterns &amp; averages</summary>
+    <p class="text-dim" style="font-size:0.78rem;margin:0 0 0.6rem 0;">
+        Aggregates across the selected period (or last 30 days if shorter than that).
+    </p>
+    <div class="patterns-grid">
+        <div class="pattern-card">
+            <h3 class="pattern-title">Hourly load profile (kWh / 30-min slot)</h3>
+            <div class="pattern-bars" id="patternHourly"></div>
+        </div>
+        <div class="pattern-card">
+            <h3 class="pattern-title">Day-of-week shape (mean import kWh / day)</h3>
+            <div class="pattern-bars" id="patternDow"></div>
+        </div>
+        <div class="pattern-card">
+            <h3 class="pattern-title">Tariff slot kinds (% of slots)</h3>
+            <div class="pattern-distribution" id="patternPriceDist"></div>
+        </div>
+        <div class="pattern-card">
+            <h3 class="pattern-title">PV daily yield (kWh)</h3>
+            <div class="pattern-spark" id="patternPv"></div>
+        </div>
+    </div>
+</details>
+
+<details class="card insights-section" id="dailyBreakdownSection">
+    <summary class="card-title">Daily breakdown</summary>
+    <div style="overflow-x:auto;">
+        <table class="plan-table" id="dailyTable">
+            <thead><tr>
+                <th>Date</th>
+                <th class="num">Import kWh</th>
+                <th class="num">Export kWh</th>
+                <th class="num">Solar kWh</th>
+                <th class="num">Load kWh</th>
+                <th class="num">Charge</th>
+                <th class="num">Discharge</th>
+            </tr></thead>
+            <tbody id="dailyTbody"><tr><td colspan="7" class="text-mute">—</td></tr></tbody>
+        </table>
+    </div>
+</details>
+
+<details class="card insights-section">
+    <summary class="card-title">Tariff comparison</summary>
+    <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
+        Estimated cost across alternative Octopus tariffs based on your last 3 months of consumption.
+    </p>
+    <button class="btn btn-secondary btn-sm" id="btnRunCompare">Run comparison now</button>
+    <div id="tariffCompareTable" style="margin-top:0.85rem;"></div>
+</details>
+</main>
+
+<div class="modal-backdrop" id="modalBackdrop" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <header class="modal-header">
+            <h2 id="modalTitle">Confirm action</h2>
+            <button class="modal-close" type="button" id="modalCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body" id="modalBody">
+            <p class="modal-summary" id="modalSummary"></p>
+
+            <div class="modal-section" id="modalBatchSection" hidden>
+                <h3>Changes</h3>
+                <div class="modal-batch-table-wrap">
+                    <table class="modal-batch-table">
+                        <thead>
+                            <tr><th>Key</th><th>Before</th><th>After</th><th>Safety</th></tr>
+                        </thead>
+                        <tbody id="modalBatchBody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="modal-section" id="modalBeforeSection">
+                <h3>Before</h3>
+                <pre class="kv-block" id="modalBefore"></pre>
+            </div>
+
+            <div class="modal-section" id="modalAfterSection">
+                <h3>After</h3>
+                <pre class="kv-block" id="modalAfter"></pre>
+            </div>
+
+            <div class="modal-section" id="modalImpact" hidden>
+                <h3>Impact</h3>
+                <p id="modalImpactBody"></p>
+            </div>
+
+            <div class="modal-section flags-section" id="modalFlagsSection" hidden>
+                <h3 class="flags-heading">⚠ Safety flags</h3>
+                <ul class="flags-list" id="modalFlags"></ul>
+                <label class="flags-confirm" id="modalFlagsConfirmLabel" hidden>
+                    Type <code id="modalFlagsConfirmWord"></code> to confirm:
+                    <input type="text" id="modalFlagsConfirmInput" autocomplete="off">
+                </label>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modalCancelBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modalApplyBtn">Confirm &amp; apply</button>
+        </footer>
+    </div>
+</div>
+<div class="mode-switcher-backdrop" id="modeSwitcherBackdrop" hidden>
+    <div class="mode-switcher" role="dialog" aria-modal="true" aria-labelledby="modeSwitcherTitle">
+        <header class="modal-header">
+            <h2 id="modeSwitcherTitle">System mode</h2>
+            <button class="modal-close" type="button" id="modeSwitcherCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body">
+            <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
+                Stage one or more toggles, then <strong>Review changes</strong> opens a single
+                preview → modal → confirm — all applied as one batch.
+            </p>
+
+            <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Daikin control</h3>
+                    <span class="status-badge" id="msDaikinBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
+                    <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
+                </p>
+                <div class="mode-row-toggle" data-pending-key="DAIKIN_CONTROL_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="passive">passive</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="active">active</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="REQUIRE_SIMULATION_ID">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Require simulation-id for writes</h3>
+                    <span class="status-badge" id="msRequireSimBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    When ON, every state-changing API call must first go through its <code>/simulate</code> endpoint
+                    and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
+                    scripts and accidental writes — the cockpit always uses this flow regardless.
+                </p>
+                <div class="mode-row-toggle" data-pending-key="REQUIRE_SIMULATION_ID">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="false">off</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="true">on</button>
+                </div>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modeSwitcherReviewBtn" disabled>Review changes</button>
+        </footer>
+    </div>
+</div>
+
+<div class="toast-stack" id="toastStack" aria-live="polite"></div>
+
+<script src="/js/modal.js"></script>
+<script src="/js/tz.js"></script>
+<script src="/js/quota.js"></script>
+<script src="/js/mode_switcher.js"></script>
+<script src="/js/_chrome.js"></script>
+<script src="/js/plan_render.js"></script>
+<script src="/js/insights.js"></script>
+</body>
+</html>

--- a/ui/html/settings.html
+++ b/ui/html/settings.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0f17">
+  <title>Settings · Home Energy</title>
+  <link rel="stylesheet" href="/css/cockpit.css">
+  <script src="/config.js"></script>
+  <script src="/js/_api.js"></script>
+</head>
+<body>
+<header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">⚡ Home Energy</div>
+            <button id="modeBadge"
+                    class="mode-badge"
+                    type="button"
+                    data-daikin="passive"
+                    data-require-sim="false"
+                    title="Daikin control + simulate-id enforcement. Passive = heat pump runs on its own curve (normal). Active = the LP schedules tank + LWT.">
+                <span class="mode-dot"></span>
+                <span class="mode-label">Daikin:</span>
+                <span class="mode-value">passive</span>
+            </button>
+            <nav class="tabs" aria-label="Pages">
+                <a href="/" class="tab">Cockpit</a>
+                <a href="/forecast" class="tab">Forecast</a>
+                <a href="/history" class="tab">History</a>
+                <a href="/insights" class="tab">Insights</a>
+                <a href="/workbench" class="tab">Workbench</a>
+                <a href="/settings" class="tab">Settings</a>
+            </nav>
+            <div class="quota-pills" id="quotaPills">
+                <span class="pill" id="quotaDaikin" title="Daikin Onecta API requests today">D —/180</span>
+                <span class="pill" id="quotaFox" title="Fox ESS API requests today">F —/1200</span>
+            </div>
+            <span class="pill tz-pill" id="tzBadge"
+                  title="Planning + cockpit use this timezone. The nightly plan-push cron is UTC-anchored so each new day&apos;s first dispatches land on a fresh Daikin quota day.">
+                🕒 —
+            </span>
+        </div>
+    </header>
+
+<main class="page">
+<p class="text-dim" style="margin:0 0 0.85rem 0;font-size:0.88rem;">
+    Every change goes through preview → confirm. Mode controls
+    (operation mode, Daikin control, simulate-id enforcement) live on the
+    <strong>mode badge</strong> in the topbar — click it from any page.
+</p>
+
+<section class="card">
+    <h2 class="card-title">Snapshot rollback</h2>
+    <div class="setting-block" id="settingRollback">
+        <div class="setting-head">
+            <h3 class="setting-name">Rollback latest snapshot</h3>
+        </div>
+        <p class="setting-desc">Restore the most recent config snapshot and force simulation mode.</p>
+        <div class="setting-actions">
+            <button class="btn btn-danger btn-sm" id="btnRollback">⟲ Rollback latest snapshot</button>
+        </div>
+    </div>
+</section>
+
+<!-- COMFORT -->
+<section class="card">
+    <h2 class="card-title">Comfort targets</h2>
+    <div id="settingsComfort"></div>
+</section>
+
+<!-- STRATEGY -->
+<section class="card">
+    <h2 class="card-title">Optimization strategy</h2>
+    <div id="settingsStrategy"></div>
+</section>
+
+<!-- SCHEDULE -->
+<section class="card">
+    <h2 class="card-title">Schedule cadence</h2>
+    <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.5rem 0;">
+        When the LP re-solves the plan. Cron jobs are re-registered automatically when these change.
+    </p>
+    <div id="settingsSchedule"></div>
+</section>
+</main>
+
+<div class="modal-backdrop" id="modalBackdrop" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <header class="modal-header">
+            <h2 id="modalTitle">Confirm action</h2>
+            <button class="modal-close" type="button" id="modalCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body" id="modalBody">
+            <p class="modal-summary" id="modalSummary"></p>
+
+            <div class="modal-section" id="modalBatchSection" hidden>
+                <h3>Changes</h3>
+                <div class="modal-batch-table-wrap">
+                    <table class="modal-batch-table">
+                        <thead>
+                            <tr><th>Key</th><th>Before</th><th>After</th><th>Safety</th></tr>
+                        </thead>
+                        <tbody id="modalBatchBody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="modal-section" id="modalBeforeSection">
+                <h3>Before</h3>
+                <pre class="kv-block" id="modalBefore"></pre>
+            </div>
+
+            <div class="modal-section" id="modalAfterSection">
+                <h3>After</h3>
+                <pre class="kv-block" id="modalAfter"></pre>
+            </div>
+
+            <div class="modal-section" id="modalImpact" hidden>
+                <h3>Impact</h3>
+                <p id="modalImpactBody"></p>
+            </div>
+
+            <div class="modal-section flags-section" id="modalFlagsSection" hidden>
+                <h3 class="flags-heading">⚠ Safety flags</h3>
+                <ul class="flags-list" id="modalFlags"></ul>
+                <label class="flags-confirm" id="modalFlagsConfirmLabel" hidden>
+                    Type <code id="modalFlagsConfirmWord"></code> to confirm:
+                    <input type="text" id="modalFlagsConfirmInput" autocomplete="off">
+                </label>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modalCancelBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modalApplyBtn">Confirm &amp; apply</button>
+        </footer>
+    </div>
+</div>
+<div class="mode-switcher-backdrop" id="modeSwitcherBackdrop" hidden>
+    <div class="mode-switcher" role="dialog" aria-modal="true" aria-labelledby="modeSwitcherTitle">
+        <header class="modal-header">
+            <h2 id="modeSwitcherTitle">System mode</h2>
+            <button class="modal-close" type="button" id="modeSwitcherCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body">
+            <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
+                Stage one or more toggles, then <strong>Review changes</strong> opens a single
+                preview → modal → confirm — all applied as one batch.
+            </p>
+
+            <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Daikin control</h3>
+                    <span class="status-badge" id="msDaikinBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
+                    <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
+                </p>
+                <div class="mode-row-toggle" data-pending-key="DAIKIN_CONTROL_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="passive">passive</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="active">active</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="REQUIRE_SIMULATION_ID">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Require simulation-id for writes</h3>
+                    <span class="status-badge" id="msRequireSimBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    When ON, every state-changing API call must first go through its <code>/simulate</code> endpoint
+                    and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
+                    scripts and accidental writes — the cockpit always uses this flow regardless.
+                </p>
+                <div class="mode-row-toggle" data-pending-key="REQUIRE_SIMULATION_ID">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="false">off</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="true">on</button>
+                </div>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modeSwitcherReviewBtn" disabled>Review changes</button>
+        </footer>
+    </div>
+</div>
+
+<div class="toast-stack" id="toastStack" aria-live="polite"></div>
+
+<script src="/js/modal.js"></script>
+<script src="/js/tz.js"></script>
+<script src="/js/quota.js"></script>
+<script src="/js/mode_switcher.js"></script>
+<script src="/js/_chrome.js"></script>
+<script src="/js/settings.js"></script>
+</body>
+</html>

--- a/ui/html/workbench.html
+++ b/ui/html/workbench.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0f17">
+  <title>Workbench · Home Energy</title>
+  <link rel="stylesheet" href="/css/cockpit.css">
+  <script src="/config.js"></script>
+  <script src="/js/_api.js"></script>
+</head>
+<body>
+<header class="topbar">
+        <div class="topbar-inner">
+            <div class="brand">⚡ Home Energy</div>
+            <button id="modeBadge"
+                    class="mode-badge"
+                    type="button"
+                    data-daikin="passive"
+                    data-require-sim="false"
+                    title="Daikin control + simulate-id enforcement. Passive = heat pump runs on its own curve (normal). Active = the LP schedules tank + LWT.">
+                <span class="mode-dot"></span>
+                <span class="mode-label">Daikin:</span>
+                <span class="mode-value">passive</span>
+            </button>
+            <nav class="tabs" aria-label="Pages">
+                <a href="/" class="tab">Cockpit</a>
+                <a href="/forecast" class="tab">Forecast</a>
+                <a href="/history" class="tab">History</a>
+                <a href="/insights" class="tab">Insights</a>
+                <a href="/workbench" class="tab">Workbench</a>
+                <a href="/settings" class="tab">Settings</a>
+            </nav>
+            <div class="quota-pills" id="quotaPills">
+                <span class="pill" id="quotaDaikin" title="Daikin Onecta API requests today">D —/180</span>
+                <span class="pill" id="quotaFox" title="Fox ESS API requests today">F —/1200</span>
+            </div>
+            <span class="pill tz-pill" id="tzBadge"
+                  title="Planning + cockpit use this timezone. The nightly plan-push cron is UTC-anchored so each new day&apos;s first dispatches land on a fresh Daikin quota day.">
+                🕒 —
+            </span>
+        </div>
+    </header>
+
+<main class="page">
+<section class="card workbench-header">
+    <div class="workbench-header-row">
+        <h2 class="card-title" style="margin:0;">Workbench</h2>
+        <div class="workbench-actions">
+            <select id="profileSelect" class="btn btn-sm btn-secondary" aria-label="Load profile">
+                <option value="">Load profile…</option>
+            </select>
+            <button id="btnSaveProfile" class="btn btn-sm btn-secondary">Save as…</button>
+            <button id="btnDeleteProfile" class="btn btn-sm btn-secondary">Delete</button>
+            <button id="btnSimulate" class="btn btn-sm btn-primary">Run simulation</button>
+            <button id="btnPromote" class="btn btn-sm btn-primary" disabled>Promote to prod</button>
+        </div>
+    </div>
+    <p class="text-dim" style="font-size:0.78rem;margin:0.45rem 0 0 0;">
+        Edit LP knobs, run a simulation, then promote the promotable subset to prod through the standard simulate-confirm gate. Non-promotable knobs (penalties, solver flags) only affect the simulation.
+    </p>
+</section>
+
+<div class="workbench-grid">
+    <section class="card workbench-edit">
+        <div class="workbench-tabs" id="workbenchTabs">
+            <button class="workbench-tab is-active" data-tab="edit">Edit</button>
+            <button class="workbench-tab" data-tab="compare">Compare</button>
+        </div>
+
+        <div class="workbench-pane is-active" id="paneEdit">
+            <p class="text-dim" style="font-size:0.78rem;margin:0 0 0.55rem 0;">
+                Tweak any field then <strong>Run simulation</strong>. Promotable fields are marked
+                <span class="badge-promotable">●</span>.
+            </p>
+            <div id="editorBody" class="editor-body">Loading schema…</div>
+        </div>
+
+        <div class="workbench-pane" id="paneCompare">
+            <p class="text-dim" style="font-size:0.78rem;margin:0 0 0.55rem 0;">
+                Side-by-side: current production plan vs the simulated plan with your overrides.
+            </p>
+            <div class="compare-summary" id="compareSummary"></div>
+            <div style="overflow-x:auto;">
+                <table class="plan-table" id="compareTable">
+                    <thead><tr>
+                        <th>Slot</th>
+                        <th class="num">Tariff</th>
+                        <th class="num">Curr import</th>
+                        <th class="num">Sim import</th>
+                        <th class="num">Curr SOC</th>
+                        <th class="num">Sim SOC</th>
+                        <th class="num">Δ import</th>
+                    </tr></thead>
+                    <tbody><tr><td colspan="7" class="text-mute">Run a simulation to compare.</td></tr></tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+</div>
+</main>
+
+<div class="modal-backdrop" id="modalBackdrop" hidden>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <header class="modal-header">
+            <h2 id="modalTitle">Confirm action</h2>
+            <button class="modal-close" type="button" id="modalCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body" id="modalBody">
+            <p class="modal-summary" id="modalSummary"></p>
+
+            <div class="modal-section" id="modalBatchSection" hidden>
+                <h3>Changes</h3>
+                <div class="modal-batch-table-wrap">
+                    <table class="modal-batch-table">
+                        <thead>
+                            <tr><th>Key</th><th>Before</th><th>After</th><th>Safety</th></tr>
+                        </thead>
+                        <tbody id="modalBatchBody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="modal-section" id="modalBeforeSection">
+                <h3>Before</h3>
+                <pre class="kv-block" id="modalBefore"></pre>
+            </div>
+
+            <div class="modal-section" id="modalAfterSection">
+                <h3>After</h3>
+                <pre class="kv-block" id="modalAfter"></pre>
+            </div>
+
+            <div class="modal-section" id="modalImpact" hidden>
+                <h3>Impact</h3>
+                <p id="modalImpactBody"></p>
+            </div>
+
+            <div class="modal-section flags-section" id="modalFlagsSection" hidden>
+                <h3 class="flags-heading">⚠ Safety flags</h3>
+                <ul class="flags-list" id="modalFlags"></ul>
+                <label class="flags-confirm" id="modalFlagsConfirmLabel" hidden>
+                    Type <code id="modalFlagsConfirmWord"></code> to confirm:
+                    <input type="text" id="modalFlagsConfirmInput" autocomplete="off">
+                </label>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modalCancelBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modalApplyBtn">Confirm &amp; apply</button>
+        </footer>
+    </div>
+</div>
+<div class="mode-switcher-backdrop" id="modeSwitcherBackdrop" hidden>
+    <div class="mode-switcher" role="dialog" aria-modal="true" aria-labelledby="modeSwitcherTitle">
+        <header class="modal-header">
+            <h2 id="modeSwitcherTitle">System mode</h2>
+            <button class="modal-close" type="button" id="modeSwitcherCloseBtn" aria-label="Close">&times;</button>
+        </header>
+        <section class="modal-body">
+            <p class="text-dim" style="font-size:0.85rem;margin:0 0 0.85rem 0;">
+                Stage one or more toggles, then <strong>Review changes</strong> opens a single
+                preview → modal → confirm — all applied as one batch.
+            </p>
+
+            <div class="mode-row" data-key="DAIKIN_CONTROL_MODE">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Daikin control</h3>
+                    <span class="status-badge" id="msDaikinBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    <code>passive</code> = service NEVER writes to the heat pump (firmware autonomous).
+                    <code>active</code> = legacy v9 control (LP schedules tank temps, LWT offsets, etc.).
+                </p>
+                <div class="mode-row-toggle" data-pending-key="DAIKIN_CONTROL_MODE">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="passive">passive</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="DAIKIN_CONTROL_MODE" data-stage-value="active">active</button>
+                </div>
+            </div>
+
+            <div class="mode-row" data-key="REQUIRE_SIMULATION_ID">
+                <div class="mode-row-head">
+                    <h3 class="mode-row-name">Require simulation-id for writes</h3>
+                    <span class="status-badge" id="msRequireSimBadge">—</span>
+                </div>
+                <p class="mode-row-desc">
+                    When ON, every state-changing API call must first go through its <code>/simulate</code> endpoint
+                    and pass the <code>simulation_id</code> back as <code>X-Simulation-Id</code>. Protects against
+                    scripts and accidental writes — the cockpit always uses this flow regardless.
+                </p>
+                <div class="mode-row-toggle" data-pending-key="REQUIRE_SIMULATION_ID">
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="false">off</button>
+                    <button class="btn btn-secondary btn-sm" data-stage-key="REQUIRE_SIMULATION_ID" data-stage-value="true">on</button>
+                </div>
+            </div>
+        </section>
+        <footer class="modal-footer">
+            <button class="btn btn-secondary" type="button" id="modeSwitcherDismissBtn">Cancel</button>
+            <button class="btn btn-primary" type="button" id="modeSwitcherReviewBtn" disabled>Review changes</button>
+        </footer>
+    </div>
+</div>
+
+<div class="toast-stack" id="toastStack" aria-live="polite"></div>
+
+<script src="/js/modal.js"></script>
+<script src="/js/tz.js"></script>
+<script src="/js/quota.js"></script>
+<script src="/js/mode_switcher.js"></script>
+<script src="/js/_chrome.js"></script>
+<script src="/js/plan_render.js"></script>
+<script src="/js/workbench.js"></script>
+</body>
+</html>

--- a/ui/src/css/cockpit.css
+++ b/ui/src/css/cockpit.css
@@ -1,0 +1,1776 @@
+/* v10.1 cockpit — mobile-first (375px primary), scales up */
+
+:root {
+    --bg: #0b0f17;
+    --bg-card: #111827;
+    --bg-card-2: #1f2937;
+    --border: #374151;
+    --text: #f3f4f6;
+    --text-dim: #9ca3af;
+    --text-mute: #6b7280;
+    --accent: #3b82f6;
+    --ok: #10b981;
+    --warn: #f59e0b;
+    --bad: #ef4444;
+    --neg-price: #2563eb;
+    --cheap: #10b981;
+    --standard: #6b7280;
+    --peak: #f59e0b;
+    --peak-export: #ef4444;
+    --radius: 10px;
+    --shadow: 0 1px 2px rgba(0,0,0,0.4);
+    --gap: 0.75rem;
+}
+
+* { box-sizing: border-box; }
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 16px/1.45 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    min-height: 100vh;
+}
+a { color: inherit; text-decoration: none; }
+
+/* Topbar */
+.topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    padding-top: env(safe-area-inset-top);
+}
+.topbar-inner {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+        "brand badge pills"
+        "tabs  tabs  tabs";
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    max-width: 960px;
+    margin: 0 auto;
+}
+.brand { grid-area: brand; font-weight: 600; font-size: 1rem; }
+
+/* Mode badge — compact clickable Daikin-control indicator.
+ *
+ * Passive is the default + *desired* state (firmware runs the heat pump
+ * on its own curve); the old pill used a warning-orange "simulation"
+ * style which read as "something is wrong". Now: neutral chip always,
+ * subtle dot colour to hint at the mode, and a terse "Daikin: passive"
+ * label so first-time viewers understand what they're looking at.
+ */
+.mode-badge {
+    grid-area: badge;
+    appearance: none;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.74rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 30px;
+    justify-self: center;
+    line-height: 1;
+}
+.mode-badge:hover { border-color: var(--text-dim); color: var(--text); }
+.mode-badge:active { transform: scale(0.97); }
+.mode-badge .mode-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--text-dim);
+}
+.mode-badge .mode-label { color: var(--text-dim); font-weight: 500; }
+.mode-badge .mode-value { color: var(--text); font-weight: 600; font-variant: small-caps; }
+
+/* Passive = firmware autonomous (normal). Neutral blue dot to say "this is
+ * the default; nothing is wrong." Active = LP controls the HP: warmer tone
+ * to flag that the service is writing to the device. */
+.mode-badge[data-daikin="passive"] .mode-dot { background: #5b9bd5; }
+.mode-badge[data-daikin="active"] {
+    border-color: rgba(245,158,11,0.5);
+}
+.mode-badge[data-daikin="active"] .mode-dot {
+    background: var(--warn);
+    box-shadow: 0 0 6px var(--warn);
+}
+/* Simulate-id enforcement on: show a tiny 🔒 after the label. */
+.mode-badge[data-require-sim="true"]::after {
+    content: "🔒";
+    font-size: 0.72rem;
+    opacity: 0.75;
+}
+@media (max-width: 480px) {
+    .mode-badge .mode-label { display: none; }
+    .mode-badge { padding: 0.3rem 0.55rem; }
+}
+.tabs { grid-area: tabs; display: flex; gap: 0.25rem; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+.tabs::-webkit-scrollbar { display: none; }
+.tab {
+    flex: 0 0 auto;
+    padding: 0.55rem 0.9rem;
+    border-radius: var(--radius);
+    color: var(--text-dim);
+    font-size: 0.92rem;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+}
+.tab:hover { color: var(--text); }
+.tab.is-active { background: var(--bg-card); color: var(--text); }
+.quota-pills { grid-area: pills; display: flex; gap: 0.35rem; justify-self: end; }
+.pill {
+    background: var(--bg-card);
+    color: var(--text-dim);
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+}
+.pill.is-warn { color: var(--warn); }
+.pill.is-bad { color: var(--bad); }
+.pill.tz-pill {
+    /* Sits at the far right of the topbar next to the quota pills. */
+    margin-left: 0.35rem;
+    font-size: 0.7rem;
+    cursor: help;
+}
+
+/* -----------------------------------------------------------------------
+ * Phase 2: cockpit hero — replaces the old four-card status grid.
+ * ----------------------------------------------------------------------- */
+.cockpit-hero {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.hero-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.6fr);
+    gap: 1rem;
+    align-items: start;
+}
+@media (max-width: 720px) {
+    .hero-main { grid-template-columns: 1fr; }
+}
+.hero-now, .hero-next {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.hero-kicker {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+}
+.hero-slot-line {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+.hero-slot-time {
+    font-size: 1.35rem;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+.hero-slot-kind {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    background: var(--bg-card-2);
+    color: var(--text-dim);
+}
+.hero-slot-kind.kind-cheap { background: var(--cheap); color: #08180a; }
+.hero-slot-kind.kind-peak { background: var(--peak); color: #180a08; }
+.hero-slot-kind.kind-negative { background: var(--neg-price); color: #fff; }
+.hero-slot-kind.kind-standard { background: var(--standard); color: #0b0f17; }
+.hero-slot-price {
+    font-size: 0.9rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+}
+.hero-state-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 0.35rem 0.75rem;
+    margin-top: 0.4rem;
+}
+.hero-kpi {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding: 0.3rem 0;
+    border-top: 1px solid var(--border);
+}
+.hero-kpi-label {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+}
+.hero-kpi-value {
+    font-size: 0.92rem;
+    font-variant-numeric: tabular-nums;
+}
+.hero-next {
+    background: var(--bg-card-2);
+    border-radius: 8px;
+    padding: 0.65rem 0.85rem;
+}
+.hero-next-count {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+.hero-next-label {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+/* --- Freshness ribbon --- */
+.freshness-ribbon {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding-top: 0.5rem;
+    border-top: 1px dashed var(--border);
+}
+.fresh-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.28rem 0.6rem;
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    cursor: pointer;
+    transition: border-color 120ms ease;
+}
+.fresh-chip:hover:not(:disabled) { border-color: var(--text-dim); }
+.fresh-chip:disabled { opacity: 0.5; cursor: progress; }
+.fresh-chip .fresh-chip-name {
+    font-weight: 600;
+    color: var(--text);
+}
+.fresh-chip.is-stale { border-color: var(--warn); color: var(--warn); }
+.fresh-chip.is-very-stale { border-color: var(--bad); color: var(--bad); }
+.fresh-chip .fresh-chip-refresh {
+    margin-left: 0.15rem;
+    font-size: 0.8rem;
+    opacity: 0.7;
+}
+
+/* Recent-triggers strip — lives at the bottom of the NOW hero. Fed by
+ * /api/v1/recent-triggers, auto-refreshes after any wrapAction() flow
+ * so user-fired writes appear within a second. Horizontal scroll when
+ * > screen-width of chips. */
+.recent-triggers {
+    display: flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    margin-top: 0.55rem;
+    padding-top: 0.45rem;
+    border-top: 1px dashed var(--border);
+    font-size: 0.7rem;
+}
+.recent-triggers-head {
+    font-size: 0.64rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+    flex-shrink: 0;
+}
+.recent-triggers-list {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+    min-width: 0;
+    flex: 1;
+}
+.trigger-chip {
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: baseline;
+    padding: 0.2rem 0.5rem;
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.trigger-chip.is-failure {
+    border-color: rgba(220, 38, 38, 0.5);
+    background: rgba(220, 38, 38, 0.08);
+}
+.trigger-chip .trigger-action {
+    font-weight: 600;
+    color: var(--text);
+}
+.trigger-chip .trigger-meta {
+    color: var(--text-dim);
+    font-size: 0.64rem;
+}
+
+/* -----------------------------------------------------------------------
+ * Phase 3: Forecast tab
+ * ----------------------------------------------------------------------- */
+.forecast-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.6rem;
+}
+.fcs-kpi {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.4rem 0.5rem;
+    background: var(--bg-card-2);
+    border-radius: 6px;
+}
+.fcs-k {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+}
+.fcs-v {
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+}
+.fc-kv-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+.fc-kv-table th, .fc-kv-table td {
+    padding: 0.35rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+.fc-kv-table th {
+    color: var(--text-dim);
+    font-weight: 500;
+    width: 20%;
+}
+.fc-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+.fc-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    padding: 0.22rem 0.55rem;
+    background: var(--bg-card-2);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+}
+.fc-chip strong { color: var(--text-dim); font-weight: 500; }
+.fc-chip span { color: var(--text); }
+.fc-spark-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+.fc-spark-label {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+    margin-bottom: 0.25rem;
+}
+.fc-spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 50px;
+    background: var(--bg-card-2);
+    padding: 2px;
+    border-radius: 4px;
+}
+.fc-bar {
+    flex: 1;
+    min-width: 2px;
+    background: var(--standard);
+    border-radius: 1px;
+}
+.fc-bar.is-missing {
+    background: repeating-linear-gradient(
+        45deg,
+        var(--border), var(--border) 2px,
+        transparent 2px, transparent 4px
+    );
+    opacity: 0.6;
+    height: 100%;
+}
+.fc-slot-table-wrap {
+    max-height: 360px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+}
+.fc-slot-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+}
+.fc-slot-table th, .fc-slot-table td {
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+}
+.fc-slot-table th {
+    background: var(--bg-card-2);
+    position: sticky;
+    top: 0;
+    text-align: left;
+    color: var(--text-dim);
+    font-weight: 500;
+}
+.fc-slot-table td.num, .fc-slot-table th.num { text-align: right; }
+
+/* -----------------------------------------------------------------------
+ * Phase 4: History page
+ * ----------------------------------------------------------------------- */
+.history-picker {
+    background: var(--bg-card-2);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+}
+.history-source {
+    font-size: 0.74rem;
+    color: var(--text-dim);
+    font-family: monospace;
+    word-break: break-all;
+}
+
+/* Attribution donut (Phase 5) */
+.attribution-block {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 1rem;
+    align-items: center;
+}
+@media (max-width: 480px) {
+    .attribution-block { grid-template-columns: 1fr; }
+}
+.attribution-donut {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background: var(--bg-card-2);
+    /* Center hole so it reads as a donut rather than a pie. */
+    mask: radial-gradient(circle, transparent 42%, #000 43%);
+    -webkit-mask: radial-gradient(circle, transparent 42%, #000 43%);
+}
+.attribution-legend {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+}
+.attribution-legend .attr-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.attribution-legend .attr-swatch {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+}
+.attribution-legend .attr-totals {
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    margin-top: 0.25rem;
+}
+
+/* Simulating… busy state */
+.btn.is-busy {
+    opacity: 0.7;
+    cursor: progress;
+}
+body.is-simulating {
+    /* Subtle top progress hint while a simulate is running. */
+    box-shadow: inset 0 2px 0 0 var(--warn);
+}
+
+/* Generalised busy state for any wrapAction simulate+apply flow */
+body.is-busy {
+    cursor: progress;
+}
+body.is-busy::before {
+    /* Indeterminate top progress bar. Appears for every simulate-apply
+     * round-trip so users always see "something is happening". */
+    content: "";
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    z-index: 9999;
+    background: linear-gradient(
+        90deg,
+        transparent 0%, var(--standard) 20%, var(--standard) 40%,
+        transparent 60%, transparent 100%
+    );
+    background-size: 250% 100%;
+    animation: hem-progress 1.1s linear infinite;
+    pointer-events: none;
+}
+@keyframes hem-progress {
+    0%   { background-position: 100% 0%; }
+    100% { background-position: -150% 0%; }
+}
+
+/* LP re-plan in flight — pulse the Plan freshness chip so the user
+ * connects "I clicked re-plan" to "the system is running the solver".
+ * Fires via body.is-optimizing (set by wrapAction when the simulate URL
+ * is an optimisation endpoint). */
+body.is-optimizing .fresh-chip[data-source="plan"] {
+    animation: hem-chip-pulse 1.2s ease-in-out infinite;
+    border-color: var(--standard);
+}
+@keyframes hem-chip-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(var(--standard-rgb, 100, 149, 237), 0.4); }
+    50%      { box-shadow: 0 0 0 6px rgba(var(--standard-rgb, 100, 149, 237), 0.05); }
+}
+
+/* Phase 6: daikin-controls grey-out when passive (not hidden — we want
+ * the user to see what's there and why it's disabled). */
+.daikin-controls.is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    filter: grayscale(0.4);
+}
+.daikin-controls.is-disabled input,
+.daikin-controls.is-disabled button {
+    pointer-events: none;
+}
+
+/* MPC hours 24-cell toggle grid (replaces the CSV text input). */
+.mpc-grid {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 3px;
+    margin: 0.55rem 0;
+}
+@media (max-width: 480px) {
+    .mpc-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+}
+.mpc-cell {
+    appearance: none;
+    border: 1px solid var(--border);
+    background: var(--bg-card-2);
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    padding: 0.35rem 0;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+.mpc-cell:hover { border-color: var(--text-dim); color: var(--text); }
+.mpc-cell.is-on {
+    background: var(--cheap);
+    border-color: var(--cheap);
+    color: #08180a;
+    font-weight: 600;
+}
+
+/* Controls section header — was a plain-text button that didn't read as
+ * clickable. Now a proper row with an expand arrow + subtitle. */
+.override-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.55rem 0.85rem;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text);
+    font-size: 0.85rem;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 120ms ease, background 120ms ease;
+}
+.override-toggle:hover { border-color: var(--text-dim); }
+.override-toggle-left {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+}
+.override-toggle-icon {
+    display: inline-block;
+    transition: transform 160ms ease;
+    color: var(--text-dim);
+}
+.override-toggle[aria-expanded="true"] .override-toggle-icon { transform: rotate(90deg); }
+.override-toggle-right {
+    font-size: 0.74rem;
+    font-weight: 400;
+}
+@media (max-width: 480px) {
+    .override-toggle-right { display: none; }
+}
+
+/* Settings drawer — opens from the ⚙ chip in the hero ribbon. Right-side
+ * slide-in so the underlying cockpit stays visible (users can flip a knob
+ * and immediately see the effect on the live view). */
+.fresh-chip-settings {
+    margin-left: auto;
+}
+body.drawer-open { overflow: hidden; }
+.drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 80;
+    display: flex;
+    justify-content: flex-end;
+}
+.drawer-backdrop[hidden] { display: none; }
+.drawer {
+    width: min(100%, 480px);
+    max-width: 100%;
+    height: 100%;
+    background: var(--bg);
+    border-left: 1px solid var(--border);
+    box-shadow: -8px 0 24px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    animation: drawer-slide-in 180ms ease;
+}
+@keyframes drawer-slide-in {
+    from { transform: translateX(100%); }
+    to   { transform: translateX(0); }
+}
+.drawer-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.7rem 0.95rem;
+    border-bottom: 1px solid var(--border);
+}
+.drawer-header h2 {
+    flex: 1;
+    margin: 0;
+    font-size: 1rem;
+}
+.drawer-close {
+    appearance: none;
+    background: none;
+    border: none;
+    color: var(--text-dim);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.3rem;
+}
+.drawer-close:hover { color: var(--text); }
+.drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.85rem;
+}
+.drawer-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.7rem 0.85rem;
+    margin-bottom: 0.75rem;
+}
+.drawer-card-title {
+    margin: 0 0 0.45rem 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-dim);
+}
+
+/* ----------------------------------------------------------------------
+ * Merged 24-hour timeline — replaces the previous three stacked strips
+ * (tariff import / tariff export / plan). One row of 48 cells with:
+ *   • background = price kind (colored by cheap/std/peak/negative)
+ *   • bottom accent bar = Fox mode decided by the LP
+ *   • vertical "now" cursor overlaid at the current slot
+ *   • thin secondary export row below for reference
+ * Click any cell → slot detail modal with full info.
+ * ---------------------------------------------------------------------- */
+.timeline-summary {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.82rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+}
+.timeline-summary strong { color: var(--text); font-weight: 600; }
+.timeline-wrap {
+    position: relative;
+    padding-top: 1.1rem;
+}
+.timeline-axis-top {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.66rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+}
+.threshold-marker { padding: 0 0.25rem; }
+.timeline-strip {
+    display: grid;
+    grid-template-columns: repeat(48, minmax(0, 1fr));
+    gap: 1px;
+    height: 40px;
+    background: var(--bg-card-2);
+}
+.tl-cell {
+    appearance: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: transform 80ms ease;
+    background: var(--bg-card-2);
+}
+.tl-cell:hover { transform: scaleY(1.08); z-index: 2; outline: 1px solid var(--text-dim); }
+.tl-cell.kind-negative  { background: var(--neg-price); }
+.tl-cell.kind-cheap     { background: var(--cheap); }
+.tl-cell.kind-standard  { background: var(--standard); }
+.tl-cell.kind-peak      { background: var(--peak); }
+.tl-cell.is-now {
+    outline: 2px solid var(--text);
+    z-index: 2;
+}
+.tl-mode {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 6px;
+    background: transparent;
+}
+/* Fox mode accents — darker variants of the base palette for differentiation */
+.tl-mode.mode-force-charge      { background: #059669; }  /* deep green — grid → battery */
+.tl-mode.mode-force-discharge   { background: #dc2626; }  /* deep red — battery → grid */
+.tl-mode.mode-feed-in           { background: #f59e0b; }  /* amber — solar → grid */
+.tl-mode.mode-backup            { background: #7c3aed; }  /* violet — reserve */
+.tl-mode.mode-self-use          { background: transparent; }  /* default, no accent */
+.tl-mode.mode-none              { background: transparent; }
+
+.timeline-cursor {
+    position: absolute;
+    top: 1.1rem;
+    bottom: 1.4rem;
+    width: 2px;
+    background: var(--text);
+    box-shadow: 0 0 6px rgba(255, 255, 255, 0.4);
+    pointer-events: none;
+    z-index: 3;
+}
+.timeline-axis {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.64rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    padding: 0.2rem 0 0 0;
+}
+.timeline-export-wrap {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.4rem;
+    align-items: center;
+    margin-top: 0.3rem;
+}
+.timeline-export-label {
+    font-size: 0.66rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+.timeline-export {
+    display: grid;
+    grid-template-columns: repeat(48, minmax(0, 1fr));
+    gap: 1px;
+    height: 10px;
+    background: var(--bg-card-2);
+    border-radius: 2px;
+    overflow: hidden;
+}
+.tl-export-cell { background: var(--bg-card-2); }
+.tl-export-cell.kind-negative  { background: var(--neg-price); opacity: 0.7; }
+.tl-export-cell.kind-cheap     { background: var(--cheap); opacity: 0.7; }
+.tl-export-cell.kind-standard  { background: var(--standard); opacity: 0.7; }
+.tl-export-cell.kind-peak      { background: var(--peak); opacity: 0.7; }
+
+.timeline-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.2rem 0.6rem;
+    margin-top: 0.7rem;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+}
+.timeline-legend .leg-group {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.55rem;
+    align-items: center;
+}
+.timeline-legend .leg-head {
+    font-weight: 600;
+    color: var(--text);
+    margin-right: 0.25rem;
+    font-variant: small-caps;
+}
+.timeline-legend .legend-swatch {
+    display: inline-block;
+    width: 10px; height: 10px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 0.25rem;
+}
+.timeline-legend .legend-mode {
+    display: inline-block;
+    width: 10px; height: 10px;
+    vertical-align: middle;
+    margin-right: 0.25rem;
+    border-radius: 2px;
+}
+.legend-mode.mode-force-charge    { background: #059669; }
+.legend-mode.mode-force-discharge { background: #dc2626; }
+.legend-mode.mode-feed-in         { background: #f59e0b; }
+.legend-mode.mode-backup          { background: #7c3aed; }
+.legend-mode.mode-self-use        { background: var(--border); }
+
+/* Slot detail modal (shared for timeline click). */
+.slot-detail {
+    margin: auto;
+    width: min(100%, 420px);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.6rem 0.85rem 0.85rem;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.slot-detail-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding-bottom: 0.45rem;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 0.5rem;
+}
+.slot-detail-head h3 {
+    flex: 1;
+    margin: 0;
+    font-size: 0.92rem;
+}
+.slot-detail-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+}
+.slot-detail-table th, .slot-detail-table td {
+    padding: 0.28rem 0.35rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    font-variant-numeric: tabular-nums;
+}
+.slot-detail-table th {
+    color: var(--text-dim);
+    font-weight: 500;
+    width: 42%;
+}
+.slot-detail-table .kind-negative .legend-swatch { background: var(--neg-price); }
+.slot-detail-table .kind-cheap .legend-swatch { background: var(--cheap); }
+.slot-detail-table .kind-standard .legend-swatch { background: var(--standard); }
+.slot-detail-table .kind-peak .legend-swatch { background: var(--peak); }
+
+/* Layout */
+.page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0.75rem;
+    padding-bottom: calc(env(safe-area-inset-bottom) + 1rem);
+    display: grid;
+    gap: var(--gap);
+}
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.85rem;
+    box-shadow: var(--shadow);
+}
+.card-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-mute);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+.card-actions { display: flex; gap: 0.35rem; align-items: center; }
+
+/* Status strip */
+.status-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--gap);
+}
+@media (max-width: 480px) {
+    .status-grid { grid-template-columns: 1fr; }
+}
+.status-card { display: flex; flex-direction: column; gap: 0.5rem; }
+.status-card .header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+.status-light {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.status-light.is-ok { background: var(--ok); box-shadow: 0 0 6px var(--ok); }
+.status-light.is-warn { background: var(--warn); }
+.status-light.is-bad { background: var(--bad); }
+.status-name { font-weight: 600; font-size: 0.95rem; flex: 1; }
+.status-staleness {
+    color: var(--text-mute);
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+}
+.status-staleness.is-stale { color: var(--warn); }
+.status-staleness.is-very-stale { color: var(--bad); }
+.status-rows {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.15rem 0.6rem;
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+}
+.status-rows .label { color: var(--text-dim); }
+.status-rows .value { color: var(--text); }
+.status-badge {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    background: var(--bg-card-2);
+    color: var(--text-dim);
+}
+.status-badge.is-passive { background: rgba(99,102,241,0.15); color: #c7d2fe; }
+.status-badge.is-active { background: rgba(245,158,11,0.18); color: #fde68a; }
+
+/* Buttons */
+.btn {
+    appearance: none;
+    border: 1px solid var(--border);
+    background: var(--bg-card-2);
+    color: var(--text);
+    padding: 0.55rem 0.9rem;
+    border-radius: var(--radius);
+    font-size: 0.85rem;
+    cursor: pointer;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    line-height: 1;
+}
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn:active { transform: scale(0.98); }
+.btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn-secondary { background: var(--bg-card-2); }
+.btn-danger { background: var(--bad); border-color: var(--bad); color: #fff; }
+.btn-sm { padding: 0.35rem 0.65rem; min-height: 32px; font-size: 0.78rem; }
+.btn-icon {
+    background: transparent;
+    border: none;
+    padding: 0.4rem;
+    color: var(--text-dim);
+    min-height: 32px;
+    min-width: 32px;
+}
+.btn-icon:hover { color: var(--text); }
+
+/* Daikin vs Fox breakdown */
+.load-breakdown {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.4rem;
+}
+.load-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.92rem;
+}
+.load-row.is-total { font-weight: 600; padding-bottom: 0.4rem; border-bottom: 1px solid var(--border); }
+.load-row.is-sub { padding-left: 1rem; color: var(--text-dim); font-size: 0.85rem; }
+.load-row .value {
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+}
+
+/* Tariff bands (separate import / export rows) */
+.tariff-bands { display: grid; gap: 0.55rem; }
+.tariff-row { display: grid; grid-template-columns: 60px 1fr; gap: 0.5rem; align-items: center; }
+.tariff-label { font-size: 0.8rem; color: var(--text-dim); }
+.tariff-strip {
+    height: 22px;
+    border-radius: 4px;
+    overflow: hidden;
+    display: flex;
+    background: var(--bg-card-2);
+}
+.tariff-slot {
+    flex: 1 1 auto;
+    height: 100%;
+    border-right: 1px solid rgba(0,0,0,0.2);
+}
+.tariff-slot:last-child { border-right: none; }
+.tariff-slot.is-current { box-shadow: inset 0 0 0 2px var(--text); }
+.tariff-current-label {
+    font-variant-numeric: tabular-nums;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    margin-top: 0.2rem;
+}
+
+/* v10.2 Insights — per-slot tariff strip (Day view) */
+.tariff-day-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(36px, 1fr));
+    gap: 1px;
+    background: var(--border);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+    margin: 0 0 0.85rem 0;
+}
+.tariff-day-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.3rem 0.1rem;
+    background: var(--bg-card-2);
+    font-size: 0.6rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+    min-height: 38px;
+    cursor: help;
+}
+.tariff-day-cell-time { font-size: 0.55rem; color: var(--text-mute); }
+.tariff-day-cell-price { font-size: 0.7rem; color: var(--text); font-weight: 600; }
+.tariff-day-cell.kind-cheap    { background: rgba(16,185,129,0.18); }
+.tariff-day-cell.kind-cheap .tariff-day-cell-price { color: var(--ok); }
+.tariff-day-cell.kind-peak     { background: rgba(245,158,11,0.22); }
+.tariff-day-cell.kind-peak .tariff-day-cell-price { color: var(--warn); }
+.tariff-day-cell.kind-negative { background: rgba(37,99,235,0.25); }
+.tariff-day-cell.kind-negative .tariff-day-cell-price { color: #93c5fd; }
+.tariff-day-cell.kind-standard { background: var(--bg-card-2); }
+
+/* Period browser bar */
+.period-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+.period-nav { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
+.period-nav-label {
+    font-size: 0.95rem;
+    font-weight: 600;
+    min-width: 12ch;
+    text-align: center;
+    color: var(--text);
+}
+.period-tabs { display: flex; gap: 0.3rem; flex-wrap: wrap; }
+
+/* Collapsible <details> insights cards */
+.insights-section { padding: 0.85rem 1rem; }
+.insights-section > summary.card-title {
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.insights-section > summary.card-title::before {
+    content: "▸";
+    font-size: 0.7rem;
+    color: var(--text-mute);
+    transition: transform 0.12s ease-out;
+    display: inline-block;
+}
+.insights-section[open] > summary.card-title::before { transform: rotate(90deg); }
+.insights-section > summary.card-title::-webkit-details-marker { display: none; }
+
+/* Pattern panels */
+.patterns-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+}
+@media (min-width: 720px) {
+    .patterns-grid { grid-template-columns: 1fr 1fr; }
+}
+.pattern-card {
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.65rem 0.85rem;
+}
+.pattern-title {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-mute);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.pattern-bar-row {
+    display: grid;
+    grid-template-columns: 3.5rem 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.78rem;
+    margin: 0.15rem 0;
+    font-variant-numeric: tabular-nums;
+}
+.pattern-bar-label { color: var(--text-dim); }
+.pattern-bar-track { background: var(--bg); border-radius: 3px; height: 10px; overflow: hidden; }
+.pattern-bar-fill { display: block; height: 100%; background: var(--accent); border-radius: 3px; }
+.pattern-bar-fill.kind-cheap    { background: var(--ok); }
+.pattern-bar-fill.kind-peak     { background: var(--warn); }
+.pattern-bar-fill.kind-negative { background: #60a5fa; }
+.pattern-bar-fill.kind-standard { background: var(--text-mute); }
+.pattern-bar-label.kind-cheap   { color: var(--ok); }
+.pattern-bar-label.kind-peak    { color: var(--warn); }
+.pattern-bar-label.kind-negative{ color: #93c5fd; }
+.pattern-bar-val { color: var(--text); }
+.pv-spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 44px;
+    padding-top: 4px;
+}
+.pv-spark-bar {
+    flex: 1 1 auto;
+    background: rgba(245,158,11,0.55);
+    border-radius: 1px 1px 0 0;
+    min-width: 2px;
+}
+
+/* v10.2 Workbench */
+.workbench-header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.workbench-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.workbench-actions select.btn { background: var(--bg-card-2); padding: 0.3rem 0.45rem; }
+.workbench-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+}
+@media (min-width: 880px) {
+    .workbench-grid { grid-template-columns: 1fr 1fr; }
+    .workbench-tabs { display: none; }
+    .workbench-pane { display: block !important; }
+}
+.workbench-tabs {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--border);
+    margin: -0.85rem -1rem 0.85rem -1rem;
+}
+.workbench-tab {
+    flex: 1;
+    background: transparent;
+    border: none;
+    padding: 0.65rem 0.5rem;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 0.9rem;
+    border-bottom: 2px solid transparent;
+}
+.workbench-tab.is-active { color: var(--text); border-bottom-color: var(--accent); }
+.workbench-pane { display: none; }
+.workbench-pane.is-active { display: block; }
+@media (min-width: 880px) { .workbench-tab { display: none; } }
+
+.editor-body { display: grid; gap: 0.65rem; }
+.editor-group {
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+}
+.editor-group-title {
+    cursor: pointer;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-mute);
+    font-weight: 600;
+    padding: 0.2rem 0;
+    list-style: none;
+}
+.editor-group-title::-webkit-details-marker { display: none; }
+.editor-group-title::before {
+    content: "▸";
+    font-size: 0.65rem;
+    margin-right: 0.4rem;
+    color: var(--text-mute);
+    transition: transform 0.12s ease-out;
+    display: inline-block;
+}
+.editor-group[open] .editor-group-title::before { transform: rotate(90deg); }
+.editor-fields { display: grid; gap: 0.5rem; padding-top: 0.4rem; }
+.editor-field {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.15rem;
+    padding: 0.45rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+}
+.editor-field-label {
+    font-size: 0.75rem;
+    color: var(--text);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+.editor-field-desc {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    margin: 0 0 0.2rem 0;
+    line-height: 1.35;
+}
+.editor-field-meta { color: var(--text-mute); margin-left: 0.4rem; }
+.editor-input {
+    background: var(--bg-card-2);
+    color: var(--text);
+    border: 1px solid var(--border);
+    padding: 0.35rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.82rem;
+    font-family: inherit;
+    min-height: 32px;
+}
+.editor-input.is-dirty {
+    border-color: var(--warn);
+    box-shadow: 0 0 0 1px var(--warn);
+}
+.badge-promotable {
+    color: var(--accent);
+    font-size: 0.65rem;
+}
+.compare-summary { margin-bottom: 0.65rem; }
+
+/* Plan timeline strip */
+.plan-strip {
+    display: flex;
+    height: 28px;
+    border-radius: 4px;
+    overflow: hidden;
+    background: var(--bg-card-2);
+}
+.plan-slot {
+    flex: 1 1 auto;
+    height: 100%;
+    border-right: 1px solid rgba(0,0,0,0.2);
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+.plan-slot:hover { opacity: 0.7; }
+.plan-slot.is-now { box-shadow: inset 0 0 0 2px var(--text); }
+.plan-slot.kind-negative { background: var(--neg-price); }
+.plan-slot.kind-cheap { background: var(--cheap); }
+.plan-slot.kind-standard { background: var(--standard); }
+.plan-slot.kind-peak { background: var(--peak); }
+.plan-slot.kind-peak_export { background: var(--peak-export); }
+.plan-slot.kind-solar_charge { background: #06b6d4; }
+
+.plan-legend { display: flex; gap: 0.6rem; flex-wrap: wrap; font-size: 0.72rem; color: var(--text-dim); margin-top: 0.5rem; }
+.legend-swatch {
+    display: inline-block;
+    width: 10px; height: 10px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 0.25rem;
+}
+
+/* Manual override expander */
+.override-section {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-card);
+}
+.override-toggle {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: var(--text);
+    padding: 0.85rem;
+    font-size: 0.92rem;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    min-height: 44px;
+}
+.override-toggle::after {
+    content: "▾";
+    color: var(--text-dim);
+    transition: transform 0.15s;
+}
+.override-toggle[aria-expanded="true"]::after { transform: rotate(180deg); }
+.override-body {
+    padding: 0.85rem;
+    border-top: 1px solid var(--border);
+    display: grid;
+    gap: 0.85rem;
+}
+.override-body[hidden] { display: none; }
+.override-tabs { display: flex; gap: 0.3rem; border-bottom: 1px solid var(--border); padding-bottom: 0.4rem; }
+.override-tab {
+    background: transparent;
+    border: none;
+    color: var(--text-dim);
+    padding: 0.4rem 0.7rem;
+    cursor: pointer;
+    font-size: 0.82rem;
+    border-radius: 6px;
+    min-height: 36px;
+}
+.override-tab.is-active { background: var(--bg-card-2); color: var(--text); }
+.override-tab-panel { display: grid; gap: 0.6rem; }
+
+.field {
+    display: grid;
+    gap: 0.3rem;
+}
+.field label {
+    font-size: 0.78rem;
+    color: var(--text-dim);
+}
+.field input, .field select {
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.55rem 0.75rem;
+    border-radius: var(--radius);
+    font-size: 0.95rem;
+    min-height: 44px;
+}
+
+/* Modal */
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.7);
+    z-index: 100;
+    display: grid;
+    place-items: end center;
+    padding: 0;
+    padding-bottom: env(safe-area-inset-bottom);
+}
+.modal-backdrop[hidden] { display: none; }
+@media (min-width: 600px) {
+    .modal-backdrop { place-items: center; padding: 1rem; }
+}
+.modal {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius) var(--radius) 0 0;
+    width: 100%;
+    max-width: 560px;
+    max-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 -4px 24px rgba(0,0,0,0.6);
+}
+@media (min-width: 600px) {
+    .modal { border-radius: var(--radius); box-shadow: 0 4px 24px rgba(0,0,0,0.6); }
+}
+.modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--border);
+}
+.modal-header h2 { margin: 0; font-size: 1rem; font-weight: 600; }
+.modal-close { background: transparent; border: none; color: var(--text-dim); font-size: 1.5rem; cursor: pointer; padding: 0 0.5rem; min-height: 44px; }
+.modal-body { padding: 0.85rem 1rem; overflow-y: auto; flex: 1; display: grid; gap: 0.85rem; }
+.modal-summary { font-size: 0.95rem; margin: 0; }
+.modal-section { display: grid; gap: 0.35rem; }
+.modal-section h3 { margin: 0; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-mute); }
+.kv-block {
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.55rem 0.75rem;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    margin: 0;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.modal-batch-table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-card-2);
+}
+.modal-batch-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+.modal-batch-table th,
+.modal-batch-table td {
+    padding: 0.45rem 0.65rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+}
+.modal-batch-table thead th {
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    letter-spacing: 0.06em;
+    color: var(--text-mute);
+    background: var(--bg);
+    position: sticky;
+    top: 0;
+}
+.modal-batch-table tbody tr:last-child td { border-bottom: none; }
+.modal-batch-table .bcell-key code { color: var(--text); }
+.modal-batch-table .bcell-before { color: var(--text-dim); }
+.modal-batch-table .bcell-after  { color: var(--ok); }
+.modal-batch-table .bcell-safety { white-space: normal; }
+.batch-flag {
+    display: inline-block;
+    padding: 0.05rem 0.3rem;
+    border-radius: 4px;
+    margin-right: 0.2rem;
+    font-size: 0.7rem;
+}
+.batch-flag-soft { background: rgba(245,158,11,0.15); color: var(--warn); border: 1px solid rgba(245,158,11,0.4); }
+.batch-flag-hard { background: rgba(239,68,68,0.15); color: var(--bad); border: 1px solid rgba(239,68,68,0.5); }
+.flags-section { background: rgba(239,68,68,0.08); border: 1px solid rgba(239,68,68,0.4); border-radius: var(--radius); padding: 0.65rem; }
+.flags-heading { color: var(--bad); }
+.flags-list { margin: 0; padding-left: 1.2rem; font-size: 0.82rem; }
+.flags-confirm { display: flex; flex-direction: column; gap: 0.3rem; margin-top: 0.5rem; font-size: 0.82rem; color: var(--text-dim); }
+.flags-confirm input { background: var(--bg-card-2); border: 1px solid var(--border); color: var(--text); padding: 0.45rem 0.65rem; border-radius: 6px; min-height: 38px; }
+.flags-confirm code { background: var(--bg); padding: 0.1rem 0.35rem; border-radius: 4px; color: var(--bad); }
+.modal-footer { display: flex; gap: 0.5rem; padding: 0.85rem 1rem; border-top: 1px solid var(--border); }
+.modal-footer .btn { flex: 1; }
+
+/* Toasts */
+.toast-stack {
+    position: fixed;
+    left: 50%;
+    bottom: calc(env(safe-area-inset-bottom) + 1rem);
+    transform: translateX(-50%);
+    z-index: 200;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+    pointer-events: none;
+}
+.toast {
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.55rem 0.85rem;
+    border-radius: var(--radius);
+    font-size: 0.85rem;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.5);
+    pointer-events: auto;
+    max-width: 90vw;
+}
+.toast.is-ok { border-color: var(--ok); }
+.toast.is-warn { border-color: var(--warn); }
+.toast.is-bad { border-color: var(--bad); }
+
+/* Mode switcher dialog (v10.2) */
+.mode-switcher-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.7);
+    z-index: 110;
+    display: grid;
+    place-items: end center;
+    padding: 0;
+    padding-bottom: env(safe-area-inset-bottom);
+}
+.mode-switcher-backdrop[hidden] { display: none; }
+@media (min-width: 600px) {
+    .mode-switcher-backdrop { place-items: center; padding: 1rem; }
+}
+.mode-switcher {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius) var(--radius) 0 0;
+    width: 100%;
+    max-width: 560px;
+    max-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 -4px 24px rgba(0,0,0,0.6);
+}
+@media (min-width: 600px) {
+    .mode-switcher { border-radius: var(--radius); box-shadow: 0 4px 24px rgba(0,0,0,0.6); }
+}
+.mode-row {
+    padding: 0.85rem 0;
+    border-bottom: 1px solid var(--border);
+}
+.mode-row:last-child { border-bottom: none; }
+.mode-row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    margin-bottom: 0.3rem;
+}
+.mode-row-name { margin: 0; font-size: 0.95rem; font-weight: 600; }
+.mode-row-desc {
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    margin: 0 0 0.55rem 0;
+    line-height: 1.45;
+}
+.mode-row-desc code {
+    background: var(--bg-card-2);
+    color: var(--text);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.76rem;
+}
+.mode-row-toggle {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+}
+.mode-row-toggle .btn.is-selected {
+    background: rgba(59,130,246,0.18);
+    border-color: var(--accent);
+    color: var(--text);
+}
+.mode-row-toggle .btn.is-pending {
+    background: rgba(245,158,11,0.18);
+    border-color: var(--warn);
+    color: var(--warn);
+    box-shadow: 0 0 0 1px var(--warn);
+}
+
+/* Plan page table */
+.plan-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+}
+.plan-table th, .plan-table td {
+    padding: 0.45rem 0.6rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+.plan-table th { color: var(--text-mute); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+.plan-table th.num, .plan-table td.num { text-align: right; }
+.plan-table tr.is-now { background: rgba(59,130,246,0.08); }
+.plan-table tr.kind-cheap { background: rgba(16,185,129,0.04); }
+.plan-table tr.kind-peak { background: rgba(245,158,11,0.06); }
+.plan-table tr.kind-peak_export { background: rgba(239,68,68,0.06); }
+.plan-table tr.kind-negative { background: rgba(37,99,235,0.06); }
+.plan-table tr:hover { background: rgba(255,255,255,0.03); }
+.plan-table tfoot tr.totals-row {
+    background: rgba(59,130,246,0.06);
+    font-variant-numeric: tabular-nums;
+    border-top: 2px solid var(--accent);
+}
+.plan-table tfoot tr.totals-row td {
+    padding: 0.65rem 0.6rem;
+    border-bottom: none;
+}
+.data-quality-note {
+    background: rgba(245,158,11,0.08);
+    border: 1px solid rgba(245,158,11,0.35);
+    color: var(--warn);
+    padding: 0.55rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.78rem;
+    margin: 0 0 0.6rem 0;
+    line-height: 1.5;
+}
+.plan-table .col-actual.is-positive { color: var(--ok); }
+.plan-table .col-actual.is-negative { color: var(--bad); }
+.plan-table .col-actual.is-pending { color: var(--text-mute); font-style: italic; }
+
+/* Settings page — v10.1 iteration 2 */
+.danger-zone {
+    border-color: rgba(239,68,68,0.4);
+    background: linear-gradient(180deg, rgba(239,68,68,0.04) 0%, var(--bg-card) 30%);
+}
+.setting-block {
+    padding: 0.85rem 0;
+    border-bottom: 1px solid var(--border);
+}
+.setting-block:last-child { border-bottom: none; }
+.setting-block.is-danger {
+    background: rgba(239,68,68,0.04);
+    border-radius: 6px;
+    padding: 0.85rem;
+    margin: 0.5rem 0;
+}
+.setting-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    margin-bottom: 0.3rem;
+}
+.setting-name { margin: 0; font-size: 0.95rem; font-weight: 600; }
+.setting-desc {
+    color: var(--text-dim);
+    font-size: 0.82rem;
+    margin: 0 0 0.55rem 0;
+    line-height: 1.45;
+}
+.setting-desc code {
+    background: var(--bg-card-2);
+    color: var(--text);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.78rem;
+}
+.setting-actions {
+    display: flex;
+    gap: 0.45rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+.setting-actions input, .setting-actions select {
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.45rem 0.65rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    min-height: 38px;
+}
+
+/* Settings page (legacy block patterns kept for old dashboard) */
+.settings-group { display: grid; gap: 0.7rem; }
+.settings-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.7rem;
+    align-items: center;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid var(--border);
+}
+.settings-row:last-child { border-bottom: none; }
+.settings-row .label { font-size: 0.92rem; }
+.settings-row .description { font-size: 0.77rem; color: var(--text-dim); margin-top: 0.15rem; }
+.settings-row .control { display: flex; gap: 0.4rem; align-items: center; }
+.settings-row .current {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    background: var(--bg-card-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.35rem 0.55rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    min-width: 80px;
+    text-align: center;
+}
+
+/* Insights page */
+.insights-tabs { display: flex; gap: 0.3rem; flex-wrap: wrap; margin-bottom: 0.5rem; }
+.insights-period { display: flex; gap: 0.3rem; flex-wrap: wrap; }
+.insights-summary {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+    margin-bottom: 0.85rem;
+}
+@media (min-width: 600px) {
+    .insights-summary { grid-template-columns: repeat(4, 1fr); }
+}
+.insight-tile {
+    background: var(--bg-card-2);
+    padding: 0.7rem 0.85rem;
+    border-radius: var(--radius);
+}
+.insight-tile .label { font-size: 0.72rem; color: var(--text-mute); text-transform: uppercase; letter-spacing: 0.05em; }
+.insight-tile .value { font-size: 1.3rem; font-weight: 600; font-variant-numeric: tabular-nums; margin-top: 0.2rem; }
+
+/* Utility */
+.text-mute { color: var(--text-mute); }
+.text-dim { color: var(--text-dim); }
+.text-warn { color: var(--warn); }
+.text-bad { color: var(--bad); }
+.text-ok { color: var(--ok); }
+.spaced { display: grid; gap: 0.35rem; }
+[hidden] { display: none !important; }

--- a/ui/src/js/_api.js
+++ b/ui/src/js/_api.js
@@ -64,4 +64,31 @@
   global.hemFetch    = hemFetch;
   global.hemGetJson  = hemGetJson;
   global.hemPostJson = hemPostJson;
+
+  // Transparent bearer injection on the global fetch.
+  // The legacy JS files in src/api/static/js/ (lifted in Story B4) call
+  // fetch('/api/v1/...') directly. Rather than rewrite every callsite,
+  // we wrap the global fetch so any URL beginning with /api/ gets the
+  // bearer header attached automatically. This is purely additive — if
+  // the caller already set Authorization the header is left alone.
+  const _originalFetch = global.fetch.bind(global);
+  global.fetch = function patchedFetch(input, init) {
+    let url;
+    try {
+      url = typeof input === "string" ? input : (input && input.url) || "";
+    } catch (_) {
+      url = "";
+    }
+    if (typeof url === "string" && url.startsWith("/api/")) {
+      const cfg = _config();
+      if (cfg.bearer) {
+        const headers = new Headers((init && init.headers) || {});
+        if (!headers.has("Authorization")) {
+          headers.set("Authorization", "Bearer " + cfg.bearer);
+        }
+        init = Object.assign({}, init || {}, { headers });
+      }
+    }
+    return _originalFetch(input, init);
+  };
 })(window);

--- a/ui/src/js/_chrome.js
+++ b/ui/src/js/_chrome.js
@@ -1,0 +1,45 @@
+// Chrome bootstrap — populates the topbar mode badge from /api/v1/settings.
+//
+// Replaces the server-side Jinja2 render of `data-daikin` / `data-require-sim`
+// attributes on the #modeBadge button. Called on every page load so the
+// mode-switcher.js script (which reads those attrs) sees fresh values.
+(function () {
+  "use strict";
+
+  function _markActiveTab() {
+    // The active tab class was set server-side via Jinja's
+    // {% if active_page == 'X' %}. Now we infer from window.location.
+    const path = (window.location.pathname || "/").replace(/\/$/, "");
+    document.querySelectorAll(".tab").forEach(a => {
+      const href = (a.getAttribute("href") || "/").replace(/\/$/, "");
+      if (href === path || (path === "" && href === "")) {
+        a.classList.add("is-active");
+      }
+    });
+  }
+
+  async function _populateModeBadge() {
+    const badge = document.getElementById("modeBadge");
+    if (!badge) return;
+    try {
+      const r = await hemGetJson("/settings");
+      // /api/v1/settings returns a flat dict; the mode-switcher partial
+      // expects 'passive'|'active' and 'true'|'false' as data attrs.
+      const dcm = (r && r.DAIKIN_CONTROL_MODE) || "";
+      const rsi = !!(r && r.REQUIRE_SIMULATION_ID);
+      badge.setAttribute("data-daikin", dcm || "passive");
+      badge.setAttribute("data-require-sim", rsi ? "true" : "false");
+      const value = badge.querySelector(".mode-value");
+      if (value) value.textContent = dcm || "passive";
+    } catch (e) {
+      // Defensive: leave the placeholder attrs in place if /settings is
+      // unreachable; mode_switcher.js handles missing data gracefully.
+      console.warn("chrome: /settings fetch failed", e);
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    _markActiveTab();
+    _populateModeBadge();
+  });
+})();

--- a/ui/src/js/cockpit.js
+++ b/ui/src/js/cockpit.js
@@ -1,0 +1,564 @@
+/* Cockpit page — Phase 2 rework.
+ *
+ * The old four-card layout (Octopus / Fox / Daikin / Plan) has been replaced
+ * by a single hero panel backed by /api/v1/cockpit/now — one coherent
+ * snapshot of where we are now, with a freshness ribbon per source. The
+ * tariff + plan strips and the house-load breakdown are still rendered below
+ * via their existing endpoints.
+ */
+(function () {
+  'use strict';
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+  const { jsonFetch, wrapAction, toast, refreshQuota } = window.HEM || {};
+
+  // --- formatting helpers -------------------------------------------------
+
+  function fmtAge(iso) {
+    if (!iso) return { text: '—', class: 'is-very-stale' };
+    const d = new Date(iso);
+    if (isNaN(d)) return { text: '—', class: 'is-very-stale' };
+    const sec = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (sec < 60) return { text: `${sec}s ago`, class: '' };
+    if (sec < 3600) {
+      const m = Math.floor(sec / 60);
+      return { text: `${m}m ago`, class: m > 5 ? (m > 30 ? 'is-very-stale' : 'is-stale') : '' };
+    }
+    const h = Math.floor(sec / 3600);
+    return { text: `${h}h ago`, class: 'is-very-stale' };
+  }
+
+  function fmtKwh(v, suffix) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(2)} ${suffix || 'kW'}`;
+  }
+  function fmtPct(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(0)}%`;
+  }
+  function fmtC(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(1)}°C`;
+  }
+  function fmtP(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(1)}p`;
+  }
+
+  function slotKindForPrice(p, thresholds) {
+    if (p == null) return 'standard';
+    if (p < 0) return 'negative';
+    const cheap = thresholds?.cheap_p;
+    const peak = thresholds?.peak_p;
+    if (cheap != null && p < cheap) return 'cheap';
+    if (peak != null && p > peak) return 'peak';
+    return 'standard';
+  }
+
+  // --- Hero panel ---------------------------------------------------------
+
+  let _thresholds = { cheap_p: null, peak_p: null };
+
+  async function loadNow() {
+    let n;
+    try {
+      n = await jsonFetch('/api/v1/cockpit/now');
+    } catch (e) {
+      toast(`Cockpit: ${e.message}`, 'bad');
+      return;
+    }
+
+    _thresholds = n.thresholds || { cheap_p: null, peak_p: null };
+
+    const cur = n.current_slot || {};
+    const state = n.state || {};
+    const fresh = n.freshness || {};
+    const next = n.next_transition || {};
+
+    const kind = slotKindForPrice(cur.price_import_p, _thresholds);
+    const heroKind = $('#heroSlotKind');
+    if (heroKind) {
+      heroKind.textContent = kind;
+      heroKind.className = `hero-slot-kind kind-${kind}`;
+    }
+    const heroTime = $('#heroSlotTime');
+    if (heroTime) {
+      heroTime.textContent = (window.HEM && window.HEM.fmtSlotRange && cur.t_utc && cur.t_end_utc)
+        ? window.HEM.fmtSlotRange(cur.t_utc, cur.t_end_utc)
+        : '—';
+    }
+    const heroPrice = $('#heroSlotPrice');
+    if (heroPrice) {
+      const ip = cur.price_import_p != null ? `${cur.price_import_p.toFixed(1)}p` : '—';
+      const ep = cur.price_export_p != null ? `${cur.price_export_p.toFixed(1)}p` : '—';
+      heroPrice.textContent = `imp ${ip} · exp ${ep}`;
+    }
+
+    $('#heroSoc').textContent = state.soc_pct != null ? `${fmtPct(state.soc_pct)} · ${fmtKwh(state.soc_kwh, 'kWh')}` : '—';
+    $('#heroSolar').textContent = fmtKwh(state.solar_kw);
+    $('#heroLoad').textContent = fmtKwh(state.load_kw);
+    const grid = state.grid_kw;
+    $('#heroGrid').textContent = grid == null ? '—' : `${grid >= 0 ? '+' : ''}${Number(grid).toFixed(2)} kW`;
+    $('#heroTank').textContent = fmtC(state.tank_c);
+    $('#heroIndoor').textContent = fmtC(state.indoor_c);
+    $('#heroOutdoor').textContent = fmtC(state.outdoor_c);
+    $('#heroLwt').textContent = fmtC(state.lwt_c);
+    $('#heroFoxMode').textContent = state.fox_mode || cur.fox_mode || '—';
+    $('#heroDaikinMode').textContent = state.daikin_mode || n.modes?.daikin_control_mode || '—';
+
+    // Phase 6 gating: grey-out (not hide) the Daikin tank/LWT controls when
+    // DAIKIN_CONTROL_MODE is passive. The user sees they exist and understands
+    // *why* they're inert — flipping hidden made the controls silently vanish.
+    const dkMode = n.modes?.daikin_control_mode || 'passive';
+    const isPassive = dkMode === 'passive';
+    const passiveNote = $('#daikinOverridePassiveNote');
+    const daikinBlock = $('#daikinOverrideActive');
+    const modeText = $('[data-daikin-mode-text]');
+    if (modeText) modeText.textContent = dkMode;
+    if (passiveNote) passiveNote.hidden = !isPassive;
+    if (daikinBlock) {
+      daikinBlock.classList.toggle('is-disabled', isPassive);
+      daikinBlock.querySelectorAll('input, button').forEach(el => { el.disabled = isPassive; });
+    }
+
+    // Next transition — countdown + label.
+    const countdown = $('#heroNextCountdown');
+    const nextLabel = $('#heroNextLabel');
+    if (next.t_utc) {
+      const until = Math.max(0, Math.floor((new Date(next.t_utc).getTime() - Date.now()) / 1000));
+      const m = Math.floor(until / 60);
+      const h = Math.floor(m / 60);
+      countdown.textContent = h > 0 ? `in ${h}h ${m % 60}m` : `in ${m}m`;
+      const t = (window.HEM && window.HEM.fmtSlotTime) ? window.HEM.fmtSlotTime(next.t_utc) : '';
+      nextLabel.textContent = `${t} → ${next.new_fox_mode || '—'}`;
+    } else {
+      countdown.textContent = '—';
+      nextLabel.textContent = '—';
+    }
+
+    // Freshness ribbon — one chip per source.
+    ['agile', 'fox', 'daikin', 'plan'].forEach(k => {
+      const chip = $(`.fresh-chip[data-source="${k}"]`);
+      if (!chip) return;
+      const f = fresh[k] || {};
+      const a = fmtAge(f.fetched_at_utc);
+      const ageEl = chip.querySelector('[data-age]');
+      if (ageEl) ageEl.textContent = a.text;
+      chip.classList.remove('is-stale', 'is-very-stale');
+      if (a.class) chip.classList.add(a.class);
+    });
+  }
+
+  // --- Tariff + Plan strips (reused; overlay now-cursor + thresholds) -----
+
+  function priceColor(p) {
+    if (p == null) return 'var(--bg-card-2)';
+    const kind = slotKindForPrice(p, _thresholds);
+    if (kind === 'negative') return 'var(--neg-price)';
+    if (kind === 'cheap') return 'var(--cheap)';
+    if (kind === 'peak') return 'var(--peak)';
+    return 'var(--standard)';
+  }
+
+  // ---------------------------------------------------------------------
+  // Merged 24-hour timeline (replaces the previous 3 separate strips).
+  // One row of 48 cells: background = price kind, bottom accent bar =
+  // Fox mode; vertical cursor overlays "now"; export shown as a thin
+  // secondary row below for reference. Click any cell for details.
+  // ---------------------------------------------------------------------
+
+  let _lastAgile = null;
+  let _lastGroups = [];
+
+  async function loadTariff() {
+    _lastAgile = await jsonFetch('/api/v1/agile/today').catch(() => null);
+    renderMergedTimeline();
+  }
+
+  async function loadPlan() {
+    const p = await jsonFetch('/api/v1/optimization/plan').catch(() => null);
+    if (p) {
+      const fox = p.fox || {};
+      try { _lastGroups = JSON.parse(fox.groups_json || '[]'); } catch (_e) { _lastGroups = []; }
+    }
+    renderMergedTimeline();
+  }
+
+  function pad2(n) { return String(n).padStart(2, '0'); }
+
+  function priceKind(p) {
+    if (p == null) return 'standard';
+    if (p < 0) return 'negative';
+    if (_thresholds.cheap_p != null && p < _thresholds.cheap_p) return 'cheap';
+    if (_thresholds.peak_p != null && p > _thresholds.peak_p) return 'peak';
+    return 'standard';
+  }
+
+  function foxModeClass(workMode) {
+    if (!workMode) return 'mode-none';
+    const m = workMode.toLowerCase();
+    if (m.includes('forcecharge')) return 'mode-force-charge';
+    if (m.includes('forcedischarge')) return 'mode-force-discharge';
+    if (m.includes('feed-in') || m.includes('feedin')) return 'mode-feed-in';
+    if (m.includes('backup')) return 'mode-backup';
+    return 'mode-self-use';
+  }
+
+  function findGroupForSlot(groups, slotStart) {
+    // Fox groups are UTC-clock HH:MM windows. Anchor comparison on
+    // slotStart's UTC day so midnight-crossing windows still match.
+    const dayStart = new Date(slotStart);
+    dayStart.setUTCHours(0, 0, 0, 0);
+    return groups.find(g => {
+      const gs = new Date(dayStart); gs.setUTCHours(g.startHour, g.startMinute || 0, 0, 0);
+      let ge = new Date(dayStart); ge.setUTCHours(g.endHour, g.endMinute || 0, 0, 0);
+      // Handle end=00:00 which Fox treats as end of day.
+      if (ge <= gs) ge = new Date(ge.getTime() + 24 * 3600 * 1000);
+      return slotStart >= gs && slotStart < ge;
+    }) || null;
+  }
+
+  function renderMergedTimeline() {
+    const strip = $('#timelineStrip');
+    const exportStrip = $('#timelineExport');
+    if (!strip) return;
+    strip.innerHTML = '';
+    if (exportStrip) exportStrip.innerHTML = '';
+
+    const now = new Date();
+    const dayStart = new Date(now); dayStart.setUTCHours(0, 0, 0, 0);
+    const importSlots = _lastAgile?.import_slots || [];
+    const exportSlots = _lastAgile?.export_slots || [];
+    const importByIso = Object.fromEntries(importSlots.map(s => [s.valid_from, s]));
+    const exportByIso = Object.fromEntries(exportSlots.map(s => [s.valid_from, s]));
+
+    let nowIndex = -1;
+    for (let i = 0; i < 48; i++) {
+      const hour = Math.floor(i / 2);
+      const min = (i % 2) * 30;
+      const slotStart = new Date(dayStart); slotStart.setUTCHours(hour, min, 0, 0);
+      const slotEnd = new Date(slotStart.getTime() + 30 * 60 * 1000);
+      const iso = slotStart.toISOString().replace('.000Z', 'Z');
+      const importP = importByIso[iso]?.p ?? null;
+      const exportP = exportByIso[iso]?.p ?? null;
+      const group = findGroupForSlot(_lastGroups, slotStart);
+      const kind = priceKind(importP);
+      const modeCls = foxModeClass(group?.workMode);
+
+      const cell = document.createElement('button');
+      cell.className = `tl-cell kind-${kind}`;
+      cell.dataset.i = String(i);
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(iso)
+        : `${pad2(hour)}:${pad2(min)}`;
+      cell.title = `${lbl} · ${kind}` + (importP != null ? ` · ${importP.toFixed(1)}p` : '')
+                 + (group ? ` · ${group.workMode}` : '');
+      // Accent bar at the bottom of the cell = Fox mode.
+      cell.innerHTML = `<span class="tl-mode ${modeCls}"></span>`;
+      if (now >= slotStart && now < slotEnd) {
+        cell.classList.add('is-now');
+        nowIndex = i;
+      }
+      cell.addEventListener('click', () => {
+        openSlotDetail({
+          label: lbl,
+          isoStart: iso,
+          isoEnd: slotEnd.toISOString(),
+          kind, importP, exportP,
+          workMode: group?.workMode || null,
+          fdSoc: group?.extraParam?.fdSoc,
+          fdPwr: group?.extraParam?.fdPwr,
+          minSocOnGrid: group?.extraParam?.minSocOnGrid,
+        });
+      });
+      strip.appendChild(cell);
+
+      if (exportStrip) {
+        const xc = document.createElement('div');
+        xc.className = `tl-export-cell kind-${priceKind(exportP)}`;
+        xc.title = `${lbl} export: ${exportP != null ? exportP.toFixed(1) + 'p' : '—'}`;
+        exportStrip.appendChild(xc);
+      }
+    }
+
+    // Position the vertical "now" cursor at the correct slot.
+    const cursor = $('#timelineCursor');
+    if (cursor && nowIndex >= 0) {
+      cursor.style.display = 'block';
+      cursor.style.left = `calc(${(nowIndex + 0.5) / 48 * 100}% - 1px)`;
+    } else if (cursor) {
+      cursor.style.display = 'none';
+    }
+
+    // Threshold markers — shown inline above the strip so the user reads
+    // "this band is cheap because the threshold is here".
+    const thrPeak = $('#thrPeak');
+    const thrCheap = $('#thrCheap');
+    if (thrPeak) thrPeak.textContent = _thresholds.peak_p != null ? `peak > ${_thresholds.peak_p.toFixed(1)}p` : 'peak —';
+    if (thrCheap) thrCheap.textContent = _thresholds.cheap_p != null ? `cheap < ${_thresholds.cheap_p.toFixed(1)}p` : 'cheap —';
+
+    // Summary line replaces the old "Current — / —" label.
+    const summary = $('#timelineSummary');
+    if (summary) {
+      const curSlot = nowIndex >= 0 ? strip.children[nowIndex] : null;
+      const curKind = curSlot ? curSlot.className.match(/kind-(\S+)/)?.[1] || '—' : '—';
+      const curImport = _lastAgile?.current_import_p;
+      const curExport = _lastAgile?.current_export_p;
+      const curGroup = nowIndex >= 0 ? findGroupForSlot(_lastGroups,
+        new Date(new Date(dayStart).setUTCHours(Math.floor(nowIndex / 2), (nowIndex % 2) * 30, 0, 0))) : null;
+      summary.innerHTML = `Now: <strong>${curKind}</strong> · import ${fmtP(curImport)} · export ${fmtP(curExport)}` +
+                        (curGroup ? ` · Fox <strong>${curGroup.workMode}</strong>` : '');
+    }
+  }
+
+  function openSlotDetail(s) {
+    const backdrop = $('#slotDetailBackdrop');
+    const body = $('#slotDetailBody');
+    const title = $('#slotDetailTitle');
+    if (!backdrop || !body || !title) return;
+    title.textContent = `${s.label} · ${s.kind}`;
+    body.innerHTML = `
+      <table class="slot-detail-table">
+        <tr><th>Time (local)</th><td>${s.label} — ${(window.HEM && window.HEM.fmtSlotTime) ? window.HEM.fmtSlotTime(s.isoEnd) : s.isoEnd.slice(11, 16)}</td></tr>
+        <tr><th>Kind</th><td class="kind-${s.kind}"><span class="legend-swatch" style="vertical-align:middle;margin-right:0.35rem;"></span>${s.kind}</td></tr>
+        <tr><th>Import price</th><td>${s.importP != null ? s.importP.toFixed(2) + ' p/kWh' : '—'}</td></tr>
+        <tr><th>Export price</th><td>${s.exportP != null ? s.exportP.toFixed(2) + ' p/kWh' : '—'}</td></tr>
+        <tr><th>Fox mode</th><td>${s.workMode || '—'}</td></tr>
+        <tr><th>fdSoc (target %)</th><td>${s.fdSoc != null ? s.fdSoc : '—'}</td></tr>
+        <tr><th>fdPwr (W)</th><td>${s.fdPwr != null ? s.fdPwr : '—'}</td></tr>
+        <tr><th>minSocOnGrid</th><td>${s.minSocOnGrid != null ? s.minSocOnGrid + '%' : '—'}</td></tr>
+      </table>
+    `;
+    backdrop.hidden = false;
+    document.body.classList.add('drawer-open');
+  }
+
+  function bindSlotDetail() {
+    const backdrop = $('#slotDetailBackdrop');
+    const closeBtn = $('#btnSlotDetailClose');
+    if (!backdrop) return;
+    const hide = () => { backdrop.hidden = true; document.body.classList.remove('drawer-open'); };
+    closeBtn?.addEventListener('click', hide);
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) hide(); });
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape' && !backdrop.hidden) hide();
+    });
+  }
+
+  async function loadBreakdown() {
+    try {
+      const b = await jsonFetch('/api/v1/load/breakdown');
+      $('[data-load-total]').textContent = fmtKwh(b.house_total_kw);
+      $('[data-load-daikin]').textContent = fmtKwh(b.daikin_estimate_kw);
+      $('[data-load-residual]').textContent = fmtKwh(b.residual_kw);
+      $('[data-load-source]').textContent = b.daikin_source === 'physics_instantaneous'
+        ? 'Daikin estimate from cached outdoor temp + climate curve. Daily-anchor calibration arrives with backfill.'
+        : `Daikin source: ${b.daikin_source}`;
+    } catch (e) {
+      toast(`Breakdown: ${e.message}`, 'bad');
+    }
+  }
+
+  // --- Freshness chip handlers -------------------------------------------
+
+  function bindFreshnessChips() {
+    $$('.fresh-chip').forEach(chip => chip.addEventListener('click', async () => {
+      const source = chip.dataset.source;
+      chip.disabled = true;
+      try {
+        if (source === 'agile') {
+          await jsonFetch('/api/v1/optimization/refresh', { method: 'POST' });
+        } else if (source === 'fox') {
+          await jsonFetch('/api/v1/foxess/status?refresh=true');
+        } else if (source === 'daikin') {
+          await jsonFetch('/api/v1/daikin/status?refresh=true');
+        } else if (source === 'plan') {
+          // No side-effect endpoint — just a reload of the current plan view.
+        }
+        await loadNow();
+        if (source === 'agile') await loadTariff();
+        if (source === 'plan') await loadPlan();
+        if (refreshQuota) refreshQuota();
+      } catch (e) {
+        toast(`${source} refresh failed: ${e.message}`, 'bad');
+      } finally {
+        chip.disabled = false;
+      }
+    }));
+  }
+
+  // --- Manual override panel (unchanged from v10.1) -----------------------
+
+  function bindOverride() {
+    const toggle = $('#overrideToggle');
+    const body = $('#overrideBody');
+    if (toggle) toggle.addEventListener('click', () => {
+      const open = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', String(!open));
+      body.hidden = open;
+    });
+    $$('.override-tab').forEach(t => t.addEventListener('click', () => {
+      $$('.override-tab').forEach(x => x.classList.remove('is-active'));
+      t.classList.add('is-active');
+      const id = t.dataset.tabTarget;
+      $$('.override-tab-panel').forEach(p => p.hidden = (p.id !== id));
+    }));
+
+    $$('[data-fox-mode]').forEach(b => b.addEventListener('click', async () => {
+      const mode = b.dataset.foxMode;
+      await wrapAction({
+        simulateUrl: '/api/v1/foxess/mode/simulate',
+        applyUrl: '/api/v1/foxess/mode',
+        body: { mode },
+      });
+      loadNow();
+      loadPlan();
+    }));
+
+    $('#btnProposeNow')?.addEventListener('click', async () => {
+      await wrapAction({
+        simulateUrl: '/api/v1/optimization/propose/simulate',
+        applyUrl: '/api/v1/optimization/propose',
+      });
+      loadPlan();
+      loadNow();
+    });
+
+    $('#btnSimulateRePlanCockpit')?.addEventListener('click', async () => {
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/optimization/propose/simulate',
+        applyUrl: '/api/v1/optimization/propose',
+      });
+      if (result.applied) setTimeout(() => { loadPlan(); loadNow(); }, 4000);
+    });
+
+    $('#btnDaikinTank')?.addEventListener('click', async () => {
+      const t = parseFloat($('#daikinTankInput').value);
+      if (isNaN(t)) { toast('Enter a temperature', 'warn'); return; }
+      await wrapAction({
+        simulateUrl: '/api/v1/daikin/tank-temperature/simulate',
+        applyUrl: '/api/v1/daikin/tank-temperature',
+        body: { temperature: t },
+      });
+      loadNow();
+    });
+
+    $('#btnDaikinLwt')?.addEventListener('click', async () => {
+      const off = parseFloat($('#daikinLwtInput').value);
+      if (isNaN(off)) { toast('Enter an offset', 'warn'); return; }
+      await wrapAction({
+        simulateUrl: '/api/v1/daikin/lwt-offset/simulate',
+        applyUrl: '/api/v1/daikin/lwt-offset',
+        body: { offset: off },
+      });
+      loadNow();
+    });
+  }
+
+  // --- Boot ---------------------------------------------------------------
+
+  // --- Recent triggers strip ---------------------------------------------
+  // Populated by /api/v1/recent-triggers on page load + after any write
+  // (the latter happens via the MutationObserver on body.is-busy — when
+  // wrapAction removes the busy class, a fresh trigger has just fired).
+  function fmtDurationMs(ms) {
+    if (ms == null) return '';
+    if (ms < 1000) return `${ms}ms`;
+    const s = ms / 1000;
+    if (s < 10) return `${s.toFixed(1)}s`;
+    if (s < 60) return `${Math.round(s)}s`;
+    return `${Math.floor(s / 60)}m${Math.round(s % 60)}s`;
+  }
+
+  function fmtSinceShort(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (isNaN(d)) return '—';
+    const sec = Math.floor((Date.now() - d.getTime()) / 1000);
+    if (sec < 60) return `${sec}s`;
+    if (sec < 3600) return `${Math.floor(sec / 60)}m`;
+    if (sec < 86400) return `${Math.floor(sec / 3600)}h`;
+    return `${Math.floor(sec / 86400)}d`;
+  }
+
+  async function loadRecentTriggers() {
+    const mount = $('#recentTriggersList');
+    if (!mount) return;
+    let data;
+    try {
+      data = await jsonFetch('/api/v1/recent-triggers?limit=6');
+    } catch (_e) {
+      mount.textContent = '—';
+      return;
+    }
+    const rows = (data && data.rows) || [];
+    if (!rows.length) { mount.textContent = 'no recent activity'; return; }
+    mount.innerHTML = '';
+    rows.forEach(r => {
+      const chip = document.createElement('span');
+      chip.className = 'trigger-chip' + (r.result === 'failure' ? ' is-failure' : '');
+      const when = r.started_at || r.timestamp;
+      const dur = fmtDurationMs(r.duration_ms);
+      const actorChip = r.actor ? ` · ${r.actor}` : '';
+      chip.innerHTML = `
+        <span class="trigger-action">${r.action}</span>
+        <span class="trigger-meta">${fmtSinceShort(when)} ago${dur ? ` · ${dur}` : ''}${actorChip}</span>
+      `;
+      if (r.error_msg) chip.title = `FAILED: ${r.error_msg}`;
+      else if (r.params) chip.title = `${r.action} · ${r.params}`;
+      mount.appendChild(chip);
+    });
+  }
+
+  // --- Settings drawer ---------------------------------------------------
+  // The drawer reuses settings.js — the container IDs on the cockpit page
+  // (#settingsComfort / #settingsStrategy / #settingsSchedule) match the
+  // full /settings page, so settings.js's own load() populates both.
+  function bindSettingsDrawer() {
+    const open = $('#btnSettingsDrawer');
+    const backdrop = $('#settingsDrawerBackdrop');
+    const closeBtn = $('#btnSettingsDrawerClose');
+    if (!backdrop) return;
+    const show = () => { backdrop.hidden = false; document.body.classList.add('drawer-open'); };
+    const hide = () => { backdrop.hidden = true; document.body.classList.remove('drawer-open'); };
+    open?.addEventListener('click', show);
+    closeBtn?.addEventListener('click', hide);
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) hide(); });
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape' && !backdrop.hidden) hide();
+    });
+  }
+
+  // Hook the generic wrapAction busy-state: when body.is-busy flips off we
+  // know a user-fired write just finished, so pull the recent-triggers
+  // strip to show it landed. MutationObserver keeps the wiring loose — no
+  // coupling to individual button handlers.
+  function bindRecentTriggersAutoRefresh() {
+    const body = document.body;
+    let wasBusy = body.classList.contains('is-busy');
+    const obs = new MutationObserver(() => {
+      const busy = body.classList.contains('is-busy');
+      if (wasBusy && !busy) {
+        // Small delay so the INSERT has been committed before we re-fetch.
+        setTimeout(loadRecentTriggers, 400);
+      }
+      wasBusy = busy;
+    });
+    obs.observe(body, { attributes: true, attributeFilter: ['class'] });
+  }
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    bindOverride();
+    bindFreshnessChips();
+    bindSettingsDrawer();
+    bindSlotDetail();
+    bindRecentTriggersAutoRefresh();
+    // Load the hero first so thresholds are available when strips render.
+    await loadNow();
+    loadTariff();
+    loadPlan();
+    loadBreakdown();
+    loadRecentTriggers();
+  });
+})();

--- a/ui/src/js/forecast.js
+++ b/ui/src/js/forecast.js
@@ -1,0 +1,146 @@
+/* Forecast page — renders /api/v1/optimization/inputs. Phase 3.
+ *
+ * Answers: "what will the LP see on its next run?". Pure read — opening
+ * the page never triggers a cloud fetch.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
+  const { jsonFetch, wrapAction, toast } = window.HEM || {};
+
+  function fmtP(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(1)}p`;
+  }
+  function fmtC(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(1)}°C`;
+  }
+  function fmtKwh(v) {
+    if (v == null || isNaN(v)) return '—';
+    return `${Number(v).toFixed(3)} kWh`;
+  }
+
+  /**
+   * Render a compact CSS-only sparkline: one vertical bar per slot, height
+   * scaled within [0, max]. Keeps the tab render fast without pulling a
+   * charting library.
+   */
+  function renderSpark(mount, values) {
+    if (!mount) return;
+    mount.innerHTML = '';
+    const cleaned = values.map(v => (v == null || isNaN(v) ? null : Number(v)));
+    const present = cleaned.filter(v => v != null);
+    if (!present.length) {
+      mount.textContent = '—';
+      return;
+    }
+    const min = Math.min(0, ...present);
+    const max = Math.max(...present);
+    const span = max - min || 1;
+    cleaned.forEach((v, i) => {
+      const bar = document.createElement('span');
+      bar.className = 'fc-bar' + (v == null ? ' is-missing' : '');
+      if (v != null) {
+        const h = Math.max(2, ((v - min) / span) * 100);
+        bar.style.height = `${h}%`;
+      }
+      mount.appendChild(bar);
+    });
+  }
+
+  function renderChips(mount, snapshot) {
+    if (!mount) return;
+    const entries = Object.entries(snapshot || {});
+    if (!entries.length) { mount.textContent = '—'; return; }
+    mount.innerHTML = '';
+    entries.forEach(([k, v]) => {
+      const chip = document.createElement('span');
+      chip.className = 'fc-chip';
+      const val = typeof v === 'number' ? (Number.isInteger(v) ? v : Number(v).toFixed(3)) : v;
+      chip.innerHTML = `<strong>${k}</strong> <span>${val}</span>`;
+      mount.appendChild(chip);
+    });
+  }
+
+  function renderSlotTable(rows) {
+    const tbody = $('#fcSlotTable tbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    if (!rows.length) {
+      tbody.innerHTML = '<tr><td colspan="6" class="text-mute">No slot data. Run the optimizer once to populate inputs.</td></tr>';
+      return;
+    }
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      const t = (window.HEM && window.HEM.fmtSlotTime) ? window.HEM.fmtSlotTime(r.t_utc) : r.t_utc.slice(11, 16);
+      tr.innerHTML = `
+        <td>${t}</td>
+        <td class="num">${fmtP(r.price_import_p)}</td>
+        <td class="num">${fmtP(r.price_export_p)}</td>
+        <td class="num">${fmtC(r.temp_c)}</td>
+        <td class="num">${r.solar_w_m2 == null ? '—' : Number(r.solar_w_m2).toFixed(0)}</td>
+        <td class="num">${fmtKwh(r.base_load_kwh)}</td>`;
+      tbody.appendChild(tr);
+    });
+  }
+
+  async function load() {
+    let d;
+    try {
+      d = await jsonFetch('/api/v1/optimization/inputs');
+    } catch (e) {
+      toast(`Forecast: ${e.message}`, 'bad');
+      return;
+    }
+
+    $('#fcHorizon').textContent = `${d.horizon_hours} h`;
+    $('#fcTz').textContent = d.planner_tz || '—';
+    // Octopus publishes next-day rates around 16:00 UTC. Until then, horizon
+    // slots landing in "tomorrow" will have null import/export prices — the
+    // LP solves a shorter effective window, which is expected, not broken.
+    $('#fcTomorrow').textContent = d.tomorrow_rates_available
+      ? 'published'
+      : 'not yet (Octopus publishes around 16:00 UTC)';
+    $('#fcCheap').textContent = d.thresholds?.cheap_p != null ? fmtP(d.thresholds.cheap_p) : '—';
+    $('#fcPeak').textContent = d.thresholds?.peak_p != null ? fmtP(d.thresholds.peak_p) : '—';
+    $('#fcMicro').textContent = d.micro_climate_offset_c != null ? `${Number(d.micro_climate_offset_c).toFixed(2)} °C` : '—';
+
+    const init = d.initial || {};
+    $('#fcInitSoc').textContent = init.soc_kwh != null
+      ? `${Number(init.soc_kwh).toFixed(2)} kWh (${init.soc_pct != null ? init.soc_pct.toFixed(0) + '%' : '—'})`
+      : '—';
+    $('#fcInitSocSrc').textContent = init.soc_source || '—';
+    $('#fcInitTank').textContent = fmtC(init.tank_c);
+    $('#fcInitTankSrc').textContent = init.tank_source || '—';
+    $('#fcInitIndoor').textContent = fmtC(init.indoor_c);
+    $('#fcInitIndoorSrc').textContent = init.indoor_source || '—';
+
+    renderChips($('#fcConfigChips'), d.config_snapshot);
+
+    const rows = d.slots || [];
+    renderSpark($('#fcSparkPrice'), rows.map(r => r.price_import_p));
+    renderSpark($('#fcSparkTemp'), rows.map(r => r.temp_c));
+    renderSpark($('#fcSparkSolar'), rows.map(r => r.solar_w_m2));
+    renderSpark($('#fcSparkLoad'), rows.map(r => r.base_load_kwh));
+    renderSlotTable(rows);
+  }
+
+  function bind() {
+    $('#btnForecastReload')?.addEventListener('click', load);
+    $('#btnForecastReplan')?.addEventListener('click', async () => {
+      // Use the existing simulate→confirm flow via wrapAction, then reload.
+      const r = await wrapAction({
+        simulateUrl: '/api/v1/optimization/propose/simulate',
+        applyUrl: '/api/v1/optimization/propose',
+      });
+      if (r.applied) setTimeout(load, 4000);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    bind();
+    load();
+  });
+})();

--- a/ui/src/js/history.js
+++ b/ui/src/js/history.js
@@ -1,0 +1,204 @@
+/* History page — Phase 4.
+ *
+ * Drives the date-time picker, calls /api/v1/cockpit/at?when=..., and
+ * renders the same-shape hero + plan-vs-actual table from the LP snapshot
+ * tables. Zero cloud calls.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const { jsonFetch, toast } = window.HEM || {};
+
+  function fmtC(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(1)}°C`; }
+  function fmtP(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(1)}p`; }
+  function fmtKwh(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(3)} kWh`; }
+  function fmtPct(v) { return (v == null || isNaN(v)) ? '—' : `${Number(v).toFixed(0)}%`; }
+  function sumList(v) {
+    if (!Array.isArray(v)) return null;
+    const nums = v.map(Number).filter(n => !Number.isNaN(n));
+    return nums.length ? nums.reduce((a, b) => a + b, 0) : null;
+  }
+
+  function inputToIso(val) {
+    // datetime-local gives "2026-04-24T10:00"; treat as UTC — the picker
+    // displays the wall-clock moment the user typed, interpreted as UTC.
+    if (!val) return null;
+    return val.length <= 16 ? val + ':00Z' : val + 'Z';
+  }
+
+  async function replay(whenIso) {
+    let data;
+    try {
+      data = await jsonFetch(`/api/v1/cockpit/at?when=${encodeURIComponent(whenIso)}`);
+    } catch (e) {
+      toast(`History: ${e.message}`, 'bad');
+      return;
+    }
+
+    const cur = data.current_slot || {};
+    const state = data.state || {};
+    const plan = data.planned_slot || {};
+    const li = data.lp_inputs || {};
+    const lx = data.lp_exogenous || {};
+    const why = Array.isArray(data.lp_why) ? data.lp_why : [];
+    const src = data.source || {};
+
+    // Source readout: which run + which log row fed this payload.
+    const srcEl = $('#historySource');
+    if (srcEl) {
+      const parts = [];
+      if (src.lp_run_at_utc) parts.push(`LP run ${src.lp_run_at_utc}`);
+      if (src.run_id != null) parts.push(`run_id=${src.run_id}`);
+      if (src.execution_log_timestamp) parts.push(`execution_log @ ${src.execution_log_timestamp}`);
+      srcEl.textContent = parts.length ? `Source: ${parts.join(' · ')}` : 'No snapshots available for that moment.';
+    }
+
+    // State row.
+    $('#hSoc').textContent = state.soc_pct != null ? `${fmtPct(state.soc_pct)} · ${fmtKwh(state.soc_kwh)}` : '—';
+    $('#hLoad').textContent = state.load_kw != null ? `${Number(state.load_kw).toFixed(2)} kW` : '—';
+    $('#hFoxMode').textContent = state.fox_mode || '—';
+    $('#hTank').textContent = fmtC(state.tank_c);
+    $('#hIndoor').textContent = fmtC(state.indoor_c);
+    $('#hOutdoor').textContent = fmtC(state.outdoor_c);
+    $('#hLwt').textContent = fmtC(state.lwt_c);
+    $('#hKind').textContent = data.slot_kind || '—';
+    $('#hPriceImp').textContent = fmtP(cur.price_import_p);
+    $('#hPriceExp').textContent = fmtP(cur.price_export_p);
+
+    // Plan vs actual (actuals come from state where telemetry exists).
+    $('#paPlanImport').textContent = fmtKwh(plan.import_kwh);
+    $('#paActImport').textContent = state.load_kw != null ? `~${Number(state.load_kw * 0.5).toFixed(3)} kWh` : '—';
+    $('#paPlanChg').textContent = fmtKwh(plan.charge_kwh);
+    $('#paPlanDis').textContent = fmtKwh(plan.discharge_kwh);
+    $('#paPlanDhw').textContent = fmtKwh(plan.dhw_kwh);
+    $('#paPlanSpace').textContent = fmtKwh(plan.space_kwh);
+    $('#paPlanTank').textContent = fmtC(plan.tank_temp_c);
+    $('#paActTank').textContent = fmtC(state.tank_c);
+    $('#paPlanIndoor').textContent = fmtC(plan.indoor_temp_c);
+    $('#paActIndoor').textContent = fmtC(state.indoor_c);
+    $('#paPlanSoc').textContent = plan.soc_kwh != null ? `${Number(plan.soc_kwh).toFixed(2)} kWh` : '—';
+    $('#paActSoc').textContent = state.soc_kwh != null ? `${Number(state.soc_kwh).toFixed(2)} kWh` : '—';
+
+    // Attribution donut — fetched separately for the date of replay.
+    try {
+      const whenDate = whenIso.slice(0, 10);  // "2026-04-24"
+      const a = await jsonFetch(`/api/v1/attribution/day?date=${whenDate}`);
+      renderAttribution(a);
+    } catch (_e) {
+      renderAttribution(null);
+    }
+
+    // LP inputs at solve time.
+    $('#liRunAt').textContent = li.run_at_utc || '—';
+    $('#liPlanDate').textContent = li.plan_date || '—';
+    $('#liHorizon').textContent = li.horizon_hours != null ? `${li.horizon_hours} h` : '—';
+    $('#liSoc').textContent = li.soc_initial_kwh != null
+      ? `${Number(li.soc_initial_kwh).toFixed(2)} kWh (source: ${li.soc_source || '?'})`
+      : '—';
+    $('#liTank').textContent = li.tank_initial_c != null
+      ? `${fmtC(li.tank_initial_c)} (source: ${li.tank_source || '?'})`
+      : '—';
+    $('#liIndoor').textContent = li.indoor_initial_c != null
+      ? `${fmtC(li.indoor_initial_c)} (source: ${li.indoor_source || '?'})`
+      : '—';
+    $('#liMicro').textContent = li.micro_climate_offset_c != null
+      ? `${Number(li.micro_climate_offset_c).toFixed(2)} °C`
+      : '—';
+    $('#liCheap').textContent = fmtP(li.cheap_threshold_p);
+    $('#liPeak').textContent = fmtP(li.peak_threshold_p);
+    $('#liDkMode').textContent = li.daikin_control_mode || '—';
+    $('#liPreset').textContent = li.optimization_preset || '—';
+
+    const loadBits = lx.base_load_components || {};
+    const weatherBits = lx.weather_adjustment || {};
+    const tariffBits = lx.tariffs || {};
+    const residualTotal = sumList(loadBits.residual_profile_kwh);
+    const applianceTotal = sumList(loadBits.appliance_profile_kwh);
+    $('#lxResidual').textContent = fmtKwh(residualTotal);
+    $('#lxAppliance').textContent = fmtKwh(applianceTotal);
+    $('#lxFlat').textContent = fmtKwh(loadBits.flat_fallback_kwh);
+    $('#lxFoxMean').textContent = fmtKwh(loadBits.fox_mean_kwh_per_slot);
+    $('#lxBuckets').textContent = loadBits.profile_bucket_count != null
+      ? `${loadBits.profile_bucket_count} buckets`
+      : '—';
+    $('#lxFetch').textContent = weatherBits.forecast_fetch_at_utc || '—';
+    $('#lxPvAdjust').textContent = weatherBits.today_factor != null
+      ? `today=${Number(weatherBits.today_factor).toFixed(3)} flat=${Number(weatherBits.flat_scale ?? 1).toFixed(3)} cloud=${weatherBits.cloud_table_cells ?? 0} hourly=${weatherBits.hourly_table_cells ?? 0}`
+      : '—';
+    if (Array.isArray(tariffBits.export_price_pence) && tariffBits.export_price_pence.length) {
+      const xs = tariffBits.export_price_pence.map(Number).filter(n => !Number.isNaN(n));
+      const min = Math.min(...xs);
+      const max = Math.max(...xs);
+      $('#lxExport').textContent = `${xs.length} slots · ${fmtP(min)} to ${fmtP(max)}`;
+    } else {
+      $('#lxExport').textContent = tariffBits.uses_flat_export_rate ? 'flat export rate' : '—';
+    }
+
+    const whyEl = $('#historyWhy');
+    if (whyEl) {
+      if (!why.length) {
+        whyEl.textContent = 'No slot-specific explanation available for that moment.';
+      } else {
+        whyEl.innerHTML = `<ul>${why.map(line => `<li>${line}</li>`).join('')}</ul>`;
+      }
+    }
+  }
+
+  /**
+   * Render a CSS conic-gradient donut showing how solar was split across
+   * self-use / battery / export for the replay date.
+   */
+  function renderAttribution(a) {
+    const donut = $('#attributionDonut');
+    const legend = $('#attributionLegend');
+    if (!donut || !legend) return;
+    if (!a || !a.available || !a.shares) {
+      donut.style.background = 'var(--bg-card-2)';
+      legend.textContent = a && !a.available
+        ? `No rollup yet for ${a.date} (Fox rollup runs overnight).`
+        : '—';
+      return;
+    }
+    const s = a.shares;
+    // conic-gradient sweep: self-use → battery → export.
+    const sCol = '#4caf50', bCol = '#2196f3', eCol = '#ff9800';
+    const end1 = s.self_use_pct;
+    const end2 = end1 + s.battery_pct;
+    donut.style.background =
+      `conic-gradient(${sCol} 0 ${end1}%, ${bCol} ${end1}% ${end2}%, ${eCol} ${end2}% 100%)`;
+    legend.innerHTML = `
+      <div class="attr-item"><span class="attr-swatch" style="background:${sCol}"></span> Self-use ${s.self_use_pct}%</div>
+      <div class="attr-item"><span class="attr-swatch" style="background:${bCol}"></span> Battery ${s.battery_pct}%</div>
+      <div class="attr-item"><span class="attr-swatch" style="background:${eCol}"></span> Export ${s.export_pct}%</div>
+      <div class="attr-totals">${Number(a.solar_kwh).toFixed(1)} kWh solar · ${Number(a.load_kwh).toFixed(1)} kWh load · ${Number(a.export_kwh).toFixed(1)} kWh export</div>
+    `;
+  }
+
+  function bind() {
+    const picker = $('#historyWhen');
+    // Default to 1 hour ago, formatted for datetime-local input (no TZ).
+    const d = new Date(Date.now() - 60 * 60 * 1000);
+    const pad = n => String(n).padStart(2, '0');
+    if (picker) {
+      picker.value = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+    }
+    $('#btnHistoryJump')?.addEventListener('click', () => {
+      const iso = inputToIso(picker?.value);
+      if (iso) replay(iso);
+    });
+    $('#btnHistoryNow')?.addEventListener('click', async () => {
+      const now = new Date();
+      if (picker) {
+        picker.value = `${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}T${pad(now.getUTCHours())}:${pad(now.getUTCMinutes())}`;
+      }
+      replay(now.toISOString());
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    bind();
+    const picker = $('#historyWhen');
+    const iso = inputToIso(picker?.value);
+    if (iso) replay(iso);
+  });
+})();

--- a/ui/src/js/insights.js
+++ b/ui/src/js/insights.js
@@ -1,0 +1,369 @@
+/* v10.2 insights — Fox-ESS-style period browser.
+ *
+ * URL state: ?period=day|week|month|year&date=YYYY-MM-DD (or month=YYYY-MM /
+ * year=YYYY). Keyboard shortcuts: ← → for prev/next, 1/7/30/Y to switch
+ * granularity, T jumps to today.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
+  const { jsonFetch, toast, PlanRender } = window.HEM || {};
+
+  function fmtP(v) { return v == null ? '—' : `${Number(v).toFixed(1)}p`; }
+  function fmtGBP(v) { return v == null ? '—' : `£${(Number(v) / 100).toFixed(2)}`; }
+  function fmtKwh(v) { return v == null ? '—' : `${Number(v).toFixed(1)} kWh`; }
+  function fmtPct(v) { return v == null ? '—' : `${Number(v).toFixed(1)}%`; }
+  function pad(n) { return String(n).padStart(2, '0'); }
+
+  function todayUTCDate() {
+    const n = new Date();
+    return new Date(Date.UTC(n.getUTCFullYear(), n.getUTCMonth(), n.getUTCDate()));
+  }
+
+  const State = {
+    period: 'month',
+    cursor: todayUTCDate(),  // anchor date (for day/week) or 1st-of-month (for month/year)
+
+    fromUrl() {
+      const url = new URL(window.location.href);
+      const p = url.searchParams.get('period');
+      if (p && ['day', 'week', 'month', 'year'].includes(p)) this.period = p;
+      const date = url.searchParams.get('date');
+      const month = url.searchParams.get('month');
+      const year = url.searchParams.get('year');
+      if (date) {
+        const d = new Date(date + 'T00:00:00Z');
+        if (!isNaN(d)) this.cursor = d;
+      } else if (month) {
+        const d = new Date(month + '-01T00:00:00Z');
+        if (!isNaN(d)) this.cursor = d;
+      } else if (year) {
+        const d = new Date(year + '-01-01T00:00:00Z');
+        if (!isNaN(d)) this.cursor = d;
+      }
+    },
+
+    toUrl(replace) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('period', this.period);
+      ['date', 'month', 'year'].forEach(k => url.searchParams.delete(k));
+      if (this.period === 'day' || this.period === 'week') {
+        url.searchParams.set('date', this.dateParam());
+      } else if (this.period === 'month') {
+        url.searchParams.set('month', this.monthParam());
+      } else if (this.period === 'year') {
+        url.searchParams.set('year', String(this.cursor.getUTCFullYear()));
+      }
+      const fn = replace ? 'replaceState' : 'pushState';
+      window.history[fn]({}, '', url);
+    },
+
+    dateParam() {
+      const c = this.cursor;
+      return `${c.getUTCFullYear()}-${pad(c.getUTCMonth() + 1)}-${pad(c.getUTCDate())}`;
+    },
+    monthParam() {
+      const c = this.cursor;
+      return `${c.getUTCFullYear()}-${pad(c.getUTCMonth() + 1)}`;
+    },
+
+    apiParams() {
+      const p = { period: this.period };
+      if (this.period === 'day' || this.period === 'week') p.date = this.dateParam();
+      else if (this.period === 'month') p.month = this.monthParam();
+      else if (this.period === 'year') p.year = String(this.cursor.getUTCFullYear());
+      return p;
+    },
+
+    label() {
+      const c = this.cursor;
+      const opts = { timeZone: 'UTC' };
+      if (this.period === 'day') {
+        return c.toLocaleDateString(undefined, { ...opts, weekday: 'short', day: 'numeric', month: 'long', year: 'numeric' });
+      }
+      if (this.period === 'week') {
+        const end = new Date(c); end.setUTCDate(end.getUTCDate() + 6);
+        return `Week of ${c.toLocaleDateString(undefined, { ...opts, day: 'numeric', month: 'short' })} – ${end.toLocaleDateString(undefined, { ...opts, day: 'numeric', month: 'short', year: 'numeric' })}`;
+      }
+      if (this.period === 'month') return c.toLocaleDateString(undefined, { ...opts, month: 'long', year: 'numeric' });
+      if (this.period === 'year') return String(c.getUTCFullYear());
+      return '—';
+    },
+
+    nav(delta) {
+      const c = new Date(this.cursor);
+      if (this.period === 'day') c.setUTCDate(c.getUTCDate() + delta);
+      else if (this.period === 'week') c.setUTCDate(c.getUTCDate() + 7 * delta);
+      else if (this.period === 'month') c.setUTCMonth(c.getUTCMonth() + delta);
+      else if (this.period === 'year') c.setUTCFullYear(c.getUTCFullYear() + delta);
+      this.cursor = c;
+    },
+
+    setPeriod(p) {
+      this.period = p;
+      // For month/year, snap cursor to 1st-of-period for consistent URLs
+      if (p === 'month') this.cursor = new Date(Date.UTC(this.cursor.getUTCFullYear(), this.cursor.getUTCMonth(), 1));
+      if (p === 'year') this.cursor = new Date(Date.UTC(this.cursor.getUTCFullYear(), 0, 1));
+    },
+  };
+
+  function repaintControls() {
+    $$('.insights-period-btn').forEach(b => {
+      const active = b.dataset.period === State.period;
+      b.classList.toggle('btn-primary', active);
+      b.classList.toggle('btn-secondary', !active);
+    });
+    $('#insightPeriodLabel').textContent = State.label();
+    $('#dayViewSection').hidden = (State.period !== 'day');
+    $('#dailyBreakdownSection').hidden = (State.period === 'day');
+  }
+
+  async function load() {
+    repaintControls();
+    State.toUrl(true);
+
+    let d;
+    try {
+      const params = new URLSearchParams(State.apiParams());
+      d = await jsonFetch(`/api/v1/energy/period?${params}`);
+    } catch (e) {
+      toast(`Insights: ${e.message}`, 'bad');
+      return;
+    }
+    if (!d || d.detail) {
+      toast(`Insights: ${d?.detail || 'no data'}`, 'bad');
+      return;
+    }
+
+    // Economics
+    const c = d.cost || {};
+    $('#ecoNet').textContent = fmtGBP(c.net_cost_pence);
+    $('#ecoImport').textContent = fmtGBP(c.import_cost_pence);
+    $('#ecoExport').textContent = fmtGBP(c.export_earnings_pence);
+    $('#ecoStanding').textContent = fmtGBP(c.standing_charge_pence);
+
+    const en = d.energy || {};
+    $('#ecoImpKwh').textContent = fmtKwh(en.import_kwh);
+    $('#ecoSolarKwh').textContent = fmtKwh(en.solar_kwh);
+    $('#ecoLoadKwh').textContent = fmtKwh(en.load_kwh);
+    $('#ecoExpKwh').textContent = fmtKwh(en.export_kwh);
+
+    // Daikin
+    $('#daikinKwh').textContent = fmtKwh(d.heating_estimate_kwh);
+    $('#daikinCost').textContent = fmtGBP(d.heating_estimate_cost_pence);
+    const ha = d.heating_analytics || {};
+    $('#daikinPctCost').textContent = fmtPct(ha.heating_percent_of_cost);
+    $('#daikinPctKwh').textContent = fmtPct(ha.heating_percent_of_consumption);
+
+    // Gas comparison (if configured)
+    if (d.equivalent_gas_cost_pence != null) {
+      $('#gasCompareCard').hidden = false;
+      $('#gasCost').textContent = fmtGBP(d.equivalent_gas_cost_pence);
+      const adv = d.gas_comparison_ahead_pounds;
+      $('#gasAdvantage').textContent = adv == null ? '—' : `£${Number(adv).toFixed(2)} saved`;
+    } else {
+      $('#gasCompareCard').hidden = true;
+    }
+
+    // Daily breakdown (everything except day view)
+    if (State.period !== 'day') {
+      const tbody = $('#dailyTbody');
+      const days = (d.chart_data || []).filter(r => (r.import_kwh || r.solar_kwh || r.load_kwh));
+      if (!days.length) {
+        tbody.innerHTML = '<tr><td colspan="7" class="text-mute">No daily data for this period.</td></tr>';
+      } else {
+        tbody.innerHTML = days.map(r => `
+            <tr>
+              <td><a href="?period=day&date=${r.date}" data-deeplink="${r.date}">${r.date}</a></td>
+              <td class="num">${(r.import_kwh ?? 0).toFixed(1)}</td>
+              <td class="num">${(r.export_kwh ?? 0).toFixed(1)}</td>
+              <td class="num">${(r.solar_kwh ?? 0).toFixed(1)}</td>
+              <td class="num">${(r.load_kwh ?? 0).toFixed(1)}</td>
+              <td class="num text-dim">${(r.charge_kwh ?? 0).toFixed(1)}</td>
+              <td class="num text-dim">${(r.discharge_kwh ?? 0).toFixed(1)}</td>
+            </tr>`).join('');
+        // Intercept deep-link clicks so we don't full-reload
+        $$('a[data-deeplink]', tbody).forEach(a => a.addEventListener('click', e => {
+          e.preventDefault();
+          State.cursor = new Date(a.dataset.deeplink + 'T00:00:00Z');
+          State.setPeriod('day');
+          load();
+        }));
+      }
+    }
+
+    // Day-view: tariff strip + slot table
+    if (State.period === 'day') {
+      try {
+        const date = State.dateParam();
+        const [tariff, exec, plan] = await Promise.all([
+          jsonFetch(`/api/v1/agile/day?date=${date}`).catch(() => ({ slots: [] })),
+          jsonFetch(`/api/v1/execution/today?date=${date}`).catch(() => ({ slots: [] })),
+          jsonFetch('/api/v1/optimization/plan').catch(() => ({})),
+        ]);
+        PlanRender.renderTariffStrip({ mount: $('#tariffStrip'), tariff });
+        PlanRender.renderSlotTable({
+          table: $('#daySlotTable'),
+          exec, plan,
+          dataQualityNoteEl: $('#dayDataQualityNote'),
+          totalsEl: $('#dayTotals'),
+        });
+      } catch (e) {
+        toast(`Day view: ${e.message}`, 'bad');
+      }
+    }
+
+    // Patterns (independent fetches; failures non-fatal)
+    loadPatterns().catch(() => {});
+
+    // Freshness line (E1.S2 cache metadata when available)
+    const fresh = d.data_freshness;
+    const freshEl = $('#insightFreshnessLine');
+    if (Array.isArray(fresh) && fresh.length) {
+      const oldest = fresh.reduce((a, b) => (b.age_seconds > a.age_seconds ? b : a), fresh[0]);
+      const ageMin = Math.round((oldest.age_seconds || 0) / 60);
+      freshEl.textContent = `Data age: oldest ${ageMin} min ago (${oldest.date}). Use ⟳ on Settings to refresh.`;
+    } else {
+      freshEl.textContent = '';
+    }
+  }
+
+  function patternsRange() {
+    const c = State.cursor;
+    let start, end;
+    if (State.period === 'day') {
+      end = new Date(c);
+      start = new Date(c); start.setUTCDate(start.getUTCDate() - 29);
+    } else if (State.period === 'week') {
+      end = new Date(c); end.setUTCDate(end.getUTCDate() + 6);
+      start = new Date(c);
+    } else if (State.period === 'month') {
+      start = new Date(Date.UTC(c.getUTCFullYear(), c.getUTCMonth(), 1));
+      end = new Date(Date.UTC(c.getUTCFullYear(), c.getUTCMonth() + 1, 0));
+    } else {
+      start = new Date(Date.UTC(c.getUTCFullYear(), 0, 1));
+      end = new Date(Date.UTC(c.getUTCFullYear(), 11, 31));
+    }
+    const fmt = d => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+    return { start: fmt(start), end: fmt(end) };
+  }
+
+  function renderBars(mount, items, { unit = '', max = null } = {}) {
+    if (!mount) return;
+    if (!items.length) {
+      mount.innerHTML = '<p class="text-mute" style="font-size:0.78rem;">No data.</p>';
+      return;
+    }
+    const cap = max ?? Math.max(0.001, ...items.map(i => Number(i.value) || 0));
+    mount.innerHTML = items.map(i => {
+      const pct = Math.min(100, 100 * (Number(i.value) || 0) / cap);
+      return `<div class="pattern-bar-row">
+          <span class="pattern-bar-label">${i.label}</span>
+          <span class="pattern-bar-track"><span class="pattern-bar-fill" style="width:${pct.toFixed(1)}%"></span></span>
+          <span class="pattern-bar-val">${(Number(i.value) || 0).toFixed(2)}${unit}</span>
+      </div>`;
+    }).join('');
+  }
+
+  async function loadPatterns() {
+    const { start, end } = patternsRange();
+    const qs = new URLSearchParams({ start, end });
+    const [hourly, dow, dist, pv] = await Promise.all([
+      jsonFetch(`/api/v1/patterns/hourly?${qs}`).catch(() => null),
+      jsonFetch(`/api/v1/patterns/dow?${qs}`).catch(() => null),
+      jsonFetch(`/api/v1/patterns/price-distribution?${qs}`).catch(() => null),
+      jsonFetch(`/api/v1/patterns/pv-calibration?${qs}`).catch(() => null),
+    ]);
+
+    if (hourly) {
+      const items = Object.entries(hourly.profile || {})
+        .sort(([a], [b]) => Number(a) - Number(b))
+        .map(([h, v]) => ({ label: `${pad(h)}h`, value: v.mean_kwh }));
+      renderBars($('#patternHourly'), items);
+    }
+    if (dow) {
+      const order = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+      const items = order.map(d => ({ label: d, value: (dow.profile?.[d]?.mean_import_kwh) ?? 0 }));
+      renderBars($('#patternDow'), items, { unit: ' kWh' });
+    }
+    if (dist) {
+      const kinds = dist.kinds || {};
+      const order = ['negative', 'cheap', 'standard', 'peak'];
+      const total = dist.total_slots || 0;
+      $('#patternPriceDist').innerHTML = total ? order.map(k => {
+        const e = kinds[k] || { count: 0, pct: 0, mean_p: null };
+        return `<div class="pattern-bar-row">
+            <span class="pattern-bar-label kind-${k}">${k}</span>
+            <span class="pattern-bar-track"><span class="pattern-bar-fill kind-${k}" style="width:${e.pct.toFixed(1)}%"></span></span>
+            <span class="pattern-bar-val">${e.pct.toFixed(1)}% · ${e.count} · ${e.mean_p == null ? '—' : Number(e.mean_p).toFixed(1) + 'p'}</span>
+        </div>`;
+      }).join('') : '<p class="text-mute" style="font-size:0.78rem;">No tariff data in range.</p>';
+    }
+    if (pv) {
+      const series = (pv.series || []).filter(s => s.actual_kwh != null);
+      if (!series.length) {
+        $('#patternPv').innerHTML = '<p class="text-mute" style="font-size:0.78rem;">No PV data in range.</p>';
+      } else {
+        const max = Math.max(...series.map(s => s.actual_kwh || 0)) || 1;
+        $('#patternPv').innerHTML = `<div class="pv-spark">${series.map(s => {
+          const h = Math.max(2, Math.round(40 * (s.actual_kwh || 0) / max));
+          return `<div class="pv-spark-bar" style="height:${h}px" title="${s.date}: ${(s.actual_kwh || 0).toFixed(1)} kWh"></div>`;
+        }).join('')}</div>`;
+      }
+    }
+  }
+
+  async function runCompare() {
+    try {
+      const d = await jsonFetch('/api/v1/tariffs/compare', { method: 'POST', body: { months_back: 3 } });
+      const rows = (d?.tariffs || d?.results || []).slice(0, 10);
+      if (!rows.length) {
+        $('#tariffCompareTable').innerHTML = '<p class="text-dim">No comparison data returned.</p>';
+        return;
+      }
+      const html = `<table class="plan-table">
+        <thead><tr><th>Tariff</th><th class="num">Est. monthly</th><th class="num">vs current</th></tr></thead>
+        <tbody>${rows.map(r => `<tr>
+          <td>${r.tariff_code || r.name || '—'}</td>
+          <td class="num">${fmtGBP(r.estimated_monthly_pence)}</td>
+          <td class="num">${fmtGBP(r.delta_vs_current_pence)}</td>
+        </tr>`).join('')}</tbody></table>`;
+      $('#tariffCompareTable').innerHTML = html;
+    } catch (e) {
+      $('#tariffCompareTable').innerHTML = `<p class="text-bad">${e.message}</p>`;
+    }
+  }
+
+  function bind() {
+    $$('.insights-period-btn').forEach(b => b.addEventListener('click', () => {
+      State.setPeriod(b.dataset.period);
+      load();
+    }));
+    $$('.period-nav-btn').forEach(b => b.addEventListener('click', () => {
+      const a = b.dataset.nav;
+      if (a === 'prev') State.nav(-1);
+      else if (a === 'next') State.nav(+1);
+      else if (a === 'today') State.cursor = todayUTCDate();
+      load();
+    }));
+    document.addEventListener('keydown', e => {
+      if (e.target.matches('input, textarea, [contenteditable]')) return;
+      if (e.key === 'ArrowLeft') { State.nav(-1); load(); }
+      else if (e.key === 'ArrowRight') { State.nav(+1); load(); }
+      else if (e.key === '1') { State.setPeriod('day'); load(); }
+      else if (e.key === '7') { State.setPeriod('week'); load(); }
+      else if (e.key.toLowerCase() === 'm') { State.setPeriod('month'); load(); }
+      else if (e.key.toLowerCase() === 'y') { State.setPeriod('year'); load(); }
+      else if (e.key.toLowerCase() === 't') { State.cursor = todayUTCDate(); load(); }
+    });
+    window.addEventListener('popstate', () => { State.fromUrl(); load(); });
+    $('#btnRunCompare')?.addEventListener('click', runCompare);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    State.fromUrl();
+    bind();
+    load();
+  });
+})();

--- a/ui/src/js/modal.js
+++ b/ui/src/js/modal.js
@@ -1,0 +1,310 @@
+/* v10.1 cockpit — simulate → modal → confirm flow.
+ *
+ * Every action button on the cockpit/insights/plan/settings pages calls
+ * wrapAction(simulateUrl, applyUrl, payload) instead of writing directly.
+ * The /simulate endpoint never hits cloud APIs — it returns an ActionDiff
+ * computed from cached state. The modal renders the diff, the operator
+ * confirms, and the real-write happens with the X-Simulation-Id header.
+ *
+ * No frameworks; vanilla JS. ES2017+.
+ */
+(function () {
+  'use strict';
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, ch => (
+      { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]
+    ));
+  }
+
+  function fmtJson(obj) {
+    if (obj == null) return '—';
+    try {
+      return JSON.stringify(obj, null, 2);
+    } catch (_e) {
+      return String(obj);
+    }
+  }
+
+  function fmtScalar(v) {
+    // Pull a single scalar out of a {key: value} dict (per-row before/after
+    // entries from diff_settings_batch); fall back to JSON for nested shapes.
+    if (v == null) return '—';
+    if (typeof v === 'object') {
+      const keys = Object.keys(v);
+      if (keys.length === 1) return fmtScalar(v[keys[0]]);
+      if (keys.length === 0) return '—';
+      try { return JSON.stringify(v); } catch (_e) { return String(v); }
+    }
+    if (typeof v === 'number') {
+      return Math.abs(v) < 0.01 || Math.abs(v) >= 1000 ? String(v) : (Math.round(v * 1000) / 1000).toString();
+    }
+    return String(v);
+  }
+
+  function classifyFlag(flag) {
+    // Flags that require typed-confirmation are the most dangerous ones.
+    const HARD = new Set([
+      'enables_real_hardware_writes',
+      'enables_daikin_writes',
+      'plans_will_apply_without_review',
+      'overwrites_fox_schedule',
+      'may_lose_in_flight_dispatch',
+    ]);
+    return HARD.has(flag) ? 'hard' : 'soft';
+  }
+
+  const Modal = {
+    backdrop: null,
+    titleEl: null,
+    summaryEl: null,
+    beforeEl: null,
+    afterEl: null,
+    beforeSection: null,
+    afterSection: null,
+    batchSection: null,
+    batchBody: null,
+    flagsSection: null,
+    flagsList: null,
+    flagsConfirmLabel: null,
+    flagsConfirmInput: null,
+    flagsConfirmWord: null,
+    cancelBtn: null,
+    applyBtn: null,
+    closeBtn: null,
+    impactSection: null,
+    impactBody: null,
+    _resolve: null,
+
+    init() {
+      if (this.backdrop) return;
+      this.backdrop = $('#modalBackdrop');
+      this.titleEl = $('#modalTitle');
+      this.summaryEl = $('#modalSummary');
+      this.beforeEl = $('#modalBefore');
+      this.afterEl = $('#modalAfter');
+      this.beforeSection = $('#modalBeforeSection');
+      this.afterSection = $('#modalAfterSection');
+      this.batchSection = $('#modalBatchSection');
+      this.batchBody = $('#modalBatchBody');
+      this.flagsSection = $('#modalFlagsSection');
+      this.flagsList = $('#modalFlags');
+      this.flagsConfirmLabel = $('#modalFlagsConfirmLabel');
+      this.flagsConfirmInput = $('#modalFlagsConfirmInput');
+      this.flagsConfirmWord = $('#modalFlagsConfirmWord');
+      this.impactSection = $('#modalImpact');
+      this.impactBody = $('#modalImpactBody');
+      this.cancelBtn = $('#modalCancelBtn');
+      this.applyBtn = $('#modalApplyBtn');
+      this.closeBtn = $('#modalCloseBtn');
+
+      const close = () => this._close(false);
+      this.cancelBtn.addEventListener('click', close);
+      this.closeBtn.addEventListener('click', close);
+      this.backdrop.addEventListener('click', e => {
+        if (e.target === this.backdrop) close();
+      });
+      document.addEventListener('keydown', e => {
+        if (e.key === 'Escape' && !this.backdrop.hidden) close();
+      });
+      this.applyBtn.addEventListener('click', () => this._close(true));
+      this.flagsConfirmInput.addEventListener('input', () => this._refreshApplyState());
+    },
+
+    show(diff) {
+      this.init();
+      this._diff = diff;
+      this.titleEl.textContent = diff.action || 'Confirm';
+      this.summaryEl.textContent = diff.human_summary || '';
+
+      const subs = Array.isArray(diff.sub_actions) ? diff.sub_actions : [];
+      if (subs.length) {
+        // Batch mode: render table, hide raw before/after blocks.
+        this.batchBody.innerHTML = subs.map(s => {
+          const safety = (s.safety_flags || []).map(f => `<code class="batch-flag batch-flag-${classifyFlag(f)}">${escapeHtml(f)}</code>`).join(' ') || '<span class="text-dim">—</span>';
+          return `<tr>
+              <td class="bcell-key"><code>${escapeHtml(s.key || s.action || '?')}</code></td>
+              <td class="bcell-before">${escapeHtml(fmtScalar(s.before))}</td>
+              <td class="bcell-after">${escapeHtml(fmtScalar(s.after))}</td>
+              <td class="bcell-safety">${safety}</td>
+          </tr>`;
+        }).join('');
+        this.batchSection.hidden = false;
+        this.beforeSection.hidden = true;
+        this.afterSection.hidden = true;
+      } else {
+        this.batchSection.hidden = true;
+        this.beforeSection.hidden = false;
+        this.afterSection.hidden = false;
+        this.beforeEl.textContent = fmtJson(diff.before);
+        this.afterEl.textContent = fmtJson(diff.after);
+      }
+
+      const cost = diff.cost_delta_pence;
+      const slots = diff.affected_slots || [];
+      if (cost != null || slots.length) {
+        const parts = [];
+        if (cost != null) {
+          const sign = cost >= 0 ? '+' : '';
+          parts.push(`Estimated cost change: <strong>${sign}${cost.toFixed(1)}p</strong>`);
+        }
+        if (slots.length) {
+          parts.push(`Affects ${slots.length} slot${slots.length === 1 ? '' : 's'}`);
+        }
+        this.impactBody.innerHTML = parts.join(' · ');
+        this.impactSection.hidden = false;
+      } else {
+        this.impactSection.hidden = true;
+      }
+
+      const flags = diff.safety_flags || [];
+      if (flags.length) {
+        this.flagsList.innerHTML = flags.map(f => `<li><code>${escapeHtml(f)}</code></li>`).join('');
+        this.flagsSection.hidden = false;
+        const hardFlag = flags.find(f => classifyFlag(f) === 'hard');
+        if (hardFlag) {
+          this.flagsConfirmWord.textContent = hardFlag;
+          this.flagsConfirmInput.value = '';
+          this.flagsConfirmLabel.hidden = false;
+          this._needTypedConfirm = hardFlag;
+        } else {
+          this.flagsConfirmLabel.hidden = true;
+          this._needTypedConfirm = null;
+        }
+      } else {
+        this.flagsSection.hidden = true;
+        this.flagsConfirmLabel.hidden = true;
+        this._needTypedConfirm = null;
+      }
+
+      this._refreshApplyState();
+      this.backdrop.hidden = false;
+      // Focus management
+      setTimeout(() => {
+        if (this._needTypedConfirm) this.flagsConfirmInput.focus();
+        else this.applyBtn.focus();
+      }, 30);
+
+      return new Promise(resolve => { this._resolve = resolve; });
+    },
+
+    _refreshApplyState() {
+      if (!this._needTypedConfirm) {
+        this.applyBtn.disabled = false;
+        return;
+      }
+      this.applyBtn.disabled = (this.flagsConfirmInput.value.trim() !== this._needTypedConfirm);
+    },
+
+    _close(confirmed) {
+      this.backdrop.hidden = true;
+      const r = this._resolve;
+      this._resolve = null;
+      if (r) r(confirmed);
+    },
+  };
+
+  /* ----- HTTP helpers ----- */
+
+  async function jsonFetch(url, opts = {}) {
+    const init = Object.assign({
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    }, opts);
+    if (init.body && typeof init.body === 'object') {
+      init.body = JSON.stringify(init.body);
+      init.headers['Content-Type'] = 'application/json';
+    }
+    const r = await fetch(url, init);
+    let payload = null;
+    try { payload = await r.json(); } catch (_e) { payload = null; }
+    if (!r.ok) {
+      const detail = (payload && payload.detail) || r.statusText;
+      const msg = (typeof detail === 'object' && detail.message) ? detail.message : (typeof detail === 'string' ? detail : `HTTP ${r.status}`);
+      const err = new Error(msg);
+      err.status = r.status;
+      err.payload = payload;
+      throw err;
+    }
+    return payload;
+  }
+
+  /* ----- Toast ----- */
+
+  function toast(message, kind) {
+    const stack = $('#toastStack');
+    if (!stack) return;
+    const t = document.createElement('div');
+    t.className = 'toast' + (kind ? ` is-${kind}` : '');
+    t.textContent = message;
+    stack.appendChild(t);
+    setTimeout(() => t.remove(), 4000);
+  }
+
+  /* ----- Public API ----- */
+
+  /**
+   * Run an action through simulate → modal → confirm → real apply.
+   *
+   * @param {object} opts
+   * @param {string} opts.simulateUrl  — POST /api/v1/.../simulate or PUT /api/v1/settings/{key}/simulate
+   * @param {string} opts.applyUrl     — paired real-write URL
+   * @param {string} [opts.method=POST] — verb for both calls
+   * @param {object} [opts.body]       — request body (same for both calls)
+   * @returns {Promise<{applied: boolean, response?: any}>}
+   */
+  async function wrapAction(opts) {
+    const method = opts.method || 'POST';
+    const body = opts.body || {};
+    // Generalised busy state — `is-busy` fires on EVERY wrapAction flow so
+    // users always see "something is happening" during simulate + apply.
+    // CSS hooks on body.is-busy add a thin top progress bar + cursor: progress.
+    // Separately, `is-optimizing` fires only when the action is an LP propose
+    // (so the Plan freshness chip can pulse distinctively vs a generic write).
+    const isOptimise = (opts.simulateUrl || "").includes("optimization/propose")
+                    || (opts.simulateUrl || "").includes("workbench/simulate");
+    document.body.classList.add('is-busy');
+    if (isOptimise) document.body.classList.add('is-optimizing');
+    let diff;
+    try {
+      try {
+        diff = await jsonFetch(opts.simulateUrl, { method, body });
+      } catch (e) {
+        toast(`Simulate failed: ${e.message}`, 'bad');
+        return { applied: false };
+      }
+      if (!diff || !diff.simulation_id) {
+        toast('Simulate returned no diff — refusing to apply', 'bad');
+        return { applied: false };
+      }
+      const confirmed = await Modal.show(diff);
+      if (!confirmed) return { applied: false };
+
+      try {
+        const response = await jsonFetch(opts.applyUrl, {
+          method,
+          body,
+          headers: { 'X-Simulation-Id': diff.simulation_id },
+        });
+        toast(`Applied: ${diff.action || 'change'}`, 'ok');
+        return { applied: true, response };
+      } catch (e) {
+        const status = e.status || '?';
+        toast(`Apply failed (${status}): ${e.message}`, 'bad');
+        return { applied: false };
+      }
+    } finally {
+      document.body.classList.remove('is-busy');
+      document.body.classList.remove('is-optimizing');
+    }
+  }
+
+  // Expose as globals for inline event handlers in templates.
+  window.HEM = window.HEM || {};
+  window.HEM.wrapAction = wrapAction;
+  window.HEM.toast = toast;
+  window.HEM.jsonFetch = jsonFetch;
+  window.HEM.Modal = Modal;
+})();

--- a/ui/src/js/mode_switcher.js
+++ b/ui/src/js/mode_switcher.js
@@ -1,0 +1,143 @@
+/* v10.2 mode switcher — opened from the topbar mode badge.
+ *
+ * The dialog stages pending toggles for DAIKIN_CONTROL_MODE /
+ * REQUIRE_SIMULATION_ID; clicking "Review changes" sends them all through the
+ * batch settings endpoint as ONE simulate → modal → confirm. Single-toggle
+ * usage still works — the batch endpoint accepts a 1-key payload too.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
+  const { wrapAction, jsonFetch } = window.HEM || {};
+
+  const Switcher = {
+    backdrop: null,
+    closeBtn: null,
+    dismissBtn: null,
+    reviewBtn: null,
+    pending: {},   // { KEY: stagedValue } — only diverges-from-current entries
+    current: {},   // { KEY: livedValue from API }
+
+    init() {
+      if (this.backdrop) return;
+      this.backdrop = $('#modeSwitcherBackdrop');
+      if (!this.backdrop) return;
+      this.closeBtn = $('#modeSwitcherCloseBtn');
+      this.dismissBtn = $('#modeSwitcherDismissBtn');
+      this.reviewBtn = $('#modeSwitcherReviewBtn');
+
+      this.closeBtn.addEventListener('click', () => this.close());
+      this.dismissBtn.addEventListener('click', () => this.close());
+      this.backdrop.addEventListener('click', e => {
+        if (e.target === this.backdrop) this.close();
+      });
+      document.addEventListener('keydown', e => {
+        if (e.key === 'Escape' && !this.backdrop.hidden) this.close();
+      });
+
+      $$('[data-stage-key]').forEach(b => b.addEventListener('click', () => {
+        this.stage(b.dataset.stageKey, b.dataset.stageValue);
+      }));
+
+      this.reviewBtn.addEventListener('click', () => this.submit());
+    },
+
+    async open() {
+      this.init();
+      if (!this.backdrop) return;
+      this.pending = {};
+      this.backdrop.hidden = false;
+      await this.refresh();
+      this.repaint();
+    },
+
+    close() {
+      if (this.backdrop) this.backdrop.hidden = true;
+      this.pending = {};
+    },
+
+    stage(key, rawValue) {
+      const current = this.current[key];
+      const value = this._coerceForCompare(key, rawValue);
+      const cur = this._coerceForCompare(key, current);
+      if (String(value) === String(cur)) {
+        delete this.pending[key];
+      } else {
+        this.pending[key] = this._coerceForSubmit(key, rawValue);
+      }
+      this.repaint();
+    },
+
+    _coerceForCompare(key, v) {
+      if (key === 'REQUIRE_SIMULATION_ID') return String(v).toLowerCase() === 'true';
+      return v;
+    },
+
+    _coerceForSubmit(key, v) {
+      if (key === 'REQUIRE_SIMULATION_ID') return String(v).toLowerCase() === 'true';
+      return v;
+    },
+
+    repaint() {
+      // Highlight active button (matches current OR pending state)
+      $$('[data-pending-key]').forEach(group => {
+        const key = group.dataset.pendingKey;
+        const staged = key in this.pending ? this.pending[key] : null;
+        const current = this.current[key];
+        const effective = staged !== null ? staged : current;
+        $$('[data-stage-key]', group).forEach(b => {
+          const matches = String(this._coerceForCompare(key, b.dataset.stageValue))
+                       === String(this._coerceForCompare(key, effective));
+          b.classList.toggle('is-selected', matches);
+          b.classList.toggle('is-pending', matches && staged !== null);
+        });
+      });
+      const n = Object.keys(this.pending).length;
+      this.reviewBtn.disabled = (n === 0);
+      this.reviewBtn.textContent = n === 0 ? 'Review changes' : `Review ${n} change${n === 1 ? '' : 's'}`;
+    },
+
+    async submit() {
+      const changes = { ...this.pending };
+      if (Object.keys(changes).length === 0) return;
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/settings/batch/simulate',
+        applyUrl: '/api/v1/settings/batch',
+        body: { changes },
+      });
+      if (result.applied) {
+        this.pending = {};
+        await this.refresh();
+        this.repaint();
+        // Soft reload so the topbar badge re-renders from the new server-side context.
+        setTimeout(() => window.location.reload(), 400);
+      }
+    },
+
+    async refresh() {
+      try {
+        const r = await jsonFetch('/api/v1/settings/DAIKIN_CONTROL_MODE');
+        const v = r?.value || '—';
+        this.current.DAIKIN_CONTROL_MODE = v;
+        $('#msDaikinBadge').textContent = v;
+        $('#msDaikinBadge').className = 'status-badge ' + (v === 'active' ? 'is-active' : 'is-passive');
+      } catch (_e) {}
+      try {
+        const r = await jsonFetch('/api/v1/settings/REQUIRE_SIMULATION_ID');
+        const v = String(r?.value).toLowerCase() === 'true';
+        this.current.REQUIRE_SIMULATION_ID = v;
+        $('#msRequireSimBadge').textContent = v ? 'on' : 'off';
+        $('#msRequireSimBadge').className = 'status-badge ' + (v ? 'is-active' : 'is-passive');
+      } catch (_e) {}
+    },
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const badge = $('#modeBadge');
+    if (badge) badge.addEventListener('click', () => Switcher.open());
+  });
+
+  window.HEM = window.HEM || {};
+  window.HEM.ModeSwitcher = Switcher;
+})();

--- a/ui/src/js/plan_render.js
+++ b/ui/src/js/plan_render.js
@@ -1,0 +1,169 @@
+/* v10.2 — shared plan/slot table renderer.
+ *
+ * Used by the legacy Plan tab and the new Insights · Day view (and later by
+ * the Workbench). Inputs are the JSON shapes already produced by:
+ *   /api/v1/execution/today[?date=…]   → exec  (slots[], totals, data_quality_note)
+ *   /api/v1/optimization/plan          → plan  (.fox.groups_json for strategy column)
+ *   /api/v1/agile/day?date=…           → tariff (.slots with kind labels)
+ *
+ * Pure rendering — no fetching, no mutation outside the passed mount node.
+ */
+(function () {
+  'use strict';
+
+  function pad(n) { return String(n).padStart(2, '0'); }
+  function fmtP(v) { return v == null ? '—' : `${Number(v).toFixed(1)}p`; }
+  function fmtKwh(v) { return v == null ? '—' : `${Number(v).toFixed(2)}`; }
+
+  function strategyForSlot(groups, slotUtc) {
+    const t = new Date(slotUtc);
+    const h = t.getHours();
+    const m = t.getMinutes();
+    const cur = (groups || []).find(g => {
+      const inAfterStart = (h > g.startHour) || (h === g.startHour && m >= (g.startMinute || 0));
+      const inBeforeEnd  = (h < g.endHour)   || (h === g.endHour   && m <  (g.endMinute   || 0));
+      return inAfterStart && inBeforeEnd;
+    });
+    if (!cur) return '—';
+    const wm = (cur.workMode || '').toLowerCase();
+    if (wm.includes('forcecharge')) return `cheap → charge ${cur.extraParam?.fdSoc ?? '?'}%`;
+    if (wm.includes('forcedischarge')) return 'peak → discharge';
+    if (wm.includes('feed-in')) return 'export';
+    if (wm.includes('backup')) return 'backup';
+    return wm || '—';
+  }
+
+  function kindClass(k) {
+    if (!k) return '';
+    return ' kind-' + String(k).replace(/[^a-z0-9_]/g, '-').toLowerCase();
+  }
+
+  /**
+   * Render the per-slot cost table.
+   *
+   * @param {object} opts
+   * @param {HTMLTableElement} opts.table   — table element with thead already in DOM
+   * @param {object} opts.exec              — /execution/today response shape
+   * @param {object} [opts.plan]            — /optimization/plan response shape
+   * @param {HTMLElement} [opts.dataQualityNoteEl]  — optional <p> to fill if note present
+   * @param {HTMLElement} [opts.totalsEl]   — optional element for totals tiles
+   */
+  function renderSlotTable(opts) {
+    const { table, exec, plan, dataQualityNoteEl, totalsEl } = opts;
+    let groups = [];
+    try { groups = JSON.parse(plan?.fox?.groups_json || '[]'); } catch (_e) {}
+
+    const slots = exec?.slots || [];
+    const t = exec?.totals || {};
+
+    if (dataQualityNoteEl) {
+      if (exec?.data_quality_note) {
+        dataQualityNoteEl.textContent = '⚠ ' + exec.data_quality_note;
+        dataQualityNoteEl.hidden = false;
+      } else {
+        dataQualityNoteEl.hidden = true;
+      }
+    }
+
+    if (totalsEl) {
+      const dlt = t.delta_vs_svt_p;
+      const dCls = dlt == null ? '' : (dlt > 0 ? 'text-bad' : (dlt < 0 ? 'text-ok' : ''));
+      totalsEl.querySelector('[data-tot=cost]')?.replaceChildren(document.createTextNode(fmtP(t.cost_realised_p)));
+      const dEl = totalsEl.querySelector('[data-tot=delta]');
+      if (dEl) {
+        dEl.textContent = dlt == null ? '—' : `${dlt >= 0 ? '+' : ''}${dlt.toFixed(1)}p`;
+        dEl.className = 'value ' + dCls;
+      }
+      const dShare = totalsEl.querySelector('[data-tot=daikin_share]');
+      if (dShare) dShare.textContent = t.daikin_share_pct == null ? '—' : `${t.daikin_share_pct.toFixed(0)}%`;
+      const dLoad = totalsEl.querySelector('[data-tot=load]');
+      if (dLoad) dLoad.textContent = `${fmtKwh(t.load_kwh)} kWh`;
+    }
+
+    let tbody = table.querySelector('tbody');
+    if (!tbody) { tbody = document.createElement('tbody'); table.appendChild(tbody); }
+    let tfoot = table.querySelector('tfoot');
+    if (!tfoot) { tfoot = document.createElement('tfoot'); table.appendChild(tfoot); }
+    tfoot.innerHTML = '';
+
+    if (!slots.length) {
+      tbody.innerHTML = '<tr><td colspan="9" class="text-mute">No execution rows yet for this date.</td></tr>';
+      return;
+    }
+
+    tbody.innerHTML = '';
+    let sumDaikin = 0, sumRes = 0, sumCost = 0, sumSvt = 0;
+    slots.forEach(s => {
+      sumDaikin += s.cost_daikin_p || 0;
+      sumRes    += s.cost_residual_p || 0;
+      sumCost   += s.cost_realised_p || 0;
+      sumSvt    += s.cost_svt_p || 0;
+      // Format in the planner timezone, not browser local — otherwise a
+      // VPN/travel user sees times shifted from what the LP actually planned.
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(s.slot_utc)
+        : (() => { const d = new Date(s.slot_utc); return `${pad(d.getHours())}:${pad(d.getMinutes())}`; })();
+      const strategy = strategyForSlot(groups, s.slot_utc) + (s.slot_kind ? ` · ${s.slot_kind}` : '');
+      const dvs = s.delta_vs_svt_p || 0;
+      const dvsCls = dvs > 0 ? 'text-bad' : (dvs < 0 ? 'text-ok' : '');
+      const tr = document.createElement('tr');
+      tr.className = kindClass(s.slot_kind);
+      tr.innerHTML = `
+          <td>${lbl}</td>
+          <td>${strategy}</td>
+          <td class="num">${fmtP(s.agile_p)}</td>
+          <td class="num">${fmtKwh(s.consumption_kwh)}</td>
+          <td class="num">${fmtP(s.cost_realised_p)}</td>
+          <td class="num text-dim">${fmtP(s.cost_daikin_p)}</td>
+          <td class="num text-dim">${fmtP(s.cost_residual_p)}</td>
+          <td class="num text-mute">${fmtP(s.cost_svt_p)}</td>
+          <td class="num ${dvsCls}">${dvs >= 0 ? '+' : ''}${dvs.toFixed(1)}p</td>`;
+      tbody.appendChild(tr);
+    });
+
+    const totalDelta = sumCost - sumSvt;
+    const totalDeltaCls = totalDelta > 0 ? 'text-bad' : (totalDelta < 0 ? 'text-ok' : '');
+    tfoot.innerHTML = `<tr class="totals-row">
+      <td><strong>Total</strong></td>
+      <td class="text-dim">${slots.length} slots</td>
+      <td class="num"></td>
+      <td class="num"><strong>${fmtKwh(t.load_kwh)}</strong></td>
+      <td class="num"><strong>${fmtP(sumCost)}</strong></td>
+      <td class="num"><strong>${fmtP(sumDaikin)}</strong></td>
+      <td class="num"><strong>${fmtP(sumRes)}</strong></td>
+      <td class="num text-mute"><strong>${fmtP(sumSvt)}</strong></td>
+      <td class="num ${totalDeltaCls}"><strong>${totalDelta >= 0 ? '+' : ''}${totalDelta.toFixed(1)}p</strong></td>
+    </tr>`;
+  }
+
+  /**
+   * Render the tariff strip (one cell per tariff slot, colour-coded by kind).
+   *
+   * @param {object} opts
+   * @param {HTMLElement} opts.mount
+   * @param {object} opts.tariff  — /api/v1/agile/day response
+   * @param {string} [opts.tz]    — IANA tz for slot label rendering
+   */
+  function renderTariffStrip(opts) {
+    const { mount, tariff } = opts;
+    if (!mount) return;
+    const slots = tariff?.slots || [];
+    if (!slots.length) {
+      mount.innerHTML = '<p class="text-mute" style="font-size:0.78rem;">No tariff data for this day.</p>';
+      return;
+    }
+    const html = slots.map(s => {
+      // Planner-tz formatting — see the equivalent comment in renderSlotTable.
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(s.valid_from)
+        : (() => { const t = new Date(s.valid_from); return `${pad(t.getHours())}:${pad(t.getMinutes())}`; })();
+      const tooltip = `${lbl} · ${Number(s.p).toFixed(2)}p · ${s.kind || ''}`;
+      return `<div class="tariff-day-cell kind-${s.kind || 'standard'}" title="${tooltip}"><span class="tariff-day-cell-time">${lbl}</span><span class="tariff-day-cell-price">${Number(s.p).toFixed(0)}p</span></div>`;
+    }).join('');
+    mount.className = 'tariff-day-strip';
+    mount.innerHTML = html;
+  }
+
+  window.HEM = window.HEM || {};
+  window.HEM.PlanRender = { renderSlotTable, renderTariffStrip, fmtP, fmtKwh };
+})();

--- a/ui/src/js/quota.js
+++ b/ui/src/js/quota.js
@@ -1,0 +1,51 @@
+/* Topbar quota pills — Daikin (180/day cap) + Fox (1200/day cap).
+ * Reads /api/v1/{daikin,foxess}/quota. NEVER triggers a cloud refresh.
+ * Single fetch on page load; no auto-refresh. Click pill to refresh manually.
+ */
+(function () {
+  'use strict';
+
+  async function readQuota(provider) {
+    try {
+      const r = await fetch(`/api/v1/${provider}/quota`, { headers: { 'Accept': 'application/json' } });
+      if (!r.ok) return null;
+      return await r.json();
+    } catch (_e) { return null; }
+  }
+
+  function renderPill(el, used, cap, prefix) {
+    if (used == null || cap == null) {
+      el.textContent = `${prefix} —/${cap || '?'}`;
+      return;
+    }
+    el.textContent = `${prefix} ${used}/${cap}`;
+    const ratio = used / cap;
+    el.classList.toggle('is-warn', ratio >= 0.6 && ratio < 0.85);
+    el.classList.toggle('is-bad', ratio >= 0.85);
+  }
+
+  async function refresh() {
+    const dEl = document.getElementById('quotaDaikin');
+    const fEl = document.getElementById('quotaFox');
+    if (!dEl || !fEl) return;
+    const [dq, fq] = await Promise.all([readQuota('daikin'), readQuota('foxess')]);
+    if (dq) {
+      const used = dq.calls_today ?? dq.used ?? dq.daily_used ?? 0;
+      const cap = dq.daily_budget ?? dq.daily_limit ?? 180;
+      renderPill(dEl, used, cap, 'D');
+    }
+    if (fq) {
+      const used = fq.calls_today ?? fq.used ?? fq.daily_used ?? 0;
+      const cap = fq.daily_budget ?? fq.daily_limit ?? 1200;
+      renderPill(fEl, used, cap, 'F');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    refresh();
+    document.getElementById('quotaPills')?.addEventListener('click', refresh);
+  });
+
+  window.HEM = window.HEM || {};
+  window.HEM.refreshQuota = refresh;
+})();

--- a/ui/src/js/settings.js
+++ b/ui/src/js/settings.js
@@ -1,0 +1,212 @@
+/* v10.1 settings page — categorised, human-labelled, simulate-confirm.
+ * Every change flows through wrapAction (simulate → modal → apply).
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const { jsonFetch, wrapAction, toast } = window.HEM || {};
+
+  /* Per-key human metadata. Anything not in here falls back to the raw key.
+   * v10.2: DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID moved to the topbar
+   * mode badge / mode-switcher dialog (see _mode_switcher.html). They no
+   * longer render here.
+   */
+  const META = {
+    DHW_TEMP_NORMAL_C: {
+      label: 'Normal hot-water target',
+      desc: 'Target tank temperature on a typical day (°C). Higher = more buffer for evening showers but more standing loss.',
+      group: 'settingsComfort',
+    },
+    DHW_TEMP_COMFORT_C: {
+      label: 'Plunge ceiling for hot water',
+      desc: 'Maximum tank temperature when the LP wants to absorb a cheap-price slot (°C). Only reached when it actively pays to do so.',
+      group: 'settingsComfort',
+    },
+    INDOOR_SETPOINT_C: {
+      label: 'Indoor target temperature',
+      desc: 'Target room temperature used for the LP comfort constraint (°C).',
+      group: 'settingsComfort',
+    },
+    OPTIMIZATION_PRESET: {
+      label: 'Occupancy preset',
+      desc:
+        'normal = standard household. guests = higher hot water + warmer rooms. travel/away = frost protection only, max battery export. ' +
+        '(BOOST retired in v10 — silently aliased to normal.)',
+      group: 'settingsStrategy',
+    },
+    ENERGY_STRATEGY_MODE: {
+      label: 'Energy strategy mode',
+      desc: 'savings_first = LP allows discharging the battery to the grid during peak tariff (peak-export). strict_savings = never discharge to grid.',
+      group: 'settingsStrategy',
+    },
+    LP_PLAN_PUSH_HOUR: {
+      label: 'Nightly plan push hour (UTC)',
+      desc: 'UTC hour when the next-day plan is force-pushed (anchored to Daikin quota rollover at 00:00 UTC).',
+      group: 'settingsSchedule',
+    },
+    LP_PLAN_PUSH_MINUTE: {
+      label: 'Nightly plan push minute',
+      desc: 'UTC minute (paired with the hour above).',
+      group: 'settingsSchedule',
+    },
+  };
+
+  function fmtCurrent(item) {
+    const v = item.value;
+    if (v == null) return '—';
+    if (Array.isArray(v)) return v.join(', ');
+    if (typeof v === 'number') return v.toString();
+    return String(v);
+  }
+
+  function controlFor(item) {
+    if (item.enum) {
+      return `<select data-key="${item.key}">
+        ${item.enum.map(o => `<option value="${o}" ${String(item.value) === String(o) ? 'selected' : ''}>${o}</option>`).join('')}
+      </select>`;
+    }
+    if (item.type === 'int' || item.type === 'float') {
+      const step = item.type === 'int' ? '1' : '0.5';
+      return `<input type="number" data-key="${item.key}" value="${item.value ?? ''}" step="${step}"
+              ${item.min != null ? `min="${item.min}"` : ''}
+              ${item.max != null ? `max="${item.max}"` : ''}
+              style="width:5.5rem;">`;
+    }
+    return `<input type="text" data-key="${item.key}" value="${fmtCurrent(item)}" style="width:8rem;">`;
+  }
+
+  function badgeClass(item) {
+    if (item.key === 'DAIKIN_CONTROL_MODE') {
+      return item.value === 'passive' ? 'is-passive' : 'is-active';
+    }
+    if (item.key === 'REQUIRE_SIMULATION_ID') {
+      return String(item.value) === 'true' ? 'is-active' : 'is-passive';
+    }
+    return '';
+  }
+
+  function renderInline(item, container) {
+    const meta = META[item.key] || {};
+    const block = document.createElement('div');
+    block.className = 'setting-block' + (meta.danger ? ' is-danger' : '');
+    block.innerHTML = `
+      <div class="setting-head">
+        <h3 class="setting-name">${meta.label || item.key}</h3>
+        <span class="status-badge ${badgeClass(item)}">${fmtCurrent(item)}</span>
+      </div>
+      <p class="setting-desc">${meta.desc || item.description || ''}</p>
+      <div class="setting-actions">
+        ${controlFor(item)}
+        <button class="btn btn-secondary btn-sm" data-apply="${item.key}">Change…</button>
+      </div>`;
+    bindControl(block, item);
+    container.appendChild(block);
+  }
+
+  function bindControl(wrap, item) {
+    const btn = wrap.querySelector(`[data-apply="${item.key}"]`);
+    btn.addEventListener('click', async () => {
+      const inp = wrap.querySelector(`[data-key="${item.key}"]`);
+      let value = inp.value;
+      if (item.type === 'int') value = parseInt(value);
+      else if (item.type === 'float') value = parseFloat(value);
+      const result = await wrapAction({
+        method: 'PUT',
+        simulateUrl: `/api/v1/settings/${item.key}/simulate`,
+        applyUrl: `/api/v1/settings/${item.key}`,
+        body: { value },
+      });
+      if (result.applied) load();
+    });
+  }
+
+  /* ---------------------------------------------------------------------
+   * Composite controls — hour + minute as two separate spinbox fields was
+   * awful. Renders as a single <input type="time"> and applies both keys
+   * in one batch so simulate → confirm fires only once.
+   *
+   * V12 removed the LP_MPC_HOURS 24-cell grid — the MPC is now fully
+   * event-driven (tier_boundary + octopus_fetch + drift + forecast_revision
+   * + plan_push), no fixed-hour cron to configure.
+   * ---------------------------------------------------------------------
+   */
+
+  function renderPlanPushTime(hourItem, minuteItem, container) {
+    const hh = String(hourItem.value ?? 0).padStart(2, '0');
+    const mm = String(minuteItem.value ?? 0).padStart(2, '0');
+    const block = document.createElement('div');
+    block.className = 'setting-block';
+    block.innerHTML = `
+      <div class="setting-head">
+        <h3 class="setting-name">Nightly plan push (UTC)</h3>
+        <span class="status-badge">${hh}:${mm}</span>
+      </div>
+      <p class="setting-desc">When the next-day plan is pushed to Fox + Daikin. Anchored to UTC so it always lands just after the Daikin quota rollover at 00:00 UTC. Default 00:05 UTC.</p>
+      <div class="setting-actions">
+        <input type="time" id="planPushTime" value="${hh}:${mm}" step="60" style="width:8rem;">
+        <button class="btn btn-secondary btn-sm" id="btnApplyPlanPushTime">Change…</button>
+      </div>`;
+    container.appendChild(block);
+    block.querySelector('#btnApplyPlanPushTime').addEventListener('click', async () => {
+      const raw = block.querySelector('#planPushTime').value || '00:05';
+      const [h, m] = raw.split(':').map(n => parseInt(n, 10));
+      if (isNaN(h) || isNaN(m)) { toast('Invalid time', 'warn'); return; }
+      // Batch-apply both keys in one simulate → confirm round-trip so the
+      // user sees a single diff, not two.
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/settings/batch/simulate',
+        applyUrl: '/api/v1/settings/batch',
+        body: { changes: { LP_PLAN_PUSH_HOUR: h, LP_PLAN_PUSH_MINUTE: m } },
+      });
+      if (result.applied) load();
+    });
+  }
+
+  async function load() {
+    try {
+      const resp = await jsonFetch('/api/v1/settings');
+      const all = Array.isArray(resp) ? resp : (resp?.settings || []);
+      const byKey = Object.fromEntries(all.map(s => [s.key, s]));
+
+      // v10.2: DAIKIN_CONTROL_MODE + REQUIRE_SIMULATION_ID moved to the
+      // topbar mode-switcher dialog. They no longer render here.
+
+      // Grouped sections — schedule uses composite renderers for its two
+      // awkward inputs (hour/minute pair → time picker; CSV hours → 24-cell grid).
+      const simple = {
+        settingsComfort: ['DHW_TEMP_NORMAL_C', 'DHW_TEMP_COMFORT_C', 'INDOOR_SETPOINT_C'],
+        settingsStrategy: ['OPTIMIZATION_PRESET', 'ENERGY_STRATEGY_MODE'],
+      };
+      Object.entries(simple).forEach(([containerId, keys]) => {
+        const c = $('#' + containerId);
+        if (!c) return;
+        c.innerHTML = '';
+        keys.forEach(k => {
+          const item = byKey[k];
+          if (item) renderInline(item, c);
+        });
+      });
+
+      const sched = $('#settingsSchedule');
+      if (sched) {
+        sched.innerHTML = '';
+        if (byKey.LP_PLAN_PUSH_HOUR && byKey.LP_PLAN_PUSH_MINUTE) {
+          renderPlanPushTime(byKey.LP_PLAN_PUSH_HOUR, byKey.LP_PLAN_PUSH_MINUTE, sched);
+        }
+      }
+    } catch (e) {
+      toast(`Settings: ${e.message}`, 'bad');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    $('#btnRollback')?.addEventListener('click', async () => {
+      const result = await wrapAction({
+        simulateUrl: '/api/v1/optimization/rollback/simulate',
+        applyUrl: '/api/v1/optimization/rollback',
+      });
+      if (result.applied) load();
+    });
+    load();
+  });
+})();

--- a/ui/src/js/tz.js
+++ b/ui/src/js/tz.js
@@ -1,0 +1,123 @@
+/* Shared timezone helpers (Phase 1 of cockpit rework).
+ *
+ * The cockpit was previously doing `new Date(iso).getHours()` on UTC slot
+ * timestamps, which returns the BROWSER's local hour, not the planner's. If
+ * the user's browser is not in `Europe/London` (VPN, travel, wrong TZ),
+ * labels like "16:30" become wrong while the LP is still correctly planning
+ * in Europe/London.
+ *
+ * Every cockpit JS module formatting a slot time should now call
+ * `HEM.fmtSlotTime(iso)` or `HEM.fmtSlotRange(fromIso, toIso)`. Those
+ * delegate to Intl.DateTimeFormat with the planner_tz returned by
+ * `/api/v1/system/timezone`, cached for the lifetime of the page.
+ */
+(function () {
+  'use strict';
+  const { jsonFetch } = window.HEM || {};
+
+  // One in-flight fetch, memoized once resolved.
+  let _tzPromise = null;
+  let _tz = null;  // { planner_tz, plan_push_tz, now_utc, now_local }
+
+  function loadTz() {
+    if (_tz) return Promise.resolve(_tz);
+    if (_tzPromise) return _tzPromise;
+    _tzPromise = (jsonFetch ? jsonFetch('/api/v1/system/timezone') : fetch('/api/v1/system/timezone').then(r => r.json()))
+      .then(r => { _tz = r; return r; })
+      .catch(() => {
+        // Fallback so the page still renders if the endpoint fails.
+        _tz = { planner_tz: 'Europe/London', plan_push_tz: 'UTC' };
+        return _tz;
+      });
+    return _tzPromise;
+  }
+
+  function plannerTz() {
+    return (_tz && _tz.planner_tz) || 'Europe/London';
+  }
+
+  function _fmt(iso, opts) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '—';
+    try {
+      return new Intl.DateTimeFormat(undefined, Object.assign({ timeZone: plannerTz() }, opts)).format(d);
+    } catch (_e) {
+      return iso;
+    }
+  }
+
+  // Slot time like "16:30" in the planner tz.
+  function fmtSlotTime(iso) {
+    return _fmt(iso, { hour: '2-digit', minute: '2-digit', hour12: false });
+  }
+
+  // Slot range like "16:30–17:00" in the planner tz.
+  function fmtSlotRange(fromIso, toIso) {
+    return `${fmtSlotTime(fromIso)}–${fmtSlotTime(toIso)}`;
+  }
+
+  // Full local timestamp, e.g. "24/04/2026, 16:30:12".
+  function fmtLocal(iso) {
+    return _fmt(iso, {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+    });
+  }
+
+  // Produce a Date that represents "now in the planner tz but with local clock"
+  // — useful for hour-of-day bucket math without leaking the browser tz. Returns
+  // a Date whose Y/M/D/H/M fields match the planner clock; callers should use
+  // those fields (getFullYear/getHours etc.) rather than the raw timestamp.
+  function nowInPlannerTz() {
+    const now = new Date();
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: plannerTz(),
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+    }).formatToParts(now).reduce((acc, p) => { acc[p.type] = p.value; return acc; }, {});
+    return new Date(
+      `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`
+    );
+  }
+
+  // Hour + minute of the planner-tz clock for a given UTC ISO stamp.
+  function slotHM(iso) {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return { hour: 0, minute: 0 };
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: plannerTz(),
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    }).formatToParts(d);
+    const hour = Number(parts.find(p => p.type === 'hour')?.value || 0);
+    const minute = Number(parts.find(p => p.type === 'minute')?.value || 0);
+    return { hour, minute };
+  }
+
+  window.HEM = window.HEM || {};
+  window.HEM.Tz = {
+    loadTz,
+    plannerTz,
+    fmtSlotTime,
+    fmtSlotRange,
+    fmtLocal,
+    nowInPlannerTz,
+    slotHM,
+  };
+
+  // Shortcuts used widely.
+  window.HEM.fmtSlotTime = fmtSlotTime;
+  window.HEM.fmtSlotRange = fmtSlotRange;
+
+  // Kick off the fetch eagerly so callers who don't await loadTz() still
+  // converge quickly. Any early call formats in the fallback tz (Europe/London)
+  // which is correct for this single-home deployment anyway.
+  document.addEventListener('DOMContentLoaded', () => {
+    loadTz().then(tz => {
+      const badge = document.getElementById('tzBadge');
+      if (badge && tz && tz.planner_tz) {
+        badge.textContent = `🕒 ${tz.planner_tz}`;
+      }
+    });
+  });
+})();

--- a/ui/src/js/workbench.js
+++ b/ui/src/js/workbench.js
@@ -1,0 +1,294 @@
+/* v10.2 E3 Workbench — tune, simulate, compare, promote.
+ *
+ * State machine:
+ *   1. On load: GET /api/v1/workbench/schema → render grouped editor
+ *   2. User edits → values stored locally; "Run simulation" POSTs current
+ *      overrides to /api/v1/workbench/simulate → renders Compare table
+ *   3. "Promote to prod" → wrapAction({simulateUrl, applyUrl}) using
+ *      /api/v1/workbench/promote/* → batch-confirm via the standard modal.
+ *   4. Profiles: GET/POST/DELETE /api/v1/workbench/profiles*.
+ */
+(function () {
+  'use strict';
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
+  const { jsonFetch, wrapAction, toast } = window.HEM || {};
+
+  const State = {
+    schema: null,         // GET /workbench/schema response
+    overrides: {},        // KEY -> value (only diverges-from-current entries)
+    lastSim: null,        // GET /workbench/simulate response
+    currentPlan: null,    // GET /optimization/plan response
+  };
+
+  function fmt(v) {
+    if (v == null) return '—';
+    if (typeof v === 'number') return Math.abs(v) < 0.01 ? v.toString() : (Math.round(v * 1000) / 1000).toString();
+    return String(v);
+  }
+
+  function fieldId(key) { return `wbf-${key}`; }
+
+  function renderEditor() {
+    const groups = State.schema?.groups || [];
+    const fields = State.schema?.fields || [];
+    const byGroup = {};
+    for (const f of fields) {
+      (byGroup[f.group] = byGroup[f.group] || []).push(f);
+    }
+    const groupTitles = {
+      comfort: 'Comfort', battery: 'Battery', hardware: 'Hardware',
+      penalty: 'Penalties', solver: 'Solver', schedule: 'Schedule', mode: 'Mode',
+    };
+    const html = groups.filter(g => byGroup[g]).map(g => `
+      <details class="editor-group" open>
+        <summary class="editor-group-title">${groupTitles[g] || g}</summary>
+        <div class="editor-fields">
+          ${byGroup[g].map(f => renderField(f)).join('')}
+        </div>
+      </details>
+    `).join('');
+    $('#editorBody').innerHTML = html;
+
+    // Wire input events
+    $$('input[data-key], select[data-key]').forEach(input => {
+      input.addEventListener('input', () => {
+        const key = input.dataset.key;
+        const f = fields.find(x => x.key === key);
+        const raw = input.value;
+        if (raw === '' || raw == null) {
+          delete State.overrides[key];
+        } else {
+          let v;
+          if (f.type === 'float') v = parseFloat(raw);
+          else if (f.type === 'int') v = parseInt(raw, 10);
+          else v = String(raw);
+          if (Number.isNaN(v)) { delete State.overrides[key]; }
+          else if (v === f.current) { delete State.overrides[key]; }
+          else State.overrides[key] = v;
+        }
+        repaintHeader();
+        input.classList.toggle('is-dirty', key in State.overrides);
+      });
+    });
+    repaintHeader();
+  }
+
+  function renderField(f) {
+    const promoBadge = f.promotable ? '<span class="badge-promotable" title="Promotable to prod">●</span>' : '';
+    const meta = [];
+    if (f.min != null) meta.push(`min ${f.min}`);
+    if (f.max != null) meta.push(`max ${f.max}`);
+    if (f.enum) meta.push(`one of [${f.enum.join('|')}]`);
+    const metaLine = meta.length ? `<span class="editor-field-meta">${meta.join(' · ')}</span>` : '';
+    let inputHtml;
+    if (f.enum) {
+      inputHtml = `<select id="${fieldId(f.key)}" data-key="${f.key}" class="editor-input">
+        ${f.enum.map(opt => `<option value="${opt}" ${String(opt) === String(f.current) ? 'selected' : ''}>${opt}</option>`).join('')}
+      </select>`;
+    } else {
+      const t = f.type === 'int' ? 'number' : (f.type === 'float' ? 'number' : 'text');
+      const step = f.type === 'int' ? '1' : 'any';
+      inputHtml = `<input type="${t}" step="${step}" id="${fieldId(f.key)}" data-key="${f.key}" class="editor-input"
+        value="${f.current == null ? '' : f.current}" placeholder="${fmt(f.current)}">`;
+    }
+    return `<div class="editor-field">
+        <label class="editor-field-label" for="${fieldId(f.key)}">${promoBadge} ${f.key}</label>
+        <p class="editor-field-desc">${f.description || ''} ${metaLine}</p>
+        ${inputHtml}
+      </div>`;
+  }
+
+  function repaintHeader() {
+    const n = Object.keys(State.overrides).length;
+    $('#btnPromote').disabled = (n === 0);
+    $('#btnSimulate').textContent = n === 0 ? 'Run simulation' : `Run simulation (${n} change${n === 1 ? '' : 's'})`;
+  }
+
+  async function runSimulate() {
+    if (Object.keys(State.overrides).length === 0) {
+      toast('No overrides to simulate', 'warn');
+      return;
+    }
+    // Phase 5: loading-state feedback. The solver is typically sub-second
+    // but LP_HORIZON_HOURS=48 + many overrides can push into the 2-3s range,
+    // and a disabled button with "Simulating…" copy tells the user why.
+    const btn = document.getElementById('btnSimulate');
+    const originalLabel = btn ? btn.textContent : '';
+    if (btn) {
+      btn.disabled = true;
+      btn.textContent = 'Simulating…';
+      btn.classList.add('is-busy');
+    }
+    document.body.classList.add('is-simulating');
+    try {
+      const [sim, current] = await Promise.all([
+        jsonFetch('/api/v1/workbench/simulate', { method: 'POST', body: { overrides: State.overrides } }),
+        jsonFetch('/api/v1/optimization/plan').catch(() => ({})),
+      ]);
+      State.lastSim = sim;
+      State.currentPlan = current;
+      switchTab('compare');
+      renderCompare();
+      if (!sim.ok) {
+        toast(`Sim error: ${sim.error || sim.status || 'unknown'}`, 'bad');
+      } else {
+        toast(`Sim OK · objective £${(sim.objective_pence/100).toFixed(2)}`, 'ok');
+      }
+    } catch (e) {
+      toast(`Simulate failed: ${e.message}`, 'bad');
+    } finally {
+      if (btn) {
+        btn.disabled = false;
+        btn.classList.remove('is-busy');
+        // Restore the label via the main refresh so N-change counter updates.
+        btn.textContent = originalLabel;
+        renderEditor();
+      }
+      document.body.classList.remove('is-simulating');
+    }
+  }
+
+  function renderCompare() {
+    const sim = State.lastSim;
+    const cur = State.currentPlan;
+    const summary = $('#compareSummary');
+    if (!sim) { summary.innerHTML = ''; return; }
+
+    let curObj = null;
+    try {
+      const lp = JSON.parse(cur?.lp?.lp_summary_json || '{}');
+      curObj = typeof lp.objective_pence === 'number' ? lp.objective_pence : null;
+    } catch (_e) {}
+    const simObj = typeof sim.objective_pence === 'number' ? sim.objective_pence : null;
+    const delta = (curObj != null && simObj != null) ? (simObj - curObj) : null;
+    const deltaCls = delta == null ? '' : (delta > 0 ? 'text-bad' : (delta < 0 ? 'text-ok' : ''));
+    summary.innerHTML = `
+      <div class="insights-summary">
+        <div class="insight-tile"><div class="label">Current obj.</div><div class="value">£${curObj == null ? '—' : (curObj/100).toFixed(2)}</div></div>
+        <div class="insight-tile"><div class="label">Simulated obj.</div><div class="value">£${simObj == null ? '—' : (simObj/100).toFixed(2)}</div></div>
+        <div class="insight-tile"><div class="label">Δ</div><div class="value ${deltaCls}">${delta == null ? '—' : (delta >= 0 ? '+' : '') + (delta/100).toFixed(2)}</div></div>
+        <div class="insight-tile"><div class="label">Status</div><div class="value">${sim.status || '—'}</div></div>
+      </div>
+      ${sim.error ? `<p class="data-quality-note">⚠ ${sim.error}</p>` : ''}
+    `;
+
+    const tbody = $('#compareTable tbody');
+    const slots = sim.slots || [];
+    if (!slots.length) {
+      tbody.innerHTML = '<tr><td colspan="7" class="text-mute">No simulated slots returned.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = slots.map((s, i) => {
+      // Slot labels in planner tz so Workbench matches Cockpit / Forecast / History.
+      const lbl = (window.HEM && window.HEM.fmtSlotTime)
+        ? window.HEM.fmtSlotTime(s.t)
+        : (() => { const t = new Date(s.t); return `${String(t.getHours()).padStart(2,'0')}:${String(t.getMinutes()).padStart(2,'0')}`; })();
+      const simImp = s.import_kwh ?? 0;
+      // We don't have current per-slot import in the same shape; show — for now.
+      return `<tr>
+        <td>${lbl}</td>
+        <td class="num">${(s.price_p == null ? '—' : Number(s.price_p).toFixed(1) + 'p')}</td>
+        <td class="num text-mute">—</td>
+        <td class="num">${Number(simImp).toFixed(2)}</td>
+        <td class="num text-mute">—</td>
+        <td class="num">${(s.soc_kwh == null ? '—' : Number(s.soc_kwh).toFixed(2))}</td>
+        <td class="num text-mute">—</td>
+      </tr>`;
+    }).join('');
+  }
+
+  function switchTab(tab) {
+    $$('.workbench-tab').forEach(t => t.classList.toggle('is-active', t.dataset.tab === tab));
+    $$('.workbench-pane').forEach(p => p.classList.toggle('is-active', p.id === `pane${tab[0].toUpperCase()}${tab.slice(1)}`));
+  }
+
+  async function promote() {
+    if (Object.keys(State.overrides).length === 0) {
+      toast('Nothing to promote', 'warn');
+      return;
+    }
+    const result = await wrapAction({
+      simulateUrl: '/api/v1/workbench/promote/simulate',
+      applyUrl: '/api/v1/workbench/promote',
+      body: { overrides: State.overrides },
+    });
+    if (result.applied) {
+      toast('Promoted', 'ok');
+      // Re-fetch schema to refresh "current" values + clear pending state
+      await loadSchema();
+      State.overrides = {};
+      renderEditor();
+    }
+  }
+
+  async function loadSchema() {
+    State.schema = await jsonFetch('/api/v1/workbench/schema');
+    renderEditor();
+  }
+
+  async function loadProfiles() {
+    try {
+      const r = await jsonFetch('/api/v1/workbench/profiles');
+      const sel = $('#profileSelect');
+      sel.innerHTML = '<option value="">Load profile…</option>' +
+        (r.profiles || []).map(p => `<option value="${p.name}">${p.name} (${p.key_count})</option>`).join('');
+    } catch (_e) {}
+  }
+
+  async function loadProfile(name) {
+    if (!name) return;
+    try {
+      const p = await jsonFetch(`/api/v1/workbench/profiles/${encodeURIComponent(name)}`);
+      State.overrides = p.overrides || {};
+      renderEditor();
+      // Push values into inputs
+      Object.entries(State.overrides).forEach(([k, v]) => {
+        const el = $(`#${fieldId(k)}`);
+        if (el) { el.value = v; el.classList.add('is-dirty'); }
+      });
+      repaintHeader();
+      toast(`Loaded profile ${name}`, 'ok');
+    } catch (e) {
+      toast(`Load failed: ${e.message}`, 'bad');
+    }
+  }
+
+  async function saveProfile() {
+    const name = window.prompt('Profile name (letters, digits, _ - only):');
+    if (!name) return;
+    try {
+      await jsonFetch(`/api/v1/workbench/profiles/${encodeURIComponent(name)}`, {
+        method: 'POST', body: { overrides: State.overrides },
+      });
+      toast(`Saved ${name}`, 'ok');
+      loadProfiles();
+    } catch (e) {
+      toast(`Save failed: ${e.message}`, 'bad');
+    }
+  }
+
+  async function deleteProfile() {
+    const name = $('#profileSelect').value;
+    if (!name) { toast('Select a profile first', 'warn'); return; }
+    if (!window.confirm(`Delete profile "${name}"?`)) return;
+    try {
+      await jsonFetch(`/api/v1/workbench/profiles/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      toast(`Deleted ${name}`, 'ok');
+      loadProfiles();
+    } catch (e) {
+      toast(`Delete failed: ${e.message}`, 'bad');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    $('#btnSimulate').addEventListener('click', runSimulate);
+    $('#btnPromote').addEventListener('click', promote);
+    $('#btnSaveProfile').addEventListener('click', saveProfile);
+    $('#btnDeleteProfile').addEventListener('click', deleteProfile);
+    $('#profileSelect').addEventListener('change', e => loadProfile(e.target.value));
+    $$('.workbench-tab').forEach(t => t.addEventListener('click', () => switchTab(t.dataset.tab)));
+    loadSchema();
+    loadProfiles();
+  });
+})();


### PR DESCRIPTION
## Summary

Mechanical lift of the six live web UI pages from \`src/api/templates/\` + \`src/api/static/js/\` into the SPA container's \`ui/html/\` + \`ui/src/{js,css}/\` layout. Per the B2 inventory ([\`docs/UI_API_INVENTORY.md\`](../blob/main/docs/UI_API_INVENTORY.md)) every page is already JSON-driven, so this is a pure frontend lift — no new API endpoints needed.

Closes #359. Tracked by #355.

## What changed per page

| Concern | Before | After |
|---|---|---|
| Layout | Jinja \`{% extends \"_layout.html\" %}\` | Inlined chrome (topbar + modal + mode-switcher partials) in each page |
| Active tab | \`{% if active_page == 'X' %}is-active{% endif %}\` | Set by \`_chrome.js\` from \`window.location.pathname\` |
| Mode badge data attrs | \`{{ daikin_control_mode }}\` / \`{{ require_simulation_id }}\` | \`_chrome.js\` fetches \`/api/v1/settings\` on load and populates them |
| Static cache-busting | \`?v={{ static_v(...) }}\` | Dropped — nginx \`etag\` handles cache; image SHA in URL changes per push |
| Script paths | \`/static/js/foo.js\` | \`/js/foo.js\` (nginx serves \`html/\` as the root) |
| Bearer header | (none — no auth required) | Injected automatically by \`_api.js\` global \`fetch\` monkey-patch |

The bearer monkey-patch in \`_api.js\` is the key trick: legacy \`fetch('/api/v1/foo')\` callsites work **unchanged**. Every URL beginning with \`/api/\` gets \`Authorization: Bearer ${window.__HEM_CONFIG__.bearer}\` attached automatically. Zero JS rewrites; the entire 2585 lines of legacy JS land verbatim.

## What ships

\`\`\`
ui/html/
├── cockpit.html       399 lines  (was placeholder from B3)
├── forecast.html      244
├── history.html       265
├── insights.html      296
├── settings.html      197
└── workbench.html     214

ui/src/css/cockpit.css   1776  (copied as-is)
ui/src/js/
├── _api.js              extended: global fetch monkey-patch for /api/* bearer injection
├── _chrome.js  (new)    fetches /api/v1/settings, sets mode-badge attrs + active-tab class
├── cockpit.js           564  (copied as-is)
├── forecast.js          146
├── history.js           204
├── insights.js          369
├── modal.js             310
├── mode_switcher.js     143
├── plan_render.js       169
├── quota.js              51
├── settings.js          212
├── tz.js                123
└── workbench.js         294
\`\`\`

Total: **6038 insertions** across 20 files. Mostly verbatim copies.

## Out of scope (next stories)

- **B5 (#360)** — decommission the inline UI from the HEM container (remove templates/, static/, route handlers, drop \`jinja2\`). Must land AFTER B6 cutover is verified.
- **B6 (#361)** — wire \`hem-ui\` service into prod compose (already drafted in parallel as PR following this one).
- \`dashboard_legacy.html\` (the v9 fallback at \`/legacy\`) is **not** migrated — B5 drops it.

## Test plan

- [x] All 6 pages render cleanly on inspection (visual diff between \`src/api/templates/X.html\` and \`ui/html/X.html\` shows only the documented transforms)
- [x] Each page's script list correct (topbar shared scripts + page-specific scripts in the right order)
- [x] B3 placeholder \`cockpit.html\` correctly replaced
- [ ] After merge + image build: \`docker run\` the new image and confirm all 6 routes load against a dev HEM instance
- [ ] After B6 cutover on prod: verify \`http://openclaw-overbot.tail0dbf20.ts.net:8080/\` and each tab work identical to the inline UI

## Note on the build script

\`tmp/build_ui_pages.py\` (not committed) generated the 6 \`ui/html/*.html\` files. The script's transform recipe lives in its docstring. Keeping the generation deterministic + idempotent meant only minor manual touch-ups after the script ran (verified by diffing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)