### PR TITLE
fix(dhw): pre-fire reconcile + drop SHUTDOWN strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,30 @@ EOF
 
 Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously (Sunday ~11:00 local). **The LP and dispatch layer do not schedule or override this cycle** — the `DHW_LEGIONELLA_*` env vars are gone from the code. Python ignores unrecognised keys in `.env` so lingering entries are harmless; delete them on your next `.env` touch. If a `shutdown` or `max_heat` action happens to overlap the cycle window, Onecta firmware arbitrates.
 
+### User-override propagation (Epic 14, #386 — 2026-05-21)
+
+When the user manually changes tank state (Onecta app / physical button),
+the active `action_schedule` row gets `overridden_by_user_at` set by the
+reactive detector in `src/daikin_bulletproof.py`. The pre-fire reconciler
+in `src/state_machine.py` now does two things:
+
+1. **Idempotency** — before firing a pending row, compare live device
+   state against the row's params. If they match, mark the row `completed`
+   with `error_msg='noop (state matched pre-fire)'` and skip the API call.
+   This is what drops the `READ_ONLY_CHARACTERISTIC` 400s and the
+   redundant solar_preheat writes that overlapping replan rows produced.
+2. **Override inheritance** — for non-`restore` rows, look up the most
+   recent `overridden_by_user_at` row for the same device within
+   `USER_OVERRIDE_RESPECT_HOURS` (default 4h). If the user's gesture is
+   still in effect (live state still contradicts the override row), mark
+   the new row overridden too and skip. One notification fires per
+   *source* user gesture, not per suppressed downstream row. Restore rows
+   are exempt so the system can always return to baseline.
+
+Both behaviours are gated by `PREFIRE_STATE_MATCH_ENABLED` (default true).
+Set to `false` for instant rollback. Telemetry shows up in `action_log` as
+`prefire_state_match` and `prefire_override_inherited` events.
+
 ---
 
 ## SmartThings (Samsung) — OAuth + appliance scheduling
@@ -205,16 +229,19 @@ PLAN_AUTO_APPROVE=true                          # default: simulate → auto-app
 PLAN_APPROVAL_TIMEOUT_SECONDS=300               # grace window advertised to OpenClaw for Telegram/Discord buttons
 DHW_TEMP_NORMAL_C=45.0                          # restore/safe-default tank target (45 °C = sufficient for normal use)
 TARGET_DHW_TEMP_MIN_GUESTS_C=55.0              # guest-mode LP floor (multiple showers at 20:30–22:00)
-DHW_PEAK_TANK_STRATEGY=shutdown                 # `shutdown` cuts tank power during peak (saves ~5p/day vs idle on
-                                                 # 14-day data); `idle` keeps tank ON at 45 °C floor (legacy default).
-                                                 # Validated 2026-05-11: 3 h shutdown drops tank ~6 °C (median decay
-                                                 # -1.97 °C/h), still ≥ 44 °C for evening showers.
-                                                 # IMPORTANT: tank pre-charge above 45 °C only happens when there's
-                                                 # an economic reason — `negative` (paid to import → 65 °C max),
-                                                 # `solar_charge` (free PV → DHW_TEMP_PV_ABUNDANCE_TARGET_C, default
-                                                 # 45 → runtime-tunable per household occupancy), `cheap` (modest
-                                                 # → 48 °C). Peak avoidance does NOT trigger pre-charging — see
-                                                 # issue #322 for conditional shutdown commit.
+# DHW_PEAK_TANK_STRATEGY was REMOVED 2026-05-21 (Epic 14, #386). The dispatch
+# layer always uses the IDLE behaviour (tank_power=True, tank_temp=DHW_TEMP_NORMAL_C)
+# during peak / peak_export windows. Prod telemetry (30d, 8 completed peak
+# windows) showed median tank decay 0.00 °C/h — the tank coasts essentially
+# perfectly even when held warm — and SHUTDOWN attempts failed 27% of the time
+# with READ_ONLY_CHARACTERISTIC errors. Leaving the env line in /srv/hem/.env
+# is harmless; remove on next .env touch.
+# IMPORTANT: tank pre-charge above 45 °C only happens when there's
+# an economic reason — `negative` (paid to import → 65 °C max),
+# `solar_charge` (free PV → DHW_TEMP_PV_ABUNDANCE_TARGET_C, default
+# 45 → runtime-tunable per household occupancy), `cheap` (modest
+# → 48 °C). Peak avoidance does NOT trigger pre-charging — see
+# issue #322 for conditional shutdown commit.
 DHW_TEMP_PV_ABUNDANCE_TARGET_C=45               # tank target during solar_charge / solar_preheat slots. Runtime-
                                                  # tunable via runtime_settings (PUT /api/v1/settings or MCP
                                                  # `set_setting`). Raise per household: single ~42, family of 4

--- a/src/config.py
+++ b/src/config.py
@@ -622,16 +622,14 @@ class Config:
     # DHW_TEMP_PV_ABUNDANCE_TARGET_C is now runtime-tunable via runtime_settings
     # (see @property below). Default lowered from 55 → 45 (= DHW_TEMP_NORMAL_C);
     # override per household occupancy at runtime without restart.
-    # Strategy for tank during peak / peak_export windows (climate is always
-    # off during peak — this is just about the tank):
-    #   "idle" (default) — tank_power=True, target=DHW_TEMP_MIN_FLOOR_C (30°C).
-    #     Firmware won't reheat (tank stays warm from prior heating, well
-    #     above 30°C). Avoids turn-off / turn-on cycle overhead. Best for
-    #     well-insulated tanks where 3-h standing losses are tiny.
-    #   "shutdown" — tank_power=False (legacy). Cleaner state but adds cycle
-    #     overhead. Pick this for poorly-insulated tanks where firmware
-    #     would attempt mid-peak reheats from standing losses alone.
-    DHW_PEAK_TANK_STRATEGY: str = os.getenv("DHW_PEAK_TANK_STRATEGY", "idle").strip().lower()
+    # NOTE: ``DHW_PEAK_TANK_STRATEGY`` was removed 2026-05-21 (Epic 14, #386).
+    # Prod telemetry showed the SHUTDOWN branch failed 27% of the time with
+    # READ_ONLY_CHARACTERISTIC errors and produced no measurable kWh savings
+    # vs the IDLE behaviour for this well-insulated tank (median decay
+    # 0.00 °C/h across 8 May peak windows). The dispatch layer always uses
+    # the IDLE behaviour now (tank_power=True, tank_temp=DHW_TEMP_NORMAL_C).
+    # The env line in ``/srv/hem/.env`` becomes a harmless unknown; remove it
+    # opportunistically on the next ``.env`` touch.
     # Post-shower overnight tank idle (LP-driven). After the LAST shower window
     # of the day, the LP has no DHW need until next-day's PV abundance — the
     # tank is set to a low BACKUP target so firmware doesn't reheat overnight,
@@ -1264,6 +1262,27 @@ class Config:
     )
     DAIKIN_OVERRIDE_TOLERANCE_LWT_C: float = float(
         os.getenv("DAIKIN_OVERRIDE_TOLERANCE_LWT_C", "0.35")
+    )
+    # Epic 14 (#386) — pre-fire reconcile knobs.
+    #
+    # When the user has overridden a recent action_schedule row (Onecta app /
+    # physical button) and the next LP replan inserts a NEW row covering the
+    # overlapping window with identical params, that fresh row would normally
+    # fire and undo the user's gesture. Within this window after an override
+    # was recorded, the pre-fire reconcile inherits the override onto any
+    # would-be reversion row. Aged past the window → normal scheduling resumes.
+    USER_OVERRIDE_RESPECT_HOURS: float = float(
+        os.getenv("USER_OVERRIDE_RESPECT_HOURS", "4.0")
+    )
+    # Feature flag for the pre-fire state-match dedupe. When True (default),
+    # the heartbeat compares the live device state against a pending row's
+    # params before firing — already-matching rows are marked completed with
+    # no API call. Kills the READ_ONLY_CHARACTERISTIC failures and the
+    # redundant writes from overlapping replan rows. Flip to "false" for an
+    # instant rollback if the comparator misbehaves.
+    PREFIRE_STATE_MATCH_ENABLED: bool = (
+        os.getenv("PREFIRE_STATE_MATCH_ENABLED", "true").strip().lower()
+        in ("1", "true", "yes", "on")
     )
 
     # Fox ESS: soft daily budget (real limit ≈1440; we stop at 1200 for 15% headroom)

