### PR TITLE
docs: audit fixes — drop unverified panel count + tighten AM/PM hedge

### DIFF
--- a/docs/PV_TRUST_GUARDRAIL.md
+++ b/docs/PV_TRUST_GUARDRAIL.md
@@ -51,13 +51,17 @@ And the bias is **not stable week-to-week**:
 | Week 19 (May 4–10) | 0.67 | **1.22** |
 | Week 20 (May 11–17) | 0.62 | **0.98** |
 
-AM bias is structural (sub-optimal angle-of-incidence on the aggregate
-SSW array, plus possible AM-side obstruction). PM bias drifts ~25%
-between adjacent weeks based on weather pattern, plus a fixed late-PM
-cliff at ~17:00 UTC consistent with a due-west obstruction (sun at
-azimuth ~270°, elevation ~21°; 50–72% drop in 30 min on 6 of 10 clear
-days, far beyond what geometry allows). **A fortnightly refresh can't
-track that.**
+**AM bias** is structural — likely sub-optimal angle-of-incidence on the
+aggregate SSW array; an AM-side obstruction is plausible but not yet
+verified.
+
+**PM bias** has two components: a slow weather-dependent drift of ~25%
+between adjacent weeks, and a *data-confirmed* fixed late-PM cliff at
+~17:00 UTC (50–72% drop in 30 min on 6 of 10 clear days, far beyond what
+geometry can account for — consistent with a due-west obstruction at
+sun azimuth ~270°, elevation ~21°).
+
+**A fortnightly refresh can't track either component.**
 
 ### 2b — No hard "today's PV will fill the battery" rule
 

--- a/src/weather.py
+++ b/src/weather.py
@@ -250,13 +250,13 @@ class ForecastFetchResult:
 # PR L3 H5 — one-shot warning latch for astral-missing degradation.
 _ASTRAL_WARNED = False
 
-# System constants for PV estimate (London W4 system — 10 × 450 W DMEGC
-# panels per MCS cert MCS-02470690-S, mounted "Above Roof" with Van der
-# Valk Valkpitched rails. Aggregate empirical azimuth ~200° SSW from
-# the 2026-05-24 orientation sweep. Production shows a late-PM cliff at
-# 17:00 UTC consistent with a fixed obstruction roughly due west.
-# Orientation/obstruction are NOT encoded here; the per-hour × cloud ×
-# elevation calibration tables absorb them empirically.
+# System constants for PV estimate (London W4 system — 4.5 kWp DMEGC
+# 450 W modules per MCS cert MCS-02470690-S, mounted "Above Roof" with
+# Van der Valk Valkpitched rails. Aggregate empirical azimuth ~200° SSW
+# from the 2026-05-24 orientation sweep. Production shows a late-PM
+# cliff at 17:00 UTC consistent with a fixed obstruction roughly due
+# west. Orientation/obstruction are NOT encoded here; the per-hour ×
+# cloud × elevation calibration tables absorb them empirically.
 _PV_CAPACITY_KWP = 4.5
 _PV_SYSTEM_EFFICIENCY = 0.85  # accounts for inverter, wiring, temp de-rating
 _IRRADIANCE_AT_STC_WM2 = 1000.0  # standard test conditions


### PR DESCRIPTION
## Summary

Two clarity fixes flagged by the post-PR audit on #414 + #415:

1. **`src/weather.py:253` no longer asserts "10 × 450 W panels"** — the MCS cert text contained 11 panel-SKU listings, ambiguous between 10 panels (one OCR duplication) and 11 panels DC-oversized to a 4.5 kW inverter. The 4.5 kWp capacity figure is the verified anchor; drop the count.

2. **`docs/PV_TRUST_GUARDRAIL.md` AM/PM bias paragraph reorganised** so the data-confirmed PM cliff (50–72% drop, 6/10 clear days) is not entangled with the still-hypothesised AM-side obstruction. Each gets its own paragraph with appropriate hedging.

## Why

Docs-only hygiene. The previous wording was technically defensible but mixed certainty levels in a single sentence, which would mislead future debugging.

## Test plan

- [x] `python -c "import src.weather, src.db, src.config"` — imports clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)