### PR TITLE
fix(dhw): chain-inheritance notification storm + audit findings

### DIFF
--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -338,8 +338,18 @@ def _reconcile_daikin_actions(
                                 result="skipped",
                                 trigger=trigger,
                             )
+                            # Audit (#386 follow-up): inherited rows themselves
+                            # become the "source" for the next replan row's
+                            # find_recent_user_override lookup (their
+                            # overridden_by_user_at is now the most recent).
+                            # Without also deduping ``aid`` here, each step of
+                            # the chain (A → B → C → D) fires its own
+                            # notification because the src_id rotates
+                            # (A, B, C…). Add aid alongside src_id so the
+                            # next iteration sees its source pre-deduped.
                             if src_id and src_id not in _USER_OVERRIDE_INHERITED_NOTIFIED:
                                 _USER_OVERRIDE_INHERITED_NOTIFIED.add(src_id)
+                                _USER_OVERRIDE_INHERITED_NOTIFIED.add(aid)
                                 try:
                                     notify_user_override(
                                         f"override inherited from row {src_id} "
@@ -351,6 +361,11 @@ def _reconcile_daikin_actions(
                                         "notify_user_override (inherited) failed (non-fatal): %s",
                                         _exc,
                                     )
+                            else:
+                                # Source already known — silent inheritance
+                                # propagation. Still track ``aid`` so deeper
+                                # chain rows continue to be silent.
+                                _USER_OVERRIDE_INHERITED_NOTIFIED.add(aid)
                             continue
                 except Exception as _exc:
                     logger.debug(

--- a/tests/test_daily_brief_split.py
+++ b/tests/test_daily_brief_split.py
@@ -71,13 +71,17 @@ def test_morning_payload_includes_tomorrow_peaks_when_rates_present(monkeypatch)
     stay — they're the actionable signal for 'when will the LP work hardest'.
     Today's full tier breakdown lives in the daily calendar + audit MCP tools."""
     from datetime import UTC, date, datetime, timedelta
+    from zoneinfo import ZoneInfo
     from src import db
     from src.analytics import daily_brief as db_mod
 
     monkeypatch.setattr(db_mod.config, "OCTOPUS_TARIFF_CODE", "TEST", raising=False)
     monkeypatch.setattr(db_mod.config, "BULLETPROOF_TIMEZONE", "Europe/London", raising=False)
 
-    today = date.today()
+    # Use the same timezone as build_morning_payload so the assertion holds
+    # across midnight UTC (CI runs anywhere — UTC, BST, etc.). Without this,
+    # the test silently flakes when UTC and London disagree on "today".
+    today = datetime.now(ZoneInfo("Europe/London")).date()
     tomorrow = today + timedelta(days=1)
     rows = []
     # Seed TOMORROW's rates with a clear peak window so the heads-up renders.

--- a/tests/test_dhw_prefire_real_scenarios.py
+++ b/tests/test_dhw_prefire_real_scenarios.py
@@ -513,3 +513,101 @@ def test_real_bug_E_falls_back_to_override_inheritance_when_idempotency_off(monk
         )
         assert len(notifications) == 1
         assert "row 5828" in notifications[0]
+
+
+# ── AUDIT (2026-05-22): chain inheritance must not storm notifications ────────
+#
+# Bug discovered while auditing the merged Epic 14 stack:
+# When N rows in a row are suppressed via inheritance (because the LP keeps
+# replanning), the source_id rotates (A → B → C → ...) because each newly-
+# inherited row becomes the most recent overridden row in DB. The dedupe set
+# was keyed only on source_id, so each step of the chain fired a fresh
+# notification — turning one user gesture into N Telegram pings.
+#
+# After the dedupe-also-on-aid fix, the entire chain produces one
+# notification per gesture episode.
+
+
+def test_audit_chain_inheritance_emits_one_notification_per_gesture(monkeypatch):
+    """User overrides row A. LP then inserts B, C, D over the next 90 min,
+    each with the same conflicting params. With the dedupe fix, only one
+    notification fires (for B inheriting from A); C and D are silently
+    suppressed even though their source rotates.
+    """
+    import src.state_machine as sm
+    from src import db
+
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", True)
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    sm._FIRST_APPLIED_SESSION.clear()
+    sm._USER_OVERRIDE_INHERITED_NOTIFIED.clear()
+
+    notifications: list[str] = []
+    monkeypatch.setattr(
+        "src.state_machine.notify_user_override",
+        lambda msg: notifications.append(msg),
+    )
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: True,
+    )
+    monkeypatch.setattr("src.state_machine.time.sleep", lambda _: None)
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "prod_replay.db"
+        _setup_test(monkeypatch, path)
+        now_utc = datetime(2026, 5, 22, 0, 0, tzinfo=UTC)
+
+        conn = db.get_connection()
+        try:
+            # Row A: real user gesture at 21:11 yesterday (~3h ago).
+            _insert_row(
+                conn, aid=100,
+                start="2026-05-21T21:00:00Z",
+                end="2026-05-22T06:00:00Z",
+                action_type="tank_idle_overnight",
+                status="active",
+                params={"tank_power": True, "tank_temp": 37},
+                overridden_at="2026-05-21T21:11:00.000000+00:00",
+            )
+            # Rows B, C, D: subsequent replan rows, all pending.
+            for i, t in enumerate(["21:30:00", "22:00:00", "22:30:00"]):
+                _insert_row(
+                    conn, aid=101 + i,
+                    start=f"2026-05-21T{t}Z",
+                    end="2026-05-22T06:00:00Z",
+                    action_type="tank_idle_overnight",
+                    status="pending",
+                    params={"tank_power": True, "tank_temp": 37},
+                )
+        finally:
+            conn.close()
+
+        # User still has the tank off (gesture in effect).
+        dev = DaikinDevice(
+            id="gw", name="x",
+            tank_on=False, tank_target=37.0, tank_powerful=False,
+        )
+        client = MagicMock()
+        rows = (
+            db.get_actions_for_plan_date("2026-05-21", device="daikin")
+            + db.get_actions_for_plan_date("2026-05-22", device="daikin")
+        )
+        sm._reconcile_daikin_actions(rows, client, dev, now_utc, trigger="heartbeat")
+
+        # All three later rows must be marked overridden.
+        for aid in (101, 102, 103):
+            r = db.get_action_by_id(aid)
+            assert r is not None
+            assert r.get("overridden_by_user_at") is not None, (
+                f"Row {aid} should be inherited-overridden"
+            )
+
+        # Pre-fix: would have been 3 notifications. Post-fix: exactly 1.
+        assert len(notifications) == 1, (
+            f"chain inheritance must collapse to one notification per "
+            f"gesture episode, got {len(notifications)}: {notifications}"
+        )
+        # The single notification references the original user-gesture row.
+        assert "row 100" in notifications[0]


### PR DESCRIPTION
## Summary

Audit of the merged Epic 14 stack (#386, #387, #388, #389) surfaced one real bug and four documented limitations.

### Bug fixed: chain-inheritance notification storm

When N rows in a row are suppressed via inheritance (because the LP keeps replanning), the source_id rotates (A → B → C → …) because each newly-inherited row becomes the most recent overridden row in DB. The dedupe set was keyed only on source_id, so each step fired a fresh notification — one gesture became N pings.

**Trace** (using tonight's prod pattern):
- 21:11: row A overridden by user → set={∅}
- 21:32: row B inherits from A → notification "row A" → set={A}
- 22:02: row C inherits from **B** (newest in DB) → notification "row B" → set={A,B}
- 22:32: row D inherits from C → notification "row C" → set={A,B,C}
- ... continues unbounded

**Fix**: when inheriting, add BOTH `src_id` AND `aid` to the dedupe set. Next iteration's `find_recent_user_override` returns `aid` → already deduped → silent suppression continues. One gesture → one notification.

Confirmed by new test `test_audit_chain_inheritance_emits_one_notification_per_gesture`.

## Other audit findings (documented, not bugs)

### Issue 2 — Stale dev cache can let bug E slip through (rare)
If the Daikin cache hasn't refreshed since a user gesture, `user_gesture_still_in_effect` reads stale `dev` that matches the override-row's pre-gesture params → returns False → no suppression → apply runs → HTTP 400 READ_ONLY. Requires gesture inside a stale-cache window with no telemetry refresh between. Mitigation: the existing 30-min cache TTL refreshes things. Not worth fixing until observed in prod.

### Issue 3 — Cross-window over-suppression (minor)
`find_recent_user_override` returns the most recent override regardless of time-window overlap. An 08:15 gesture could suppress a 12:00 cheap-charge action for the next 4h. User can revert their gesture to unblock. Acceptable trade-off given the 4h respect window default.

### Issue 4 — Restore rows undo user gestures (by design)
Restore rows are intentionally exempt from inheritance so the system can return to baseline. User has to re-override each restore. Documented behavior.

### Issue 5 — Status churn pending→active→completed in same tick (cosmetic)
When idempotency fires, the row transitions through 'active' just before being completed. 2 DB writes where 1 would do. Cosmetic, no correctness impact.

## Test plan

- [x] New test `test_audit_chain_inheritance_emits_one_notification_per_gesture` — 4 rows in chain (A user-overridden, B/C/D pending) → exactly 1 notification (was 3 pre-fix)
- [x] All existing 41 DHW-touching tests still pass
- [x] Full suite: 1186 passed, 3 skipped, 1 xfailed in 4m12s

🤖 Generated with [Claude Code](https://claude.com/claude-code)