--- a/src/daikin_bulletproof.py
+++ b/src/daikin_bulletproof.py
@@ -94,6 +94,50 @@ def detect_user_override(
     return False, None
 
 
+def user_gesture_still_in_effect(
+    dev: DaikinDevice,
+    override_row_params: dict[str, Any],
+) -> bool:
+    """Epic 14 (#386): True iff the live device state still contradicts the
+    overridden row's scheduled params on at least one known field.
+
+    The reconciler uses this to decide whether a user's earlier manual
+    gesture (e.g. tank power-off via Onecta) is still active when a fresh
+    LP-planned row arrives. Examples:
+
+    - Override row wanted ``tank_power=True``; live ``dev.tank_on`` is
+      ``False`` → user is still holding the tank off → gesture in effect.
+    - Override row wanted ``tank_power=True``; live ``dev.tank_on`` is
+      ``True`` → user has reverted (turned tank back on) → gesture over,
+      normal scheduling resumes.
+    - Live state is unknown (``None``) on every overridable field → we
+      cannot confirm divergence → return ``False`` (don't over-suppress
+      on a transient telemetry blip).
+
+    Distinct from ``daikin_device_matches_params`` which returns False on
+    unknown fields; here unknown fields are treated as non-evidence.
+    """
+    tank_tol = float(config.DAIKIN_OVERRIDE_TOLERANCE_TANK_C)
+    lwt_tol = float(config.DAIKIN_OVERRIDE_TOLERANCE_LWT_C)
+
+    if "tank_power" in override_row_params and dev.tank_on is not None:
+        if dev.tank_on != bool(override_row_params["tank_power"]):
+            return True
+    if "tank_temp" in override_row_params and dev.tank_target is not None:
+        if abs(float(dev.tank_target) - float(override_row_params["tank_temp"])) > tank_tol:
+            return True
+    if "climate_on" in override_row_params and dev.is_on is not None:
+        if dev.is_on != bool(override_row_params["climate_on"]):
+            return True
+    if "lwt_offset" in override_row_params and dev.lwt_offset is not None:
+        if abs(float(dev.lwt_offset) - float(override_row_params["lwt_offset"])) > lwt_tol:
+            return True
+    if "tank_powerful" in override_row_params and dev.tank_powerful is not None:
+        if dev.tank_powerful != bool(override_row_params["tank_powerful"]):
+            return True
+    return False
+
+
 def apply_scheduled_daikin_params(
     dev: DaikinDevice,
     client: DaikinClient,

--- a/src/db.py
+++ b/src/db.py
@@ -1338,6 +1338,40 @@ def mark_action_user_overridden(
             conn.close()
 
 
+def find_recent_user_override(
+    device: str,
+    *,
+    within_hours: float,
+    now_utc: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Epic 14 (#386): the most-recent ``user_overridden`` action_schedule row
+    for ``device`` whose ``overridden_by_user_at`` falls inside the trailing
+    ``within_hours`` window. Returns ``None`` when no such row exists.
+
+    Used by the heartbeat reconciler to propagate a user's manual gesture
+    (e.g. tank power-off via Onecta) onto fresh rows the LP inserts after
+    a replan, so the user doesn't have to keep undoing the same action.
+    """
+    if within_hours <= 0:
+        return None
+    now = now_utc or datetime.now(UTC)
+    cutoff = (now - timedelta(hours=within_hours)).isoformat()
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                "SELECT * FROM action_schedule "
+                "WHERE device = ? AND overridden_by_user_at IS NOT NULL "
+                "AND overridden_by_user_at >= ? "
+                "ORDER BY overridden_by_user_at DESC LIMIT 1",
+                (device, cutoff),
+            )
+            r = cur.fetchone()
+            return _row_action(r) if r else None
+        finally:
+            conn.close()
+
+
 def get_action_by_id(action_id: int) -> dict[str, Any] | None:
     with _lock:
         conn = get_connection()

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -457,23 +457,25 @@ def daikin_dispatch_preview(
             # runtime override (e.g. 37.5) doesn't become a 400 from the cloud.
             params["tank_temp"] = int(round(_overnight_target))
         elif is_shutdown:
-            peak_strategy = (getattr(config, "DHW_PEAK_TANK_STRATEGY", "idle") or "idle").strip().lower()
-            if peak_strategy == "shutdown":
-                params["tank_power"] = False
-                # No tank_temp — tank off, target is meaningless.
-            else:
-                # IDLE strategy: keep tank on at the NORMAL target. If tank
-                # was inherited above target (e.g. from prior solar_preheat),
-                # firmware just stops reheating — no grid draw, tank cools
-                # naturally. If tank is at-or-below target, firmware maintains
-                # at the setpoint (small reheats only when needed). User's
-                # validated approach for well-insulated tanks: don't shut off,
-                # just lower the target back to "normal" and let physics work.
-                params["tank_power"] = True
-                # Onecta stepValue=1 (see overnight comment above).
-                params["tank_temp"] = int(round(
-                    float(getattr(config, "DHW_TEMP_NORMAL_C", 45.0))
-                ))
+            # Epic 14 (#386) — single behaviour for peak / peak_export.
+            # The former ``DHW_PEAK_TANK_STRATEGY="shutdown"`` branch was
+            # removed because (a) prod telemetry across 8 May peak windows
+            # showed median tank decay of 0.00 °C/h — the tank coasts
+            # essentially perfectly even when held at 45 °C — and (b) the
+            # tank_power=False path failed 27% of the time on the Onecta
+            # cloud with READ_ONLY_CHARACTERISTIC errors when device state
+            # already matched (e.g. after a user override or a previous
+            # successful write).
+            #
+            # Keep tank ON at NORMAL target. If tank is above target from
+            # prior solar / cheap charging, firmware doesn't reheat (no grid
+            # draw). If at-or-below, firmware maintains at the setpoint.
+            # No power cycling, no Onecta state-mismatch failures.
+            params["tank_power"] = True
+            # Onecta stepValue=1 (see overnight comment above).
+            params["tank_temp"] = int(round(
+                float(getattr(config, "DHW_TEMP_NORMAL_C", 45.0))
+            ))
         elif tank_pow:
             params["tank_power"] = True
             # Floor at DHW_TEMP_COMFORT_C (48 °C). Ceiling depends on slot kind:

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -13,7 +13,9 @@ from .daikin.client import DaikinClient, DaikinError
 from .daikin_bulletproof import (
     apply_comfort_restore,
     apply_scheduled_daikin_params,
+    daikin_device_matches_params,
     detect_user_override,
+    user_gesture_still_in_effect,
 )
 from .foxess.client import FoxESSClient, FoxESSError, scheduler_groups_from_stored_json
 from .notifier import notify_risk, notify_user_override
@@ -33,6 +35,14 @@ _FIRST_APPLIED_SESSION: dict[int, datetime] = {}
 #  * the action's override is reconciled (row no longer detected as override), or
 #  * the action ends (row drops out of the reconcile window naturally).
 _USER_OVERRIDE_NOTIFIED: set[int] = set()
+
+# Epic 14 (#386) — dedup for the inherited-override notification. Keyed on the
+# SOURCE override row id (not the suppressed downstream row id), so each
+# user gesture produces a single ping even when N subsequent replan rows are
+# suppressed against it. Entries linger until the process restarts — set growth
+# is bounded by ``USER_OVERRIDE_RESPECT_HOURS`` × user-gesture frequency, well
+# below a kilobyte over a service lifetime.
+_USER_OVERRIDE_INHERITED_NOTIFIED: set[int] = set()
 
 
 def _parse_utc(s: str) -> datetime:
@@ -235,6 +245,111 @@ def _reconcile_daikin_actions(
             # LP only drives tank state — Daikin firmware owns the curve.
             apply_params.pop("lwt_offset", None)
             apply_params.pop("climate_on", None)
+
+            # Epic 14 (#386) — pre-fire reconcile.
+            #
+            # (1) Idempotency: if the live device state already matches the
+            #     row's params, mark completed without firing. Naturally
+            #     de-dupes overlapping replan rows (bug D) and prevents the
+            #     READ_ONLY_CHARACTERISTIC errors that come from PATCHing
+            #     a characteristic to a value it already holds (bug E).
+            #
+            #     We must observe *every* field in apply_params on the live
+            #     device before declaring a match. ``daikin_device_matches_params``
+            #     silently passes unknown fields (e.g. tank_temp when tank_target
+            #     is None) which would over-skip. Belt-and-braces here.
+            _obs_attr = {
+                "tank_temp": "tank_target",
+                "tank_power": "tank_on",
+                "tank_powerful": "tank_powerful",
+                "lwt_offset": "lwt_offset",
+                "climate_on": "is_on",
+            }
+            all_observable = all(
+                getattr(dev, _obs_attr[k], None) is not None
+                for k in apply_params
+                if k in _obs_attr
+            )
+            if config.PREFIRE_STATE_MATCH_ENABLED and all_observable:
+                try:
+                    if daikin_device_matches_params(dev, apply_params):
+                        db.mark_action(
+                            aid, "completed",
+                            error_msg="noop (state matched pre-fire)",
+                        )
+                        db.log_action(
+                            device="daikin",
+                            action="prefire_state_match",
+                            params={"row_id": aid, "kind": atype},
+                            result="skipped",
+                            trigger=trigger,
+                        )
+                        _USER_OVERRIDE_NOTIFIED.discard(aid)
+                        continue
+                except Exception as _exc:
+                    # Fail-open: if the comparator misbehaves we still fire.
+                    logger.debug("prefire state-match check failed (non-fatal): %s", _exc)
+
+            # (2) Override inheritance: if a recent user gesture is still
+            #     pushing the device away from the schedule, suppress fresh
+            #     replan rows that would reverse it (bug C). Restore rows are
+            #     exempted so the system can return to baseline once the
+            #     gesture either ages out or is reverted.
+            if atype != "restore":
+                try:
+                    src = db.find_recent_user_override(
+                        device="daikin",
+                        within_hours=float(config.USER_OVERRIDE_RESPECT_HOURS),
+                        now_utc=now_utc,
+                    )
+                    if src is not None and src.get("id") != aid:
+                        src_params = src.get("params") or {}
+                        if isinstance(src_params, str):
+                            try:
+                                src_params = json.loads(src_params)
+                            except (json.JSONDecodeError, TypeError):
+                                src_params = {}
+                        # Only suppress if (a) the user's gesture is still
+                        # detectable on the live device, AND (b) the row we're
+                        # about to fire would actually change device state
+                        # (i.e. would reverse the gesture). If (b) is False
+                        # the idempotency check already fired and we wouldn't
+                        # reach here — but we re-check for safety when the
+                        # idempotency feature flag is disabled.
+                        gesture_active = user_gesture_still_in_effect(dev, src_params)
+                        would_change_state = not daikin_device_matches_params(dev, apply_params)
+                        if gesture_active and would_change_state:
+                            db.mark_action_user_overridden(aid)
+                            src_id = int(src.get("id") or 0)
+                            db.log_action(
+                                device="daikin",
+                                action="prefire_override_inherited",
+                                params={
+                                    "row_id": aid,
+                                    "source_row_id": src_id,
+                                    "kind": atype,
+                                },
+                                result="skipped",
+                                trigger=trigger,
+                            )
+                            if src_id and src_id not in _USER_OVERRIDE_INHERITED_NOTIFIED:
+                                _USER_OVERRIDE_INHERITED_NOTIFIED.add(src_id)
+                                try:
+                                    notify_user_override(
+                                        f"override inherited from row {src_id} "
+                                        f"(user gesture still in effect, "
+                                        f"row {aid} suppressed)"
+                                    )
+                                except Exception as _exc:
+                                    logger.debug(
+                                        "notify_user_override (inherited) failed (non-fatal): %s",
+                                        _exc,
+                                    )
+                            continue
+                except Exception as _exc:
+                    logger.debug(
+                        "prefire override-inheritance check failed (non-fatal): %s", _exc,
+                    )
 
             # Phase 4.3 — check for user override before re-applying.
             # Phase 4 review C6: only run override detection after we've had at

--- a/tests/test_dhw_prefire_real_scenarios.py
+++ b/tests/test_dhw_prefire_real_scenarios.py
@@ -1,0 +1,515 @@
+"""Epic 14 (#386) — replay of the three prod incidents from 2026-05-21.
+
+Each test reconstructs the exact rows, params, timestamps and device state
+that was observed on prod, runs them through the new reconciler, and
+asserts the behaviour the user should have seen.
+
+Data source: ``/srv/hem/data/energy_state.db`` queried 2026-05-21 ~21:50 UTC.
+The row IDs reference real prod rows; values are reproduced exactly.
+
+Why these are kept as a separate file: they pin the new behaviour to
+concrete, named prod incidents so any future regression has a clear
+"this was the bug that drove the fix" reference.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.daikin.models import DaikinDevice
+
+
+def _insert_row(
+    conn,
+    *,
+    aid: int | None = None,
+    start: str,
+    end: str,
+    action_type: str,
+    status: str,
+    params: dict,
+    overridden_at: str | None = None,
+    restore_action_id: int | None = None,
+) -> int:
+    """Insert a row with explicit values, optionally pinning the id (so tests
+    can match the prod row id for clarity in failure messages)."""
+    now_iso = datetime.now(UTC).isoformat()
+    date_str = start[:10]
+    cols = "date, start_time, end_time, device, action_type, params, status, created_at"
+    vals: list = [date_str, start, end, "daikin", action_type, json.dumps(params), status, now_iso]
+    if overridden_at is not None:
+        cols += ", overridden_by_user_at"
+        vals.append(overridden_at)
+    if restore_action_id is not None:
+        cols += ", restore_action_id"
+        vals.append(restore_action_id)
+    if aid is not None:
+        cols = "id, " + cols
+        vals = [aid] + vals
+    placeholders = ",".join("?" * len(vals))
+    conn.execute(
+        f"INSERT INTO action_schedule ({cols}) VALUES ({placeholders})",
+        vals,
+    )
+    if aid is None:
+        aid = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    conn.commit()
+    return aid
+
+
+def _setup_test(monkeypatch, path, *, prefire_enabled: bool = True):
+    """Common setup: temp DB, common config patches, clean process state."""
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", prefire_enabled)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+    db.init_db()
+
+
+# ── BUG C — REPLAN-CHAIN OVERRIDE PATTERN ─────────────────────────────────────
+#
+# Recurring across multiple days in the prod data (sample, last 30 days):
+#   * 2026-05-13: 4 pre_heat rows (tank=48, on) overridden across 133 min
+#   * 2026-05-16: 3 solar_preheat rows (tank=45, on) overridden across 208 min
+#   * 2026-05-20 evening: rows 5518 + 5529 (tank_idle_overnight, tank=37, on)
+#       overridden 16 min apart — user CLEARLY didn't want overnight tank, but
+#       the LP replan kept inserting fresh rows with the same params.
+#   * 2026-05-21 evening: rows 6011 + 6025 — same pattern. Caveat: the user
+#       may have been testing the Onecta app rather than expressing a stable
+#       preference; the 2026-05-20 case is cleaner.
+#
+# In all cases the system behavior is identical: HEM correctly marks the
+# active row overridden, then the next LP replan inserts a NEW row covering
+# the same window with identical params and no awareness of the recent
+# user gesture. The new row fires, undoing the gesture.
+#
+# Two replay tests below: 2026-05-20 (cleanest) and 2026-05-21 (latest).
+
+
+def test_real_bug_C_overnight_2026_05_20_clean_signal(monkeypatch):
+    """Replays rows 5518 + 5529 from 2026-05-20 21:00-21:43 UTC — the cleanest
+    bug C signal in 30d of prod data (16-minute gap between two identical
+    tank_idle_overnight rows both getting overridden).
+
+    Expected: row 5529 inherits the override from 5518 and does NOT fire.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    notifications: list[str] = []
+    monkeypatch.setattr(
+        "src.state_machine.notify_user_override",
+        lambda msg: notifications.append(msg),
+    )
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "prod_replay.db"
+        _setup_test(monkeypatch, path)
+        # "Now" ≈ 21:32 — moment row 5529 fired in prod (analogous to 6025).
+        now_utc = datetime(2026, 5, 20, 21, 32, 0, tzinfo=UTC)
+
+        conn = db.get_connection()
+        try:
+            _insert_row(
+                conn, aid=5518,
+                start="2026-05-20T21:00:00Z",
+                end="2026-05-21T06:00:00Z",
+                action_type="tank_idle_overnight",
+                status="active",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": True, "tank_temp": 37},
+                overridden_at="2026-05-20T21:27:57.000000+00:00",
+            )
+            _insert_row(
+                conn, aid=5529,
+                start="2026-05-20T21:30:00Z",
+                end="2026-05-21T06:00:00Z",
+                action_type="tank_idle_overnight",
+                status="pending",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": True, "tank_temp": 37},
+            )
+        finally:
+            conn.close()
+
+        # User had the tank off after the 21:27 gesture.
+        dev = DaikinDevice(id="gw", name="x", tank_on=False, tank_target=37.0)
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="heartbeat")
+
+        row_5529 = db.get_action_by_id(5529)
+        assert row_5529 is not None
+        assert row_5529.get("overridden_by_user_at") is not None, (
+            "Row 5529 must inherit override from row 5518 — without this fix "
+            "the user had to turn the tank off again at 21:43 in prod"
+        )
+        assert len(apply_calls) == 0
+        assert len(notifications) == 1
+        assert "row 5518" in notifications[0]
+
+
+def test_real_bug_C_overnight_2026_05_21_latest_observation(monkeypatch):
+    """Replays rows 6011 + 6025 from 2026-05-21 21:00-21:42 UTC.
+
+    NOTE: the user noted they may have been testing the Onecta app on this
+    evening (rather than expressing a stable "no tank tonight" preference).
+    Either way, the system's BEHAVIOUR is the same — a new row with
+    identical params is inserted minutes after the override and fires
+    blindly. This test pins that behaviour even if the gesture was
+    exploratory. See 2026-05-20 test above for an unambiguous case.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    notifications: list[str] = []
+    monkeypatch.setattr(
+        "src.state_machine.notify_user_override",
+        lambda msg: notifications.append(msg),
+    )
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "prod_replay.db"
+        _setup_test(monkeypatch, path)
+        # "Now" = 21:32:19 UTC — the moment row 6025 fired in prod.
+        now_utc = datetime(2026, 5, 21, 21, 32, 19, tzinfo=UTC)
+
+        conn = db.get_connection()
+        try:
+            # Row 6011 — already overridden by user at 21:11:44.
+            _insert_row(
+                conn, aid=6011,
+                start="2026-05-21T21:00:00Z",
+                end="2026-05-22T06:00:00Z",
+                action_type="tank_idle_overnight",
+                status="active",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": True, "tank_temp": 37},
+                overridden_at="2026-05-21T21:11:44.114153+00:00",
+            )
+            # Row 6025 — the replacement row, pending at "now".
+            _insert_row(
+                conn, aid=6025,
+                start="2026-05-21T21:30:00Z",
+                end="2026-05-22T06:00:00Z",
+                action_type="tank_idle_overnight",
+                status="pending",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": True, "tank_temp": 37},
+            )
+        finally:
+            conn.close()
+
+        # Device state: user has the tank OFF. We don't know exact tank
+        # temperature at this moment but the telemetry sample from 22:25
+        # UTC showed 51°C target=45 (legacy from earlier in day), so it's
+        # reasonable to use tank_target=37 (the row 6011 setpoint that
+        # Daikin had echoed back before override).
+        dev = DaikinDevice(id="gw", name="x", tank_on=False, tank_target=37.0)
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="heartbeat")
+
+        # Assert row 6025 was inherited-suppressed.
+        row_6025 = db.get_action_by_id(6025)
+        assert row_6025 is not None
+        assert row_6025.get("overridden_by_user_at") is not None, (
+            "Row 6025 must inherit the override from row 6011 — otherwise the "
+            "user would have to turn the tank off again (the actual prod bug)"
+        )
+        # Assert no Daikin write happened on row 6025.
+        assert len(apply_calls) == 0, (
+            f"Expected zero apply calls when override inheritance fires; "
+            f"got {len(apply_calls)} (params: {apply_calls})"
+        )
+        # Assert single notification referencing source row 6011.
+        assert len(notifications) == 1
+        assert "row 6011" in notifications[0]
+
+
+# ── BUG D: rows 5601, 5613, 5639, 5653, 5667 (2026-05-21 08:00-14:00) ─────────
+#
+# Prod incident: between 08:00 and 14:00 UTC five separate `solar_preheat`
+# rows fired with identical params {tank_power: True, tank_temp: 45}.
+# Daikin telemetry shows tank_target stayed at 45 throughout — only the
+# first write actually changed state, the other four were redundant.
+# Each one consumed quota from the 200/day Onecta budget.
+#
+# With Epic 14, after the first write sets target=45, subsequent rows
+# pre-fire compare dev.tank_target=45 against their param.tank_temp=45
+# and complete with `noop (state matched pre-fire)` — zero further writes.
+
+
+def test_real_bug_D_overlapping_solar_preheat_dedup(monkeypatch):
+    """Replays rows 5601, 5613, 5639, 5653 from 2026-05-21 08:00-13:30 UTC.
+
+    Five rows in prod → 5 API calls. With Epic 14 → 1 API call.
+    (5667 is excluded from the assertion because its params dict on prod
+    didn't carry tank_temp; this test focuses on the canonical pattern.)
+    """
+    import src.state_machine as sm
+    from src import db
+
+    apply_calls: list[dict] = []
+
+    def _record_and_echo_to_dev(dev, client, params, trigger):
+        apply_calls.append(dict(params))
+        # Simulate the Daikin write echoing back into the cached snapshot.
+        # Each subsequent row in the same tick reads against the freshly-
+        # updated snapshot and hits the idempotency match.
+        if "tank_temp" in params:
+            dev.tank_target = float(params["tank_temp"])
+        if "tank_power" in params:
+            dev.tank_on = bool(params["tank_power"])
+        if "tank_powerful" in params:
+            dev.tank_powerful = bool(params["tank_powerful"])
+
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params", _record_and_echo_to_dev,
+    )
+    monkeypatch.setattr("src.state_machine.notify_user_override", lambda msg: None)
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "prod_replay.db"
+        _setup_test(monkeypatch, path)
+        # "Now" = 12:30 UTC — all four canonical rows are within their
+        # firing windows at this moment.
+        now_utc = datetime(2026, 5, 21, 12, 30, tzinfo=UTC)
+
+        conn = db.get_connection()
+        try:
+            # Each row from prod, in id order. Mark all pending so the
+            # reconciler tries to fire them in this tick.
+            common_params = {"tank_powerful": False, "lp_optimizer": True,
+                             "tank_power": True, "tank_temp": 45}
+            _insert_row(
+                conn, aid=5601, start="2026-05-21T08:00:00Z", end="2026-05-21T14:00:00Z",
+                action_type="solar_preheat", status="pending", params=common_params,
+            )
+            _insert_row(
+                conn, aid=5613, start="2026-05-21T09:00:00Z", end="2026-05-21T14:00:00Z",
+                action_type="solar_preheat", status="pending", params=common_params,
+            )
+            _insert_row(
+                conn, aid=5639, start="2026-05-21T11:00:00Z", end="2026-05-21T13:30:00Z",
+                action_type="solar_preheat", status="pending", params=common_params,
+            )
+            _insert_row(
+                conn, aid=5653, start="2026-05-21T11:30:00Z", end="2026-05-21T13:30:00Z",
+                action_type="solar_preheat", status="pending", params=common_params,
+            )
+        finally:
+            conn.close()
+
+        # Device state pre-apply: tank target diverges from the row's intent
+        # so the first row WILL apply and echo back. tank_powerful is set
+        # because the row's params include it (strict observability gate).
+        dev = DaikinDevice(
+            id="gw", name="x",
+            tank_on=True, tank_target=37.0, tank_powerful=False,
+        )
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="heartbeat")
+
+        # Exactly ONE apply call regardless of how many rows hit the window.
+        assert len(apply_calls) == 1, (
+            f"Expected 1 apply call (first row fires + state echoes; rest are "
+            f"deduped via pre-fire match), got {len(apply_calls)} calls. "
+            f"Prod observed 5 redundant API calls — this is the regression test."
+        )
+        # And the surviving call has the canonical params.
+        assert apply_calls[0].get("tank_temp") == 45
+        assert apply_calls[0].get("tank_power") is True
+
+
+# ── BUG E: row 5830 (2026-05-21 16:30-16:36 — failed shutdown) ────────────────
+#
+# Prod incident: at 15:30 row 5828 (`tank_idle_overnight`, tank=37, on)
+# fired. At 15:40:51 the user manually turned the tank off (override on 5828).
+# At 16:30 row 5830 (`shutdown`, tank_power=False) became active. At 16:36:37
+# it tried to set tank_power=False on an already-off tank and got
+# HTTP 400 `READ_ONLY_CHARACTERISTIC`. Row marked `failed`, error_msg
+# pollutes the daily audit timer.
+#
+# With Epic 14:
+#   - Idempotency check: dev.tank_on=False vs params.tank_power=False → MATCH
+#   - Row completes pre-fire with "noop (state matched pre-fire)"
+#   - Zero API calls, zero failures, zero audit pollution
+
+
+def test_real_bug_E_shutdown_after_user_turned_tank_off(monkeypatch):
+    """Replays rows 5828 + 5830 from 2026-05-21 15:30-16:36 UTC.
+
+    Expected: row 5830 completes via pre-fire match — no Daikin API call,
+    no READ_ONLY_CHARACTERISTIC HTTP 400, no `failed` status.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+    monkeypatch.setattr("src.state_machine.notify_user_override", lambda msg: None)
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "prod_replay.db"
+        _setup_test(monkeypatch, path)
+        # "Now" = 16:36 UTC — the moment 5830 fired and failed on prod.
+        now_utc = datetime(2026, 5, 21, 16, 36, 37, tzinfo=UTC)
+
+        conn = db.get_connection()
+        try:
+            # Row 5828 — earlier overridden row (already completed at end_time).
+            _insert_row(
+                conn, aid=5828,
+                start="2026-05-21T15:30:00Z",
+                end="2026-05-21T16:30:00Z",
+                action_type="tank_idle_overnight",
+                status="completed",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": True, "tank_temp": 37},
+                overridden_at="2026-05-21T15:40:51.873403+00:00",
+            )
+            # Row 5830 — the shutdown row that failed in prod.
+            _insert_row(
+                conn, aid=5830,
+                start="2026-05-21T16:30:00Z",
+                end="2026-05-21T18:00:00Z",
+                action_type="shutdown",
+                status="pending",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": False},
+            )
+        finally:
+            conn.close()
+
+        # Device state at 16:36: user had the tank off since 15:40.
+        # tank_powerful was already false from earlier (the param is in the
+        # row's intent so the observability gate needs it set).
+        dev = DaikinDevice(id="gw", name="x", tank_on=False, tank_powerful=False)
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="heartbeat")
+
+        # No API call attempted → no READ_ONLY error possible.
+        assert len(apply_calls) == 0, (
+            f"Expected zero apply calls (state already matches), got "
+            f"{len(apply_calls)} — pre-fire idempotency check failed"
+        )
+        # Row 5830 should be COMPLETED via pre-fire match — not 'failed'.
+        row_5830 = db.get_action_by_id(5830)
+        assert row_5830 is not None
+        assert row_5830["status"] == "completed", (
+            f"Expected completed (via pre-fire match), got '{row_5830['status']}' "
+            f"with error_msg={row_5830.get('error_msg')!r}. "
+            f"Prod observed status='failed' with the READ_ONLY_CHARACTERISTIC error."
+        )
+        assert (row_5830.get("error_msg") or "").startswith("noop")
+
+
+# ── BUG E (variant): user_override path also catches this defensively ─────────
+#
+# Even if PREFIRE_STATE_MATCH_ENABLED is somehow off, the user-override
+# inheritance path should catch row 5830 — row 5828 was overridden 56 min
+# ago, within the 4h respect window, and the user's tank-off gesture is
+# still in effect.
+
+
+def test_real_bug_E_falls_back_to_override_inheritance_when_idempotency_off(monkeypatch):
+    """Defence-in-depth: with the idempotency feature flag disabled, the
+    override-inheritance branch still suppresses row 5830."""
+    import src.state_machine as sm
+    from src import db
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+    notifications: list[str] = []
+    monkeypatch.setattr(
+        "src.state_machine.notify_user_override",
+        lambda msg: notifications.append(msg),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "prod_replay.db"
+        _setup_test(monkeypatch, path, prefire_enabled=False)
+        now_utc = datetime(2026, 5, 21, 16, 36, 37, tzinfo=UTC)
+
+        conn = db.get_connection()
+        try:
+            _insert_row(
+                conn, aid=5828,
+                start="2026-05-21T15:30:00Z",
+                end="2026-05-21T16:30:00Z",
+                action_type="tank_idle_overnight",
+                status="completed",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": True, "tank_temp": 37},
+                overridden_at="2026-05-21T15:40:51.873403+00:00",
+            )
+            _insert_row(
+                conn, aid=5830,
+                start="2026-05-21T16:30:00Z",
+                end="2026-05-21T18:00:00Z",
+                action_type="shutdown",
+                status="pending",
+                params={"tank_powerful": False, "lp_optimizer": True,
+                        "tank_power": False},
+            )
+        finally:
+            conn.close()
+
+        # Important: NOT setting tank_powerful on this dev. Real prod
+        # snapshots populate tank_powerful, but here we exercise the case
+        # where tank_powerful is unknown — which forces
+        # daikin_device_matches_params to return False on that field. That
+        # makes the override-inheritance path engage (would_change_state=True).
+        dev = DaikinDevice(id="gw", name="x", tank_on=False)
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="heartbeat")
+
+        # Defence in depth confirmed: when idempotency is off, override-
+        # inheritance still suppresses row 5830 because (a) row 5828's
+        # gesture (tank_on=False, contradicting overridden params tank_power=True)
+        # is still in effect, and (b) the strict-comparator returns False
+        # on the unknown tank_powerful field → would_change_state=True.
+        assert len(apply_calls) == 0, (
+            f"Override inheritance should fire when idempotency is off and "
+            f"a recent user gesture exists. Got {len(apply_calls)} apply call(s)."
+        )
+        row_5830 = db.get_action_by_id(5830)
+        assert row_5830 is not None
+        assert row_5830.get("overridden_by_user_at") is not None, (
+            "Row 5830 should inherit override from row 5828"
+        )
+        assert len(notifications) == 1
+        assert "row 5828" in notifications[0]

--- a/tests/test_lp_pv_abundance.py
+++ b/tests/test_lp_pv_abundance.py
@@ -616,21 +616,21 @@ def _build_peak_plan(base: datetime, n: int = 4) -> "LpPlan":
     return plan
 
 
-def test_dispatch_peak_idle_default_keeps_tank_on_normal_target(
+def test_dispatch_peak_keeps_tank_on_normal_target(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Default peak strategy ("idle") keeps tank ON at the NORMAL target
-    during peak. If tank is inherited above target (from prior solar_preheat),
+    """Epic 14 (#386): peak / peak_export windows always keep tank ON at the
+    NORMAL target. If tank is inherited above target (from prior solar_preheat),
     firmware sees current > setpoint and won't reheat — tank cools naturally.
     If tank is at or below target, firmware maintains setpoint with small
     reheats only when needed. Best for well-insulated tanks per user's
-    validated approach. Climate still goes off (saves grid)."""
+    validated approach. Climate still goes off (saves grid).
+    """
     from src.config import config as app_config
     from src.scheduler.lp_dispatch import daikin_dispatch_preview
 
     monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
     monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
-    monkeypatch.setattr(app_config, "DHW_PEAK_TANK_STRATEGY", "idle", raising=False)
     monkeypatch.setattr(app_config, "DHW_TEMP_NORMAL_C", 45.0, raising=False)
     monkeypatch.setattr(
         "src.scheduler.lp_dispatch._optimization_preset_away_like",
@@ -644,13 +644,17 @@ def test_dispatch_peak_idle_default_keeps_tank_on_normal_target(
     assert peak_pairs, "expected a shutdown action"
     for _restore, action in peak_pairs:
         params = action["params"]
-        # IDLE: tank stays ON at NORMAL target (45°C, not the 30°C floor).
+        # Epic 14 (#386): peak / peak_export always keeps tank ON at NORMAL
+        # target (45°C). The legacy SHUTDOWN branch was removed because (a)
+        # prod telemetry showed near-zero coast decay even when held warm,
+        # and (b) the tank_power=False writes failed 27% of the time with
+        # Onecta READ_ONLY_CHARACTERISTIC errors.
         assert params.get("tank_power") is True, (
-            f"idle strategy must keep tank_power=True; params={params}"
+            f"peak action must keep tank_power=True; params={params}"
         )
         assert params.get("tank_temp") == pytest.approx(45.0), (
-            f"idle strategy must set tank_temp to DHW_TEMP_NORMAL_C (45°C), "
-            f"NOT the absolute floor (30°C); got {params.get('tank_temp')}"
+            f"peak action must set tank_temp to DHW_TEMP_NORMAL_C (45°C); "
+            f"got {params.get('tank_temp')}"
         )
         # CLIMATE HANDS-OFF: HEM does not emit climate_on at all (per user
         # 2026-05-09 — "we are not discussing climate yet"). Firmware
@@ -660,38 +664,6 @@ def test_dispatch_peak_idle_default_keeps_tank_on_normal_target(
         )
         assert "lwt_offset" not in params, (
             f"HEM must not touch lwt_offset (climate-side); params={params}"
-        )
-
-
-def test_dispatch_peak_shutdown_legacy_still_works(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Legacy shutdown strategy still available via DHW_PEAK_TANK_STRATEGY=shutdown.
-    For poorly-insulated tanks where firmware would mid-peak-reheat from
-    standing losses alone."""
-    from src.config import config as app_config
-    from src.scheduler.lp_dispatch import daikin_dispatch_preview
-
-    monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
-    monkeypatch.setattr(app_config, "DAIKIN_MIN_WINDOW_SLOTS", 1, raising=False)
-    monkeypatch.setattr(app_config, "DHW_PEAK_TANK_STRATEGY", "shutdown", raising=False)
-    monkeypatch.setattr(
-        "src.scheduler.lp_dispatch._optimization_preset_away_like",
-        lambda: False,
-        raising=True,
-    )
-
-    plan = _build_peak_plan(datetime(2026, 6, 1, 17, 0, tzinfo=UTC))
-    pairs = daikin_dispatch_preview(plan, forecast=[])
-    peak_pairs = [(r, a) for r, a in pairs if a.get("action_type") == "shutdown"]
-    assert peak_pairs, "expected a shutdown action"
-    for _restore, action in peak_pairs:
-        params = action["params"]
-        assert params.get("tank_power") is False, (
-            f"shutdown strategy MUST emit tank_power=False; params={params}"
-        )
-        assert "tank_temp" not in params, (
-            f"shutdown should not emit tank_temp; params={params}"
         )
 
 

--- a/tests/test_prefire_state_idempotency.py
+++ b/tests/test_prefire_state_idempotency.py
@@ -1,0 +1,289 @@
+"""Epic 14 (#386): pre-fire state-match idempotency.
+
+The heartbeat reconciler reads live Daikin state from the cached device
+snapshot and skips PATCH writes when the state already matches a pending
+row's params. This:
+
+- Kills the READ_ONLY_CHARACTERISTIC HTTP 400s seen on prod when
+  tank_power=False is written to an already-off tank (bug E)
+- De-duplicates overlapping replan rows by completing the second/third/...
+  duplicates after the first one actually changes state (bug D)
+- Fails open: unknown live state (cache miss, telemetry blip) falls
+  through to the normal apply path
+- Honours a feature flag (PREFIRE_STATE_MATCH_ENABLED) for rollback
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.daikin.models import DaikinDevice
+
+
+def _seed_active_row(conn, *, start_offset_seconds: int, params: dict) -> int:
+    now = datetime.now(UTC)
+    start = (now - timedelta(seconds=start_offset_seconds)).isoformat()
+    end = (now + timedelta(seconds=1800)).isoformat()
+    conn.execute(
+        """INSERT INTO action_schedule
+           (date, start_time, end_time, device, action_type, params, status, created_at)
+           VALUES (?, ?, ?, 'daikin', 'pre_heat', ?, 'active', ?)""",
+        (now.date().isoformat(), start, end, json.dumps(params), now.isoformat()),
+    )
+    rid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.commit()
+    return int(rid)
+
+
+def _common_monkeypatch(monkeypatch, *, prefire_enabled: bool = True):
+    """Defaults used by every test below."""
+    import src.state_machine as sm
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", prefire_enabled)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+
+
+def test_prefire_skips_when_state_matches(monkeypatch):
+    """Tank target already at 45, row wants 45 → row completed, no API call."""
+    import src.state_machine as sm
+    from src import db
+
+    _common_monkeypatch(monkeypatch)
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            rid = _seed_active_row(
+                conn, start_offset_seconds=60,
+                params={"tank_power": True, "tank_temp": 45},
+            )
+        finally:
+            conn.close()
+
+        dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=45.0)
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        row = db.get_action_by_id(rid)
+        assert row is not None
+        assert row["status"] == "completed"
+        assert (row.get("error_msg") or "").startswith("noop")
+        assert len(apply_calls) == 0
+
+
+def test_prefire_skips_when_tank_already_off(monkeypatch):
+    """Bug E regression — row wants tank_power=False, tank already off → skip.
+
+    Pre-fix, the Daikin client would PATCH onOffMode=off and get HTTP 400
+    READ_ONLY_CHARACTERISTIC, marking the row 'failed' and polluting the audit.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    _common_monkeypatch(monkeypatch)
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            rid = _seed_active_row(
+                conn, start_offset_seconds=60, params={"tank_power": False},
+            )
+        finally:
+            conn.close()
+
+        dev = DaikinDevice(id="gw", name="x", tank_on=False)
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        row = db.get_action_by_id(rid)
+        assert row is not None
+        assert row["status"] == "completed"
+        assert len(apply_calls) == 0
+
+
+def test_prefire_writes_when_state_diverges(monkeypatch):
+    """Tank at 37, row wants 45 → state diverges → apply called normally."""
+    import src.state_machine as sm
+    from src import db
+
+    _common_monkeypatch(monkeypatch)
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            _seed_active_row(
+                conn, start_offset_seconds=60,
+                params={"tank_power": True, "tank_temp": 45},
+            )
+        finally:
+            conn.close()
+
+        dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=37.0)
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        assert len(apply_calls) == 1
+        assert apply_calls[0].get("tank_temp") == 45
+
+
+def test_prefire_falls_through_when_state_unknown(monkeypatch):
+    """Cache miss (dev.tank_target=None) → can't confirm match → apply normally."""
+    import src.state_machine as sm
+    from src import db
+
+    _common_monkeypatch(monkeypatch)
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            _seed_active_row(
+                conn, start_offset_seconds=60,
+                params={"tank_power": True, "tank_temp": 45},
+            )
+        finally:
+            conn.close()
+
+        # tank_target is None — cannot verify match.
+        dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=None)
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        assert len(apply_calls) == 1
+
+
+def test_prefire_disabled_via_flag(monkeypatch):
+    """PREFIRE_STATE_MATCH_ENABLED=False → idempotency check is bypassed."""
+    import src.state_machine as sm
+    from src import db
+
+    _common_monkeypatch(monkeypatch, prefire_enabled=False)
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            _seed_active_row(
+                conn, start_offset_seconds=60,
+                params={"tank_power": True, "tank_temp": 45},
+            )
+        finally:
+            conn.close()
+
+        dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=45.0)
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        # State matched but flag is off → apply was called anyway.
+        assert len(apply_calls) == 1
+
+
+def test_prefire_dedupes_overlapping_rows(monkeypatch):
+    """Bug D regression — five replan rows with same params, dev state matches
+    the first one immediately. After tick 1 the row that fires is whichever
+    sorts first; the rest hit the matched-state path and complete without
+    additional API calls.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    _common_monkeypatch(monkeypatch)
+
+    apply_calls: list[dict] = []
+
+    def _record_and_set_state(dev, client, params, trigger):
+        apply_calls.append(dict(params))
+        # Simulate the device echoing the write back into our cached snapshot.
+        if "tank_temp" in params:
+            dev.tank_target = float(params["tank_temp"])
+        if "tank_power" in params:
+            dev.tank_on = bool(params["tank_power"])
+
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params", _record_and_set_state,
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            # Five rows, same params, all pending and inside the firing window.
+            for _ in range(5):
+                _seed_active_row(
+                    conn, start_offset_seconds=60,
+                    params={"tank_power": True, "tank_temp": 45},
+                )
+        finally:
+            conn.close()
+
+        # Live tank starts off-target so the first row WILL apply; remaining
+        # rows in the same tick should see the just-written state and skip.
+        dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=37.0)
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        # Exactly ONE apply call, even though 5 rows existed.
+        assert len(apply_calls) == 1, f"expected 1 apply, got {len(apply_calls)}"

--- a/tests/test_user_override.py
+++ b/tests/test_user_override.py
@@ -274,6 +274,12 @@ def test_reconcile_detects_override_marks_row_and_notifies(monkeypatch):
     monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_OVERRIDE_GRACE_SECONDS", 60)
     monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_OVERRIDE_TOLERANCE_TANK_C", 0.6)
     monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    # Epic 14 (#386): this test covers the legacy first-apply + later-divergence
+    # path. With PREFIRE_STATE_MATCH_ENABLED=True the reconciler would skip the
+    # first tick (state already matches) and the row would be completed before
+    # the user gesture happens — a different code path. Force the legacy path
+    # here so the override-detection logic stays under test.
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", False)
 
     # C6: clear process-local state between tests.
     sm._FIRST_APPLIED_SESSION.clear()
@@ -369,3 +375,337 @@ def test_boot_recovery_does_not_false_flag_override_on_first_tick(monkeypatch):
         # Must have actually APPLIED on this tick — the whole point is that boot-recovery
         # pushes our value rather than assuming the user changed it.
         assert rid in sm._FIRST_APPLIED_SESSION
+
+
+# ── Epic 14 (#386): find_recent_user_override helper ──────────────────────────
+
+def test_find_recent_user_override_returns_recent(monkeypatch):
+    from src import db
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            now = datetime.now(UTC)
+            rid = _seed_active_row(
+                conn, start_offset_seconds=3600, params={"tank_power": True, "tank_temp": 45},
+            )
+        finally:
+            conn.close()
+        # Mark overridden 30 min ago.
+        ts = (now - timedelta(minutes=30)).isoformat()
+        db.mark_action_user_overridden(rid, overridden_at=ts)
+
+        result = db.find_recent_user_override(
+            "daikin", within_hours=4.0, now_utc=now,
+        )
+        assert result is not None
+        assert result["id"] == rid
+
+
+def test_find_recent_user_override_outside_window_returns_none(monkeypatch):
+    from src import db
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            now = datetime.now(UTC)
+            rid = _seed_active_row(
+                conn, start_offset_seconds=3600 * 10, params={"tank_power": True},
+            )
+        finally:
+            conn.close()
+        # Override 8 hours ago — outside the 4h window.
+        ts = (now - timedelta(hours=8)).isoformat()
+        db.mark_action_user_overridden(rid, overridden_at=ts)
+
+        result = db.find_recent_user_override(
+            "daikin", within_hours=4.0, now_utc=now,
+        )
+        assert result is None
+
+
+def test_find_recent_user_override_filters_by_device(monkeypatch):
+    from src import db
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        # Seed a Fox-side overridden row — must not match a daikin query.
+        now = datetime.now(UTC)
+        conn = db.get_connection()
+        try:
+            start = (now - timedelta(seconds=3600)).isoformat()
+            end = (now + timedelta(seconds=1800)).isoformat()
+            conn.execute(
+                """INSERT INTO action_schedule
+                   (date, start_time, end_time, device, action_type, params, status, created_at)
+                   VALUES (?, ?, ?, 'foxess', 'discharge', '{}', 'active', ?)""",
+                (now.date().isoformat(), start, end, now.isoformat()),
+            )
+            rid = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+            conn.commit()
+        finally:
+            conn.close()
+        db.mark_action_user_overridden(rid, overridden_at=(now - timedelta(minutes=10)).isoformat())
+
+        # Daikin query returns nothing.
+        result = db.find_recent_user_override(
+            "daikin", within_hours=4.0, now_utc=now,
+        )
+        assert result is None
+        # Foxess query returns the row.
+        result = db.find_recent_user_override(
+            "foxess", within_hours=4.0, now_utc=now,
+        )
+        assert result is not None
+        assert result["id"] == rid
+
+
+# ── Epic 14 (#386): user_gesture_still_in_effect ──────────────────────────────
+
+def test_user_gesture_still_in_effect_tank_power_diverged():
+    """User turned tank OFF; override row wanted ON → gesture active."""
+    from src.daikin_bulletproof import user_gesture_still_in_effect
+
+    dev = DaikinDevice(id="gw", name="x", tank_on=False)
+    assert user_gesture_still_in_effect(dev, {"tank_power": True}) is True
+
+
+def test_user_gesture_still_in_effect_user_reverted():
+    """User turned tank back ON → state matches override row's intent → gesture OVER."""
+    from src.daikin_bulletproof import user_gesture_still_in_effect
+
+    dev = DaikinDevice(id="gw", name="x", tank_on=True)
+    assert user_gesture_still_in_effect(dev, {"tank_power": True}) is False
+
+
+def test_user_gesture_still_in_effect_state_unknown_returns_false():
+    """Telemetry blip — no confirmable evidence of divergence → don't over-suppress."""
+    from src.daikin_bulletproof import user_gesture_still_in_effect
+
+    dev = DaikinDevice(id="gw", name="x", tank_on=None, tank_target=None)
+    assert user_gesture_still_in_effect(dev, {"tank_power": True, "tank_temp": 45}) is False
+
+
+# ── Epic 14 (#386): pre-fire override-inheritance integration ─────────────────
+
+def test_inherited_override_suppresses_new_row(monkeypatch):
+    """The headline bug C scenario:
+    Row A (tank_power=True) is user-overridden at t-30min.
+    Row B is a fresh replan row with the same params, pending at now.
+    On reconcile, row B should be marked user_overridden and skip the API call.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", True)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+
+    notifications: list[str] = []
+    monkeypatch.setattr(
+        "src.state_machine.notify_user_override",
+        lambda msg: notifications.append(msg),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        now_utc = datetime.now(UTC)
+        conn = db.get_connection()
+        try:
+            # Row A — historical overridden row (past end_time).
+            start_a = (now_utc - timedelta(minutes=90)).isoformat()
+            end_a = (now_utc - timedelta(minutes=10)).isoformat()
+            conn.execute(
+                """INSERT INTO action_schedule
+                   (date, start_time, end_time, device, action_type, params, status, created_at)
+                   VALUES (?, ?, ?, 'daikin', 'tank_idle_overnight', ?, 'completed', ?)""",
+                (
+                    now_utc.date().isoformat(), start_a, end_a,
+                    json.dumps({"tank_power": True, "tank_temp": 37}),
+                    now_utc.isoformat(),
+                ),
+            )
+            row_a_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+            # Row B — fresh pending row with same params.
+            row_b_id = _seed_active_row(
+                conn, start_offset_seconds=60,
+                params={"tank_power": True, "tank_temp": 37},
+            )
+        finally:
+            conn.close()
+
+        # Mark Row A user-overridden 30 min ago.
+        db.mark_action_user_overridden(
+            row_a_id, overridden_at=(now_utc - timedelta(minutes=30)).isoformat(),
+        )
+
+        # User has turned tank OFF; live state contradicts Row A's intent.
+        dev = DaikinDevice(id="gw", name="x", tank_on=False, tank_target=37.0)
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        row_b = db.get_action_by_id(row_b_id)
+        assert row_b is not None
+        assert row_b.get("overridden_by_user_at") is not None, (
+            "Row B must inherit the override from Row A"
+        )
+        assert client.set_tank_power.call_count == 0
+        assert client.set_tank_temperature.call_count == 0
+        assert len(notifications) == 1
+        assert f"row {row_a_id}" in notifications[0]
+
+
+def test_inherited_override_releases_when_user_reverts(monkeypatch):
+    """If the user turns the tank back ON between gesture and the next replan,
+    user_gesture_still_in_effect returns False → suppression skipped → row fires."""
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", True)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+
+    monkeypatch.setattr("src.state_machine.notify_user_override", lambda msg: None)
+
+    # daikin_bulletproof.apply_scheduled_daikin_params calls into the client.
+    # Mock the whole function call to avoid touching real Daikin code paths.
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        now_utc = datetime.now(UTC)
+        conn = db.get_connection()
+        try:
+            start_a = (now_utc - timedelta(minutes=90)).isoformat()
+            end_a = (now_utc - timedelta(minutes=10)).isoformat()
+            conn.execute(
+                """INSERT INTO action_schedule
+                   (date, start_time, end_time, device, action_type, params, status, created_at)
+                   VALUES (?, ?, ?, 'daikin', 'tank_idle_overnight', ?, 'completed', ?)""",
+                (
+                    now_utc.date().isoformat(), start_a, end_a,
+                    json.dumps({"tank_power": True, "tank_temp": 37}),
+                    now_utc.isoformat(),
+                ),
+            )
+            row_a_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+            row_b_id = _seed_active_row(
+                conn, start_offset_seconds=60,
+                params={"tank_power": True, "tank_temp": 50},  # diverges from current
+            )
+        finally:
+            conn.close()
+
+        db.mark_action_user_overridden(
+            row_a_id, overridden_at=(now_utc - timedelta(minutes=30)).isoformat(),
+        )
+
+        # User turned tank back ON — gesture reverted. Tank temp differs from
+        # row B's target so apply must run.
+        dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=37.0)
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        row_b = db.get_action_by_id(row_b_id)
+        assert row_b is not None
+        assert row_b.get("overridden_by_user_at") is None
+        # Apply must have been called normally
+        assert len(apply_calls) == 1
+
+
+def test_inherited_override_does_not_suppress_restore(monkeypatch):
+    """Restore rows are exempted so the system can return to baseline."""
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", True)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+    monkeypatch.setattr("src.state_machine.notify_user_override", lambda msg: None)
+
+    apply_calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: apply_calls.append(params),
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        now_utc = datetime.now(UTC)
+        conn = db.get_connection()
+        try:
+            start_a = (now_utc - timedelta(minutes=90)).isoformat()
+            end_a = (now_utc - timedelta(minutes=10)).isoformat()
+            conn.execute(
+                """INSERT INTO action_schedule
+                   (date, start_time, end_time, device, action_type, params, status, created_at)
+                   VALUES (?, ?, ?, 'daikin', 'shutdown', ?, 'completed', ?)""",
+                (
+                    now_utc.date().isoformat(), start_a, end_a,
+                    json.dumps({"tank_power": True}),
+                    now_utc.isoformat(),
+                ),
+            )
+            row_a_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+            # Restore row that must fire even with active gesture.
+            start_b = (now_utc - timedelta(seconds=60)).isoformat()
+            end_b = (now_utc + timedelta(minutes=5)).isoformat()
+            conn.execute(
+                """INSERT INTO action_schedule
+                   (date, start_time, end_time, device, action_type, params, status, created_at)
+                   VALUES (?, ?, ?, 'daikin', 'restore', ?, 'active', ?)""",
+                (
+                    now_utc.date().isoformat(), start_b, end_b,
+                    json.dumps({"tank_power": True, "tank_temp": 45}),
+                    now_utc.isoformat(),
+                ),
+            )
+            row_b_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+            conn.commit()
+        finally:
+            conn.close()
+
+        db.mark_action_user_overridden(
+            row_a_id, overridden_at=(now_utc - timedelta(minutes=30)).isoformat(),
+        )
+
+        dev = DaikinDevice(id="gw", name="x", tank_on=False, tank_target=37.0)
+        client = MagicMock()
+
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        row_b = db.get_action_by_id(row_b_id)
+        assert row_b is not None
+        # Restore must NOT be marked inherited-override.
+        assert row_b.get("overridden_by_user_at") is None
+        # Restore params must have been applied.
+        assert len(apply_calls) == 1
+        assert apply_calls[0].get("tank_power") is True


### PR DESCRIPTION
## Summary

Three intertwined production bugs (C/D/E) all rooted in the heartbeat reconciler firing rows without checking whether the live Daikin state already matched the row's intent — plus a fourth finding: a "shutdown" peak-tank strategy that prod telemetry proved was dead weight for this well-insulated tank.

- **C** — Override is one-way per row, but the LP re-creates fresh rows. After the user manually turns the tank off, the next replan inserts a new row with the same params, no override flag → fires → undoes the gesture. Now: override inheritance from the most recent gesture within `USER_OVERRIDE_RESPECT_HOURS` (default 4h), suppressed when live state still contradicts the source row. Restore rows are exempt.
- **D** — Five overlapping `solar_preheat` replan rows fired today, burning ~5× the Onecta quota. Now: pre-fire idempotency completes redundant rows with no API call.
- **E** — `READ_ONLY_CHARACTERISTIC` HTTP 400 errors when writing `tank_power=False` to an already-off tank. Same idempotency check kills these.
- **Finding 4** — Prod telemetry: median tank decay 0.00 °C/h over 8 May peak windows; SHUTDOWN attempts failed 27% with `READ_ONLY_CHARACTERISTIC`. Removed the branch + the `DHW_PEAK_TANK_STRATEGY` env var; dispatch always uses IDLE (tank_power=True, tank_temp=DHW_TEMP_NORMAL_C).

## Behaviour gate

`PREFIRE_STATE_MATCH_ENABLED` (default `true`) is the instant-rollback knob. Both new behaviours surface in `action_log` as `prefire_state_match` and `prefire_override_inherited` events.

Closes #386

## Test plan

- [x] `tests/test_prefire_state_idempotency.py` (NEW) — 6 unit tests covering idempotency, unknown state fail-open, feature flag, dedupe of overlapping rows
- [x] `tests/test_user_override.py` (EXTENDED) — 9 new tests covering `find_recent_user_override`, `user_gesture_still_in_effect`, and 3 integration scenarios for override inheritance (suppression, reversal, restore carve-out)
- [x] `tests/test_lp_pv_abundance.py` — updated `test_dispatch_peak_keeps_tank_on_normal_target` (renamed), deleted `test_dispatch_peak_shutdown_legacy_still_works`
- [x] Full suite: `pytest tests/ -x` → 1173 passed, 3 skipped, 1 xfailed in 3m24s

## Post-merge follow-ups

- Optionally remove the `DHW_PEAK_TANK_STRATEGY=shutdown` line from `/srv/hem/.env` (Python ignores unknown env vars so it's harmless to leave).
- Monitor `action_log` for `prefire_state_match` and `prefire_override_inherited` events to verify the new behaviour engages on prod.
- Tomorrow's 07:30 UTC audit timer should show the `failed` shutdown rows drop to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)