### PR TITLE
fix(pv): re-baseline cal table from Quartz direct_pv_kw — PR L1.1

### DIFF
--- a/src/scheduler/octopus_fetch.py
+++ b/src/scheduler/octopus_fetch.py
@@ -66,37 +66,29 @@ def fetch_and_store_rates(fox: FoxESSClient | None = None) -> dict[str, Any]:
         except Exception as e:
             logger.warning("Octopus export-rates fetch failed (non-fatal): %s", e)
 
-    # Refresh the per-hour-of-day + cloud-aware PV calibration tables (Fox
-    # actual vs Open-Meteo archive). Skipped when FORECAST_SOURCE=quartz — the
-    # tables are radiation-trained (actual / estimate_pv_kw(open_meteo_rad))
-    # and ``forecast_pv_kw_from_row`` ignores them on the Quartz path (PR #279
-    # removed the double-correction). Recomputing them is wasted work + an
-    # avoidable Open-Meteo archive request. If the source ever flips back to
-    # open-meteo (manual fallback / Quartz outage) the tables get rebuilt
-    # again on the next octopus fetch.
-    forecast_source = (getattr(config, "FORECAST_SOURCE", "open-meteo") or "open-meteo").strip().lower()
-    if forecast_source in ("quartz", "quartz_solar"):
-        logger.info("PV calibration recompute skipped (FORECAST_SOURCE=%s; tables unused on Quartz path)", forecast_source)
-    else:
-        # Daily cadence is sufficient — bias drifts over weeks, not minutes.
-        # Failure is non-fatal; LP falls back to the flat factor.
-        try:
-            from ..weather import compute_pv_calibration_hourly_table
+    # Refresh the per-hour-of-day + cloud-aware PV calibration tables.
+    # PR L1.1 (2026-05-24) — tables are now Quartz-trained (actual /
+    # direct_pv_kw from meteo_forecast_value), so we ALWAYS recompute
+    # regardless of FORECAST_SOURCE. Quartz path applies the new factors
+    # (PR L1); Open-Meteo fallback path also benefits (orientation
+    # correction is source-agnostic in the limit).
+    # Daily cadence is sufficient — bias drifts over weeks, not minutes.
+    # Failure is non-fatal; LP falls back to the flat factor.
+    try:
+        from ..weather import compute_pv_calibration_hourly_table
 
-            cal_status = compute_pv_calibration_hourly_table()
-            logger.info("PV per-hour calibration recompute: %s", cal_status)
-        except Exception as e:
-            logger.warning("PV per-hour calibration recompute failed (non-fatal): %s", e)
+        cal_status = compute_pv_calibration_hourly_table()
+        logger.info("PV per-hour calibration recompute: %s", cal_status)
+    except Exception as e:
+        logger.warning("PV per-hour calibration recompute failed (non-fatal): %s", e)
 
-        # PR #232: cloud-aware (hour × cloud-bucket) recompute. Same daily cadence,
-        # same failure mode (non-fatal — falls back to per-hour table or flat).
-        try:
-            from ..weather import compute_pv_calibration_hourly_cloud_table
+    try:
+        from ..weather import compute_pv_calibration_hourly_cloud_table
 
-            cloud_status = compute_pv_calibration_hourly_cloud_table()
-            logger.info("PV cloud-aware calibration recompute: %s", cloud_status)
-        except Exception as e:
-            logger.warning("PV cloud-aware calibration recompute failed (non-fatal): %s", e)
+        cloud_status = compute_pv_calibration_hourly_cloud_table()
+        logger.info("PV cloud-aware calibration recompute: %s", cloud_status)
+    except Exception as e:
+        logger.warning("PV cloud-aware calibration recompute failed (non-fatal): %s", e)
 
     summary: dict[str, Any] = {"ok": True, "rows": n, "export_rows": export_n}
     if config.USE_BULLETPROOF_ENGINE:

--- a/src/weather.py
+++ b/src/weather.py
@@ -836,19 +836,25 @@ def compute_pv_calibration_hourly_table(
     window_days: int | None = None,
     min_samples_per_hour: int = 7,
 ) -> dict[str, Any]:
-    """Recompute the per-hour-of-day PV calibration table from ``pv_realtime_history``.
+    """Recompute the per-hour-of-day PV calibration table.
 
-    For each UTC hour-of-day, sums measured PV (5-min samples × 1/12 → kWh per
-    hour) and compares against Open-Meteo Archive ``shortwave_radiation_instant``
-    converted via :func:`estimate_pv_kw`. The median ratio per hour becomes the
-    factor stored in ``pv_calibration_hourly``.
+    **PR L1.1 (2026-05-24)** — Re-baselined from Quartz ``direct_pv_kw``
+    (the same prediction the LP consumes) instead of
+    ``estimate_pv_kw(open_meteo_radiation)``. Open-Meteo's radiation-derived
+    PV assumes a south-facing array; the W4 1DZ install is east-facing.
+    The resulting "actual / Open-Meteo prediction" ratios were
+    structurally low (0.2-0.5) and would have driven Quartz forecasts
+    severely down when applied as multipliers (PR L1 over-correction bug).
 
-    Hours with fewer than ``min_samples_per_hour`` samples in the window are
-    skipped (low statistical confidence). Returns a status dict so the caller
-    can log how the recompute went.
+    The new baseline is the latest pre-slot Quartz forecast from
+    ``meteo_forecast_value.direct_pv_kw``. The ratio becomes
+    ``actual / Quartz_raw`` — exactly the correction needed to align
+    LP's Quartz-driven plan with reality.
 
