### PR TITLE
fix(lp): skip terminal DHW floor when K2 pinning is active

### DIFF
--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -1064,7 +1064,13 @@ def solve_lp(
     # Skip terminal tank/indoor floors in passive mode — same reason as shower
     # hard constraint above. Firmware controls comfort; the LP only optimises
     # battery/grid/PV around the predicted Daikin draw.
-    if not passive_daikin:
+    #
+    # Also skip when DHW is pinned (PR K2): ``tank[n]`` is already pinned by
+    # ``dhw_policy.forecast_dhw_load_per_slot``, and the policy can target a
+    # value below ``terminal_dhw_floor`` (e.g. guests mode pins 45 °C while
+    # ``t_min_dhw=55`` → floor 53 °C → infeasible). This mirrors the K2
+    # guard on the soft shower floor above.
+    if not passive_daikin and not _dhw_pinned:
         # PR 4 of plan: when the last slot lands inside a shower window, keep
         # the tight terminal floor so the LP must finish with a hot tank for
         # in-progress showers. When it lands OUTSIDE shower windows (e.g. a

--- a/tests/test_lp_dhw_pinning.py
+++ b/tests/test_lp_dhw_pinning.py
@@ -359,3 +359,31 @@ def test_lp_pinning_passive_mode_unaffected(monkeypatch):
     # Passive mode + pinning could be infeasible — LP returns ok=False if so.
     # Either outcome is acceptable as long as it doesn't crash.
     assert plan is not None
+
+
+def test_lp_pinning_guests_with_last_slot_in_shower_window_is_feasible(monkeypatch):
+    """Regression: prod run 1154 (2026-05-27 19:55 UTC) went Infeasible
+    because the K2 pin clamped ``tank[n]`` to ``DHW_TEMP_NORMAL_C=45`` while
+    ``terminal_dhw_floor`` was still active and used ``TARGET_DHW_TEMP_MIN_GUESTS_C-2=53``
+    when the last slot lands inside the evening shower window. The fix: skip
+    the terminal floor when ``_dhw_pinned`` is True (the pinned trajectory
+    fully owns the tank). Without the fix this test errors with
+    ``plan.ok=False``."""
+    monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "guests", raising=False)
+    monkeypatch.setattr(config, "TARGET_DHW_TEMP_MIN_GUESTS_C", 55.0, raising=False)
+    monkeypatch.setattr(config, "TARGET_DHW_TEMP_MIN_NORMAL_C", 45.0, raising=False)
+    # Build a horizon that ends inside the evening shower window (20:00-22:00 BST).
+    # Start at 21:00 local (slot 0 in window) so the last slot of an N-slot
+    # horizon ending at 21:30 BST + N×30min also lands in the window.
+    base_local = datetime(2026, 6, 1, 21, 0, tzinfo=TZ_LOCAL)
+    base = base_local.astimezone(UTC)
+    # 4 slots = 21:00, 21:30, 22:00, 22:30 — last slot at 22:30 is OUT of evening
+    # window but the morning shower window (07:00-09:00) exists too; we want a
+    # horizon that ENDS in evening window, so use 2 slots only.
+    n = 2  # slots: 21:00, 21:30 — both inside 20-22 evening window
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan = _solve(
+        slots=slots, prices=[15.0] * n, pv=[1.0] * n,
+        base_load=[0.3] * n, init_soc=5.8, init_tank=45.0,
+    )
+    assert plan.ok, f"LP should be Optimal under guests+pinning with last slot in shower window; got {plan.status}"


### PR DESCRIPTION
## Summary

- **Closes #421**
- One-line guard (`not _dhw_pinned`) on the terminal DHW floor at `src/scheduler/lp_optimizer.py:1067`, mirroring the K2 guards already on the soft shower floor (line 842) and legionella floor (line 912).
- Adds regression test reproducing the prod failure (run 1154, 2026-05-27 19:55 UTC) — guests preset, last slot in evening shower window, pinned `tank[n]=45` vs forced floor `53`.

## Why

PR #406 (K2) made `dhw_policy` the single source of truth for `tank[i+1]` when `DHW_FIXED_SCHEDULE_ENABLED=True`. The shower/legionella floors were correctly gated under `not _dhw_pinned`; the terminal floor was missed. In `guests` preset `t_min_dhw` falls back to `TARGET_DHW_TEMP_MIN_GUESTS_C=55` → `terminal_dhw_floor=53` whenever the last slot lands in the evening shower window — but `dhw_policy` pins `tank[n]=DHW_TEMP_NORMAL_C=45`, producing an unsatisfiable constraint pair.

## Bisection (replay of run 1154)

| Scenario | Status |
|---|---|
| guests + pinning ON (prod) | **Infeasible** |
| guests + pinning OFF | Optimal |
| normal + pinning ON | Optimal |
| `TARGET_DHW_TEMP_MIN_GUESTS_C=47` → terminal floor 45 | Optimal |
| `TARGET_DHW_TEMP_MIN_GUESTS_C=48` → terminal floor 46 | Infeasible |

## Test plan

- [x] New test `test_lp_pinning_guests_with_last_slot_in_shower_window_is_feasible` reproduces the regression (verified failing without the fix, passing with it)
- [x] `tests/test_lp_dhw_pinning.py` — 16/16 pass
- [x] Adjacent suites — `test_dhw_policy.py`, `test_dhw_policy_bugfixes.py`, `test_lp_shower_demand_model.py`, `test_lp_hp_min_on.py`, `test_lp_legionella_cycle.py` — 67/67 pass
- [ ] After deploy: verify next guests-preset solve clears `lp_failure_log` and produces a fresh dispatch_decisions row

🤖 Generated with [Claude Code](https://claude.com/claude-code)