### PR TITLE
docs: PM cliff is data-confirmed — restore west-obstruction framing

### DIFF
--- a/docs/PV_TRUST_GUARDRAIL.md
+++ b/docs/PV_TRUST_GUARDRAIL.md
@@ -51,10 +51,13 @@ And the bias is **not stable week-to-week**:
 | Week 19 (May 4–10) | 0.67 | **1.22** |
 | Week 20 (May 11–17) | 0.62 | **0.98** |
 
-AM bias is structural (sub-optimal angle-of-incidence on the split SSW
-array — likely tilt mismatch between the SW-pitched and flat-rack
-sections). PM bias drifts ~25% between adjacent weeks based on weather
-pattern. **A fortnightly refresh can't track that.**
+AM bias is structural (sub-optimal angle-of-incidence on the aggregate
+SSW array, plus possible AM-side obstruction). PM bias drifts ~25%
+between adjacent weeks based on weather pattern, plus a fixed late-PM
+cliff at ~17:00 UTC consistent with a due-west obstruction (sun at
+azimuth ~270°, elevation ~21°; 50–72% drop in 30 min on 6 of 10 clear
+days, far beyond what geometry allows). **A fortnightly refresh can't
+track that.**
 
 ### 2b — No hard "today's PV will fill the battery" rule
 

--- a/src/db.py
+++ b/src/db.py
@@ -835,8 +835,9 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     # solar elevation as a binning dimension on top of (hour, cloud_bucket).
     # Separates winter-noon (elev ~10°) from summer-noon (elev ~60°) which
     # the 2D table averages together → masks structurally-different bias
