### PR TITLE
fix(dhw): PV abundance target is STORAGE not comfort — default 46→60 (PR H)

### DIFF
--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -521,25 +521,35 @@ SCHEMA: dict[str, SettingSpec] = {
     "DHW_TEMP_PV_ABUNDANCE_TARGET_C": SettingSpec(
         key="DHW_TEMP_PV_ABUNDANCE_TARGET_C",
         type_name="float",
-        env_default=_float_env("DHW_TEMP_PV_ABUNDANCE_TARGET_C", "46"),
+        env_default=_float_env("DHW_TEMP_PV_ABUNDANCE_TARGET_C", "60"),
         min_value=40.0,
         max_value=60.0,
         description=(
             "Daikin tank target (°C) during solar_charge / solar_preheat "
-            "slots — PV-abundance window where free PV would otherwise "
-            "export. Default 46 (PR G, recalibrated from 50): matches "
-            "the user's empirical observation that 48 °C tank delivers "
-            "6 showers (guests) easily and 46 is the ideal compromise. "
-            "Gives the LP 1 °C of headroom above the NORMAL 45 baseline — "
-            "small but enough to materially store excess PV instead of "
-            "exporting it. "
-            "Standing-loss math: each +1 °C above NORMAL costs ~0.06 "
-            "kWh/day in extra UA × ΔT loss (60 W per K vs INDOOR_SETPOINT_C "
-            "21 °C). Higher targets (50–55) bleed standing loss faster "
-            "than they store useful energy; the mixer math caps useful "
-            "storage anyway because showers don't need a 55+ °C tank. "
-            "Capped at 60 to keep the tank well below the legionella "
-            "thermal-shock ceiling and protect long-term tank life."
+            "slots. This is a STORAGE target, NOT a comfort target — "
+            "the tank is lifted as high as possible WHILE PV is excess "
+            "(free energy), then a paired 'restore' action at the end of "
+            "the solar window drops the target back to "
+            "``DHW_TEMP_NORMAL_C`` (45 °C). Outside the solar window the "
+            "tank decays naturally via standing loss until evening "
+            "showers consume the stored thermal energy. "
+            "\n\n"
+            "Default 60 (PR H, 2026-05-22): matches the user's manual "
+            "preference after they observed PR G's 46 °C (a comfort-"
+            "level setting wrongly applied as the storage ceiling) was "
+            "exporting PV instead of storing thermal. "
+            "\n\n"
+            "Economics: lifting 45 → 60 °C stores ~3.5 kWh thermal "
+            "(200 L × 4186 × 15 / 3.6e6). After ~5 h decay (standing "
+            "loss 97 W at indoor 21 °C → 0.5 kWh thermal lost), evening "
+            "showers can draw ~3 kWh thermal ≈ 1 kWh elec equivalent "
+            "(vs grid import at 12-30 p/kWh). Vs exporting that same PV "
+            "at 5-15 p/kWh export rate, storage wins by ~6-12 p/day on "
+            "PV-rich days. "
+            "\n\n"
+            "Capped at 60 (= legionella target floor) to protect tank "
+            "longevity. Lower this if you don't want to push the tank "
+            "that high (e.g. 50 = ~2 kWh thermal stored, less aggressive)."
         ),
     ),
 }

--- a/tests/test_runtime_settings.py
+++ b/tests/test_runtime_settings.py
@@ -95,14 +95,19 @@ def test_config_property_reads_runtime_value():
 
 
 def test_dhw_temp_pv_abundance_target_runtime_tunable():
