### PR TITLE
fix(dhw): preserve imminent restore rows + heartbeat tank-power drift check

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1284,6 +1284,31 @@ class Config:
         os.getenv("PREFIRE_STATE_MATCH_ENABLED", "true").strip().lower()
         in ("1", "true", "yes", "on")
     )
+    # Issue #382 — preserve pending restore rows whose start_time is within
+    # this many minutes of "now" from the LP-replan clear sweep. The 2026-05-21
+    # incident left a tank at 25 °C because a 17:55 MPC re-plan deleted the
+    # paired restore (start 18:00) before it could fire — the parent shutdown
+    # had failed READ_ONLY at 16:36, so the existing "active parent → preserve
+    # its restore" rule didn't apply. Restores within this window have no
+    # safe alternative path (the next LP solve may not re-emit one), so we
+    # treat them as in-flight regardless of parent state. Set to 0 to disable.
+    RESTORE_PRESERVE_LEAD_MINUTES: float = float(
+        os.getenv("RESTORE_PRESERVE_LEAD_MINUTES", "10.0")
+    )
+    # Issue #382 follow-on — heartbeat sanity check. When the live tank is
+    # OFF and no current plan slot intends it to be OFF, treat this as state
+    # drift: alert and force-restore via apply_comfort_restore (tank_power=True,
+    # tank_temp=DHW_TEMP_NORMAL_C). Skipped when the device was overridden by
+    # the user within USER_OVERRIDE_RESPECT_HOURS. Set to false to alert only
+    # (no auto-recover) or disable entirely.
+    TANK_DRIFT_AUTO_RECOVER: bool = (
+        os.getenv("TANK_DRIFT_AUTO_RECOVER", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
+    TANK_DRIFT_CHECK_ENABLED: bool = (
+        os.getenv("TANK_DRIFT_CHECK_ENABLED", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
 
     # Fox ESS: soft daily budget (real limit ≈1440; we stop at 1200 for 15% headroom)
     FOX_DAILY_BUDGET: int = int(os.getenv("FOX_DAILY_BUDGET", "1200"))

--- a/src/db.py
+++ b/src/db.py
@@ -2405,8 +2405,20 @@ def _preserve_daikin_pending_ids_for_replan(plan_date: str) -> set[int]:
       post-shutdown restore disappears while the commanded state is still active).
     * Pending main actions in ``[start, end)`` (MPC can run before heartbeat marks them
       ``active``) plus their paired restore row, if any.
+    * Issue #382 — pending **restore** rows whose ``start_time`` is within
+      ``RESTORE_PRESERVE_LEAD_MINUTES`` of now, regardless of parent status.
+      The 2026-05-21 incident showed the existing rules don't cover a
+      restore whose parent has already failed/completed: the parent isn't
+      ``active`` (rule #1 misses) and the restore window itself hasn't
+      started (rule #2 misses). Without a third rule the LP-replan sweep
+      deletes an imminent restore and the next solve doesn't necessarily
+      re-emit one (it may see "tank already off, fine" and never command
+      the recovery), leaving the tank to drain.
     """
+    from .config import config as _cfg
     now_utc = _now_utc()
+    lead_minutes = float(getattr(_cfg, "RESTORE_PRESERVE_LEAD_MINUTES", 10.0))
+    lead_cutoff = now_utc + timedelta(minutes=lead_minutes) if lead_minutes > 0 else None
     preserve: set[int] = set()
     for r in get_actions_for_plan_date(plan_date, device="daikin"):
         st = r.get("status") or ""
@@ -2424,6 +2436,12 @@ def _preserve_daikin_pending_ids_for_replan(plan_date: str) -> set[int]:
             rid = r.get("restore_action_id")
             if rid is not None:
                 preserve.add(int(rid))
+        if (
+            lead_cutoff is not None
+            and r.get("action_type") == "restore"
+            and start <= lead_cutoff
+        ):
+            preserve.add(int(r["id"]))
     return preserve
 
 
@@ -2437,8 +2455,16 @@ def _preserve_daikin_pending_ids_in_range(
     therefore inside the rolling clear window even when the active row itself is
     not. In-flight pending preservation scans only the pending rows whose
     ``start_time`` falls in ``[start_utc_iso, end_utc_iso)``.
+
+    Issue #382 — additionally preserves pending ``restore`` rows whose
+    ``start_time`` is within ``RESTORE_PRESERVE_LEAD_MINUTES`` of now,
+    regardless of parent state. See the docstring on
+    :func:`_preserve_daikin_pending_ids_for_replan` for the rationale.
     """
+    from .config import config as _cfg
     now_utc = _now_utc()
+    lead_minutes = float(getattr(_cfg, "RESTORE_PRESERVE_LEAD_MINUTES", 10.0))
+    lead_cutoff = now_utc + timedelta(minutes=lead_minutes) if lead_minutes > 0 else None
     preserve: set[int] = set()
     with _lock:
         conn = get_connection()
@@ -2454,7 +2480,7 @@ def _preserve_daikin_pending_ids_in_range(
                     preserve.add(int(rid))
 
             cur = conn.execute(
-                """SELECT id, start_time, end_time, restore_action_id
+                """SELECT id, start_time, end_time, restore_action_id, action_type
                    FROM action_schedule
                    WHERE device = 'daikin' AND status = 'pending'
                          AND start_time >= ? AND start_time < ?""",
@@ -2471,6 +2497,12 @@ def _preserve_daikin_pending_ids_in_range(
                     rid = row["restore_action_id"]
                     if rid is not None:
                         preserve.add(int(rid))
+                if (
+                    lead_cutoff is not None
+                    and row["action_type"] == "restore"
+                    and start <= lead_cutoff
+                ):
+                    preserve.add(int(row["id"]))
         finally:
             conn.close()
     return preserve

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -19,7 +19,7 @@ from .daikin_bulletproof import (
     user_gesture_still_in_effect,
 )
 from .foxess.client import FoxESSClient, FoxESSError, scheduler_groups_from_stored_json
-from .notifier import notify_risk, notify_user_override
+from .notifier import notify_critical, notify_risk, notify_user_override
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,12 @@ _USER_OVERRIDE_NOTIFIED: set[int] = set()
 # is bounded by ``USER_OVERRIDE_RESPECT_HOURS`` × user-gesture frequency, well
 # below a kilobyte over a service lifetime.
 _USER_OVERRIDE_INHERITED_NOTIFIED: set[int] = set()
+
+# Issue #382 — drift-detection dedup. The heartbeat sanity check fires once
+# per drift *episode* (tank off when no shutdown was planned) so we don't
+# page Telegram every 2 min for the same condition. Cleared when the heartbeat
+# observes tank_on == True again — a fresh drift episode then re-pings.
+_TANK_DRIFT_NOTIFIED: bool = False
 
 
 def _parse_utc(s: str) -> datetime:
@@ -443,6 +449,135 @@ def _reconcile_daikin_actions(
                 db.mark_action(aid, "failed", error_msg=str(e))
                 # Even on failure, the attempt was made — wait before the next.
                 _applied_in_this_tick = True
+
+    # Issue #382 — heartbeat tank-power sanity check. After the per-row loop,
+    # detect "tank is off but no plan slot intended it to be off" drift and
+    # either alert or alert+auto-recover. This catches the 2026-05-21
+    # scenario where the paired restore was deleted by an MPC re-plan
+    # (clear_actions_in_range) and never re-emitted; the new
+    # RESTORE_PRESERVE_LEAD_MINUTES guard is the primary fix, this is the
+    # belt-and-braces backstop for any drift mechanism we haven't yet
+    # imagined.
+    _check_tank_power_drift(actions, client, dev, now_utc, trigger=trigger)
+
+
+def _check_tank_power_drift(
+    actions: list[dict[str, Any]],
+    client: DaikinClient,
+    dev: Any,
+    now_utc: datetime,
+    *,
+    trigger: str,
+) -> None:
+    """Issue #382 — alert + (optionally) recover when the tank is off and no
+    plan slot intends it to be off.
+
+    Bails on any of the following (fail-safe — silence is OK, false-alerts
+    are not):
+    * Feature flag disabled.
+    * Live tank state unknown (Daikin cache miss).
+    * Tank is on — no drift.
+    * Any active/pending slot covering ``now_utc`` carries
+      ``tank_power=False`` (planned shutdown, drift is expected).
+    * A recent user override on Daikin is still in effect — the user wants
+      the tank off; respect their gesture.
+
+    Dedupes via module-level ``_TANK_DRIFT_NOTIFIED`` so a sustained drift
+    only pages once. When the tank comes back on, the flag clears and a
+    fresh drift episode pages again.
+    """
+    global _TANK_DRIFT_NOTIFIED
+
+    if not config.TANK_DRIFT_CHECK_ENABLED:
+        return
+    tank_on = getattr(dev, "tank_on", None)
+    if tank_on is None:
+        return  # unknown live state — fail-safe
+    if tank_on:
+        # Tank is on — clear the dedup token so any future drift re-pings.
+        if _TANK_DRIFT_NOTIFIED:
+            _TANK_DRIFT_NOTIFIED = False
+        return
+
+    # Tank is off. Is any current slot deliberately requesting it off?
+    planned_off = False
+    for act in actions:
+        try:
+            start = _parse_utc(act["start_time"])
+            end = _parse_utc(act["end_time"])
+        except (ValueError, KeyError, TypeError):
+            continue
+        if not (start <= now_utc < end):
+            continue
+        if (act.get("status") or "") not in ("pending", "active"):
+            continue
+        if act.get("overridden_by_user_at"):
+            continue
+        params = act.get("params") or {}
+        if isinstance(params, str):
+            try:
+                params = json.loads(params)
+            except (json.JSONDecodeError, TypeError):
+                params = {}
+        if "tank_power" in params and not bool(params["tank_power"]):
+            planned_off = True
+            break
+    if planned_off:
+        return
+
+    # Respect a user gesture that's still in effect.
+    try:
+        src = db.find_recent_user_override(
+            device="daikin",
+            within_hours=float(config.USER_OVERRIDE_RESPECT_HOURS),
+            now_utc=now_utc,
+        )
+        if src is not None:
+            src_params = src.get("params") or {}
+            if isinstance(src_params, str):
+                try:
+                    src_params = json.loads(src_params)
+                except (json.JSONDecodeError, TypeError):
+                    src_params = {}
+            if user_gesture_still_in_effect(dev, src_params):
+                return
+    except Exception as _exc:
+        logger.debug("tank-drift override lookup failed (non-fatal): %s", _exc)
+
+    # Drift confirmed.
+    db.log_action(
+        device="daikin",
+        action="tank_drift_detected",
+        params={
+            "tank_on": False,
+            "auto_recover": bool(config.TANK_DRIFT_AUTO_RECOVER),
+        },
+        result="alert",
+        trigger=trigger,
+    )
+    recovered = False
+    if (
+        config.TANK_DRIFT_AUTO_RECOVER
+        and not config.OPENCLAW_READ_ONLY
+        and config.DAIKIN_CONTROL_MODE == "active"
+    ):
+        try:
+            apply_comfort_restore(dev, client, trigger=f"tank_drift_recover:{trigger}")
+            recovered = True
+        except (DaikinError, ValueError) as exc:
+            logger.warning("tank-drift auto-recover failed: %s", exc)
+
+    if not _TANK_DRIFT_NOTIFIED:
+        _TANK_DRIFT_NOTIFIED = True
+        try:
+            msg = (
+                "Tank power=OFF and no plan slot scheduled it off — "
+                f"{'force-restored to NORMAL' if recovered else 'manual recovery may be needed'} "
+                f"(trigger={trigger})"
+            )
+            notify_critical(msg) if not recovered else notify_risk(msg)
+        except Exception as _exc:
+            logger.debug("tank-drift notify failed (non-fatal): %s", _exc)
 
 
 def reconcile_daikin_schedule_for_date(

--- a/tests/test_clear_actions_in_range.py
+++ b/tests/test_clear_actions_in_range.py
@@ -148,3 +148,202 @@ def test_removes_purely_future_pending_pair(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert db.get_action_by_id(aid) is None
     assert db.get_action_by_id(rid) is None
+
+
+def test_382_preserves_imminent_restore_when_parent_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #382: real incident replay.
+
+    A 16:30→18:00 shutdown row whose ``set_tank_power(False)`` write FAILED
+    at 16:36 with READ_ONLY_CHARACTERISTIC (user had already turned the
+    tank off manually). At 17:55 the MPC ran ``clear_actions_in_range``;
+    the existing "active parent → preserve restore" rule didn't apply
+    because the parent was ``failed``, not ``active``, and the restore's
+    own window hadn't started yet. The new lead-minutes rule preserves
+    any pending restore within RESTORE_PRESERVE_LEAD_MINUTES of now.
+    """
+    now = datetime(2026, 6, 1, 17, 55, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t_main_start = datetime(2026, 6, 1, 16, 30, tzinfo=UTC)
+    t_restore_start = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)  # 5 min from now
+
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_restore_start),
+        end_time=_iso(t_restore_start + timedelta(minutes=5)),
+        device="daikin", action_type="restore",
+        params={"tank_power": True, "tank_temp": 45}, status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_main_start), end_time=_iso(t_restore_start),
+        device="daikin", action_type="shutdown",
+        params={"tank_power": False}, status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+    db.mark_action(aid, "failed", error_msg="[read_only] HTTP 400: READ_ONLY_CHARACTERISTIC")
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 17, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 17, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(rid) is not None, (
+        "imminent restore must survive even when parent shutdown FAILED"
+    )
+
+
+def test_382_preserves_imminent_restore_when_parent_completed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same as above but with parent ``completed`` (the post-#387 world
+    where pre-fire idempotency marks an already-off shutdown as completed
+    without error). Restore is still imminent and must survive."""
+    now = datetime(2026, 6, 1, 17, 55, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t_main_start = datetime(2026, 6, 1, 16, 30, tzinfo=UTC)
+    t_restore_start = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_restore_start),
+        end_time=_iso(t_restore_start + timedelta(minutes=5)),
+        device="daikin", action_type="restore",
+        params={"tank_power": True, "tank_temp": 45}, status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_main_start), end_time=_iso(t_restore_start),
+        device="daikin", action_type="shutdown",
+        params={"tank_power": False}, status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+    db.mark_action(aid, "completed")
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 17, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 17, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(rid) is not None
+
+
+def test_382_does_not_preserve_far_future_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restore well outside the lead window IS cleared — the next LP solve has
+    time to re-emit one. Only imminent restores get the bare-life guarantee."""
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t_restore_start = datetime(2026, 6, 1, 21, 0, tzinfo=UTC)  # 9h ahead
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_restore_start),
+        end_time=_iso(t_restore_start + timedelta(minutes=5)),
+        device="daikin", action_type="restore",
+        params={"tank_power": True, "tank_temp": 45}, status="pending",
+    )
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 12, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 12, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(rid) is None
+
+
+def test_382_does_not_preserve_imminent_non_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard is restore-only. A pending shutdown 5 min from now is still
+    deletable — the LP can re-emit a fresh shutdown if it wants one."""
+    now = datetime(2026, 6, 1, 17, 55, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t_start = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_start), end_time=_iso(t_start + timedelta(hours=1)),
+        device="daikin", action_type="shutdown",
+        params={"tank_power": False}, status="pending",
+    )
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 17, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 17, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(aid) is None
+
+
+def test_382_for_date_variant_also_preserves_imminent_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The plan-date-keyed clear path (clear_actions_for_date) is used by the
+    older non-rolling planner. The same lead-minutes rule applies there too —
+    the bug fix needs to cover both call sites."""
+    now = datetime(2026, 6, 1, 17, 55, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t_main_start = datetime(2026, 6, 1, 16, 30, tzinfo=UTC)
+    t_restore_start = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_restore_start),
+        end_time=_iso(t_restore_start + timedelta(minutes=5)),
+        device="daikin", action_type="restore",
+        params={"tank_power": True, "tank_temp": 45}, status="pending",
+    )
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_main_start), end_time=_iso(t_restore_start),
+        device="daikin", action_type="shutdown",
+        params={"tank_power": False}, status="pending",
+        restore_action_id=rid,
+    )
+    db.update_action_restore_link(aid, rid)
+    db.mark_action(aid, "failed", error_msg="READ_ONLY")
+
+    db.clear_actions_for_date("2026-06-01", device="daikin")
+
+    assert db.get_action_by_id(rid) is not None
+
+
+def test_382_disabled_when_lead_minutes_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting RESTORE_PRESERVE_LEAD_MINUTES=0 disables the new rule (escape
+    hatch for instant rollback if it misbehaves)."""
+    from src.config import config as _cfg
+    monkeypatch.setattr(_cfg, "RESTORE_PRESERVE_LEAD_MINUTES", 0.0, raising=False)
+
+    now = datetime(2026, 6, 1, 17, 55, tzinfo=UTC)
+    monkeypatch.setattr(db, "_now_utc", lambda: now)
+
+    t_restore_start = datetime(2026, 6, 1, 18, 0, tzinfo=UTC)
+    rid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(t_restore_start),
+        end_time=_iso(t_restore_start + timedelta(minutes=5)),
+        device="daikin", action_type="restore",
+        params={"tank_power": True, "tank_temp": 45}, status="pending",
+    )
+
+    db.clear_actions_in_range(
+        _iso(datetime(2026, 6, 1, 17, 0, tzinfo=UTC)),
+        _iso(datetime(2026, 6, 2, 17, 0, tzinfo=UTC)),
+        device="daikin",
+    )
+
+    assert db.get_action_by_id(rid) is None

--- a/tests/test_tank_drift_check.py
+++ b/tests/test_tank_drift_check.py
@@ -1,0 +1,247 @@
+"""Tests for the issue-#382 heartbeat tank-power drift check.
+
+The check sits at the end of ``_reconcile_daikin_actions``. It alerts and
+(optionally) force-restores when the live tank is OFF and no plan slot
+intends it to be OFF — the belt-and-braces backstop for any future class
+of bugs that strands the tank in a shutdown state without a recovery row.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import db
+from src import state_machine as sm
+from src.config import config
+
+
+@dataclass
+class _FakeDev:
+    id: str = "dev-1"
+    name: str = "Altherma"
+    tank_on: bool | None = None
+    tank_target: float | None = None
+    tank_powerful: bool | None = None
+    is_on: bool | None = None
+    lwt_offset: float | None = None
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr(config, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(config, "TANK_DRIFT_CHECK_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "TANK_DRIFT_AUTO_RECOVER", True, raising=False)
+    monkeypatch.setattr(config, "OPENCLAW_READ_ONLY", False, raising=False)
+    monkeypatch.setattr(config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(config, "USER_OVERRIDE_RESPECT_HOURS", 4.0, raising=False)
+    db.init_db()
+    # Reset the module-level dedup token so each test starts fresh.
+    sm._TANK_DRIFT_NOTIFIED = False
+    yield
+
+
+def _drift_iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def test_no_drift_when_tank_on() -> None:
+    dev = _FakeDev(tank_on=True)
+    client = MagicMock()
+    sm._check_tank_power_drift([], client, dev, datetime(2026, 6, 1, 18, 0, tzinfo=UTC), trigger="hb")
+    client.assert_not_called()
+    assert sm._TANK_DRIFT_NOTIFIED is False
+
+
+def test_no_drift_when_tank_state_unknown() -> None:
+    dev = _FakeDev(tank_on=None)
+    client = MagicMock()
+    sm._check_tank_power_drift([], client, dev, datetime(2026, 6, 1, 18, 0, tzinfo=UTC), trigger="hb")
+    client.assert_not_called()
+
+
+def test_no_drift_when_planned_shutdown_active(monkeypatch) -> None:
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    now = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    actions = [{
+        "id": 1,
+        "start_time": _drift_iso(datetime(2026, 6, 1, 16, 30, tzinfo=UTC)),
+        "end_time": _drift_iso(datetime(2026, 6, 1, 18, 0, tzinfo=UTC)),
+        "status": "active",
+        "action_type": "shutdown",
+        "params": {"tank_power": False},
+    }]
+    notify = MagicMock()
+    monkeypatch.setattr(sm, "notify_critical", notify)
+    monkeypatch.setattr(sm, "notify_risk", notify)
+    sm._check_tank_power_drift(actions, client, dev, now, trigger="hb")
+    client.assert_not_called()
+    notify.assert_not_called()
+
+
+def test_drift_detected_alerts_and_recovers(monkeypatch) -> None:
+    """Tank OFF, no planned shutdown, no user gesture → alert + comfort restore."""
+    dev = _FakeDev(tank_on=False, tank_target=37.0)
+    client = MagicMock()
+    notify_risk = MagicMock()
+    notify_critical = MagicMock()
+    apply_restore = MagicMock()
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "notify_critical", notify_critical)
+    monkeypatch.setattr(sm, "apply_comfort_restore", apply_restore)
+
+    now = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)
+    sm._check_tank_power_drift([], client, dev, now, trigger="hb")
+
+    apply_restore.assert_called_once()
+    notify_risk.assert_called_once()
+    notify_critical.assert_not_called()
+    assert sm._TANK_DRIFT_NOTIFIED is True
+
+
+def test_drift_dedup_within_episode(monkeypatch) -> None:
+    """Sustained drift across multiple heartbeat ticks → notify only once."""
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    notify_risk = MagicMock()
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "apply_comfort_restore", MagicMock())
+
+    now = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)
+    sm._check_tank_power_drift([], client, dev, now, trigger="hb1")
+    sm._check_tank_power_drift([], client, dev, now + timedelta(minutes=2), trigger="hb2")
+    sm._check_tank_power_drift([], client, dev, now + timedelta(minutes=4), trigger="hb3")
+
+    assert notify_risk.call_count == 1
+
+
+def test_drift_dedup_resets_when_tank_returns(monkeypatch) -> None:
+    """After tank turns on (drift cleared), the next drift episode re-pings."""
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    notify_risk = MagicMock()
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "apply_comfort_restore", MagicMock())
+
+    now = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)
+    sm._check_tank_power_drift([], client, dev, now, trigger="hb1")
+    assert notify_risk.call_count == 1
+
+    # Recovery — tank back on, dedup token clears.
+    dev.tank_on = True
+    sm._check_tank_power_drift([], client, dev, now + timedelta(minutes=10), trigger="hb2")
+    assert sm._TANK_DRIFT_NOTIFIED is False
+
+    # Fresh drift episode — should ping again.
+    dev.tank_on = False
+    sm._check_tank_power_drift([], client, dev, now + timedelta(minutes=20), trigger="hb3")
+    assert notify_risk.call_count == 2
+
+
+def test_drift_respects_user_override(monkeypatch) -> None:
+    """User turned the tank off via Onecta → respect the gesture; no alert."""
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    notify_risk = MagicMock()
+    apply_restore = MagicMock()
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "apply_comfort_restore", apply_restore)
+
+    now = datetime(2026, 6, 1, 19, 0, tzinfo=UTC)
+    # Seed a user-overridden row from 30 min ago whose intent was tank_power=True
+    aid = db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_drift_iso(now - timedelta(minutes=30)),
+        end_time=_drift_iso(now + timedelta(minutes=30)),
+        device="daikin", action_type="tank_idle_overnight",
+        params={"tank_power": True, "tank_temp": 45}, status="active",
+    )
+    # Pin the override timestamp into the fake-now timeline so
+    # find_recent_user_override's "within_hours" filter sees it as recent.
+    db.mark_action_user_overridden(
+        aid, overridden_at=(now - timedelta(minutes=30)).isoformat()
+    )
+
+    sm._check_tank_power_drift([], client, dev, now, trigger="hb")
+
+    apply_restore.assert_not_called()
+    notify_risk.assert_not_called()
+
+
+def test_drift_alert_only_when_auto_recover_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(config, "TANK_DRIFT_AUTO_RECOVER", False, raising=False)
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    apply_restore = MagicMock()
+    notify_critical = MagicMock()
+    notify_risk = MagicMock()
+    monkeypatch.setattr(sm, "apply_comfort_restore", apply_restore)
+    monkeypatch.setattr(sm, "notify_critical", notify_critical)
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+
+    sm._check_tank_power_drift([], client, dev, datetime(2026, 6, 1, 19, 0, tzinfo=UTC), trigger="hb")
+
+    apply_restore.assert_not_called()
+    notify_critical.assert_called_once()
+    notify_risk.assert_not_called()
+
+
+def test_drift_disabled_when_flag_false(monkeypatch) -> None:
+    monkeypatch.setattr(config, "TANK_DRIFT_CHECK_ENABLED", False, raising=False)
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    apply_restore = MagicMock()
+    monkeypatch.setattr(sm, "apply_comfort_restore", apply_restore)
+
+    sm._check_tank_power_drift([], client, dev, datetime(2026, 6, 1, 19, 0, tzinfo=UTC), trigger="hb")
+
+    apply_restore.assert_not_called()
+
+
+def test_drift_no_recover_in_read_only(monkeypatch) -> None:
+    """OPENCLAW_READ_ONLY=true should alert but not write."""
+    monkeypatch.setattr(config, "OPENCLAW_READ_ONLY", True, raising=False)
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    apply_restore = MagicMock()
+    notify_critical = MagicMock()
+    monkeypatch.setattr(sm, "apply_comfort_restore", apply_restore)
+    monkeypatch.setattr(sm, "notify_critical", notify_critical)
+    monkeypatch.setattr(sm, "notify_risk", MagicMock())
+
+    sm._check_tank_power_drift([], client, dev, datetime(2026, 6, 1, 19, 0, tzinfo=UTC), trigger="hb")
+
+    apply_restore.assert_not_called()
+    notify_critical.assert_called_once()
+
+
+def test_drift_ignores_overridden_row_in_window(monkeypatch) -> None:
+    """A planned ``tank_power=False`` slot that's been marked user-overridden
+    no longer counts as the intent — the user reverted it, drift checking
+    should treat it as no-planned-off."""
+    dev = _FakeDev(tank_on=False)
+    client = MagicMock()
+    notify_risk = MagicMock()
+    apply_restore = MagicMock()
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "apply_comfort_restore", apply_restore)
+
+    now = datetime(2026, 6, 1, 17, 0, tzinfo=UTC)
+    actions = [{
+        "id": 1,
+        "start_time": _drift_iso(datetime(2026, 6, 1, 16, 30, tzinfo=UTC)),
+        "end_time": _drift_iso(datetime(2026, 6, 1, 18, 0, tzinfo=UTC)),
+        "status": "active",
+        "action_type": "shutdown",
+        "params": {"tank_power": False},
+        "overridden_by_user_at": "2026-06-01T16:45:00Z",
+    }]
+    sm._check_tank_power_drift(actions, client, dev, now, trigger="hb")
+
+    apply_restore.assert_called_once()
+    notify_risk.assert_called_once()


