### PR TITLE
fix(ui): stop tariff comparison flashing projected cost before realised

### DIFF
--- a/ui/src/components/home/TariffComparisonWidget.tsx
+++ b/ui/src/components/home/TariffComparisonWidget.tsx
@@ -14,6 +14,12 @@ interface TariffComparisonWidgetProps {
   // (from /energy/period) bills measured grid import at the half-hourly
   // Agile rate per slot — the actual money out the door.
   monthPeriod: PeriodInsightsResponse | null;
+  // Whether the /energy/period fetch that feeds `monthPeriod` is still
+  // in-flight. The dashboard and monthPeriod are independent fetches: if the
+  // dashboard lands first we must NOT render the current tariff's projected
+  // total — it would flash a wrong (over-stated) number until the realised
+  // cost arrives and overwrites it. Hold the skeleton until BOTH have settled.
+  monthPeriodLoading: boolean;
 }
 
 // Default SEG floor used when a fixed-tariff doesn't expose its own outgoing
@@ -30,8 +36,10 @@ const SEG_EXPORT_FALLBACK_P = 4.0;
 // BG Fixed v58 row is computed client-side using the same real-usage block
 // + the configured FIXED_TARIFF_* rates from /metrics. No annual-from-daily
 // extrapolation; pure replay over the same window as the Octopus rows.
-export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, monthPeriod }: TariffComparisonWidgetProps) {
-  if (dashboardLoading) {
+export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, monthPeriod, monthPeriodLoading }: TariffComparisonWidgetProps) {
+  // Gate on BOTH fetches: the current tariff's realised total comes from
+  // monthPeriod, so rendering before it settles flashes the projected number.
+  if (dashboardLoading || monthPeriodLoading) {
     return <div class="tcomp"><div class="tcomp-skel skel" /></div>;
   }
   if (!dashboard?.ok || !dashboard.totals?.length) {

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -146,7 +146,7 @@ export default function Landing() {
         <Widget title="Tariff comparison" icon="📊" tone="savings" size="wide"
                 badge={tariffDash.data?.usage?.total_days ? `last ${tariffDash.data.usage.total_days}d of your usage` : undefined}
                 action={<RefreshAction onRefresh={tariffDash.refresh} loading={tariffDash.loading} />}>
-          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} monthPeriod={monthPeriod.data} />
+          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} monthPeriod={monthPeriod.data} monthPeriodLoading={monthPeriod.loading} />
         </Widget>
       </div>
 


### PR DESCRIPTION
## Context
Phase **P1** of the UI UX-review plan. The user reported the **tariff comparison pre-loads wrong values then corrects** — confusing.

## Root cause
On Home, `TariffComparisonWidget` gets `dashboard` and `monthPeriod` from two **independent** fetches (`landing.tsx`). The current tariff's row shows the dashboard's *projected* total (consumption × avg rate, no battery-arbitrage credit, over-stated ~30%) and only swaps to the *realised* cost (`monthPeriod.cost.net_cost_pence`) when the second fetch lands. Dashboard-wins-the-race → a wrong number flashes, then corrects.

## Fix
Gate the widget skeleton on **both** fetches (`dashboardLoading || monthPeriodLoading`). The current tariff now renders once, with the realised cost — no intermediate projected number. `useFetch` clears `loading` in `finally` (success *or* error), so an errored `monthPeriod` still releases the gate and renders the projected fallback as the final state (no permanent skeleton).

## Files
- `ui/src/components/home/TariffComparisonWidget.tsx` — new `monthPeriodLoading` prop + extended loading guard.
- `ui/src/routes/landing.tsx` — pass `monthPeriod.loading`.

## Verification
- `npx tsc -b --noEmit` — clean.
- Manual: Home with DevTools network throttling — the current-tariff cell shows skeleton → final realised value, never a projected number first.

## Next phases (separate PRs)
P2 unified "Today's plan" chart on Home + PV planned/realized · P3 heating controls · P4 LP load knob + workbench UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)