-    """#325 / PR F / PR G: solar_preheat target tunes per household at
-    runtime. PR F bumped 45 → 50 to give the LP headroom above NORMAL
-    for PV-driven thermal storage. PR G then recalibrated to 46 after
-    the user's empirical feedback (46 °C is the ideal ceiling — handles
-    guests easily, 50+ bleeds standing loss before evening showers)."""
-    # PR G default = 46 °C: 1 °C above NORMAL (= 45), small headroom for
-    # PV storage without over-bleeding standing loss.
-    assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 46.0
+    """#325 / PR F / PR G / PR H: solar_preheat target.
+
+    PR F: 45 → 50 (give LP headroom above NORMAL).
+    PR G: 50 → 46 (calibrated to user's comfort-ceiling — wrongly applied
+                   as the storage target, exported PV instead of storing).
+    PR H: 46 → 60 (corrected: this is a STORAGE target during free-PV
+                   windows, NOT a comfort cap. Restore drops to NORMAL
+                   after the window ends, so the tank only stays at 60 °C
+                   while solar is genuinely excess)."""
+    # PR H default = 60 °C: lifts tank by 15 °C during PV abundance,
+    # storing ~3.5 kWh thermal; restore action drops back to NORMAL
+    # immediately after the solar window.
+    assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 60.0
     # Bump for guests / larger household
     rts.set_setting("DHW_TEMP_PV_ABUNDANCE_TARGET_C", 55.0)
     assert config.DHW_TEMP_PV_ABUNDANCE_TARGET_C == 55.0


### PR DESCRIPTION
PR G confused two distinct concepts. Fix.

> "estamos exportando energia enquanto o tanque estava em 45. Manualmente eu setei o tanque pra 60..."

## The conceptual bug in PR G

| Setting | What it's for | PR G | Should be |
|---|---|---|---|
| `DHW_TEMP_NORMAL_C` | **Comfort** baseline (daily showers) | 45 ✓ | 45 ✓ |
| `DHW_TEMP_PV_ABUNDANCE_TARGET_C` | **STORAGE** ceiling during free-PV windows | 46 ❌ | **60** ✓ |

User's "46 ideal" was about comfort. I wrongly applied it to the storage target. Result: LP only had 1 °C of headroom above NORMAL → no real storage capacity → PV exported instead of stored.

## Why 60 is right (and self-limiting)

The tank only stays at 60 °C **while the solar_preheat window is active**. A paired `restore` action at end-of-window writes `tank_temp=DHW_TEMP_NORMAL_C` (45) — tank decays naturally over the afternoon and is comfortably below 60 by evening shower time.

**Economics @ 60 °C ceiling:**
- Lift 45 → 60 = 200 L × 4186 × 15 / 3.6e6 = **~3.5 kWh thermal stored**
- Standing-loss decay ~5 h after window: ~0.5 kWh lost
- Net usable evening: ~3 kWh thermal ≈ **1 kWh elec import avoided**
- Vs grid evening import (12-30 p/kWh): 12-30 p saved
- Vs PV export (5-15 p/kWh): 5-15 p forgone
- **Net: +6-12 p/day on PV-rich days**

## Safety scaffolding already in place

- Paired restore at end of solar_preheat → tank back to NORMAL (PR B/G)
- `_check_tank_target_drift` heartbeat (PR F) catches stale-high target if PV collapses mid-window → writes restore
- 60 °C ≤ legionella floor (= safe upper bound for tank longevity)

## Prod

Already set to 60 in prod runtime_settings ahead of this PR (via direct `rts.set_setting` — no wait). This PR makes that the persistent default so future rebuilds don't regress.

## Tests

`test_runtime_settings.py::test_dhw_temp_pv_abundance_target_runtime_tunable` updated; full suite **1269 passed**.

## Timing note re. user's question "talvez foi muito em cima da hora"

PR G deployed ~15:00 BST with the 46 ceiling. Prior to that PR F's 50 °C was in effect for ~1 hour. So between today's PV peak (~13:00) and when you observed the export, the ceiling was already either too low (46) or 50 (1 °C below where it could really matter). Either way the LP couldn't store materially. With this PR + the live runtime override set to 60, the NEXT solve (within 30 min of merge or earlier on the next MPC tick) will plan aggressive solar_preheat on the next PV-abundant slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)