### PR DESCRIPTION
Closes #382.

Two-part backstop for the 2026-05-21 19:48 UTC incident where the tank drained to 25 °C after a 17:55 MPC re-plan deleted the paired `restore` (start 18:00) before it could fire. The parent `shutdown` row had FAILED with `READ_ONLY_CHARACTERISTIC` at 16:36, so the existing "active parent → preserve its restore" rule didn't apply; the restore's own window hadn't started yet either.

## Primary fix — `RESTORE_PRESERVE_LEAD_MINUTES`

`_preserve_daikin_pending_ids_for_replan` and `_preserve_daikin_pending_ids_in_range` now also preserve any pending `restore` row whose `start_time` is within `RESTORE_PRESERVE_LEAD_MINUTES` (default 10) of now — regardless of parent status. The next LP solve is not a safe alternative path: it may see "tank already off, fine" and dispatch a fresh shutdown over the top, never returning to NORMAL.

## Belt-and-braces — heartbeat tank-power drift check

`_reconcile_daikin_actions` now ends with `_check_tank_power_drift`, which detects "tank is off and no current plan slot intends it to be off", alerts via Telegram, and (when `TANK_DRIFT_AUTO_RECOVER=true`) force-restores via `apply_comfort_restore` (`tank_power=True, tank_temp=DHW_TEMP_NORMAL_C`). Respects user gestures (via `find_recent_user_override` + `user_gesture_still_in_effect`) and planned shutdowns; dedupes within a drift episode and re-fires on the next episode after the tank returns to on.

