### PR TITLE
feat(dhw): fixed schedule replaces LP-driven tank arbitrage — PR K1

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -654,6 +654,43 @@ class Config:
     DHW_TANK_OVERNIGHT_TARGET_C: float = float(
         os.getenv("DHW_TANK_OVERNIGHT_TARGET_C", "38.0")
     )
+
+    # ------------------------------------------------------------------
+    # PR K (2026-05-23) — DHW fixed schedule (replaces LP-driven tank).
+    # ------------------------------------------------------------------
+    # When True, the LP no longer emits tank-write actions. Instead,
+    # ``src.dhw_policy`` writes a deterministic 2-row schedule per day:
+    #   - tank_warmup at DHW_WARMUP_START_HOUR_LOCAL → DHW_SETBACK_START_HOUR_LOCAL
+    #     with tank_temp = DHW_TEMP_NORMAL_C
+    #   - tank_setback for the rest of the day, tank_temp = DHW_TEMP_SETBACK_C
+    # Guests preset collapses to a single 24h warmup row. Vacation skips
+    # the schedule entirely (Daikin firmware owns).
+    # User constraint: "battery first, don't drain it overnight; no DHW
+    # tariff arb beyond negative-price events." Trades ~£20-50/year of
+    # DHW arbitrage savings for ZERO operational tank drama.
+    DHW_FIXED_SCHEDULE_ENABLED: bool = (
+        os.getenv("DHW_FIXED_SCHEDULE_ENABLED", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
+    # Local-time hour the daily warmup window starts (tank → NORMAL).
+    DHW_WARMUP_START_HOUR_LOCAL: int = int(
+        os.getenv("DHW_WARMUP_START_HOUR_LOCAL", "13")
+    )
+    # Local-time hour the daily setback window starts (tank → SETBACK).
+    DHW_SETBACK_START_HOUR_LOCAL: int = int(
+        os.getenv("DHW_SETBACK_START_HOUR_LOCAL", "22")
+    )
+    # Tank setback temperature during overnight window (°C).
+    # 37 °C = enough for emergency morning shower without battery drain.
+    DHW_TEMP_SETBACK_C: float = float(
+        os.getenv("DHW_TEMP_SETBACK_C", "37")
+    )
+    # Tank temperature during negative-price slots (Outgoing Agile < 0 p/kWh).
+    # Sole permitted exception to the fixed schedule — grid is paying us
+    # to consume, so load the tank.
+    DHW_NEGATIVE_PRICE_BOOST_C: float = float(
+        os.getenv("DHW_NEGATIVE_PRICE_BOOST_C", "60")
+    )
     # Forecast night-temperature bias (minimal #324 implementation).
     # Open Meteo's grid coverage (~10 km) over-estimates the W4 1DZ
     # microclimate's overnight outdoor temperature by ~3 °C in the household's
@@ -1417,8 +1454,12 @@ class Config:
     # grid export is sustained AND battery is near-full AND forecast agrees.
     # Deactivates: restores tank to DHW_TEMP_NORMAL_C when export stops.
     # Heartbeat 2 min × tick counters keeps Daikin quota safe (~2-4 writes/day).
+    # PR K1 (2026-05-23) — diverter default flipped to false. The fixed
+    # DHW schedule (DHW_FIXED_SCHEDULE_ENABLED) supersedes diverter as
+    # the sole DHW control mechanism. Diverter code remains for rollback;
+    # K2 will delete it. Set true to re-enable.
     PV_DIVERTER_ENABLED: bool = (
-        os.getenv("PV_DIVERTER_ENABLED", "true").strip().lower()
+        os.getenv("PV_DIVERTER_ENABLED", "false").strip().lower()
         in ("1", "true", "yes", "on")
     )
     # Threshold (kW) of GRID EXPORT to consider activating diverter.

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -1,0 +1,273 @@
+"""DHW (tank) policy — fixed deterministic daily schedule that replaces
+the LP-driven tank arbitrage stack (PR G/H/I/J).
+
+Per user 2026-05-23:
+
+    Overnight (22:00 → 13:00 next day):  tank = SETBACK (37 °C)
+    Daytime  (13:00 → 22:00):            tank = NORMAL  (45 °C, evening showers)
+    Guests mode:                          tank = NORMAL 24 h (no setback —
+                                            morning showers possible)
+    Vacation mode:                        no actions (Daikin firmware handles)
+    Negative-price slots (Outgoing < 0):  override to BOOST (60 °C) for the
+                                            duration of the negative window
+
+The policy intentionally does NOT optimize for tariff arbitrage on DHW
+(except the negative-price case where the grid is paying us). The user's
+explicit constraint: "battery first, tank second; don't drain the battery
+overnight just to keep water hot when no shower is happening." The
+~£20-50/year of DHW arb savings are sacrificed in exchange for operational
+simplicity and removing an entire class of bugs (drift checks, restore
+preservation chains, override propagation conflicts).
+
+This module is the SINGLE SOURCE OF TRUTH for tank actions when
+``DHW_FIXED_SCHEDULE_ENABLED=True``. The LP still optimizes battery /
+forecasts space heating, but emits no tank-write actions.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from . import db
+from .config import config
+
+logger = logging.getLogger(__name__)
+
+
+def _tz_local() -> ZoneInfo:
+    return ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
+
+
+def _iso_z(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _make_action(
+    *,
+    action_type: str,
+    start_utc: datetime,
+    end_utc: datetime,
+    tank_temp_c: int,
+    tank_powerful: bool = False,
+) -> dict[str, Any]:
+    """Build an action_schedule-shaped row dict ready for db.upsert_action."""
+    return {
+        "device": "daikin",
+        "action_type": action_type,
+        "start_time": _iso_z(start_utc),
+        "end_time": _iso_z(end_utc),
+        "params": {
+            "tank_power": True,
+            "tank_temp": int(tank_temp_c),
+            "tank_powerful": tank_powerful,
+            "dhw_policy": True,  # marker that this row came from dhw_policy
+        },
+    }
+
+
+def _detect_negative_windows(
+    outgoing_rates: list[dict[str, Any]] | None,
+    horizon_start_utc: datetime,
+    horizon_end_utc: datetime,
+) -> list[tuple[datetime, datetime]]:
+    """Group consecutive negative-price 30-min slots into contiguous windows.
+
+    ``outgoing_rates`` is a list of dicts with at least ``valid_from`` (ISO
+    UTC) and ``value_inc_vat`` (pence/kWh). Returns list of (start, end)
+    UTC datetime tuples; empty when no negative slots in horizon.
+    """
+    if not outgoing_rates:
+        return []
+    neg_slot_starts: list[datetime] = []
+    for r in outgoing_rates:
+        try:
+            ts_raw = r.get("valid_from") or r.get("slot_time_utc")
+            rate = float(r.get("value_inc_vat", r.get("rate_p", 999)))
+        except (TypeError, ValueError):
+            continue
+        if not ts_raw or rate >= 0:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+        if not (horizon_start_utc <= ts < horizon_end_utc):
+            continue
+        neg_slot_starts.append(ts)
+    if not neg_slot_starts:
+        return []
+    neg_slot_starts.sort()
+    # Group consecutive 30-min slots
+    windows: list[tuple[datetime, datetime]] = []
+    cur_start = neg_slot_starts[0]
+    cur_end = cur_start + timedelta(minutes=30)
+    for ts in neg_slot_starts[1:]:
+        if ts == cur_end:  # contiguous
+            cur_end = ts + timedelta(minutes=30)
+        else:
+            windows.append((cur_start, cur_end))
+            cur_start = ts
+            cur_end = ts + timedelta(minutes=30)
+    windows.append((cur_start, cur_end))
+    return windows
+
+
+def generate_daily_tank_schedule(
+    target_date_local: date,
+    *,
+    outgoing_rates: list[dict[str, Any]] | None = None,
+    mode: str | None = None,
+) -> list[dict[str, Any]]:
+    """Generate tank action rows for the local calendar day starting at
+    ``DHW_WARMUP_START_HOUR_LOCAL`` (default 13:00) on ``target_date_local``
+    and ending at the same time the following day.
+
+    The window matches the user's mental model: "a day's tank cycle starts
+    at the afternoon warmup and ends at the next afternoon warmup". This
+    way one call covers an entire warmup → setback → next-warmup cycle.
+
+    Args:
+        target_date_local: anchor day in local TZ
+        outgoing_rates: optional list of {valid_from, value_inc_vat}; used
+            to detect negative-price windows for boost overrides
+        mode: optimization preset; defaults to ``config.OPTIMIZATION_PRESET``
+
+    Returns:
+        List of action dicts; empty when ``mode='vacation'``.
+    """
+    if mode is None:
+        mode = (config.OPTIMIZATION_PRESET or "normal").strip().lower()
+
+    if mode == "vacation":
+        return []
+
+    tz = _tz_local()
+    warmup_hour = int(getattr(config, "DHW_WARMUP_START_HOUR_LOCAL", 13))
+    setback_hour = int(getattr(config, "DHW_SETBACK_START_HOUR_LOCAL", 22))
+    normal_c = int(round(float(config.DHW_TEMP_NORMAL_C)))
+    setback_c = int(round(float(getattr(config, "DHW_TEMP_SETBACK_C", 37))))
+    boost_c = int(round(float(getattr(config, "DHW_NEGATIVE_PRICE_BOOST_C", 60))))
+
+    warmup_start = datetime(
+        target_date_local.year, target_date_local.month, target_date_local.day,
+        warmup_hour, 0, tzinfo=tz,
+    )
+    setback_start = warmup_start.replace(hour=setback_hour)
+    next_warmup = warmup_start + timedelta(days=1)
+
+    rows: list[dict[str, Any]] = []
+
+    if mode == "guests":
+        # Single 24h warmup row — no setback during guest visits because of
+        # potential morning showers.
+        rows.append(_make_action(
+            action_type="tank_warmup",
+            start_utc=warmup_start.astimezone(UTC),
+            end_utc=next_warmup.astimezone(UTC),
+            tank_temp_c=normal_c,
+        ))
+    else:
+        # Normal mode: warmup → setback → next-day warmup pattern
+        rows.append(_make_action(
+            action_type="tank_warmup",
+            start_utc=warmup_start.astimezone(UTC),
+            end_utc=setback_start.astimezone(UTC),
+            tank_temp_c=normal_c,
+        ))
+        rows.append(_make_action(
+            action_type="tank_setback",
+            start_utc=setback_start.astimezone(UTC),
+            end_utc=next_warmup.astimezone(UTC),
+            tank_temp_c=setback_c,
+        ))
+
+    # Negative-price boost windows — sole permitted exception to the fixed
+    # schedule. Override the underlying tank_warmup / tank_setback for the
+    # duration of any negative-priced contiguous window within the horizon.
+    horizon_start = warmup_start.astimezone(UTC)
+    horizon_end = next_warmup.astimezone(UTC)
+    neg_windows = _detect_negative_windows(outgoing_rates, horizon_start, horizon_end)
+    for nw_start, nw_end in neg_windows:
+        rows.append(_make_action(
+            action_type="tank_negative_boost",
+            start_utc=nw_start,
+            end_utc=nw_end,
+            tank_temp_c=boost_c,
+            tank_powerful=True,  # grid pays us — load all the kWh
+        ))
+
+    return rows
+
+
+def write_daily_tank_schedule(
+    target_date_local: date | None = None,
+    *,
+    outgoing_rates: list[dict[str, Any]] | None = None,
+    mode: str | None = None,
+    clear_existing: bool = True,
+) -> int:
+    """Write a day's tank schedule into ``action_schedule``.
+
+    The horizon clearing is done by the LP-side ``write_daikin_from_lp_plan``
+    when ``DHW_FIXED_SCHEDULE_ENABLED=True``. This function does NOT clear
+    by default to allow concurrent LP-side writes (Fox V3 charge actions
+    sit in the same horizon but on the ``foxess`` device, not daikin).
+
+    Args:
+        target_date_local: defaults to today in local TZ
+        outgoing_rates: optional, for negative-price detection
+        mode: optional override; defaults to ``config.OPTIMIZATION_PRESET``
+        clear_existing: when True, calls ``db.clear_actions_in_range`` over
+            the warmup window before upserting
+
+    Returns:
+        Number of rows written.
+    """
+    if target_date_local is None:
+        target_date_local = datetime.now(_tz_local()).date()
+
+    rows = generate_daily_tank_schedule(
+        target_date_local,
+        outgoing_rates=outgoing_rates,
+        mode=mode,
+    )
+    if not rows:
+        logger.info("dhw_policy: no rows for %s (mode=%s)", target_date_local, mode)
+        return 0
+
+    if clear_existing:
+        # Clear daikin actions in the full warmup→next-warmup horizon
+        start_iso = rows[0]["start_time"]
+        end_iso = rows[-1]["end_time"]
+        # tank_negative_boost rows may have earlier start times — use min/max
+        start_iso = min(r["start_time"] for r in rows)
+        end_iso = max(r["end_time"] for r in rows)
+        db.clear_actions_in_range(start_iso, end_iso, device="daikin")
+
+    n_written = 0
+    for r in rows:
+        try:
+            db.upsert_action(
+                device=r["device"],
+                action_type=r["action_type"],
+                start_time=r["start_time"],
+                end_time=r["end_time"],
+                params=r["params"],
+                plan_date=str(target_date_local),
+                status="pending",
+            )
+            n_written += 1
+        except Exception as e:
+            logger.warning(
+                "dhw_policy: upsert failed for %s @ %s: %s",
+                r["action_type"], r["start_time"], e,
+            )
+    logger.info(
+        "dhw_policy: wrote %d rows for %s (mode=%s, neg_windows=%d)",
+        n_written, target_date_local, mode,
+        sum(1 for r in rows if r["action_type"] == "tank_negative_boost"),
+    )
+    return n_written

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -5,6 +5,7 @@ import dataclasses
 import logging
 import math
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from typing import TYPE_CHECKING, Any
 
 from .. import db
@@ -758,6 +759,64 @@ def write_daikin_from_lp_plan(
             db.clear_actions_for_date(plan_date, device="daikin")
         logger.info("write_daikin_from_lp_plan: skipped (DAIKIN_CONTROL_MODE=passive)")
         return 0
+
+    # PR K1 (2026-05-23) — fixed DHW schedule replaces LP-driven tank.
+    # LP still solves over the horizon for battery + space-heating
+    # forecasting, but emits no tank-write actions. The deterministic
+    # tank schedule comes from :mod:`src.dhw_policy` instead. See
+    # ``DHW_FIXED_SCHEDULE_ENABLED`` docstring in config.py for rationale.
+    if getattr(config, "DHW_FIXED_SCHEDULE_ENABLED", False):
+        if plan.slot_starts_utc:
+            window_start_iso = plan.slot_starts_utc[0].isoformat().replace("+00:00", "Z")
+            window_end = plan.slot_starts_utc[-1] + timedelta(minutes=30)
+            window_end_iso = window_end.isoformat().replace("+00:00", "Z")
+            db.clear_actions_in_range(window_start_iso, window_end_iso, device="daikin")
+        else:
+            db.clear_actions_for_date(plan_date, device="daikin")
+        # Generate fixed schedule rows. plan_date may anchor today or
+        # tomorrow depending on when this LP solve fired; write both
+        # today's and tomorrow's tank cycles to cover the full LP horizon
+        # (max 48h).
+        from datetime import UTC as _UTC_T
+        from datetime import date as _date_t
+
+        from .. import dhw_policy
+        from ..db import get_agile_export_rates_in_range
+        tz_local_local = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
+        try:
+            anchor = _date_t.fromisoformat(plan_date)
+        except (ValueError, TypeError):
+            anchor = datetime.now(tz_local_local).date()
+        days_written = 0
+        rows_total = 0
+        for offset in (0, 1):
+            day = anchor + timedelta(days=offset)
+            # Pull Outgoing Agile rates for negative-price detection
+            try:
+                day_start_local = datetime(day.year, day.month, day.day, 0, 0,
+                                            tzinfo=tz_local_local)
+                outgoing = get_agile_export_rates_in_range(
+                    day_start_local.astimezone(_UTC_T).isoformat().replace("+00:00", "Z"),
+                    (day_start_local + timedelta(days=1)).astimezone(_UTC_T).isoformat().replace("+00:00", "Z"),
+                )
+            except Exception as _e:
+                logger.debug("dhw_policy: outgoing rates unavailable for %s: %s", day, _e)
+                outgoing = None
+            try:
+                n = dhw_policy.write_daily_tank_schedule(
+                    target_date_local=day,
+                    outgoing_rates=outgoing,
+                    clear_existing=False,  # already cleared above
+                )
+                rows_total += n
+                days_written += 1
+            except Exception as e:
+                logger.warning("dhw_policy: write for %s failed: %s", day, e)
+        logger.info(
+            "write_daikin_from_lp_plan: DHW_FIXED_SCHEDULE — wrote %d rows across %d days (no LP tank actions)",
+            rows_total, days_written,
+        )
+        return rows_total
     if plan.slot_starts_utc:
         window_start_iso = plan.slot_starts_utc[0].isoformat().replace("+00:00", "Z")
         window_end = plan.slot_starts_utc[-1] + timedelta(minutes=30)

--- a/tests/test_daikin_write_budget_guard.py
+++ b/tests/test_daikin_write_budget_guard.py
@@ -226,6 +226,9 @@ def test_write_daikin_logs_dropped_actions_no_telegram_push(
     monkeypatch.setattr("src.api_quota.quota_remaining", _fake_remaining)
     monkeypatch.setattr(app_config, "DAIKIN_RESERVE_FOR_HEARTBEAT", 0, raising=False)
     monkeypatch.setattr(app_config, "DAIKIN_CONTROL_MODE", "active", raising=False)
+    # PR K1 — this test exercises the LP-driven write path (budget guard
+    # logic). Disable the fixed-schedule shortcut so the legacy path runs.
+    monkeypatch.setattr(app_config, "DHW_FIXED_SCHEDULE_ENABLED", False, raising=False)
 
     monkeypatch.setattr(lp_dispatch.db, "upsert_action", lambda **kw: 1)
     monkeypatch.setattr(lp_dispatch.db, "clear_actions_in_range", lambda *a, **kw: 0)

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -1,0 +1,382 @@
+"""Tests for the PR K1 dhw_policy module — the fixed daily tank schedule
+that replaces LP-driven tank arbitrage.
+
+The schedule shape per user 2026-05-23:
+    Normal mode:  warmup 13:00→22:00 at NORMAL=45, setback 22:00→13:00 at 37
+    Guests mode:  single 24h warmup at NORMAL=45 (no setback; morning showers)
+    Vacation:     no actions (Daikin firmware owns)
+    Negative-price slots: overlay tank_negative_boost at 60 °C
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db as _db
+from src import dhw_policy
+from src.config import config
+
+TZ_LOCAL = ZoneInfo("Europe/London")
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr(config, "DB_PATH", db_path, raising=False)
+    _db.init_db()
+    monkeypatch.setattr(config, "DHW_FIXED_SCHEDULE_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "DHW_WARMUP_START_HOUR_LOCAL", 13, raising=False)
+    monkeypatch.setattr(config, "DHW_SETBACK_START_HOUR_LOCAL", 22, raising=False)
+    monkeypatch.setattr(config, "DHW_TEMP_NORMAL_C", 45.0, raising=False)
+    monkeypatch.setattr(config, "DHW_TEMP_SETBACK_C", 37.0, raising=False)
+    monkeypatch.setattr(config, "DHW_NEGATIVE_PRICE_BOOST_C", 60.0, raising=False)
+    monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "normal", raising=False)
+    monkeypatch.setattr(config, "BULLETPROOF_TIMEZONE", "Europe/London", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Generate (pure function — no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_normal_mode_emits_two_rows():
+    """Normal mode: warmup + setback rows."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    assert len(rows) == 2
+    types = [r["action_type"] for r in rows]
+    assert types == ["tank_warmup", "tank_setback"]
+
+
+def test_normal_mode_warmup_timing():
+    """tank_warmup runs 13:00→22:00 local on the target day."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    warmup = next(r for r in rows if r["action_type"] == "tank_warmup")
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    end = datetime.fromisoformat(warmup["end_time"].replace("Z", "+00:00"))
+    # 13:00 BST = 12:00 UTC (BST = UTC+1 in June)
+    assert start.astimezone(TZ_LOCAL).hour == 13
+    assert end.astimezone(TZ_LOCAL).hour == 22
+    assert warmup["params"]["tank_temp"] == 45
+    assert warmup["params"]["tank_power"] is True
+
+
+def test_normal_mode_setback_timing():
+    """tank_setback runs 22:00→next day 13:00 local."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    setback = next(r for r in rows if r["action_type"] == "tank_setback")
+    start = datetime.fromisoformat(setback["start_time"].replace("Z", "+00:00"))
+    end = datetime.fromisoformat(setback["end_time"].replace("Z", "+00:00"))
+    assert start.astimezone(TZ_LOCAL).hour == 22
+    assert start.astimezone(TZ_LOCAL).day == 1
+    assert end.astimezone(TZ_LOCAL).hour == 13
+    assert end.astimezone(TZ_LOCAL).day == 2  # next day
+    assert setback["params"]["tank_temp"] == 37
+
+
+def test_guests_mode_emits_single_24h_row():
+    """Guests preset: tank stays at NORMAL the whole day (morning showers)."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="guests")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["action_type"] == "tank_warmup"
+    assert r["params"]["tank_temp"] == 45
+    start = datetime.fromisoformat(r["start_time"].replace("Z", "+00:00"))
+    end = datetime.fromisoformat(r["end_time"].replace("Z", "+00:00"))
+    duration = (end - start).total_seconds() / 3600
+    assert abs(duration - 24) < 0.1
+
+
+def test_vacation_mode_emits_nothing():
+    """Vacation preset: tank firmware-owned, no HEM actions."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="vacation")
+    assert rows == []
+
+
+def test_unknown_mode_defaults_to_normal_behavior():
+    """An unrecognized mode string falls through to normal (defensive)."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="bogus")
+    assert len(rows) == 2
+    assert {r["action_type"] for r in rows} == {"tank_warmup", "tank_setback"}
+
+
+def test_mode_pulled_from_config_when_none(monkeypatch):
+    """When mode=None, falls back to OPTIMIZATION_PRESET."""
+    monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "guests", raising=False)
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1))
+    assert len(rows) == 1
+    assert rows[0]["action_type"] == "tank_warmup"
+
+
+# ---------------------------------------------------------------------------
+# Negative-price overlay
+# ---------------------------------------------------------------------------
+
+
+def test_negative_price_single_slot_overlay():
+    """One negative-price 30-min slot inside the schedule horizon adds a
+    tank_negative_boost row at 60 °C."""
+    # Negative slot at 14:00 UTC (15:00 BST = inside warmup window)
+    neg_slot_utc = datetime(2026, 6, 1, 14, 0, tzinfo=UTC).isoformat().replace("+00:00", "Z")
+    outgoing = [
+        {"valid_from": neg_slot_utc, "value_inc_vat": -5.0, "tariff_code": "AGILE-OUTGOING"},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    assert len(boost) == 1
+    assert boost[0]["params"]["tank_temp"] == 60
+    assert boost[0]["params"]["tank_powerful"] is True  # grid pays — load max
+
+
+def test_consecutive_negative_slots_merged_into_window():
+    """3 consecutive negative slots → one merged boost window (90 min)."""
+    outgoing = [
+        {"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0},
+        {"valid_from": "2026-06-01T14:30:00Z", "value_inc_vat": -3.5},
+        {"valid_from": "2026-06-01T15:00:00Z", "value_inc_vat": -1.2},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    assert len(boost) == 1
+    start = datetime.fromisoformat(boost[0]["start_time"].replace("Z", "+00:00"))
+    end = datetime.fromisoformat(boost[0]["end_time"].replace("Z", "+00:00"))
+    duration_min = (end - start).total_seconds() / 60
+    assert duration_min == 90  # 3 slots × 30 min
+
+
+def test_non_contiguous_negative_slots_emit_separate_windows():
+    """A gap between negative slots → two separate boost windows."""
+    outgoing = [
+        {"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0},
+        # Gap at 14:30 (positive price)
+        {"valid_from": "2026-06-01T15:30:00Z", "value_inc_vat": -2.0},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    assert len(boost) == 2
+
+
+def test_positive_outgoing_rates_do_not_trigger_boost():
+    """All-positive outgoing rates → no boost rows, just warmup + setback."""
+    outgoing = [
+        {"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": 15.0},
+        {"valid_from": "2026-06-01T15:00:00Z", "value_inc_vat": 20.0},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    assert all(r["action_type"] != "tank_negative_boost" for r in rows)
+
+
+def test_negative_slot_outside_horizon_ignored():
+    """Negative slot before today's 13:00 warmup start is outside horizon
+    and gets skipped."""
+    # Negative at 10:00 UTC (11:00 BST = before warmup start)
+    outgoing = [
+        {"valid_from": "2026-06-01T10:00:00Z", "value_inc_vat": -5.0},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    assert boost == []
+
+
+def test_outgoing_rates_none_no_crash():
+    """outgoing_rates=None just yields warmup+setback, no boost; doesn't crash."""
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=None, mode="normal",
+    )
+    assert len(rows) == 2
+    assert all(r["action_type"] in ("tank_warmup", "tank_setback") for r in rows)
+
+
+def test_outgoing_rate_zero_does_not_trigger_boost():
+    """Rate=0 is not strictly negative; no boost."""
+    outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": 0.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    assert boost == []
+
+
+def test_malformed_outgoing_rate_skipped():
+    """Garbled rate entries don't crash; just get skipped."""
+    outgoing = [
+        {"valid_from": None, "value_inc_vat": -5.0},  # missing time
+        {"valid_from": "not-a-date", "value_inc_vat": -3.0},  # bad time
+        {"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": "huh"},  # bad rate
+        {"valid_from": "2026-06-01T15:00:00Z", "value_inc_vat": -1.0},  # good
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    # Only the one good negative rate emits a boost
+    assert len(boost) == 1
+
+
+# ---------------------------------------------------------------------------
+# DB write path (write_daily_tank_schedule)
+# ---------------------------------------------------------------------------
+
+
+def test_write_daily_tank_schedule_persists_rows():
+    """write_daily_tank_schedule upserts rows into action_schedule."""
+    n = dhw_policy.write_daily_tank_schedule(
+        target_date_local=date(2026, 6, 1),
+        outgoing_rates=None,
+        mode="normal",
+        clear_existing=False,
+    )
+    assert n == 2
+    import sqlite3
+    conn = sqlite3.connect(config.DB_PATH)
+    rows = list(conn.execute(
+        """SELECT action_type, params FROM action_schedule
+           WHERE device = 'daikin' AND date = '2026-06-01'
+           ORDER BY start_time"""
+    ))
+    assert len(rows) == 2
+    types = [r[0] for r in rows]
+    assert types == ["tank_warmup", "tank_setback"]
+    for r in rows:
+        params = json.loads(r[1])
+        assert params["dhw_policy"] is True  # marker present
+
+
+def test_write_vacation_writes_zero_rows():
+    """write_daily_tank_schedule in vacation mode is a no-op."""
+    n = dhw_policy.write_daily_tank_schedule(
+        target_date_local=date(2026, 6, 1),
+        mode="vacation",
+        clear_existing=False,
+    )
+    assert n == 0
+
+
+def test_write_with_clear_existing_clears_then_writes():
+    """clear_existing=True clears the horizon then writes the new rows."""
+    # First seed a stale solar_preheat row
+    _db.upsert_action(
+        plan_date="2026-06-01",
+        device="daikin", action_type="solar_preheat",
+        start_time="2026-06-01T13:00:00Z",
+        end_time="2026-06-01T16:00:00Z",
+        params={"tank_temp": 60},
+        status="pending",
+    )
+    import sqlite3
+    conn = sqlite3.connect(config.DB_PATH)
+    pre = list(conn.execute("SELECT COUNT(*) FROM action_schedule WHERE action_type='solar_preheat'"))[0][0]
+    assert pre == 1
+
+    n = dhw_policy.write_daily_tank_schedule(
+        target_date_local=date(2026, 6, 1),
+        mode="normal",
+        clear_existing=True,
+    )
+    assert n == 2
+    # Stale row cleared, new rows present
+    rows = list(conn.execute(
+        "SELECT action_type FROM action_schedule WHERE device='daikin' ORDER BY start_time"
+    ))
+    types = [r[0] for r in rows]
+    assert "solar_preheat" not in types
+    assert "tank_warmup" in types
+    assert "tank_setback" in types
+
+
+# ---------------------------------------------------------------------------
+# Runtime hour overrides
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_hour_runtime_override(monkeypatch):
+    """User can change warmup start via env var/runtime setting."""
+    monkeypatch.setattr(config, "DHW_WARMUP_START_HOUR_LOCAL", 15, raising=False)
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    warmup = next(r for r in rows if r["action_type"] == "tank_warmup")
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    assert start.astimezone(TZ_LOCAL).hour == 15
+
+
+def test_setback_hour_runtime_override(monkeypatch):
+    """User can shift setback start time."""
+    monkeypatch.setattr(config, "DHW_SETBACK_START_HOUR_LOCAL", 20, raising=False)
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    warmup = next(r for r in rows if r["action_type"] == "tank_warmup")
+    end = datetime.fromisoformat(warmup["end_time"].replace("Z", "+00:00"))
+    assert end.astimezone(TZ_LOCAL).hour == 20
+
+
+def test_setback_temp_override(monkeypatch):
+    """SETBACK_C is runtime-tunable."""
+    monkeypatch.setattr(config, "DHW_TEMP_SETBACK_C", 40.0, raising=False)
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    setback = next(r for r in rows if r["action_type"] == "tank_setback")
+    assert setback["params"]["tank_temp"] == 40
+
+
+def test_negative_boost_temp_override(monkeypatch):
+    """DHW_NEGATIVE_PRICE_BOOST_C is tunable (e.g. could be 65 for max)."""
+    monkeypatch.setattr(config, "DHW_NEGATIVE_PRICE_BOOST_C", 65.0, raising=False)
+    outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = next(r for r in rows if r["action_type"] == "tank_negative_boost")
+    assert boost["params"]["tank_temp"] == 65
+
+
+def test_normal_temp_override(monkeypatch):
+    """NORMAL_C runtime change reflects in warmup row."""
+    monkeypatch.setattr(config, "DHW_TEMP_NORMAL_C", 46.0, raising=False)
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    warmup = next(r for r in rows if r["action_type"] == "tank_warmup")
+    assert warmup["params"]["tank_temp"] == 46
+
+
+# ---------------------------------------------------------------------------
+# Action shape contract (so heartbeat dispatcher can apply them)
+# ---------------------------------------------------------------------------
+
+
+def test_action_row_required_keys():
+    """All rows have the keys db.upsert_action requires."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    for r in rows:
+        assert set(r.keys()) >= {"device", "action_type", "start_time", "end_time", "params"}
+        assert r["device"] == "daikin"
+        # tank_power, tank_temp are what daikin_bulletproof expects
+        assert "tank_power" in r["params"]
+        assert "tank_temp" in r["params"]
+        assert isinstance(r["params"]["tank_temp"], int)
+
+
+def test_warmup_does_not_set_tank_powerful():
+    """Default warmup is gentle: powerful=False. Only negative_boost uses powerful=True."""
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    warmup = next(r for r in rows if r["action_type"] == "tank_warmup")
+    assert warmup["params"]["tank_powerful"] is False
+
+
+def test_negative_boost_uses_powerful():
+    """Negative-price boost loads tank fast — tank_powerful=True."""
+    outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+    )
+    boost = next(r for r in rows if r["action_type"] == "tank_negative_boost")
+    assert boost["params"]["tank_powerful"] is True


### PR DESCRIPTION
Closes the architectural inconsistency observed today: LP planned solar_preheat lifting tank to 60°C while battery was at 46% (no live SoC gate on LP-scheduled actions). User asked for radical simplification — Opção 2 from the analysis.

## User policy (explicit 2026-05-23)

| Window | Tank target |
|---|---|
| Overnight 22:00 → 13:00 | SETBACK = 37°C |
| Daytime 13:00 → 22:00 | NORMAL = 45°C |
| Guests mode | NORMAL 24h (no setback) |
| Vacation | No HEM actions (firmware owns) |
| Negative-price slot | BOOST = 60°C (sole exception) |

**No arbitrage beyond that.** Sacrifice ~£20-50/year DHW arb for ZERO operational drama.

## Implementation

- **`src/dhw_policy.py`** (NEW) — pure function `generate_daily_tank_schedule(date, outgoing_rates, mode)` + persistent `write_daily_tank_schedule(...)`
- **`src/config.py`** — `DHW_FIXED_SCHEDULE_ENABLED=true` (default), `DHW_WARMUP_START_HOUR_LOCAL=13`, `DHW_SETBACK_START_HOUR_LOCAL=22`, `DHW_TEMP_SETBACK_C=37`, `DHW_NEGATIVE_PRICE_BOOST_C=60`. Diverter default flipped `true → false`.
- **`src/scheduler/lp_dispatch.py`** — when flag on, `write_daikin_from_lp_plan` short-circuits → calls `dhw_policy` for today + tomorrow. LP still solves for battery, no tank writes.

## What stays vs what goes

| Component | Status K1 | K2 plan |
|---|---|---|
| LP `solar_preheat` action emission | bypassed | delete |
| Diverter `_check_pv_tank_diverter` | disabled via env | delete |
| `PV_DIVERTER_*` config (9 keys) | retained | delete |
| `LP_PV_ABUNDANCE_TANK_*` (PR I) | retained | delete |
| `DHW_TEMP_PV_ABUNDANCE_TARGET_C` (PR H) | retained | delete |
| PR G physics (`USABLE_FRACTION`, `FLOW_LPM`, `EVENING_CAP`) | retained | delete |
| Restore preservation chain | retained | delete |
| LP battery optimization | active | active |
| Fox V3 charge actions | active | active |

## Tests (26 NEW)

Schedule shape (7): normal/guests/vacation modes, timing, defaults
Negative overlay (8): single, consecutive, gaps, positive, outside horizon, None, zero, malformed
DB persistence (3): upsert, vacation no-op, clear_existing
Runtime overrides (5): warmup hour, setback hour, setback temp, boost temp, normal temp
Action shape contract (3): required keys, tank_temp int, tank_powerful semantics

Full suite: **1343 passed**, 3 skipped, 1 xfailed (was 1317).

## Rollback

```
DHW_FIXED_SCHEDULE_ENABLED=false  # restart hem → LP legacy resumes
PV_DIVERTER_ENABLED=true          # re-enable diverter
```
or `git revert`.

## Deploy verification (post-merge)

Tomorrow morning expectations:
- `action_schedule` shows 2 rows per day (warmup + setback), maybe + boost windows
- Zero `solar_preheat`, `pre_heat`, `shutdown` rows
- Tank physical temp: 37 overnight, ramps to 45 by ~14:00-15:00, holds, decays after 22:00
- Daikin quota: scheduled_apply writes drop to ~2/day from current ~5-10/day
- No more `pv_diverter_*` action_log events (gated by env default flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)