-    # patterns (split-array angle-of-incidence depends on sun position,
-    # not just clock hour). Lookup chain: 3d → 2d → 1d → flat.
+    # patterns (angle-of-incidence + obstruction-shadow geometry both
+    # depend on sun position, not just clock hour). Lookup chain:
+    # 3d → 2d → 1d → flat.
     conn.execute(
         """CREATE TABLE IF NOT EXISTS pv_calibration_3d (
             hour_utc        INTEGER NOT NULL CHECK(hour_utc >= 0 AND hour_utc < 24),

--- a/src/weather.py
+++ b/src/weather.py
@@ -250,10 +250,13 @@ class ForecastFetchResult:
 # PR L3 H5 — one-shot warning latch for astral-missing degradation.
 _ASTRAL_WARNED = False
 
-# System constants for PV estimate (London W4 system — split install: 6 panels
-# SW-pitched ~225°/30° + 6 panels flat-roof racked ~south/10°, aggregate
-# empirical azimuth ~200° SSW). Orientation is NOT encoded here; the per-hour
-# × cloud × elevation calibration tables absorb it empirically.
+# System constants for PV estimate (London W4 system — 10 × 450 W DMEGC
+# panels per MCS cert MCS-02470690-S, mounted "Above Roof" with Van der
+# Valk Valkpitched rails. Aggregate empirical azimuth ~200° SSW from
+# the 2026-05-24 orientation sweep. Production shows a late-PM cliff at
+# 17:00 UTC consistent with a fixed obstruction roughly due west.
+# Orientation/obstruction are NOT encoded here; the per-hour × cloud ×
+# elevation calibration tables absorb them empirically.
 _PV_CAPACITY_KWP = 4.5
 _PV_SYSTEM_EFFICIENCY = 0.85  # accounts for inverter, wiring, temp de-rating
 _IRRADIANCE_AT_STC_WM2 = 1000.0  # standard test conditions
@@ -289,11 +292,15 @@ def forecast_pv_kw_from_row(
     calibration tables (was previously SKIPPED per PR #279's
     "Quartz self-calibrates" assumption). Prod telemetry showed GSP-level
     Quartz mispredicts our W4 1DZ array by ~35 % AM and ~20 % PM
-    (`forecast_skill_log` 30-day mean ratios). The bias originally read
-    as "east-facing" was actually the signature of a split install
-    (SW-pitched + flat-roof south rack, aggregate ~200° SSW) with
-    non-ideal tilt mix. The calibration tables absorb all of it
-    empirically — they don't need to know the geometry.
+    (`forecast_skill_log` 30-day mean ratios). Half-hourly evidence on 10
+    clear days (2026-05-12 to -24) shows a consistent **late-PM cliff**
+    between 16:30 and 17:00 UTC — production drops 50–72 % in 30 min on
+    6 of 10 clear days, far steeper than geometry (max ~25 %) allows.
+    Sun at that time sits at azimuth ~270°, elevation ~21°, so a fixed
+    obstruction roughly due west of the panels is the only plausible
+    cause. The calibration tables absorb the cliff empirically (hour 17 Z
+    cell ratio 0.84 vs neighbouring 16 Z ~1.01) — they don't need to know
+    the cause.
 
     **Known semantic gap (acknowledged):** the calibration tables are
     trained against ``actual / estimate_pv_kw(open_meteo_radiation)``,
@@ -1346,10 +1353,9 @@ def compute_solar_elevation_deg(
 
     PR L3 (2026-05-24) — used by the 3D calibration table to separate
     same-UTC-hour samples by sun position (winter low / summer high).
-    A real array (split SW-pitched + flat-rack at W4 1DZ, with non-ideal
-    tilt mix) has fundamentally different physics when the sun is at
-    10° vs 50° elevation — same hour, different physics → different
-    correction factor.
+    The W4 1DZ install has fundamentally different physics when the sun
+    is at 10° vs 50° elevation — same hour, different physics, different
+    obstruction-shadow geometry → different correction factor.
 
     Defaults to ``config.WEATHER_LAT`` / ``WEATHER_LON`` when omitted.
 


### PR DESCRIPTION
## Summary

PR #414 (just merged) soft-pedalled the previous session's "physical west obstruction" language to "non-ideal tilt mix" because user intuition reported no visible shadow. A proper prod half-hourly inspection on 2026-05-24 found that **the cliff is real and not geometric**:

| Day | 16:30 kW | 17:00 kW | Δ |
|---|---:|---:|---:|
| 2026-05-22 | 1.40 | 0.40 | **-71%** |
| 2026-05-23 | 1.25 | 0.63 | **-50%** |
| 2026-05-24 | 1.34 | 0.37 | **-72%** |
| median across 10 clear days |  |  | **-55%** |

Pre-cliff smooth decay is ~6 %/half-hour (consistent with sun azimuth motion). The maximum AOI-driven geometric loss in 30 min for any plausible (azimuth, tilt) is ~25 %. The observed 50–72 % drop cannot come from geometry — it requires a fixed obstruction at sun azimuth ~270° (the sun's position at 17:00 UTC late May).

The forecast-vs-actual aggregate independently confirms the cliff: hour-17 Z ratio dips to 0.84 while neighbouring 16 Z sits at 1.01 and 18 Z at 1.30 — exactly the signature of a site-specific shadow that the GSP-level Quartz forecast can't know about.

## Why this PR exists

To prevent the previous (wrong) soft-pedalling from misleading future debugging. The cliff is real; the user just doesn't notice it casually because it fires in a 30-min window per clear day in late spring/summer. Honest causal language belongs in the comments.

## Changed files (docs-only)

- `src/weather.py` — restore obstruction framing in the L1 docstring and the `_PV_CAPACITY_KWP` block-comment; restore the obstruction-shadow language in the 3D elevation-table docstring
- `src/db.py` — restore obstruction-shadow language in the `pv_calibration_3d` CREATE block-comment
- `docs/PV_TRUST_GUARDRAIL.md` — restore the late-PM cliff description with the 50–72 % figure

## Test plan

- [x] `python -c "import src.weather, src.db, src.config"` — imports clean after docstring edits
- [x] Diagnostic scripts cleaned up from `/srv/hem/data/` on the Hetzner host
- [ ] CI green

## Not in this PR (deferred to a future session)

- **Physical inspection**: walk the garden at ~17:00 UTC on the next clear day to identify the obstruction source (west-side neighbour's house/extension, tree, or self-shadow from the user's own structure).
- **Slope-identification puzzle**: the back-of-house photo shows panels visible from the NE side, which would imply NE-facing rear slope — but empirical noon-peak production is inconsistent with NE-facing. Likely the panels are on the SW-facing front slope and the back photo saw across the ridge, or there's a side-return / hip slope I can't see from one back photo. A front-of-house photo would resolve it.

## Related context

- Memory `project_quartz_site_level_killed.md` updated with the cliff data table + the address-mismatch resolution (12 Whellock Rd front, back garden onto Southfield Rd) + the slope-identification open thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)