### PR TITLE
feat(dhw): calibrate PV abundance target + tank-target drift heartbeat — PR F

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1389,6 +1389,26 @@ class Config:
         os.getenv("TANK_DRIFT_CHECK_ENABLED", "true").strip().lower()
         in ("1", "true", "yes", "on")
     )
+    # PR F (2026-05-22) — sibling of TANK_DRIFT_CHECK_ENABLED, but for the
+    # tank TARGET (vs the power switch). Catches "commanded tank_temp >
+    # NORMAL with no upcoming heating action" — typically a stale
+    # solar_preheat target after PV forecast collapsed mid-window.
+    # Auto-recovers by writing tank_temp = DHW_TEMP_NORMAL_C.
+    TANK_TARGET_DRIFT_CHECK_ENABLED: bool = (
+        os.getenv("TANK_TARGET_DRIFT_CHECK_ENABLED", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
+    # Tolerance above NORMAL (°C) before flagging drift. Daikin Onecta
+    # setpoint stepValue=1, so smaller would oscillate.
+    TANK_TARGET_DRIFT_TOLERANCE_C: float = float(
+        os.getenv("TANK_TARGET_DRIFT_TOLERANCE_C", "1.0")
+    )
+    # Look-ahead window (minutes) to scan action_schedule for a planned
+    # tank-heating action that justifies the high target. 30 min covers
+    # two heartbeat ticks of headroom.
+    TANK_TARGET_DRIFT_LOOKAHEAD_MIN: int = int(
+        os.getenv("TANK_TARGET_DRIFT_LOOKAHEAD_MIN", "30")
+    )
 
     # Fox ESS: soft daily budget (real limit ≈1440; we stop at 1200 for 15% headroom)
     FOX_DAILY_BUDGET: int = int(os.getenv("FOX_DAILY_BUDGET", "1200"))

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -486,16 +486,25 @@ SCHEMA: dict[str, SettingSpec] = {
     "DHW_TEMP_PV_ABUNDANCE_TARGET_C": SettingSpec(
         key="DHW_TEMP_PV_ABUNDANCE_TARGET_C",
         type_name="float",
-        env_default=_float_env("DHW_TEMP_PV_ABUNDANCE_TARGET_C", "45"),
+        env_default=_float_env("DHW_TEMP_PV_ABUNDANCE_TARGET_C", "50"),
         min_value=40.0,
         max_value=60.0,
         description=(
             "Daikin tank target (°C) during solar_charge / solar_preheat "
-            "slots — PV-abundance window where free PV otherwise exports. "
-            "Default 45 (= DHW_TEMP_NORMAL_C). Raise per household size: "
-            "single/couple ~42, family of 4 ~48-50, larger ~55. Capped at "
-            "60 to keep the tank well below the legionella thermal-shock "
-            "ceiling and protect long-term tank life."
+            "slots — PV-abundance window where free PV would otherwise "
+            "export. Default 50 (PR F): stores ~1.16 kWh thermal vs. the "
+            "45 °C NORMAL baseline, usable for the evening shower window. "
+            "Standing-loss trade-off: each +1 °C above NORMAL costs ~0.06 "
+            "kWh/day in extra UA × ΔT loss (60 W per K vs INDOOR_SETPOINT_C "
+            "21 °C). Sweet spot 50–55 °C for a family in W4 1DZ — higher "
+            "doesn't pay because evening showers don't need >55 °C tank "
+            "(mixer math caps useful storage). Raise per household size: "
+            "single/couple ~45, family of 4 ~50, guests/larger ~55. "
+            "Capped at 60 to keep the tank well below the legionella "
+            "thermal-shock ceiling and protect long-term tank life. "
+            "Bumping from default 45 → 50 in PR F because at 45 the LP "
+            "had zero room to lift the tank with PV (target == NORMAL → "
+            "no e_dhw allocation → PV wasted)."
         ),
     ),
 }

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -459,6 +459,9 @@ def _reconcile_daikin_actions(
     # belt-and-braces backstop for any drift mechanism we haven't yet
     # imagined.
     _check_tank_power_drift(actions, client, dev, now_utc, trigger=trigger)
+    # PR F (2026-05-22) — catches stale-high tank target after PV-collapse
+    # mid-charge or passive→active flip. Mirrors the tank-power check above.
+    _check_tank_target_drift(actions, client, dev, now_utc, trigger=trigger)
 
 
 def _check_tank_power_drift(
@@ -584,6 +587,168 @@ def _check_tank_power_drift(
             notify_critical(msg) if not recovered else notify_risk(msg)
         except Exception as _exc:
             logger.debug("tank-drift notify failed (non-fatal): %s", _exc)
+
+
+# PR F (2026-05-22) — tank-target drift dedup. Fires once per "stale-high
+# target" episode (e.g. PV abundance collapsed mid-charge but the commanded
+# tank_temp=50 lingers). Cleared when the live target drops to NORMAL.
+_TANK_TARGET_DRIFT_NOTIFIED: bool = False
+
+
+def _check_tank_target_drift(
+    actions: list[dict[str, Any]],
+    client: DaikinClient,
+    dev: Any,
+    now_utc: datetime,
+    *,
+    trigger: str,
+) -> None:
+    """PR F — restore the tank to ``DHW_TEMP_NORMAL_C`` when the commanded
+    target is above NORMAL but no upcoming heating action justifies it.
+
+    Catches two real scenarios:
+
+    1. **PV collapses mid-solar_preheat**: HEM commanded ``tank_temp=50`` at
+       noon expecting PV abundance. Clouds roll in at 13:30; LP replans
+       without the solar_preheat. The previously-pending restore (at the
+       end of the original window) might survive PR #391's preserve guard
+       only within the 10-min lead window — far-future restores get
+       cleared. Without intervention, tank stays at 50 indefinitely and
+       bleeds extra standing loss.
+
+    2. **DAIKIN_CONTROL_MODE flips passive → active mid-day**: any prior
+       command (or manual user override that lifted the target) lingers
+       until a fresh action_schedule row writes a new value. This check
+       gives the system a self-correcting fallback.
+
+    Skips when:
+    * ``TANK_TARGET_DRIFT_CHECK_ENABLED=false`` (kill switch).
+    * Mode is vacation (tank target is moot; firmware owns).
+    * Mode is passive (HEM can't write to Daikin).
+    * Read-only (OpenClaw kill switch).
+    * Live ``dev.tank_target`` is unknown (Daikin cache miss).
+    * Live target is at-or-below ``DHW_TEMP_NORMAL_C + 1 °C`` tolerance.
+    * Any pending/active action in the next 30 min carries ``tank_temp``
+      above NORMAL (planned heating — high target is intentional).
+    * Recent user override on Daikin is still in effect.
+
+    Dedupes via module-level ``_TANK_TARGET_DRIFT_NOTIFIED``; clears
+    when the target drops back to NORMAL.
+    """
+    global _TANK_TARGET_DRIFT_NOTIFIED
+
+    if not getattr(config, "TANK_TARGET_DRIFT_CHECK_ENABLED", True):
+        return
+    if (config.OPTIMIZATION_PRESET or "normal").strip().lower() == "vacation":
+        return
+    if config.DAIKIN_CONTROL_MODE != "active":
+        return
+    if config.OPENCLAW_READ_ONLY:
+        return
+
+    tank_target = getattr(dev, "tank_target", None)
+    if tank_target is None:
+        return
+
+    normal_c = float(config.DHW_TEMP_NORMAL_C)
+    tolerance_c = float(
+        getattr(config, "TANK_TARGET_DRIFT_TOLERANCE_C", 1.0)
+    )
+    if float(tank_target) <= normal_c + tolerance_c:
+        # Target at/below NORMAL — no drift. Clear dedup so future episodes re-ping.
+        if _TANK_TARGET_DRIFT_NOTIFIED:
+            _TANK_TARGET_DRIFT_NOTIFIED = False
+        return
+
+    # Is there an upcoming heating action that justifies the high target?
+    horizon_cutoff = now_utc + timedelta(
+        minutes=int(getattr(config, "TANK_TARGET_DRIFT_LOOKAHEAD_MIN", 30))
+    )
+    heating_intent = False
+    for act in actions:
+        try:
+            start = _parse_utc(act["start_time"])
+            end = _parse_utc(act["end_time"])
+        except (ValueError, KeyError, TypeError):
+            continue
+        if end < now_utc:
+            continue
+        if start > horizon_cutoff:
+            continue
+        if (act.get("status") or "") not in ("pending", "active"):
+            continue
+        if act.get("overridden_by_user_at"):
+            continue
+        params = act.get("params") or {}
+        if isinstance(params, str):
+            try:
+                params = json.loads(params)
+            except (json.JSONDecodeError, TypeError):
+                params = {}
+        if "tank_temp" in params:
+            try:
+                if float(params["tank_temp"]) > normal_c + tolerance_c:
+                    heating_intent = True
+                    break
+            except (TypeError, ValueError):
+                continue
+    if heating_intent:
+        return
+
+    # Respect a user gesture that recently lifted the target.
+    try:
+        src = db.find_recent_user_override(
+            device="daikin",
+            within_hours=float(config.USER_OVERRIDE_RESPECT_HOURS),
+            now_utc=now_utc,
+        )
+        if src is not None:
+            src_params = src.get("params") or {}
+            if isinstance(src_params, str):
+                try:
+                    src_params = json.loads(src_params)
+                except (json.JSONDecodeError, TypeError):
+                    src_params = {}
+            if user_gesture_still_in_effect(dev, src_params):
+                return
+    except Exception as _exc:
+        logger.debug("tank-target-drift override lookup failed (non-fatal): %s", _exc)
+
+    # Drift confirmed: high target with no heating intent. Restore.
+    db.log_action(
+        device="daikin",
+        action="tank_target_drift_detected",
+        params={
+            "tank_target_c": float(tank_target),
+            "normal_c": normal_c,
+            "delta_c": float(tank_target) - normal_c,
+        },
+        result="alert",
+        trigger=trigger,
+    )
+    recovered = False
+    try:
+        apply_scheduled_daikin_params(
+            dev, client,
+            params={"tank_power": True, "tank_temp": int(round(normal_c))},
+            trigger=f"tank_target_drift_recover:{trigger}",
+            skip_if_matches=True,
+        )
+        recovered = True
+    except (DaikinError, ValueError) as exc:
+        logger.warning("tank-target-drift recover failed: %s", exc)
+
+    if not _TANK_TARGET_DRIFT_NOTIFIED:
+        _TANK_TARGET_DRIFT_NOTIFIED = True
+        try:
+            msg = (
+                f"Tank target {float(tank_target):.0f}°C → "
+                f"{'restored to NORMAL ' + str(int(normal_c)) + '°C' if recovered else 'manual recovery may be needed'} "
+                f"(no upcoming heating planned; trigger={trigger})"
+            )
+            (notify_risk if recovered else notify_critical)(msg)
+        except Exception as _exc:
+            logger.debug("tank-target-drift notify failed (non-fatal): %s", _exc)
 
 
 def reconcile_daikin_schedule_for_date(

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -95,12 +95,19 @@ def test_config_property_reads_runtime_value():
 
 
 def test_dhw_temp_pv_abundance_target_runtime_tunable():
-    """#325: solar_preheat target tunes per household occupancy at runtime."""
-    # Default = 45 (matches DHW_TEMP_NORMAL_C — no extra °C unless household needs it)
-    assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 45.0
-    # Bump for a family of 4 with evening showers
-    rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 50.0)
+    """#325 / PR F: solar_preheat target tunes per household occupancy at
+    runtime. PR F bumped the default from 45 → 50 so the LP has 5 °C of
+    headroom above NORMAL to actually store PV-driven thermal energy
+    (at 45 == NORMAL the LP couldn't allocate e_dhw → PV was wasted)."""
+    # PR F default = 50 (5 °C above DHW_TEMP_NORMAL_C; ~1.16 kWh thermal
+    # storage at 200 L, usable for the evening shower window).
     assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 50.0
+    # Bump for guests / larger household
+    rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 55.0)
+    assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 55.0
+    # Tune down for a single occupant who showers less
+    rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 45.0)
+    assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 45.0
     # Range guards (40..60)
     with pytest.raises(rts.SettingValidationError):
         rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 35.0)

--- a/tests/test_tank_target_drift_check.py
+++ b/tests/test_tank_target_drift_check.py
@@ -1,0 +1,252 @@
+"""Tests for the PR F tank-target drift heartbeat check.
+
+Mirrors `tests/test_tank_drift_check.py` for the power-drift check. The
+target-drift check catches "commanded tank_temp > NORMAL with no upcoming
+heating action" — typically a stale solar_preheat target after PV
+forecast collapsed mid-window.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import db as _db
+from src import state_machine as sm
+from src.config import config
+
+
+@dataclass
+class _FakeDev:
+    id: str = "dev-1"
+    name: str = "Altherma"
+    tank_on: bool | None = True
+    tank_target: float | None = None
+    tank_powerful: bool | None = None
+    is_on: bool | None = None
+    lwt_offset: float | None = None
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr(config, "DB_PATH", db_path, raising=False)
+    _db.init_db()
+    monkeypatch.setattr(config, "TANK_TARGET_DRIFT_CHECK_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "TANK_TARGET_DRIFT_TOLERANCE_C", 1.0, raising=False)
+    monkeypatch.setattr(config, "TANK_TARGET_DRIFT_LOOKAHEAD_MIN", 30, raising=False)
+    monkeypatch.setattr(config, "OPENCLAW_READ_ONLY", False, raising=False)
+    monkeypatch.setattr(config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "normal", raising=False)
+    monkeypatch.setattr(config, "USER_OVERRIDE_RESPECT_HOURS", 4.0, raising=False)
+    monkeypatch.setattr(config, "DHW_TEMP_NORMAL_C", 45.0, raising=False)
+    sm._TANK_TARGET_DRIFT_NOTIFIED = False
+    yield
+    sm._TANK_TARGET_DRIFT_NOTIFIED = False
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Skip paths
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_flag_skips_check(monkeypatch):
+    monkeypatch.setattr(config, "TANK_TARGET_DRIFT_CHECK_ENABLED", False, raising=False)
+    dev = _FakeDev(tank_target=55.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    sm._check_tank_target_drift([], client, dev, datetime(2026, 6, 1, 14, 0, tzinfo=UTC), trigger="hb")
+    apply_mock.assert_not_called()
+
+
+def test_vacation_mode_skips_check(monkeypatch):
+    monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "vacation", raising=False)
+    dev = _FakeDev(tank_target=55.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    sm._check_tank_target_drift([], client, dev, datetime(2026, 6, 1, 14, 0, tzinfo=UTC), trigger="hb")
+    apply_mock.assert_not_called()
+
+
+def test_passive_mode_skips_check(monkeypatch):
+    monkeypatch.setattr(config, "DAIKIN_CONTROL_MODE", "passive", raising=False)
+    dev = _FakeDev(tank_target=55.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    sm._check_tank_target_drift([], client, dev, datetime(2026, 6, 1, 14, 0, tzinfo=UTC), trigger="hb")
+    apply_mock.assert_not_called()
+
+
+def test_unknown_target_skips_check(monkeypatch):
+    dev = _FakeDev(tank_target=None)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    sm._check_tank_target_drift([], client, dev, datetime(2026, 6, 1, 14, 0, tzinfo=UTC), trigger="hb")
+    apply_mock.assert_not_called()
+
+
+def test_target_at_normal_skips_check(monkeypatch):
+    dev = _FakeDev(tank_target=45.5)  # within tolerance
+    client = MagicMock()
+    apply_mock = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    sm._check_tank_target_drift([], client, dev, datetime(2026, 6, 1, 14, 0, tzinfo=UTC), trigger="hb")
+    apply_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Heating-intent gate
+# ---------------------------------------------------------------------------
+
+
+def test_upcoming_solar_preheat_is_not_drift(monkeypatch):
+    """When the next 30 min has a pending action with tank_temp > NORMAL,
+    the current high target is intentional — no drift."""
+    dev = _FakeDev(tank_target=50.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    notify_risk = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "notify_critical", MagicMock())
+    now = datetime(2026, 6, 1, 14, 0, tzinfo=UTC)
+    actions = [{
+        "id": 1,
+        "start_time": _iso(now + timedelta(minutes=15)),
+        "end_time": _iso(now + timedelta(hours=1)),
+        "status": "pending",
+        "action_type": "solar_preheat",
+        "params": {"tank_power": True, "tank_temp": 50},
+    }]
+    sm._check_tank_target_drift(actions, client, dev, now, trigger="hb")
+    apply_mock.assert_not_called()
+    notify_risk.assert_not_called()
+
+
+def test_in_flight_solar_preheat_is_not_drift(monkeypatch):
+    """Active action with end > now and tank_temp high → not drift."""
+    dev = _FakeDev(tank_target=50.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    now = datetime(2026, 6, 1, 14, 0, tzinfo=UTC)
+    actions = [{
+        "id": 1,
+        "start_time": _iso(now - timedelta(minutes=30)),
+        "end_time": _iso(now + timedelta(minutes=30)),
+        "status": "active",
+        "action_type": "solar_preheat",
+        "params": {"tank_power": True, "tank_temp": 50},
+    }]
+    sm._check_tank_target_drift(actions, client, dev, now, trigger="hb")
+    apply_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Drift detected → recovery
+# ---------------------------------------------------------------------------
+
+
+def test_drift_with_no_upcoming_heating_recovers(monkeypatch):
+    """Tank target=50, no heating planned in next 30 min → recover to 45."""
+    dev = _FakeDev(tank_target=50.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    notify_risk = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "notify_critical", MagicMock())
+    sm._check_tank_target_drift(
+        [], client, dev, datetime(2026, 6, 1, 14, 0, tzinfo=UTC), trigger="hb",
+    )
+    apply_mock.assert_called_once()
+    call_args = apply_mock.call_args
+    assert call_args.kwargs["params"]["tank_temp"] == 45
+    assert call_args.kwargs["params"]["tank_power"] is True
+    notify_risk.assert_called_once()
+    assert sm._TANK_TARGET_DRIFT_NOTIFIED is True
+
+
+def test_drift_dedup_within_episode(monkeypatch):
+    """Multiple consecutive heartbeats with drift → only one notification."""
+    dev = _FakeDev(tank_target=52.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    notify_risk = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "notify_critical", MagicMock())
+    now = datetime(2026, 6, 1, 14, 0, tzinfo=UTC)
+    sm._check_tank_target_drift([], client, dev, now, trigger="hb1")
+    sm._check_tank_target_drift([], client, dev, now + timedelta(minutes=2), trigger="hb2")
+    sm._check_tank_target_drift([], client, dev, now + timedelta(minutes=4), trigger="hb3")
+    assert notify_risk.call_count == 1
+
+
+def test_drift_dedup_resets_when_target_drops(monkeypatch):
+    """After tank target drops back to NORMAL, dedup clears so a new
+    drift episode re-notifies."""
+    dev = _FakeDev(tank_target=52.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    notify_risk = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    monkeypatch.setattr(sm, "notify_risk", notify_risk)
+    monkeypatch.setattr(sm, "notify_critical", MagicMock())
+    now = datetime(2026, 6, 1, 14, 0, tzinfo=UTC)
+    sm._check_tank_target_drift([], client, dev, now, trigger="hb1")
+    assert notify_risk.call_count == 1
+
+    # Recovery happens (apply_mock would set tank to 45). Simulate by
+    # updating dev.tank_target.
+    dev.tank_target = 45.0
+    sm._check_tank_target_drift([], client, dev, now + timedelta(minutes=10), trigger="hb2")
+    assert sm._TANK_TARGET_DRIFT_NOTIFIED is False
+
+    # Fresh drift episode
+    dev.tank_target = 53.0
+    sm._check_tank_target_drift([], client, dev, now + timedelta(minutes=20), trigger="hb3")
+    assert notify_risk.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# User-override respect
+# ---------------------------------------------------------------------------
+
+
+def test_user_override_lifted_target_respected(monkeypatch):
+    """If a recent user override is still in effect (live state matches
+    the overridden row's params), the check defers to the user."""
+    dev = _FakeDev(tank_target=55.0)
+    client = MagicMock()
+    apply_mock = MagicMock()
+    monkeypatch.setattr(sm, "apply_scheduled_daikin_params", apply_mock)
+    monkeypatch.setattr(sm, "notify_risk", MagicMock())
+    monkeypatch.setattr(sm, "notify_critical", MagicMock())
+    now = datetime(2026, 6, 1, 14, 0, tzinfo=UTC)
+    aid = _db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(now - timedelta(minutes=30)),
+        end_time=_iso(now + timedelta(hours=1)),
+        device="daikin", action_type="solar_preheat",
+        # Original LP-planned target was NORMAL (45); user lifted to 55.
+        # `user_gesture_still_in_effect`: live tank_target (55) differs
+        # from override row's tank_temp (45) → gesture is still in effect.
+        params={"tank_power": True, "tank_temp": 45}, status="active",
+    )
+    _db.mark_action_user_overridden(
+        aid, overridden_at=(now - timedelta(minutes=20)).isoformat(),
+    )
+    sm._check_tank_target_drift([], client, dev, now, trigger="hb")
+    apply_mock.assert_not_called()


### PR DESCRIPTION
Two paired fixes from the user audit (2026-05-22) addressing today's PV-rich day having the tank coasting at 45 °C (NORMAL) instead of storing thermal energy, and the broader risk of stale-high tank targets when PV forecast collapses mid-charge.

## 1. Bump `DHW_TEMP_PV_ABUNDANCE_TARGET_C` default 45 → 50

At 45 °C (== `DHW_TEMP_NORMAL_C`), the LP had **zero room** to lift the tank with PV — the dispatch ceiling and the normal floor collapsed into a single point, so `e_dhw[i]` was clamped to maintenance-only allocation. Net: solar_charge slots produced **no actual thermal storage**; PV that could have heated the tank got passively exported at ~5p/kWh.

**New default 50 °C** gives the LP 5 °C of headroom = ~1.16 kWh thermal storage at 200 L tank, usable for the evening shower window.

Standing-loss math:
- Each +1 °C above NORMAL costs ~0.06 kWh/day in UA × ΔT loss (60 W per K)
- At 50 vs 45 → +0.3 kWh/day loss (~3-4p)
- Storage gain ~1.16 kWh × 12p import-avoidance = ~14p
- **Net +10p/day on PV-abundant days when consumed**

Tuning guide added to docstring: 45 single, 50 family, 55 guests.

## 2. New `_check_tank_target_drift` heartbeat sanity check

Mirror of `_check_tank_power_drift` (PR #391). Catches:

1. **PV collapses mid-solar_preheat**: commanded `tank_temp=50` at noon; clouds roll in; LP replan removes solar_preheat; pending restore at end-of-window cleared by PR #391's lead-window logic. Without this check, tank stays at 50 indefinitely.
2. **`DAIKIN_CONTROL_MODE` flips passive → active**: any prior command lingers.

Logic:
- Skip in vacation (target moot, firmware owns)
- Skip in passive (HEM can't write)
- Skip under `OPENCLAW_READ_ONLY`
- Skip if upcoming heating action (next 30 min) has `tank_temp > NORMAL` — high target intentional
- Skip if recent user override still in effect
- Otherwise: emit `tank_temp = DHW_TEMP_NORMAL_C` via `apply_scheduled_daikin_params`
- Dedupe via module flag; clear when target drops to NORMAL

Feature flags (default-on):
- `TANK_TARGET_DRIFT_CHECK_ENABLED` (true)
- `TANK_TARGET_DRIFT_TOLERANCE_C` (1.0 °C)
- `TANK_TARGET_DRIFT_LOOKAHEAD_MIN` (30 min)

## Tests

- `tests/test_tank_target_drift_check.py` (NEW, 9 cases): disabled flag, vacation/passive/unknown/at-normal skips, upcoming-heating respected, in-flight heating respected, drift recovers + dedup + reset, user-override respect.
- `tests/test_runtime_settings.py`: updated default expectation to 50; tunability test extended.

Full suite locally: **1264 passed, 3 skipped** (pre-existing #383), 1 xfailed.

## Audit findings — items 3 & 4 already correct

**Item 3** (passive mode): handles thermal-storage correctly by construction — `e_dhw[i] == passive_e_dhw[i]` hard equality, PV-abundance reward becomes constant, no LP allocation. Target-drift check also skips in passive.

**Item 4** (radiator forecast): verified on prod LP run id=988 — overnight 00:00–06:00 UTC `Σ e_space = 0.42 kWh` at `min(t_out) = 14.8 °C`. Space-floor constraint correctly forces LP to budget cold-night space heating. No fix needed.

## Rollback

- Setting drift check: `TANK_TARGET_DRIFT_CHECK_ENABLED=false` to disable.
- Default bump: operators can set `DHW_TEMP_PV_ABUNDANCE_TARGET_C=45` via `PUT /api/v1/settings` to revert without code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)