## Feature flags / rollback knobs

| Var | Default | Effect |
|---|---|---|
| `RESTORE_PRESERVE_LEAD_MINUTES` | 10.0 | 0 disables the preservation rule |
| `TANK_DRIFT_CHECK_ENABLED` | true | false disables the heartbeat check entirely |
| `TANK_DRIFT_AUTO_RECOVER` | true | false alerts only (no force-restore) |

`OPENCLAW_READ_ONLY=true` and `DAIKIN_CONTROL_MODE!=active` both already short-circuit the recovery write (alert still fires).

## Tests

- `tests/test_clear_actions_in_range.py` — 6 new cases covering the #382 scenarios (failed parent, completed parent, far-future restore not preserved, non-restore not preserved, plan-date variant, kill-switch)
- `tests/test_tank_drift_check.py` — 11 cases covering all branches (tank on, unknown state, planned shutdown, user override, dedup, read-only, disabled, recovery, overridden plan row)

Full suite green: 1203 passed locally.

## Verification (post-deploy)

1. Spot-check `action_log` for new event types: `tank_drift_detected` should be rare (ideally zero).
2. Next time we plan a shutdown→restore pair, watch the restore survive any in-window MPC re-plans.
3. Audit timer `hem-audit-held-schedule` at 07:30 UTC will surface failed/orphaned rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)