### PR TITLE
feat(deploy): wire hem-ui compose service + cutover runbook (B6)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -211,6 +211,45 @@ systemctl daemon-reload
 
 A partir desse ponto o código vive **só** na imagem em `ghcr.io/albinati/home-energy-manager` e no Git. OpenClaw, mesmo se for comprometido, não tem caminho de escrita pra alterar comportamento da próxima invocação.
 
+## 11. Cutover do SPA container (Epic 13b / B6)
+
+A partir do PR #356 (B1) o token UI já é gerado no boot do HEM em
+`/srv/hem/data/.hem-ui-token`. O B6 só liga o container `hem-ui` no
+compose e (uma vez que a SPA estiver verificada) flipa o gate flag.
+
+```bash
+# 1. Garante que o image SPA está publicado (após B3/B4 baterem em main).
+docker pull ghcr.io/albinati/home-energy-manager-ui:main
+
+# 2. Sobe o serviço hem-ui (já está em compose.yaml; o pull_policy=always
+#    cuida do refresh). HEM continua servindo a UI legacy em paralelo.
+cd /srv/hem && docker compose up -d hem-ui
+
+# 3. Smoke test do SPA na porta 8080 (loopback + Tailnet).
+curl -sS http://127.0.0.1:8080/healthz
+# Esperado: "ok"
+
+# 4. Abrir http://openclaw-overbot.tail0dbf20.ts.net:8080/ no navegador.
+#    Cockpit, history, forecast, insights, workbench, settings devem
+#    funcionar idênticos à UI inline (que segue rodando na :8000).
+#    Inspect Network: as chamadas /api/v1/* devem ter Authorization: Bearer.
+
+# 5. Quando confiar que está OK, flipa o gate flag pra exigir bearer em
+#    /api/v1/* — depois disso a UI inline em :8000 NÃO funciona mais
+#    (não envia bearer). Só faz esse passo depois de verificar :8080.
+echo 'HEM_UI_AUTH_REQUIRED=true' >> /srv/hem/.env
+chmod 640 /srv/hem/.env   # perms importam — ver feedback_flag_before_env_overwrite
+systemctl restart hem
+sleep 8
+curl -sS http://127.0.0.1:8000/api/v1/health   # health stays public
+# A UI legacy em :8000 vai responder 401 sem header — esperado.
+# B5 remove ela do container HEM no PR seguinte.
+
+# 6. Rollback (se o SPA tiver bug): tira o flag + restart, UI legacy volta.
+sed -i '/^HEM_UI_AUTH_REQUIRED=/d' /srv/hem/.env
+systemctl restart hem
+```
+
 ## Troubleshooting
 
 | Sintoma | Causa provável | Ação |

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -60,6 +60,78 @@ services:
     networks:
       - hem-net
 
+  # ── Story B6 — SPA container ────────────────────────────────────────────
+  # nginx-served frontend lifted from src/api/templates/ + src/api/static/.
+  # Reverse-proxies /api → hem:8000. Reads the bearer token from
+  # /srv/hem/data/.hem-ui-token (minted by HEM lifespan, B1) and writes it
+  # into /usr/share/nginx/html/config.js at boot so the SPA can attach it
+  # to every /api/* fetch.
+  #
+  # Rollback: `docker compose stop hem-ui` (the inline UI in HEM keeps
+  # serving until B5 decommissions it). Until HEM_UI_AUTH_REQUIRED=true
+  # the new bearer guard is inert — turning the SPA off is safe.
+  hem-ui:
+    image: ghcr.io/albinati/home-energy-manager-ui:${HEM_UI_IMAGE_TAG:-main}
+    container_name: hem-ui
+    pull_policy: always
+    restart: unless-stopped
+    depends_on:
+      hem:
+        condition: service_healthy
+
+    ports:
+      - "127.0.0.1:8080:80"
+      - "${HEM_TAILSCALE_IP:-127.0.0.1}:8080:80"
+
+    environment:
+      HEM_API_URL: http://hem:8000
+      # The token is loaded from the bind-mounted hem-ui-token file by
+      # ui-entrypoint.sh on container start. The file lives in HEM's
+      # data volume so the SPA container reads what HEM minted.
+      HEM_UI_TOKEN_FILE: /run/secrets/hem-ui-token
+
+    volumes:
+      # Read-only mount of the token file as a "secret" — mounted under
+      # /run/secrets/ which the entrypoint reads. Using a bind mount
+      # rather than docker secrets keeps the existing root-on-host
+      # operations the user has been doing.
+      - /srv/hem/data/.hem-ui-token:/run/secrets/hem-ui-token:ro
+
+    read_only: true
+    tmpfs:
+      - /tmp:rw,size=8m,mode=1777
+      - /var/cache/nginx:rw,size=32m,mode=1777
+      - /var/run:rw,size=8m,mode=1777
+      # nginx writes its boot-time generated /config.js into html/ — give
+      # it a writable tmpfs overlay there.
+      - /usr/share/nginx/html:rw,size=32m,mode=1777
+    cap_drop: [ALL]
+    cap_add:
+      - CHOWN
+      - NET_BIND_SERVICE
+      - SETUID
+      - SETGID
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 100
+    mem_limit: 64m
+    mem_reservation: 32m
+
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:80/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    logging:
+      driver: journald
+      options:
+        tag: hem-ui
+
+    networks:
+      - hem-net
+
 # Pin a known subnet so the bridge gateway IP (172.30.0.1) is stable. The
 # container resolves openclaw.host -> 172.30.0.1 (extra_hosts above) and
 # reaches OpenClaw on the host. Without this, compose picks the next free

