### PR TITLE
fix(dhw): mutate local dev snapshot + inter-row settle

### DIFF
--- a/src/daikin_bulletproof.py
+++ b/src/daikin_bulletproof.py
@@ -188,8 +188,17 @@ def apply_scheduled_daikin_params(
         # If turning ON: send power first so lwt_offset is writable on the next call.
         # The 3-way valve needs time to settle; sleep before DHW commands to prevent
         # silent command drops from the Daikin mainboard.
+        # Epic 14 follow-up (#388): after each successful client.set_*, mutate
+        # the local ``dev`` snapshot so subsequent reads in this process see
+        # the predicted state. Without this, the Onecta cache only refreshes
+        # via the 30-min DAIKIN_DEVICES_CACHE_TTL_SECONDS cycle, and the
+        # state_machine pre-fire idempotency check (and the skip_if_matches
+        # branch above) keep falling through on rows fired in subsequent
+        # heartbeat ticks within the same window — the prod bug D pattern.
+
         if climate_going_on:
             client.set_power(dev, True)
+            dev.is_on = True
             if has_dhw_cmds and settle:
                 time.sleep(settle)
 
@@ -207,7 +216,9 @@ def apply_scheduled_daikin_params(
                 try:
                     # Onecta leavingWaterOffset.stepValue == 1 → quantise to
                     # int at the boundary (same reason as tank_temp above).
-                    client.set_lwt_offset(dev, int(round(float(p["lwt_offset"]))))
+                    _lwt = int(round(float(p["lwt_offset"])))
+                    client.set_lwt_offset(dev, _lwt)
+                    dev.lwt_offset = float(_lwt)
                 except DaikinError as exc:
                     if "[read_only]" in str(exc):
                         # Non-fatal: caught only when our pre-check above
@@ -222,6 +233,7 @@ def apply_scheduled_daikin_params(
 
         if climate_going_off:
             client.set_power(dev, False)
+            dev.is_on = False
             if has_dhw_cmds and settle:
                 time.sleep(settle)
 
@@ -230,6 +242,7 @@ def apply_scheduled_daikin_params(
         tank_turning_on = "tank_power" in p and bool(p["tank_power"])
         if tank_turning_on:
             client.set_tank_power(dev, True)
+            dev.tank_on = True
             if "tank_temp" in p and settle:
                 time.sleep(settle)  # onOffMode must settle before temperatureControl is writable
 
@@ -240,7 +253,9 @@ def apply_scheduled_daikin_params(
                 # API. Quantise defensively at the boundary so legacy callers
                 # or stale action_schedule rows that stored a float (e.g. 38.0)
                 # still go through cleanly.
-                client.set_tank_temperature(dev, int(round(float(p["tank_temp"]))))
+                _tt = int(round(float(p["tank_temp"])))
+                client.set_tank_temperature(dev, _tt)
+                dev.tank_target = float(_tt)
             except DaikinError as exc:
                 if "[read_only]" in str(exc) and tank_turning_on:
                     # Cloud hasn't propagated tank-on yet; heartbeat will retry next tick
@@ -249,8 +264,10 @@ def apply_scheduled_daikin_params(
                     raise
         if not tank_turning_on and "tank_power" in p:
             client.set_tank_power(dev, bool(p["tank_power"]))
+            dev.tank_on = bool(p["tank_power"])
         if "tank_powerful" in p:
             client.set_tank_powerful(dev, bool(p["tank_powerful"]))
+            dev.tank_powerful = bool(p["tank_powerful"])
     except (DaikinError, ValueError) as e:
         db.log_action(
             device="daikin",

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -192,6 +193,11 @@ def _reconcile_daikin_actions(
     outdoor_c: float | None = None,
 ) -> None:
     """Transition statuses and apply params for today's Daikin rows."""
+    # Epic 14 follow-up (#388): when more than one row triggers an apply in
+    # the SAME heartbeat tick, sleep DAIKIN_VALVE_SETTLE_SECONDS between
+    # them so the cloud has propagation time before our next read/write.
+    # Idle ticks (all rows pre-fire-skipped) take zero extra time.
+    _applied_in_this_tick = False
     for act in sorted(actions, key=lambda a: (a["start_time"], int(a["id"]))):
         try:
             start = _parse_utc(act["start_time"])
@@ -387,14 +393,41 @@ def _reconcile_daikin_actions(
                 # this same row would fire a fresh notification.
                 _USER_OVERRIDE_NOTIFIED.discard(aid)
 
+            # Epic 14 follow-up (#388): inter-row settle. If we already
+            # called apply_scheduled_daikin_params earlier in this same
+            # heartbeat tick for this device, give Onecta time to
+            # propagate the previous write before we PATCH again.
+            # Reusing DAIKIN_VALVE_SETTLE_SECONDS keeps the knob count low.
+            if _applied_in_this_tick:
+                inter_row_settle = max(
+                    0, int(getattr(config, "DAIKIN_VALVE_SETTLE_SECONDS", 10)),
+                )
+                if inter_row_settle > 0:
+                    logger.debug(
+                        "inter-row settle: sleeping %ds before applying row %s",
+                        inter_row_settle, aid,
+                    )
+                    time.sleep(inter_row_settle)
+
             try:
-                apply_scheduled_daikin_params(dev, client, apply_params, trigger=trigger)
+                applied = apply_scheduled_daikin_params(
+                    dev, client, apply_params, trigger=trigger,
+                )
                 # Mark the row as applied-in-session on the first successful call
                 # (skip_if_matches=True path also counts — match confirms alignment).
                 _FIRST_APPLIED_SESSION.setdefault(aid, now_utc)
+                # Track whether THIS call actually attempted writes. The fn
+                # returns False when skip_if_matches catches a match, or when
+                # the passive / read-only / disabled gates short-circuit.
+                # We only want to settle before the next row if the previous
+                # one actually hit the cloud.
+                if applied:
+                    _applied_in_this_tick = True
             except (DaikinError, ValueError) as e:
                 logger.warning("Boot Daikin apply %s: %s", aid, e)
                 db.mark_action(aid, "failed", error_msg=str(e))
+                # Even on failure, the attempt was made — wait before the next.
+                _applied_in_this_tick = True
 
 
 def reconcile_daikin_schedule_for_date(

--- a/tests/test_daikin_local_snapshot_mutation.py
+++ b/tests/test_daikin_local_snapshot_mutation.py
@@ -1,0 +1,315 @@
+"""Epic 14 follow-up (#388): local dev snapshot mutation + inter-row settle.
+
+After each successful ``client.set_*`` PATCH, ``apply_scheduled_daikin_params``
+must mutate the local ``dev`` snapshot so subsequent reads in the same
+process see the predicted state. Without this, the cached snapshot is only
+refreshed via the 30-min ``DAIKIN_DEVICES_CACHE_TTL_SECONDS`` cycle, and
+pre-fire idempotency checks in later heartbeat ticks would correctly fall
+through (stale dev) → redundant PATCH (the prod bug D pattern).
+
+Plus the heartbeat reconciler now sleeps ``DAIKIN_VALVE_SETTLE_SECONDS``
+between consecutive applies in the same tick so Onecta has propagation
+time. Idle ticks (all rows pre-fire-skipped) take zero extra time.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.daikin.models import DaikinDevice
+
+
+@pytest.fixture
+def _db(monkeypatch):
+    """Temp SQLite — needed because apply_scheduled_daikin_params writes
+    action_log rows via db.log_action."""
+    from src import db
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        yield path
+
+
+# ── Local snapshot mutation ───────────────────────────────────────────────────
+
+def test_apply_mutates_tank_target_after_set_tank_temperature(monkeypatch, _db):
+    """After client.set_tank_temperature(45), dev.tank_target == 45.0."""
+    from src.daikin_bulletproof import apply_scheduled_daikin_params
+
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    # Eliminate sleep noise in the test
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_VALVE_SETTLE_SECONDS", 0)
+    monkeypatch.setattr("src.daikin_bulletproof.time.sleep", lambda _: None)
+
+    dev = DaikinDevice(
+        id="gw", name="x", tank_on=True, tank_target=37.0, tank_powerful=False,
+    )
+    client = MagicMock()
+    apply_scheduled_daikin_params(
+        dev, client,
+        {"tank_power": True, "tank_temp": 45, "tank_powerful": False},
+        trigger="test",
+    )
+    assert dev.tank_target == 45.0
+    assert dev.tank_on is True
+    assert dev.tank_powerful is False
+
+
+def test_apply_mutates_tank_on_after_set_tank_power_off(monkeypatch, _db):
+    """tank_power=False path must also mutate dev.tank_on."""
+    from src.daikin_bulletproof import apply_scheduled_daikin_params
+
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_VALVE_SETTLE_SECONDS", 0)
+    monkeypatch.setattr("src.daikin_bulletproof.time.sleep", lambda _: None)
+
+    dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_powerful=False)
+    client = MagicMock()
+    apply_scheduled_daikin_params(
+        dev, client,
+        {"tank_power": False, "tank_powerful": False},
+        trigger="test",
+    )
+    assert dev.tank_on is False
+
+
+def test_apply_mutates_lwt_offset(monkeypatch, _db):
+    """After successful client.set_lwt_offset(-2), dev.lwt_offset == -2.0."""
+    from src.daikin_bulletproof import apply_scheduled_daikin_params
+
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_VALVE_SETTLE_SECONDS", 0)
+    monkeypatch.setattr("src.daikin_bulletproof.time.sleep", lambda _: None)
+
+    dev = DaikinDevice(
+        id="gw", name="x", is_on=True, lwt_offset=0.0, tank_on=True,
+    )
+    client = MagicMock()
+    apply_scheduled_daikin_params(
+        dev, client,
+        {"lwt_offset": -2, "climate_on": True},
+        trigger="test",
+    )
+    assert dev.lwt_offset == -2.0
+    assert dev.is_on is True
+
+
+def test_apply_does_not_mutate_when_client_raises(monkeypatch, _db):
+    """If client.set_tank_temperature raises a non-read_only error, dev.tank_target
+    must NOT be updated (the write didn't land)."""
+    from src.daikin.client import DaikinError
+    from src.daikin_bulletproof import apply_scheduled_daikin_params
+
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_VALVE_SETTLE_SECONDS", 0)
+    monkeypatch.setattr("src.daikin_bulletproof.time.sleep", lambda _: None)
+
+    dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=37.0)
+    client = MagicMock()
+    client.set_tank_temperature.side_effect = DaikinError("HTTP 503 service unavailable")
+
+    import pytest as _pytest
+    with _pytest.raises(DaikinError):
+        apply_scheduled_daikin_params(
+            dev, client, {"tank_power": True, "tank_temp": 45}, trigger="test",
+        )
+
+    # tank_on was set successfully BEFORE the temp call raised — so True is correct.
+    assert dev.tank_on is True
+    # tank_target must NOT have been mutated since the PATCH failed.
+    assert dev.tank_target == 37.0
+
+
+# ── Inter-row settle in the reconciler ────────────────────────────────────────
+
+def _seed_active_row(conn, *, start_offset_seconds: int, params: dict) -> int:
+    now = datetime.now(UTC)
+    start = (now - timedelta(seconds=start_offset_seconds)).isoformat()
+    end = (now + timedelta(seconds=1800)).isoformat()
+    conn.execute(
+        """INSERT INTO action_schedule
+           (date, start_time, end_time, device, action_type, params, status, created_at)
+           VALUES (?, ?, ?, 'daikin', 'pre_heat', ?, 'active', ?)""",
+        (now.date().isoformat(), start, end, json.dumps(params), now.isoformat()),
+    )
+    rid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.commit()
+    return int(rid)
+
+
+def test_inter_row_settle_fires_when_two_rows_apply(monkeypatch):
+    """Two rows both trigger apply in the same tick → exactly one settle
+    sleep between them, at DAIKIN_VALVE_SETTLE_SECONDS."""
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", True)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr("src.config.config.DAIKIN_VALVE_SETTLE_SECONDS", 10)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+
+    # Mock the apply function to always return True (write attempted).
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: True,
+    )
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("src.state_machine.time.sleep", lambda s: sleep_calls.append(s))
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            # Two distinct rows that both fall in the fire window. Different
+            # params to avoid the idempotency-match path.
+            _seed_active_row(conn, start_offset_seconds=60,
+                             params={"tank_power": True, "tank_temp": 45})
+            _seed_active_row(conn, start_offset_seconds=60,
+                             params={"tank_power": True, "tank_temp": 50})
+        finally:
+            conn.close()
+
+        dev = DaikinDevice(id="gw", name="x", tank_on=True, tank_target=37.0)
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        # Exactly one inter-row sleep, at the configured 10s value.
+        assert sleep_calls == [10], (
+            f"Expected one 10s inter-row settle between two applies, "
+            f"got sleep_calls={sleep_calls}"
+        )
+
+
+def test_inter_row_settle_skipped_when_first_row_does_not_apply(monkeypatch):
+    """If the first row hits the pre-fire match (no API call), the second
+    row should NOT sleep. Idle tick = zero overhead."""
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", True)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr("src.config.config.DAIKIN_VALVE_SETTLE_SECONDS", 10)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: True,
+    )
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("src.state_machine.time.sleep", lambda s: sleep_calls.append(s))
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            # Row 1: state matches → pre-fire skip → no apply, no flag set.
+            _seed_active_row(conn, start_offset_seconds=60,
+                             params={"tank_power": True, "tank_temp": 45,
+                                     "tank_powerful": False})
+            # Row 2: state differs → apply.
+            _seed_active_row(conn, start_offset_seconds=60,
+                             params={"tank_power": True, "tank_temp": 50,
+                                     "tank_powerful": False})
+        finally:
+            conn.close()
+
+        dev = DaikinDevice(
+            id="gw", name="x", tank_on=True, tank_target=45.0, tank_powerful=False,
+        )
+        client = MagicMock()
+        now_utc = datetime.now(UTC)
+        rows = db.get_actions_for_plan_date(now_utc.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="test")
+
+        # No sleeps — first row skipped pre-fire, so the flag stayed False
+        # when the second row processed.
+        assert sleep_calls == [], (
+            f"Expected zero sleeps when first row was pre-fire-skipped, "
+            f"got {sleep_calls}"
+        )
+
+
+# ── End-to-end: bug D dedup via REAL apply (no mock mutation needed) ──────────
+
+def test_real_bug_D_dedup_with_real_apply_path(monkeypatch):
+    """Same scenario as test_real_bug_D_overlapping_solar_preheat_dedup but
+    using the REAL apply_scheduled_daikin_params (not a mocked one that
+    manually echoes state). The local snapshot mutation in
+    apply_scheduled_daikin_params is what makes this work without manual
+    echo — pinning the integration.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", True)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr("src.daikin_bulletproof.config.DAIKIN_VALVE_SETTLE_SECONDS", 0)
+    monkeypatch.setattr("src.daikin_bulletproof.time.sleep", lambda _: None)
+    # Same for the reconciler's inter-row settle — eliminate sleep noise.
+    monkeypatch.setattr("src.config.config.DAIKIN_VALVE_SETTLE_SECONDS", 0)
+    monkeypatch.setattr("src.state_machine.time.sleep", lambda _: None)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        now_utc = datetime(2026, 5, 21, 12, 30, tzinfo=UTC)
+        conn = db.get_connection()
+        try:
+            common_params = {"tank_powerful": False, "lp_optimizer": True,
+                             "tank_power": True, "tank_temp": 45}
+            for s in ("08:00", "09:00", "11:00", "11:30"):
+                conn.execute(
+                    """INSERT INTO action_schedule
+                       (date, start_time, end_time, device, action_type, params, status, created_at)
+                       VALUES (?, ?, ?, 'daikin', 'solar_preheat', ?, 'pending', ?)""",
+                    ("2026-05-21",
+                     f"2026-05-21T{s}:00Z", "2026-05-21T14:00:00Z",
+                     json.dumps(common_params),
+                     now_utc.isoformat()),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Stale dev — first row should apply and mutate; remaining 3 hit match.
+        dev = DaikinDevice(
+            id="gw", name="x", tank_on=True, tank_target=37.0, tank_powerful=False,
+        )
+        client = MagicMock()
+        rows = db.get_actions_for_plan_date("2026-05-21", device="daikin")
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="heartbeat")
+
+        # Tank temp written exactly once (rest were deduped via the now-
+        # current local snapshot).
+        assert client.set_tank_temperature.call_count == 1, (
+            f"Expected 1 PATCH (rest deduped via local snapshot mutation), "
+            f"got {client.set_tank_temperature.call_count}"
+        )
+        # And the snapshot reflects the write.
+        assert dev.tank_target == 45.0


### PR DESCRIPTION
## Summary

Two related gaps after Epic 14's pre-fire reconcile shipped (#387):

1. **Local snapshot mutation** — `apply_scheduled_daikin_params` PATCHed Onecta but never mutated the local `DaikinDevice` attributes. Subsequent rows in the same process (across heartbeat ticks within the 30-min cache TTL) read a stale `dev` and the idempotency check correctly fell through → redundant PATCH. This is why prod bug D could still happen even with #387's pre-fire check. Fix: after each successful `client.set_*`, set `dev.{is_on, tank_on, tank_target, tank_powerful, lwt_offset}` to the just-written value. On exception the mutation does NOT happen.
2. **Inter-row settle** — when multiple rows trigger `apply` in the same heartbeat tick, sleep `DAIKIN_VALVE_SETTLE_SECONDS` (default 10s) between them so Onecta has propagation time. Idle ticks (all rows pre-fire-skipped) take zero extra time. Reuses the existing knob — no new env vars.

## Net effect on the 200/day Daikin quota

**Actively reduces calls** in the multi-row windows that #387 couldn't dedupe due to the stale-snapshot blind spot. Combined with #387, the 5x `solar_preheat` pattern from 2026-05-21 (08:00-14:00) should now produce 1 PATCH instead of 5.

Closes #388

## Test plan

- [x] 4 unit tests covering local mutation on success / exception / each field
- [x] 2 unit tests covering inter-row settle (fires between applies, skipped when first row pre-fire-matched)
- [x] 1 end-to-end test: bug D dedup using REAL `apply_scheduled_daikin_params` (no manual echo mocking) — verifies the local mutation makes the integration work
- [x] Full suite: 1185 passed, 3 skipped, 1 xfailed in 3m39s

🤖 Generated with [Claude Code](https://claude.com/claude-code)