### PR TITLE
fix(spa): hem-ui bearer + read_only + DAC perm cutover hot fixes

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -97,20 +97,27 @@ services:
       # operations the user has been doing.
       - /srv/hem/data/.hem-ui-token:/run/secrets/hem-ui-token:ro
 
-    read_only: true
+    # read_only is intentionally OFF — the upstream nginx:alpine entrypoint
+    # chain writes to /etc/nginx/conf.d (envsubst-on-templates.sh) on every
+    # start, and tmpfs-mounting it just to keep read_only=true was more pain
+    # than the marginal hardening was worth for a static-asset + proxy
+    # container with no application code. Risk surface = the nginx binary
+    # itself, which is mature + audited.
+    read_only: false
     tmpfs:
       - /tmp:rw,size=8m,mode=1777
-      - /var/cache/nginx:rw,size=32m,mode=1777
-      - /var/run:rw,size=8m,mode=1777
-      # nginx writes its boot-time generated /config.js into html/ — give
-      # it a writable tmpfs overlay there.
-      - /usr/share/nginx/html:rw,size=32m,mode=1777
     cap_drop: [ALL]
     cap_add:
       - CHOWN
       - NET_BIND_SERVICE
       - SETUID
       - SETGID
+      # DAC_READ_SEARCH lets the entrypoint read the 0640 bearer-token file
+      # mounted at /run/secrets/hem-ui-token (owned by uid:gid 1001:1001 on
+      # the host — written by HEM's lifespan). Without this cap a default
+      # cap_drop:ALL strips the kernel's DAC bypass that root usually relies
+      # on, so the container's root user gets EACCES on the bind-mounted file.
+      - DAC_READ_SEARCH
     security_opt:
       - no-new-privileges:true
     pids_limit: 100

--- a/ui/ui-entrypoint.sh
+++ b/ui/ui-entrypoint.sh
@@ -25,12 +25,25 @@ if [ -z "$TOKEN" ] && [ -n "${HEM_UI_TOKEN_FILE:-}" ] && [ -r "$HEM_UI_TOKEN_FIL
   TOKEN="$(tr -d '\n\r ' < "$HEM_UI_TOKEN_FILE")"
 fi
 
+# Render bearer as a JSON literal — either "<token>" (string) or null. The
+# previous ``${TOKEN:+\"$TOKEN\"}${TOKEN:-null}`` trick was broken in POSIX
+# sh: the :- expansion fires whenever TOKEN is empty OR unset, so when TOKEN
+# was set the output was `"TOKEN"TOKEN` (string + bare token). That produced
+# a JS syntax error and the SPA fell back to ``window.__HEM_CONFIG__``
+# undefined, killing every authenticated /api/v1 call once the gate flag
+# flipped.
+if [ -n "$TOKEN" ]; then
+  BEARER_LITERAL="\"$TOKEN\""
+else
+  BEARER_LITERAL="null"
+fi
+
 cat > "$CONFIG_PATH" <<EOF
 // Generated at container start by ui-entrypoint.sh — DO NOT EDIT.
 // Cached:no-store via nginx config.
 window.__HEM_CONFIG__ = {
   apiBase: "/api/v1",
-  bearer:  ${TOKEN:+\"$TOKEN\"}${TOKEN:-null},
+  bearer:  $BEARER_LITERAL,
   buildSha: "${BUILD_SHA:-unknown}"
 };
 EOF


### PR DESCRIPTION
## Summary

Three issues surfaced during the 2026-05-21 SPA cutover, all in B3/B6 (PRs #372 + #375). Fixed live on prod first; bundling the repo-side fixes here.

| # | Where | Bug | Fix |
|---|---|---|---|
| 1 | \`ui/ui-entrypoint.sh\` | \`config.js\` rendered bearer twice — invalid JS | Explicit if/else builds \`BEARER_LITERAL\` upfront |
| 2 | \`deploy/compose.yaml\` (hem-ui) | \`read_only:true\` broke nginx's envsubst-on-templates.sh; \`/usr/share/nginx/html\` tmpfs erased COPY'd pages | Drop \`read_only\`; drop html tmpfs |
| 3 | \`deploy/compose.yaml\` (hem-ui) | \`cap_drop:ALL\` blocked reading 0640 bearer token file | Add \`DAC_READ_SEARCH\` to \`cap_add\` |

## Why all three together

Each broke the next step of the cutover — fixing one only to discover the next added latency. Bundling means one rebuild + redeploy cycle.

## Verified live on prod (21:30 BST)

- \`docker ps\` → hem-ui Status=healthy
- \`curl :8080/healthz\` → \`ok\`
- \`curl :8080/\` → HTTP 200 (cockpit serves)
- \`curl :8080/config.js\` → bearer correctly rendered as JSON string
- \`curl :8080/api/v1/health\` → 200 (reverse-proxy works)

## Deploy after merge

Once the next image build lands, just \`docker compose pull hem-ui && docker compose up -d hem-ui\` on prod to pick up the entrypoint fix. The two compose.yaml fixes are already on prod (patched directly during the cutover); this PR makes the repo match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)