### PR TITLE
fix(spa): nginx try_files $uri.html so /history → history.html (cutover hot fix)

### DIFF
--- a/ui/conf/nginx.conf.template
+++ b/ui/conf/nginx.conf.template
@@ -50,10 +50,17 @@ server {
         try_files $uri =404;
     }
 
-    # SPA routes — every HTML path falls through to its corresponding file in
-    # html/. Unknown paths fall back to cockpit.html (Single-Page App default).
+    # SPA routes — every clean URL maps to its `.html` file in html/. Unknown
+    # paths fall back to cockpit.html (single-page-app default).
+    #
+    # The `$uri.html` step is critical: clicking the nav tab to /history
+    # requests the bare path; without this step nginx tries `history` then
+    # `history/`, both miss, and the request falls through to cockpit.html
+    # — which was the "tabs don't change" bug observed on the 2026-05-21
+    # cutover. /api/ + /healthz + /config.js are handled by their own
+    # location blocks above; everything else is a page or a static asset.
     location / {
         add_header Cache-Control "no-cache" always;
-        try_files $uri $uri/ /cockpit.html;
+        try_files $uri $uri.html $uri/ /cockpit.html;
     }
 }


### PR DESCRIPTION
## Summary

One-line nginx config fix for the SPA cutover. Without \`\$uri.html\` in the \`try_files\` chain, every clean URL (\`/history\`, \`/forecast\`, \`/insights\`, \`/workbench\`, \`/settings\`) fell through to the cockpit fallback. Observed as the \"tabs don't change\" symptom right after PR #384 landed.

## Fix

\`\`\`diff
-        try_files \$uri \$uri/ /cockpit.html;
+        try_files \$uri \$uri.html \$uri/ /cockpit.html;
\`\`\`

Already hot-patched on prod via \`docker exec hem-ui sed ... && nginx -s reload\`. Verified live:

| Path | Returns |
|---|---|
| \`/\` | Cockpit (21k) |
| \`/history\` | History (14k) |
| \`/forecast\` | Forecast (12k) |
| \`/insights\` | Insights (15k) |
| \`/workbench\` | Workbench (11k) |
| \`/settings\` | Settings (9k) |

This PR bakes the fix into the image so future container restarts retain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)