-    Failure modes (no Fox data, Open-Meteo down, etc.) return a dict with
-    ``status='skipped'`` and never raise — the LP keeps the flat fallback.
+    Hours with fewer than ``min_samples_per_hour`` Quartz samples in the
+    window are skipped (low statistical confidence). Returns a status dict.
+    Failure modes return ``status='skipped'`` and never raise — LP keeps
+    the flat fallback.
     """
     from . import db as _db
     from datetime import date as _date, timedelta as _td
@@ -859,13 +865,7 @@ def compute_pv_calibration_hourly_table(
     start = end - _td(days=window_days)
 
     # Pull measured PV per UTC hour from pv_realtime_history.
-    # NOTE: average kW × 1h, NOT sum × (5/60). The previous "kw × (5/60)" formula
-    # assumed 12 samples/hour (5-min cadence). In practice the heartbeat writes
-    # samples sparsely (often 1-3/hour), so the sum-based formula collapses
-    # by ~10× — the resulting "ratio" was artificially low and made the per-hour
-    # calibration table over-correct against forecast (audit 2026-05-02:
-    # factors at the 0.10 floor when reality should give 0.5-0.7).
-    measured_per_hour: dict[int, list[float]] = {h: [] for h in range(24)}
+    # mean kW × 1h = kWh per hour (sample-density-independent).
     measured_kw_samples: dict[tuple[str, int], list[float]] = {}
     with _db._lock:
         conn = _db.get_connection()
@@ -891,7 +891,6 @@ def compute_pv_calibration_hourly_table(
                 measured_kw_samples.setdefault((day, hour), []).append(kw)
         finally:
             conn.close()
-    # mean kW × 1h = kWh per hour (sample-density-independent)
     measured_per_day_hour: dict[tuple[str, int], float] = {
         k: (sum(samples) / len(samples)) for k, samples in measured_kw_samples.items() if samples
     }
@@ -899,40 +898,46 @@ def compute_pv_calibration_hourly_table(
     if not measured_per_day_hour:
         return {"status": "skipped", "reason": "no pv_realtime_history in window"}
 
-    # Pull modelled PV per hour from Open-Meteo Archive — same conversion the LP uses.
-    lat = (config.WEATHER_LAT or "").strip()
-    lon = (config.WEATHER_LON or "").strip()
-    if not lat or not lon:
-        return {"status": "skipped", "reason": "no lat/lon configured"}
-    try:
-        url = (
-            "https://archive-api.open-meteo.com/v1/archive?"
-            f"latitude={lat}&longitude={lon}"
-            f"&start_date={start.isoformat()}&end_date={end.isoformat()}"
-            "&hourly=shortwave_radiation_instant"
-            "&timezone=UTC"
-        )
-        req = urllib.request.Request(url, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            api_data = json.loads(resp.read().decode())
-    except (urllib.error.URLError, json.JSONDecodeError, KeyError, TypeError) as e:
-        return {"status": "skipped", "reason": f"open-meteo fetch failed: {e}"}
-
-    times = api_data.get("hourly", {}).get("time", [])
-    rads = api_data.get("hourly", {}).get("shortwave_radiation_instant", [])
+    # PR L1.1 — pull modelled PV per hour from Quartz forecasts (the
+    # actual baseline the LP uses). Pick the LATEST pre-slot fetch for
+    # each slot so the calibration trains against what the LP planned
+    # against, not against revisions that only became available after
+    # the fact.
     modelled_per_day_hour: dict[tuple[str, int], float] = {}
-    for t, r in zip(times, rads):
-        if r is None:
-            continue
+    with _db._lock:
+        conn = _db.get_connection()
         try:
-            dt = datetime.fromisoformat(str(t).replace("Z", "+00:00"))
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=UTC)
-            day = dt.date().isoformat()
-            hour = dt.hour
-            modelled_per_day_hour[(day, hour)] = estimate_pv_kw(float(r))  # 1-hour slot → kWh
-        except (ValueError, TypeError):
-            continue
+            cur = conn.execute(
+                """SELECT mv.slot_time, mv.direct_pv_kw, mv.forecast_fetch_at_utc
+                   FROM meteo_forecast_value mv
+                   WHERE mv.direct_pv_kw IS NOT NULL
+                     AND substr(mv.slot_time, 1, 10) BETWEEN ? AND ?
+                     AND mv.forecast_fetch_at_utc < mv.slot_time
+                   ORDER BY mv.slot_time ASC, mv.forecast_fetch_at_utc ASC""",
+                (start.isoformat(), end.isoformat()),
+            )
+            # Iterate in order; later rows overwrite earlier → latest pre-slot wins
+            for row in cur.fetchall():
+                slot_time_str = row[0]
+                direct_pv = float(row[1] or 0.0)
+                try:
+                    slot_dt = datetime.fromisoformat(str(slot_time_str).replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    continue
+                if slot_dt.tzinfo is None:
+                    slot_dt = slot_dt.replace(tzinfo=UTC)
+                day = slot_dt.date().isoformat()
+                hour = slot_dt.hour
+                # direct_pv_kw is a kW value for the hour → kWh for that 1-h slot
+                modelled_per_day_hour[(day, hour)] = direct_pv
+        finally:
+            conn.close()
+
+    if not modelled_per_day_hour:
+        return {
+            "status": "skipped",
+            "reason": "no Quartz direct_pv_kw in meteo_forecast_value window",
+        }
 
     # Build per-hour ratio lists, skipping dawn/dusk noise (both < 0.05).
     ratios_per_hour: dict[int, list[float]] = {h: [] for h in range(24)}
@@ -943,7 +948,7 @@ def compute_pv_calibration_hourly_table(
         if measured_kwh < 0.05 and modelled_kwh < 0.05:
             continue
         ratio = measured_kwh / modelled_kwh
-        # Drop egregious outliers (sensor spike or archive anomaly)
+        # Drop egregious outliers (sensor spike or forecast anomaly)
         if ratio > 5.0:
             continue
         ratios_per_hour[hour].append(ratio)
@@ -953,10 +958,13 @@ def compute_pv_calibration_hourly_table(
     for hour, rs in ratios_per_hour.items():
         if len(rs) < min_samples_per_hour:
             continue
-        # Use median (robust to single bad day) and clamp to safe range
+        # Use median (robust to single bad day) and clamp.
+        # PR L1.1 — UPPER bound raised to 2.0 (was 1.10) because Quartz can
+        # legitimately UNDER-predict (PM ratio observed ~1.19-1.59 for
+        # east-facing array). Lower bound stays at 0.10 as a safety floor.
         rs_sorted = sorted(rs)
         median = rs_sorted[len(rs_sorted) // 2]
-        clamped = max(0.10, min(1.10, median))
+        clamped = max(0.10, min(2.0, median))
         factors[hour] = round(clamped, 4)
         samples[hour] = len(rs)
 
@@ -1412,43 +1420,43 @@ def compute_pv_calibration_hourly_cloud_table(
         k: sum(s) / len(s) for k, s in actual_kw_samples.items() if s
     }
 
-    # 2. Pull historical forecasts WITH cloud_cover via Open-Meteo Archive
-    lat = (config.WEATHER_LAT or "").strip()
-    lon = (config.WEATHER_LON or "").strip()
-    if not lat or not lon:
-        return {"status": "skipped", "reason": "no lat/lon configured"}
-    try:
-        url = (
-            "https://archive-api.open-meteo.com/v1/archive?"
-            f"latitude={lat}&longitude={lon}"
-            f"&start_date={start.isoformat()}&end_date={end.isoformat()}"
-            "&hourly=shortwave_radiation_instant,cloud_cover"
-            "&timezone=UTC"
-        )
-        req = urllib.request.Request(url, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            api_data = json.loads(resp.read().decode())
-    except (urllib.error.URLError, json.JSONDecodeError, KeyError, TypeError) as e:
-        return {"status": "skipped", "reason": f"open-meteo archive fetch failed: {e}"}
-
-    times = api_data.get("hourly", {}).get("time", [])
-    rads = api_data.get("hourly", {}).get("shortwave_radiation_instant", [])
-    clouds = api_data.get("hourly", {}).get("cloud_cover", [])
+    # 2. PR L1.1 — pull Quartz forecasts (with Open-Meteo cloud_cover for
+    # bucketing) from our local snapshot store. Latest pre-slot fetch wins.
     archive: dict[tuple[str, int], tuple[float, float | None]] = {}
-    for i, t in enumerate(times):
+    with _db._lock:
+        conn = _db.get_connection()
         try:
-            dt = _dt.fromisoformat(str(t).replace("Z", "+00:00"))
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=_UTC)
-            day = dt.date().isoformat()
-            hour = dt.hour
-            r = rads[i] if i < len(rads) else None
-            c = clouds[i] if i < len(clouds) else None
-            if r is None:
-                continue
-            archive[(day, hour)] = (float(r), float(c) if c is not None else None)
-        except (ValueError, TypeError, IndexError):
-            continue
+            cur = conn.execute(
+                """SELECT mv.slot_time, mv.direct_pv_kw, mv.cloud_cover_pct,
+                          mv.forecast_fetch_at_utc
+                   FROM meteo_forecast_value mv
+                   WHERE mv.direct_pv_kw IS NOT NULL
+                     AND substr(mv.slot_time, 1, 10) BETWEEN ? AND ?
+                     AND mv.forecast_fetch_at_utc < mv.slot_time
+                   ORDER BY mv.slot_time ASC, mv.forecast_fetch_at_utc ASC""",
+                (start.isoformat(), end.isoformat()),
+            )
+            for row in cur.fetchall():
+                slot_time_str, direct_pv, cloud_pct, _fetch_at = row
+                try:
+                    slot_dt = _dt.fromisoformat(str(slot_time_str).replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    continue
+                if slot_dt.tzinfo is None:
+                    slot_dt = slot_dt.replace(tzinfo=_UTC)
+                day = slot_dt.date().isoformat()
+                hour = slot_dt.hour
+                # direct_pv_kw is kW for the hour → kWh for the 1-h slot
+                cloud_f = float(cloud_pct) if cloud_pct is not None else None
+                archive[(day, hour)] = (float(direct_pv or 0.0), cloud_f)
+        finally:
+            conn.close()
+
+    if not archive:
+        return {
+            "status": "skipped",
+            "reason": "no Quartz direct_pv_kw in meteo_forecast_value window",
+        }
 
     # 3. Build per-(hour, bucket) ratio lists
     ratios_per_cell: dict[tuple[int, int], list[float]] = defaultdict(list)
@@ -1456,8 +1464,7 @@ def compute_pv_calibration_hourly_cloud_table(
         forecast = archive.get((day, hour))
         if forecast is None:
             continue
-        rad, cloud = forecast
-        modelled_kw = estimate_pv_kw(rad)
+        modelled_kw, cloud = forecast
         if modelled_kw < 0.05 or measured_kw < 0.05:
             continue                          # dawn/dusk noise
         ratio = measured_kw / modelled_kw
@@ -1466,8 +1473,10 @@ def compute_pv_calibration_hourly_cloud_table(
         bucket = cloud_bucket(cloud)
         ratios_per_cell[(hour, bucket)].append(ratio)
 
-    # 4. Median per cell, clamp to [0.05, 1.20] (slightly wider than per-hour
-    #    table because clear-sky bucket can legitimately reach 1.0+)
+    # 4. Median per cell, clamp to [0.05, 2.0]
+    # PR L1.1 — upper bound raised from 1.20 → 2.0 because Quartz can
+    # legitimately under-predict for east-facing arrays (observed PM ratios
+    # 1.19-1.59 in W4 1DZ). Lower bound stays at 0.05 as safety floor.
     factors: dict[tuple[int, int], float] = {}
     samples: dict[tuple[int, int], int] = {}
     for cell, rs in ratios_per_cell.items():
@@ -1475,7 +1484,7 @@ def compute_pv_calibration_hourly_cloud_table(
             continue
         rs_sorted = sorted(rs)
         median = rs_sorted[len(rs_sorted) // 2]
-        clamped = max(0.05, min(1.20, median))
+        clamped = max(0.05, min(2.0, median))
         factors[cell] = round(clamped, 4)
         samples[cell] = len(rs)
 

--- a/src/weather.py
+++ b/src/weather.py
@@ -898,12 +898,14 @@ def compute_pv_calibration_hourly_table(
     if not measured_per_day_hour:
         return {"status": "skipped", "reason": "no pv_realtime_history in window"}
 
-    # PR L1.1 — pull modelled PV per hour from Quartz forecasts (the
-    # actual baseline the LP uses). Pick the LATEST pre-slot fetch for
-    # each slot so the calibration trains against what the LP planned
-    # against, not against revisions that only became available after
-    # the fact.
-    modelled_per_day_hour: dict[tuple[str, int], float] = {}
+    # PR L1.1 — pull modelled PV from Quartz forecasts (the actual
+    # baseline the LP uses). Quartz writes HALF-HOUR slots (slot_time
+    # at :00 + :30 per hour, each = avg kW for that 30-min window).
+    # For each half-hour, pick the LATEST pre-slot fetch (calibration
+    # trains against what the LP saw, not post-hoc revisions). Then
+    # aggregate half-hours into hourly kWh for ratio against measured
+    # mean-kW-over-hour × 1h.
+    modelled_per_half: dict[tuple[str, int, int], float] = {}
     with _db._lock:
         conn = _db.get_connection()
         try:
@@ -917,6 +919,7 @@ def compute_pv_calibration_hourly_table(
                 (start.isoformat(), end.isoformat()),
             )
             # Iterate in order; later rows overwrite earlier → latest pre-slot wins
+            # per (day, hour, half_of_hour)
             for row in cur.fetchall():
                 slot_time_str = row[0]
                 direct_pv = float(row[1] or 0.0)
@@ -928,16 +931,34 @@ def compute_pv_calibration_hourly_table(
                     slot_dt = slot_dt.replace(tzinfo=UTC)
                 day = slot_dt.date().isoformat()
                 hour = slot_dt.hour
-                # direct_pv_kw is a kW value for the hour → kWh for that 1-h slot
-                modelled_per_day_hour[(day, hour)] = direct_pv
+                half = 0 if slot_dt.minute < 30 else 1
+                modelled_per_half[(day, hour, half)] = direct_pv
         finally:
             conn.close()
 
-    if not modelled_per_day_hour:
+    if not modelled_per_half:
         return {
             "status": "skipped",
             "reason": "no Quartz direct_pv_kw in meteo_forecast_value window",
         }
+
+    # Aggregate half-hour kW values to hourly kWh.
+    # hourly kWh = sum_over_halves(direct_pv_kw × 0.5h). When only one
+    # half is present (rare; usually edge of horizon), we extrapolate
+    # by doubling rather than under-counting — keeps the ratio sane.
+    modelled_per_day_hour: dict[tuple[str, int], float] = {}
+    for (day, hour, half), direct_pv in modelled_per_half.items():
+        key = (day, hour)
+        modelled_per_day_hour[key] = modelled_per_day_hour.get(key, 0.0) + direct_pv * 0.5
+    # For hours with only ONE half-hour present, double up so we approximate
+    # the full hour rather than reporting half. This avoids a 2x under-count
+    # on hours that lack their second sample.
+    halves_count: dict[tuple[str, int], int] = {}
+    for (day, hour, _half) in modelled_per_half:
+        halves_count[(day, hour)] = halves_count.get((day, hour), 0) + 1
+    for key, cnt in halves_count.items():
+        if cnt == 1:
+            modelled_per_day_hour[key] = modelled_per_day_hour[key] * 2.0
 
     # Build per-hour ratio lists, skipping dawn/dusk noise (both < 0.05).
     ratios_per_hour: dict[int, list[float]] = {h: [] for h in range(24)}
@@ -1420,9 +1441,11 @@ def compute_pv_calibration_hourly_cloud_table(
         k: sum(s) / len(s) for k, s in actual_kw_samples.items() if s
     }
 
-    # 2. PR L1.1 — pull Quartz forecasts (with Open-Meteo cloud_cover for
-    # bucketing) from our local snapshot store. Latest pre-slot fetch wins.
-    archive: dict[tuple[str, int], tuple[float, float | None]] = {}
+    # 2. PR L1.1 — pull Quartz half-hour forecasts (with Open-Meteo
+    # cloud_cover for bucketing) from local snapshot store. Latest
+    # pre-slot fetch wins per half-hour, then aggregate to hourly kWh
+    # (matching the measured side's mean kW × 1h units).
+    archive_per_half: dict[tuple[str, int, int], tuple[float, float | None]] = {}
     with _db._lock:
         conn = _db.get_connection()
         try:
@@ -1446,28 +1469,47 @@ def compute_pv_calibration_hourly_cloud_table(
                     slot_dt = slot_dt.replace(tzinfo=_UTC)
                 day = slot_dt.date().isoformat()
                 hour = slot_dt.hour
-                # direct_pv_kw is kW for the hour → kWh for the 1-h slot
+                half = 0 if slot_dt.minute < 30 else 1
                 cloud_f = float(cloud_pct) if cloud_pct is not None else None
-                archive[(day, hour)] = (float(direct_pv or 0.0), cloud_f)
+                archive_per_half[(day, hour, half)] = (float(direct_pv or 0.0), cloud_f)
         finally:
             conn.close()
 
-    if not archive:
+    if not archive_per_half:
         return {
             "status": "skipped",
             "reason": "no Quartz direct_pv_kw in meteo_forecast_value window",
         }
 
-    # 3. Build per-(hour, bucket) ratio lists
+    # Aggregate half-hour kW into hourly kWh; pick the dominant cloud
+    # bucket per hour (when halves differ in cloud cover, the average is
+    # close enough — clouds drift slowly). Single-half-only hours
+    # extrapolate by ×2.
+    archive: dict[tuple[str, int], tuple[float, float | None]] = {}
+    halves_seen: dict[tuple[str, int], list[tuple[float, float | None]]] = defaultdict(list)
+    for (day, hour, _half), data in archive_per_half.items():
+        halves_seen[(day, hour)].append(data)
+    for key, datas in halves_seen.items():
+        total_kwh = sum(pv * 0.5 for pv, _c in datas)
+        if len(datas) == 1:
+            total_kwh *= 2.0
+        # Average cloud over the halves (ignore Nones).
+        clouds = [c for _pv, c in datas if c is not None]
+        avg_cloud = (sum(clouds) / len(clouds)) if clouds else None
+        archive[key] = (total_kwh, avg_cloud)
+
+    # 3. Build per-(hour, bucket) ratio lists.
+    # measured_per_day_hour value is mean kW over hour → numerically = kWh
+    # for that hour. archive value is hourly kWh from above aggregation.
     ratios_per_cell: dict[tuple[int, int], list[float]] = defaultdict(list)
-    for (day, hour), measured_kw in measured_per_day_hour.items():
+    for (day, hour), measured_kwh in measured_per_day_hour.items():
         forecast = archive.get((day, hour))
         if forecast is None:
             continue
-        modelled_kw, cloud = forecast
-        if modelled_kw < 0.05 or measured_kw < 0.05:
+        modelled_kwh, cloud = forecast
+        if modelled_kwh < 0.05 or measured_kwh < 0.05:
             continue                          # dawn/dusk noise
-        ratio = measured_kw / modelled_kw
+        ratio = measured_kwh / modelled_kwh
         if ratio > 5.0:
             continue                          # outlier
         bucket = cloud_bucket(cloud)

--- a/tests/test_pv_calibration_from_quartz.py
+++ b/tests/test_pv_calibration_from_quartz.py
@@ -1,0 +1,241 @@
+"""PR L1.1 integration tests — exercise the REAL compute functions
+against a seeded ``meteo_forecast_value`` + ``pv_realtime_history``
+dataset. Catches granularity/unit bugs (H1, H2 from L1.1 review) that
+mock-based tests miss.
+
+The tests verify:
+1. Half-hour aggregation correctly produces hourly kWh
+2. The latest pre-slot fetch wins (revision picking)
+3. The single-half-only edge case extrapolates by 2x
+4. The cloud-bucket aggregation averages cloud_cover across halves
+5. Computed factor matches expected actual/forecast ratio
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src import db
+from src.config import config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(config, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(config, "PV_CALIBRATION_WINDOW_DAYS", 30, raising=False)
+    monkeypatch.setattr(config, "WEATHER_LAT", "51.494", raising=False)
+    monkeypatch.setattr(config, "WEATHER_LON", "-0.275", raising=False)
+    db.init_db()
+
+
+def _seed_meteo_snapshot(
+    conn: sqlite3.Connection,
+    slot_time_utc: datetime,
+    direct_pv_kw: float,
+    cloud_pct: float | None = 20.0,
+    fetch_at_utc: datetime | None = None,
+) -> None:
+    """Seed one meteo_forecast_value row (and its parent snapshot)."""
+    if fetch_at_utc is None:
+        fetch_at_utc = slot_time_utc - timedelta(hours=1)
+    fetch_iso = fetch_at_utc.isoformat().replace("+00:00", "Z")
+    slot_iso = slot_time_utc.isoformat().replace("+00:00", "Z")
+    # Parent snapshot (UNIQUE key)
+    conn.execute(
+        "INSERT OR IGNORE INTO meteo_forecast_snapshot (forecast_fetch_at_utc, source)"
+        " VALUES (?, ?)",
+        (fetch_iso, "quartz"),
+    )
+    conn.execute(
+        """INSERT OR REPLACE INTO meteo_forecast_value
+           (forecast_fetch_at_utc, slot_time, direct_pv_kw, cloud_cover_pct,
+            solar_w_m2, temp_c)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (fetch_iso, slot_iso, direct_pv_kw, cloud_pct, 0.0, 15.0),
+    )
+
+
+def _seed_actual(
+    conn: sqlite3.Connection,
+    captured_at_utc: datetime,
+    solar_kw: float,
+) -> None:
+    """Seed one pv_realtime_history row."""
+    conn.execute(
+        """INSERT INTO pv_realtime_history
+           (captured_at, solar_power_kw, soc_pct, load_power_kw, source)
+           VALUES (?, ?, ?, ?, ?)""",
+        (
+            captured_at_utc.isoformat().replace("+00:00", "Z"),
+            solar_kw, 50.0, 0.3, "test",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-hour table
+# ---------------------------------------------------------------------------
+
+
+def test_compute_hourly_aggregates_two_halves_correctly():
+    """For one hour with Quartz forecasts at :00 (3.0 kW) + :30 (2.0 kW),
+    expected hourly kWh = 3.0×0.5 + 2.0×0.5 = 2.5 kWh.
+    Actual mean kW over the hour = 2.0 → ratio = 2.0 / 2.5 = 0.8.
+
+    We seed enough days that hour passes the min_samples_per_hour=7 floor.
+    """
+    from src.weather import compute_pv_calibration_hourly_table
+
+    conn = sqlite3.connect(config.DB_PATH)
+    today = datetime.now(UTC).date()
+    # Seed 8 days of hour-12 data, each with 3.0 kW @:00 + 2.0 kW @:30 forecast
+    # and 2.0 mean kW actual.
+    for d in range(1, 9):
+        day = today - timedelta(days=d)
+        base = datetime(day.year, day.month, day.day, 12, 0, tzinfo=UTC)
+        # Two half-hour Quartz rows
+        _seed_meteo_snapshot(conn, base, direct_pv_kw=3.0)
+        _seed_meteo_snapshot(conn, base + timedelta(minutes=30), direct_pv_kw=2.0)
+        # Actual samples: four readings of 2.0 kW over the hour → mean 2.0
+        for m in (5, 20, 35, 50):
+            _seed_actual(conn, base + timedelta(minutes=m), solar_kw=2.0)
+    conn.commit()
+    conn.close()
+
+    result = compute_pv_calibration_hourly_table(window_days=30, min_samples_per_hour=7)
+    assert result["status"] == "ok", result
+    factors = db.get_pv_calibration_hourly()
+    assert 12 in factors, f"hour 12 should be present in factors; got {factors}"
+    # Expected ratio: actual mean kW (=2.0 kWh/h) / modelled hourly kWh (=2.5)
+    # = 0.8. Clamped within [0.10, 2.0].
+    assert factors[12] == pytest.approx(0.8, abs=0.05), (
+        f"Expected ratio 0.8 (= 2.0 actual / 2.5 modelled); got {factors[12]}. "
+        "If = 1.0, H1 bug still active (only :30 forecast used = 2.0; "
+        "ratio 2.0/2.0=1.0). If = 0.67, ratio uses sum of halves without ×0.5."
+    )
+
+
+def test_compute_hourly_latest_pre_slot_fetch_wins():
+    """When the same slot has multiple Quartz fetches, the LATEST
+    PRE-SLOT one should be used (the value the LP saw). Verify the
+    revision picker behaviour."""
+    from src.weather import compute_pv_calibration_hourly_table
+
+    conn = sqlite3.connect(config.DB_PATH)
+    today = datetime.now(UTC).date()
+    for d in range(1, 9):
+        day = today - timedelta(days=d)
+        base = datetime(day.year, day.month, day.day, 14, 0, tzinfo=UTC)
+        # OLD fetch (8h before slot) — value 1.0 kW. Should be IGNORED.
+        _seed_meteo_snapshot(conn, base, direct_pv_kw=1.0,
+                              fetch_at_utc=base - timedelta(hours=8))
+        # NEWER fetch (30 min before slot) — value 3.0 kW. Should WIN.
+        _seed_meteo_snapshot(conn, base, direct_pv_kw=3.0,
+                              fetch_at_utc=base - timedelta(minutes=30))
+        # Mirror :30 slot
+        s30 = base + timedelta(minutes=30)
+        _seed_meteo_snapshot(conn, s30, direct_pv_kw=3.0,
+                              fetch_at_utc=s30 - timedelta(minutes=30))
+        # Actual 3.0 mean
+        for m in (10, 40):
+            _seed_actual(conn, base + timedelta(minutes=m), solar_kw=3.0)
+    conn.commit()
+    conn.close()
+
+    result = compute_pv_calibration_hourly_table(window_days=30, min_samples_per_hour=7)
+    assert result["status"] == "ok", result
+    factors = db.get_pv_calibration_hourly()
+    # If the latest fetch wins (3.0 kW per half), modelled hourly kWh = 3.0×0.5 + 3.0×0.5 = 3.0
+    # actual mean = 3.0 → ratio 3.0/3.0 = 1.0
+    # If the OLD fetch leaked in (1.0 kW), ratio = 3.0/2.0 = 1.5 (different)
+    assert factors[14] == pytest.approx(1.0, abs=0.05), (
+        f"Latest-fetch picker broken; got {factors[14]} (expected ~1.0). "
+        "1.5 would indicate the old fetch leaked into the calc."
+    )
+
+
+def test_compute_hourly_single_half_extrapolates():
+    """When only ONE of the two half-hours has data (e.g. dawn/dusk where
+    Quartz starts/stops mid-hour), modelled hourly kWh should be the
+    single half × 1 (effectively 2× to fill the missing half)."""
+    from src.weather import compute_pv_calibration_hourly_table
+
+    conn = sqlite3.connect(config.DB_PATH)
+    today = datetime.now(UTC).date()
+    for d in range(1, 9):
+        day = today - timedelta(days=d)
+        # Only :00 half present, no :30
+        slot = datetime(day.year, day.month, day.day, 6, 0, tzinfo=UTC)
+        _seed_meteo_snapshot(conn, slot, direct_pv_kw=2.0)
+        # actual 2.0 mean
+        _seed_actual(conn, slot + timedelta(minutes=10), solar_kw=2.0)
+        _seed_actual(conn, slot + timedelta(minutes=20), solar_kw=2.0)
+    conn.commit()
+    conn.close()
+
+    result = compute_pv_calibration_hourly_table(window_days=30, min_samples_per_hour=7)
+    assert result["status"] == "ok", result
+    factors = db.get_pv_calibration_hourly()
+    # modelled hourly kWh = 2.0 × 0.5 × 2 (extrapolation) = 2.0
+    # actual mean kW = 2.0
+    # ratio = 1.0
+    assert factors[6] == pytest.approx(1.0, abs=0.05), (
+        f"Single-half extrapolation broken; got {factors[6]}. "
+        "= 2.0 means extrapolation didn't fire (only counted 0.5h instead of 1h)."
+    )
+
+
+def test_compute_hourly_no_quartz_data_returns_skipped():
+    """When meteo_forecast_value has NO direct_pv_kw rows in window
+    (cold-start before Quartz was enabled), compute returns skipped."""
+    from src.weather import compute_pv_calibration_hourly_table
+
+    conn = sqlite3.connect(config.DB_PATH)
+    today = datetime.now(UTC).date()
+    base = datetime(today.year, today.month, today.day, 12, 0, tzinfo=UTC)
+    # Only actuals, no forecasts
+    _seed_actual(conn, base, solar_kw=2.0)
+    conn.commit()
+    conn.close()
+
+    result = compute_pv_calibration_hourly_table(window_days=30)
+    assert result["status"] == "skipped"
+    assert "no quartz" in result["reason"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Cloud-bucket table
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cloud_aware_bucket_assignment():
+    """Cloud bucket from average of half-hour cloud_cover values."""
+    from src.weather import compute_pv_calibration_hourly_cloud_table
+
+    conn = sqlite3.connect(config.DB_PATH)
+    today = datetime.now(UTC).date()
+    # Seed 5 days of hour 13 with cloud_cover 10% (clear bucket = 0)
+    # Quartz at 4.0 kW per half-hour, actual 3.0 mean kW
+    for d in range(1, 6):
+        day = today - timedelta(days=d)
+        base = datetime(day.year, day.month, day.day, 13, 0, tzinfo=UTC)
+        _seed_meteo_snapshot(conn, base, direct_pv_kw=4.0, cloud_pct=10.0)
+        _seed_meteo_snapshot(conn, base + timedelta(minutes=30),
+                              direct_pv_kw=4.0, cloud_pct=10.0)
+        for m in (5, 25, 45):
+            _seed_actual(conn, base + timedelta(minutes=m), solar_kw=3.0)
+    conn.commit()
+    conn.close()
+
+    result = compute_pv_calibration_hourly_cloud_table(window_days=30, min_samples_per_cell=4)
+    assert result["status"] == "ok", result
+    factors = db.get_pv_calibration_hourly_cloud()
+    # Expect (13, 0) bucket present, ratio = 3.0 / (4.0×0.5 + 4.0×0.5) = 3.0/4.0 = 0.75
+    assert (13, 0) in factors, f"(13, 0) clear bucket should be present; got {factors}"
+    assert factors[(13, 0)] == pytest.approx(0.75, abs=0.05), (
+        f"Expected ratio 0.75; got {factors[(13, 0)]}"
+    )

--- a/tests/test_quartz_skip_cal_rebuild.py
+++ b/tests/test_quartz_skip_cal_rebuild.py
@@ -1,7 +1,10 @@
-"""When FORECAST_SOURCE=quartz, the radiation-trained PV calibration tables
-(``pv_calibration_hourly`` + ``pv_calibration_hourly_cloud``) are unused at
-apply time (PR #279). The Octopus fetch job must skip the daily rebuild
-to avoid wasted Open-Meteo archive requests.
+"""PR L1.1 (2026-05-24) — the cal-rebuild skip on FORECAST_SOURCE=quartz
+is REMOVED. Calibration tables are now Quartz-trained (compute uses
+``meteo_forecast_value.direct_pv_kw`` as baseline instead of
+``estimate_pv_kw(open_meteo_rad)``), so the rebuild produces useful
+factors for both Quartz and Open-Meteo paths.
+
+This file replaces the legacy PR #279 skip-on-quartz semantics.
 """
 from __future__ import annotations
 
@@ -22,12 +25,16 @@ def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 
 _FAKE_RATES = [
-    # one minimal Agile rate row in the shape save_agile_rates expects
     {"slot_time": "2026-05-09T00:00:00Z", "value_inc_vat": 5.0},
 ]
 
 
-def test_cal_rebuild_skipped_on_quartz(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cal_rebuild_runs_on_quartz_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR L1.1 — when FORECAST_SOURCE=quartz, calibration tables MUST
+    still rebuild because they're now Quartz-trained (not Open-Meteo
+    radiation-trained). The old skip (PR #279) was based on the
+    "Quartz self-calibrates" assumption that proved wrong for the
+    W4 1DZ east-facing array."""
     monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
     monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", "TEST-AGILE", raising=False)
     monkeypatch.setattr(app_config, "USE_BULLETPROOF_ENGINE", False, raising=False)
@@ -36,16 +43,26 @@ def test_cal_rebuild_skipped_on_quartz(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with patch.object(of, "fetch_agile_rates", return_value=_FAKE_RATES), \
          patch("src.db.save_agile_rates", return_value=len(_FAKE_RATES)), \
-         patch("src.weather.compute_pv_calibration_hourly_table") as cal_h, \
-         patch("src.weather.compute_pv_calibration_hourly_cloud_table") as cal_c:
+         patch("src.weather.compute_pv_calibration_hourly_table",
+               return_value={"status": "ok"}) as cal_h, \
+         patch("src.weather.compute_pv_calibration_hourly_cloud_table",
+               return_value={"status": "ok"}) as cal_c:
         of.fetch_and_store_rates()
 
-    assert not cal_h.called, "compute_pv_calibration_hourly_table called with FORECAST_SOURCE=quartz"
-    assert not cal_c.called, "compute_pv_calibration_hourly_cloud_table called with FORECAST_SOURCE=quartz"
+    assert cal_h.called, (
+        "PR L1.1: hourly calibration MUST rebuild on Quartz source "
+        "(table is now Quartz-trained)"
+    )
+    assert cal_c.called, (
+        "PR L1.1: cloud-aware calibration MUST rebuild on Quartz source"
+    )
 
 
-def test_cal_rebuild_runs_on_open_meteo(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Sanity: when source is open-meteo, the rebuild still runs (no regression)."""
+def test_cal_rebuild_runs_on_open_meteo_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: Open-Meteo source also rebuilds. The compute function
+    finds direct_pv_kw=NULL rows on this path and yields fewer samples
+    (or none, falling back to the flat factor); that's expected
+    graceful degradation."""
     monkeypatch.setattr(app_config, "FORECAST_SOURCE", "open-meteo", raising=False)
     monkeypatch.setattr(app_config, "OCTOPUS_TARIFF_CODE", "TEST-AGILE", raising=False)
     monkeypatch.setattr(app_config, "USE_BULLETPROOF_ENGINE", False, raising=False)
@@ -54,9 +71,11 @@ def test_cal_rebuild_runs_on_open_meteo(monkeypatch: pytest.MonkeyPatch) -> None
 
     with patch.object(of, "fetch_agile_rates", return_value=_FAKE_RATES), \
          patch("src.db.save_agile_rates", return_value=len(_FAKE_RATES)), \
-         patch("src.weather.compute_pv_calibration_hourly_table", return_value={"status": "ok"}) as cal_h, \
-         patch("src.weather.compute_pv_calibration_hourly_cloud_table", return_value={"status": "ok"}) as cal_c:
+         patch("src.weather.compute_pv_calibration_hourly_table",
+               return_value={"status": "ok"}) as cal_h, \
+         patch("src.weather.compute_pv_calibration_hourly_cloud_table",
+               return_value={"status": "ok"}) as cal_c:
         of.fetch_and_store_rates()
 
-    assert cal_h.called, "open-meteo path must still rebuild per-hour calibration"
-    assert cal_c.called, "open-meteo path must still rebuild cloud-aware calibration"
+    assert cal_h.called
+    assert cal_c.called


### PR DESCRIPTION
PR L1 (#411) over-corrected Quartz because it applied factors trained against Open-Meteo radiation (which assumes south-facing array, ours is east-facing). Rolled L1 back via env flag immediately. L1.1 fixes the baseline.

## Root cause of L1 bug

\`compute_pv_calibration_*_table\` baseline was:
\`\`\`
modelled = estimate_pv_kw(open_meteo_archive_radiation)
ratio = actual / modelled
\`\`\`

Open-Meteo treats panels as south-facing → over-predicts AM/PM → ratios sit at 0.20–0.50. Applied as multiplier to Quartz (which is regional-aggregate, less wrong than Open-Meteo) → forecast becomes 30 %+ LOWER than actual → LP plans MORE Force Charge defensively.

## L1.1 fix

New baseline: \`meteo_forecast_value.direct_pv_kw\` (Quartz raw output for that slot, latest pre-slot fetch).

\`\`\`
modelled = quartz_direct_pv_kw  # actual baseline LP uses
ratio = actual / modelled
\`\`\`

Same SQL pattern as \`rebuild_forecast_skill_log_for_date\`. Local DB query instead of Open-Meteo Archive HTTP fetch (faster, no external dep).

## What stays Open-Meteo

- outdoor temperature (LP COP, tank physics)
- cloud_cover_pct (calibration bucketing, scenarios)
- Fallback PV source if Quartz API down

User stated: \"não precisamos de open-meteo pra PV ok? só pra outdoor temp e etc.\" — confirmed.

## Operational changes

- Cal rebuild now runs on FORECAST_SOURCE=quartz (was skipped per PR #279)
- Clamp upper bound: 1.20 → 2.0 (Quartz can legitimately under-predict)
- 04:30 UTC daily cron is faster (local SQL vs HTTP)

## Deploy plan

1. Merge + deploy this PR (no behavior change yet — calibration still bypassed for Quartz via env flag)
2. Wait for 04:30 UTC rebuild to populate tables with Quartz-trained factors (or trigger manually)
3. Verify factors look like ~0.65 AM / ~1.1 PM (matching user-observed bias)
4. Re-enable \`PV_QUARTZ_APPLY_CALIBRATION=true\` in \`/srv/hem/.env\` + restart
5. Observe 7-14 days of LP behavior

## Tests

- 27 passed (test_pv_cloud_aware_calibration + test_quartz_forecast)
- Suite full: **1356 passed**, 3 skipped, 1 xfailed
- \`test_quartz_skip_cal_rebuild.py\` rewritten: asserts rebuild RUNS on quartz (was: skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)