--- a/ui/ui-entrypoint.sh
+++ b/ui/ui-entrypoint.sh
@@ -18,6 +18,13 @@ set -eu
 CONFIG_PATH=/usr/share/nginx/html/config.js
 TOKEN="${HEM_UI_TOKEN:-}"
 
+# Token-file fallback — prod compose mounts /srv/hem/data/.hem-ui-token at
+# /run/secrets/hem-ui-token (read-only) so the SPA container reads what
+# HEM's lifespan minted. Env still wins (handy for local dev `docker run`).
+if [ -z "$TOKEN" ] && [ -n "${HEM_UI_TOKEN_FILE:-}" ] && [ -r "$HEM_UI_TOKEN_FILE" ]; then
+  TOKEN="$(tr -d '\n\r ' < "$HEM_UI_TOKEN_FILE")"
+fi
+
 cat > "$CONFIG_PATH" <<EOF
 // Generated at container start by ui-entrypoint.sh — DO NOT EDIT.
 // Cached:no-store via nginx config.


### PR DESCRIPTION
## Summary

Wires the \`hem-ui\` SPA container into \`deploy/compose.yaml\` so prod can run it alongside the inline UI for verification, then flip \`HEM_UI_AUTH_REQUIRED=true\` to enforce bearer auth on \`/api/v1/*\`.

Closes #361. Tracked by #355 (Epic 13b).

## What changes

- **\`deploy/compose.yaml\`** — new \`hem-ui\` service. Image \`ghcr.io/<owner>/home-energy-manager-ui:main\`, reverse-proxies \`/api → hem:8000\`, listens on \`:8080\` (loopback + Tailnet IP), \`depends_on: { hem: { condition: service_healthy } }\`. Same hardening as the \`hem\` service: read-only rootfs, tmpfs for \`/tmp\` + nginx working dirs, \`cap_drop: ALL\` + minimum nginx caps, \`no-new-privileges\`, \`pids_limit: 100\`, \`mem_limit: 64m\`.
- **Token wiring** — bind-mounts \`/srv/hem/data/.hem-ui-token\` (read-only) at \`/run/secrets/hem-ui-token\`. \`ui-entrypoint.sh\` extended (new \`HEM_UI_TOKEN_FILE\` fallback) to read from the file if the env var is empty. Env still wins for local \`docker run\`.
- **\`deploy/README.md\` §11** — cutover runbook in pt-BR: pull image → \`up hem-ui\` → smoke \`:8080\` → flip \`HEM_UI_AUTH_REQUIRED=true\` → restart \`hem\` → rollback path.

## Deploy sequence

\`\`\`bash
# Pre-req: B3 (#372) image must be live in GHCR (it is — landed in main).
docker pull ghcr.io/albinati/home-energy-manager-ui:main

# Sobe o serviço hem-ui em paralelo (HEM continua servindo a UI legacy).
cd /srv/hem && docker compose up -d hem-ui
curl -sS http://127.0.0.1:8080/healthz   # → "ok"

# Smoke test no browser: http://openclaw-overbot.tail0dbf20.ts.net:8080/
# Confirma que cockpit / history / forecast / insights / workbench / settings
# todas funcionam idênticas à UI legacy em :8000.

# Quando confiar, flipa o gate flag pra exigir bearer em /api/v1.
echo 'HEM_UI_AUTH_REQUIRED=true' >> /srv/hem/.env
chmod 640 /srv/hem/.env   # perms importam — feedback_flag_before_env_overwrite
systemctl restart hem
# A UI legacy em :8000 vai responder 401 sem header — esperado.
# Próximo passo: B5 (PR #374) remove a UI legacy do container HEM.
\`\`\`

## Rollback

\`\`\`bash
sed -i '/^HEM_UI_AUTH_REQUIRED=/d' /srv/hem/.env
systemctl restart hem    # UI legacy volta funcionando
docker compose stop hem-ui   # opcional, se quiser desligar a SPA
\`\`\`

## Why minimal cap_add

nginx's official image runs the worker processes as \`nginx\` uid (101) but the master needs to bind \`:80\`, then \`setuid\`/\`setgid\` to drop to that worker. The four caps allowed (\`CHOWN\`, \`NET_BIND_SERVICE\`, \`SETUID\`, \`SETGID\`) cover exactly that, no more.

## Test plan

- [x] \`docker compose -f deploy/compose.yaml config\` validates the YAML
- [ ] After merge: \`docker compose -f /srv/hem/compose.yaml up -d hem-ui\` on prod
- [ ] Curl \`:8080/healthz\` returns 200
- [ ] Open \`:8080\` in browser, click through every tab
- [ ] Flip the gate flag → restart → verify \`/api/v1/health\` still 200 unauthenticated, every other \`/api/v1/*\` route requires bearer
- [ ] Then PR #374 (B5) can deploy safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)