### PR TITLE
feat(ui): unified "Today's plan" chart on Home + /pv/today endpoint

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -117,6 +117,7 @@ from .models import (
 from .routers import appliances as appliances_router
 from .routers import dispatch as dispatch_router
 from .routers import energy_providers as energy_providers_router
+from .routers import pv as pv_router
 from .routers import workbench as workbench_router
 
 
@@ -282,6 +283,7 @@ app.include_router(energy_providers_router.router)
 app.include_router(workbench_router.router)
 app.include_router(dispatch_router.router)
 app.include_router(appliances_router.router)
+app.include_router(pv_router.router)
 
 # Mount the FastMCP streamable-HTTP transport at /mcp, guarded by a bearer
 # token. Replaces the legacy stdio subprocess (`bin/mcp`) for OpenClaw in

--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -1,0 +1,181 @@
+"""PV planned-vs-realised endpoint.
+
+``GET /api/v1/pv/today`` returns, per 30-min UTC slot for the day, the
+*planned* PV (the calibrated forecast the LP plans against) and the *realised*
+PV (trapezoidal roll-up of ``pv_realtime_history.solar_power_kw``), plus a
+running accuracy summary over the slots already elapsed. Powers the Home
+"Today's plan" overlay (planned vs realised solar). Read-only, SQLite +
+forecast cache only — no cloud writes.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException
+
+from ... import db
+from ...config import config
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["pv"])
+
+_SLOTS_PER_DAY = 48  # 30-min slots
+_SLOT_MINUTES = 30
+
+
+def _iso_z(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _norm_z(iso: str) -> str:
+    """Normalise any UTC ISO string to the ``...Z`` form used as the slot key."""
+    try:
+        return _iso_z(datetime.fromisoformat(iso.replace("Z", "+00:00")))
+    except (ValueError, TypeError):
+        return iso
+
+
+@router.get("/api/v1/pv/today")
+async def get_pv_today(date: str | None = None) -> dict[str, Any]:
+    """Per-slot planned (forecast) vs realised PV for the UTC calendar day.
+
+    Query params:
+      * ``date`` — optional ``YYYY-MM-DD`` (UTC day). Defaults to today UTC.
+
+    Response:
+      * ``date`` — the UTC day rendered.
+      * ``now_utc`` — server time (the boundary between realised and future).
+      * ``slots[]`` — one per 30-min slot: ``{slot_utc, pv_forecast_kwh,
+        pv_actual_kwh}``. ``pv_actual_kwh`` is ``null`` for future slots (and
+        for past slots with no telemetry) so the UI doesn't plot a zero.
+      * ``accuracy`` — over elapsed slots: ``{slots_compared, forecast_kwh,
+        actual_kwh, mae_kwh, bias_kwh}`` (bias = actual − forecast; positive =
+        forecast under-predicted). ``null`` when nothing has elapsed yet.
+      * ``forecast_kwh_day_total`` — full-day forecast sum (kWh).
+    """
+    # Resolve the target UTC day (mirrors /api/v1/execution/today).
+    if date:
+        try:
+            d = _date_from_iso(date)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="date must be YYYY-MM-DD")
+    else:
+        d = datetime.now(UTC).date()
+
+    day_start = datetime(d.year, d.month, d.day, tzinfo=UTC)
+    slot_starts = [day_start + timedelta(minutes=_SLOT_MINUTES * i) for i in range(_SLOTS_PER_DAY)]
+    now = datetime.now(UTC)
+
+    # --- Planned PV: the LP's exact forecast→kWh conversion (calibration
+    # tables + W/m²→kW + 0.5h), so the planned line matches what the optimizer
+    # plans against. Default pv_scale (no today-factor) — this is the
+    # calibrated forecast, not a post-hoc re-fit.
+    forecast_kwh: list[float] = [0.0] * _SLOTS_PER_DAY
+    try:
+        from ... import weather
+
+        fc = weather.fetch_forecast(hours=48)
+        series = weather.forecast_to_lp_inputs(fc, slot_starts)
+        pv = series.pv_kwh_per_slot
+        for i in range(min(_SLOTS_PER_DAY, len(pv))):
+            forecast_kwh[i] = round(float(pv[i]), 4)
+    except Exception as e:  # forecast provider down / no cache — degrade gracefully
+        logger.warning("pv/today: forecast unavailable (%s); planned line will be zero", e)
+
+    # --- Realised PV: trapezoidal roll-up of pv_realtime_history (same helper
+    # the PnL export valuation uses), keyed by UTC half-hour slot ISO.
+    try:
+        actual_map = db.half_hourly_solar_kwh_for_day(d)
+    except Exception as e:
+        logger.warning("pv/today: realised roll-up failed (%s)", e)
+        actual_map = {}
+
+    # --- Full-day overlays so the chart needs only this one endpoint (no
+    # client-side key-matching across differently-formatted ISO strings):
+    #   import price (Agile, per slot), residual load forecast (per slot),
+    #   and the dispatch kind (charge/discharge classification per slot).
+    price_by_start: dict[str, float] = {}
+    try:
+        tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+        if tariff:
+            for r in db.get_rates_for_period(tariff, day_start, day_start + timedelta(days=1)):
+                price_by_start[_norm_z(r["valid_from"])] = float(r["value_inc_vat"])
+    except Exception as e:
+        logger.warning("pv/today: import-rate lookup failed (%s)", e)
+
+    load_profile: dict[tuple[int, int], float] = {}
+    try:
+        load_profile = db.half_hourly_residual_load_profile_kwh()
+    except Exception as e:
+        logger.warning("pv/today: load profile failed (%s)", e)
+    try:
+        tz = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
+    except Exception:
+        tz = UTC  # type: ignore[assignment]
+
+    kind_by: dict[str, str] = {}
+    try:
+        rid = db.find_latest_optimizer_run_id()
+        if rid is not None:
+            for dec in db.get_dispatch_decisions(rid):
+                k = dec.get("dispatched_kind") or dec.get("lp_kind")
+                stu = dec.get("slot_time_utc")
+                if k and stu:
+                    kind_by[_norm_z(stu)] = k
+    except Exception as e:
+        logger.warning("pv/today: dispatch kinds failed (%s)", e)
+
+    slots_out: list[dict[str, Any]] = []
+    acc_f = acc_a = 0.0
+    acc_abs = 0.0
+    compared = 0
+    for i, st in enumerate(slot_starts):
+        key = _iso_z(st)
+        f = forecast_kwh[i]
+        slot_end = st + timedelta(minutes=_SLOT_MINUTES)
+        elapsed = slot_end <= now
+        # Realised only exists for elapsed slots with telemetry; future slots
+        # (and gaps) stay null so the chart draws a clean planned-only line.
+        a_raw = actual_map.get(key)
+        a: float | None = round(float(a_raw), 4) if (elapsed and a_raw is not None) else None
+        local = st.astimezone(tz)
+        bl = load_profile.get((local.hour, local.minute))
+        slots_out.append({
+            "slot_utc": key,
+            "pv_forecast_kwh": f,
+            "pv_actual_kwh": a,
+            "import_price_p": price_by_start.get(key),
+            "base_load_kwh": round(float(bl), 4) if bl is not None else None,
+            "kind": kind_by.get(key),
+        })
+        if elapsed and a is not None:
+            compared += 1
+            acc_f += f
+            acc_a += a
+            acc_abs += abs(a - f)
+
+    accuracy: dict[str, Any] | None = None
+    if compared > 0:
+        accuracy = {
+            "slots_compared": compared,
+            "forecast_kwh": round(acc_f, 3),
+            "actual_kwh": round(acc_a, 3),
+            "mae_kwh": round(acc_abs / compared, 4),
+            "bias_kwh": round(acc_a - acc_f, 3),  # +ve = forecast under-predicted
+        }
+
+    return {
+        "date": d.isoformat(),
+        "now_utc": _iso_z(now),
+        "slots": slots_out,
+        "accuracy": accuracy,
+        "forecast_kwh_day_total": round(sum(forecast_kwh), 3),
+    }
+
+
+def _date_from_iso(s: str) -> date:
+    return date.fromisoformat(s)

--- a/src/db.py
+++ b/src/db.py
@@ -3072,7 +3072,7 @@ def _half_hourly_grid_kwh_for_day(
 ) -> dict[str, float]:
     """Shared trapezoidal-integration over ``pv_realtime_history.<column>`` for
     ``day``, keyed by ISO half-hour slot start (UTC). ``column`` must be one of
-    ``grid_export_kw`` / ``grid_import_kw`` (caller-vetted).
+    ``grid_export_kw`` / ``grid_import_kw`` / ``solar_power_kw`` (caller-vetted).
 
     Each sample-pair's energy is assigned to the bucket containing the EARLIER
     sample (matching :func:`compute_fox_energy_daily_from_realtime`). Slots with
@@ -3082,7 +3082,7 @@ def _half_hourly_grid_kwh_for_day(
     from collections import defaultdict
     from datetime import datetime as _dt
 
-    if column not in ("grid_export_kw", "grid_import_kw"):
+    if column not in ("grid_export_kw", "grid_import_kw", "solar_power_kw"):
         raise ValueError(f"unsupported column: {column}")
 
     day_iso = day.isoformat()
@@ -3156,6 +3156,21 @@ def half_hourly_grid_export_kwh_for_day(
     Octopus Outgoing rates (issue #207).
     """
     return _half_hourly_grid_kwh_for_day(day, "grid_export_kw", max_gap_seconds=max_gap_seconds)
+
+
+def half_hourly_solar_kwh_for_day(
+    day: date,
+    *,
+    max_gap_seconds: int = 1800,
+) -> dict[str, float]:
+    """Per-slot realised solar (PV generation) kWh for ``day``, keyed by ISO
+    half-hour slot start (UTC).
+
+    Trapezoidal integration of ``pv_realtime_history.solar_power_kw``. See
+    :func:`_half_hourly_grid_kwh_for_day` for mechanics. Powers the
+    ``GET /api/v1/pv/today`` planned-vs-realised overlay.
+    """
+    return _half_hourly_grid_kwh_for_day(day, "solar_power_kw", max_gap_seconds=max_gap_seconds)
 
 
 def half_hourly_grid_import_kwh_for_day(

--- a/tests/test_pv_today_endpoint.py
+++ b/tests/test_pv_today_endpoint.py
@@ -1,0 +1,83 @@
+"""GET /api/v1/pv/today — planned-vs-realised PV roll-up + accuracy."""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.api.routers import pv as pv_router
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db.config, "DB_PATH", str(db_path))
+    db.init_db()
+    # No network / forecast provider in tests — degrade planned line to zero
+    # so the test isolates the realised roll-up + accuracy maths.
+    import src.weather as weather
+    monkeypatch.setattr(weather, "fetch_forecast", lambda hours=48: [])
+    yield db_path
+
+
+def _seed_constant_solar(day, hour_utc: int, kw: float, *, minutes=(0, 15, 30, 45, 60)):
+    """Insert constant-kW solar samples across one hour of ``day`` (UTC)."""
+    for m in minutes:
+        ts = datetime(day.year, day.month, day.day, hour_utc, 0, tzinfo=UTC) + timedelta(minutes=m)
+        db.save_pv_realtime_sample(
+            ts.isoformat().replace("+00:00", "Z"),
+            solar_power_kw=kw,
+            source="test",
+        )
+
+
+def test_solar_rollup_integrates_to_kwh():
+    day = (datetime.now(UTC) - timedelta(days=1)).date()
+    _seed_constant_solar(day, 10, 3.0)  # 3 kW held for one hour → ~3 kWh
+    rollup = db.half_hourly_solar_kwh_for_day(day)
+    total = sum(rollup.values())
+    assert 2.5 <= total <= 3.5, f"expected ~3 kWh integrated, got {total}"
+
+
+def test_pv_today_shape_and_accuracy():
+    day = (datetime.now(UTC) - timedelta(days=1)).date()  # fully elapsed
+    _seed_constant_solar(day, 10, 3.0)
+
+    resp = asyncio.run(pv_router.get_pv_today(date=day.isoformat()))
+
+    assert resp["date"] == day.isoformat()
+    assert len(resp["slots"]) == 48
+    # Every slot carries the full overlay key set; forecast is 0 (no provider
+    # in test); price/load/kind are null (no rates/profile/runs seeded).
+    expected_keys = {"slot_utc", "pv_forecast_kwh", "pv_actual_kwh", "import_price_p", "base_load_kwh", "kind"}
+    assert all(set(s) == expected_keys for s in resp["slots"])
+    assert all(s["pv_forecast_kwh"] == 0.0 for s in resp["slots"])
+
+    realised = [s["pv_actual_kwh"] for s in resp["slots"] if s["pv_actual_kwh"] is not None]
+    assert realised, "expected at least one slot with realised PV"
+    assert 2.5 <= sum(realised) <= 3.5
+
+    acc = resp["accuracy"]
+    assert acc is not None
+    assert acc["slots_compared"] >= 1
+    assert acc["forecast_kwh"] == 0.0
+    assert 2.5 <= acc["actual_kwh"] <= 3.5
+    # Forecast is zero, so bias (actual − forecast) == realised total, and MAE
+    # is the mean realised kWh per compared slot.
+    assert acc["bias_kwh"] == pytest.approx(acc["actual_kwh"], abs=1e-6)
+
+
+def test_pv_today_future_day_has_no_realised():
+    day = (datetime.now(UTC) + timedelta(days=1)).date()  # all slots in the future
+    resp = asyncio.run(pv_router.get_pv_today(date=day.isoformat()))
+    assert len(resp["slots"]) == 48
+    assert all(s["pv_actual_kwh"] is None for s in resp["slots"])
+    assert resp["accuracy"] is None
+
+
+def test_pv_today_rejects_bad_date():
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException):
+        asyncio.run(pv_router.get_pv_today(date="not-a-date"))

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef } from "preact/hooks";
+import { makeChart, baseOption, chartTheme, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
+import { useResolvedTheme } from "../../lib/theme";
+import type { PvTodayResponse } from "../../lib/types";
+import "./today-plan.css";
+
+interface TodayPlanWidgetProps {
+  pv: PvTodayResponse | null;
+  loading: boolean;
+}
+
+// Slot kinds that mean the battery is being FILLED (cheap/free energy in) vs
+// EMPTIED to the grid. Mirrors DispatchPlanStrip's colour buckets so the bands
+// read the same across the app.
+const CHARGE_KINDS = new Set(["negative", "cheap", "solar_charge", "solar_preheat", "charge"]);
+const DISCHARGE_KINDS = new Set(["peak_export", "peak", "discharge"]);
+
+function localHM(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+// One chart that answers "what's the plan today?" without tab-switching:
+// import price + charge/discharge windows + load forecast + PV planned vs
+// realised, all on a shared 30-min slot axis. Price on the right axis (p/kWh),
+// energy on the left (kWh). All series come from /pv/today — a single
+// full-day, server-aligned source (no client-side ISO key-matching).
+export function TodayPlanWidget({ pv, loading }: TodayPlanWidgetProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+  const theme = useResolvedTheme();
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const ch = makeChart(ref.current);
+    chartRef.current = ch;
+    const onResize = () => ch.resize();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      ch.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current || !pv?.slots?.length) return;
+    const t = chartTheme();
+    const base = baseOption();
+    const slots = pv.slots;
+    const labels = slots.map((s) => localHM(s.slot_utc));
+
+    const pvPlanned = slots.map((s) => round2(s.pv_forecast_kwh));
+    const pvActual = slots.map((s) => (s.pv_actual_kwh == null ? null : round2(s.pv_actual_kwh)));
+    const load = slots.map((s) => (s.base_load_kwh == null ? null : round2(s.base_load_kwh)));
+    const price = slots.map((s) => (s.import_price_p == null ? null : s.import_price_p));
+
+    // Charge/discharge background bands — contiguous runs of charge/discharge
+    // kinds. markArea references the slot INDEX (DST-safe; two slots can share
+    // a local HH:MM label on the autumn clock change).
+    const bands: Array<[{ xAxis: number; itemStyle: object }, { xAxis: number }]> = [];
+    let runStart = -1;
+    let runKind: "charge" | "discharge" | null = null;
+    const flush = (endIdx: number) => {
+      if (runStart < 0 || runKind == null) return;
+      const color = runKind === "charge" ? t.cheap : t.peak;
+      bands.push([
+        { xAxis: runStart, itemStyle: { color: withAlpha(color, 0.1) } },
+        { xAxis: endIdx },
+      ]);
+    };
+    slots.forEach((s, i) => {
+      const k = s.kind || undefined;
+      const cur: "charge" | "discharge" | null =
+        k && CHARGE_KINDS.has(k) ? "charge" : k && DISCHARGE_KINDS.has(k) ? "discharge" : null;
+      if (cur !== runKind) {
+        if (runKind != null) flush(i - 1);
+        runKind = cur;
+        runStart = cur != null ? i : -1;
+      }
+    });
+    if (runKind != null) flush(slots.length - 1);
+
+    // "Now" marker — only when now falls within this day's slots.
+    const nowMs = pv.now_utc ? new Date(pv.now_utc).getTime() : Date.now();
+    const firstMs = new Date(slots[0].slot_utc).getTime();
+    const lastMs = new Date(slots[slots.length - 1].slot_utc).getTime() + 30 * 60_000;
+    let nowIdx = -1;
+    if (nowMs >= firstMs && nowMs < lastMs) {
+      const idx = slots.findIndex((s) => new Date(s.slot_utc).getTime() > nowMs);
+      nowIdx = idx <= 0 ? slots.length - 1 : idx - 1;
+    }
+
+    chartRef.current.setOption({
+      ...base,
+      grid: { left: 48, right: 52, top: 28, bottom: 28, containLabel: true },
+      legend: { ...(base.legend as object), show: true },
+      tooltip: {
+        ...(base.tooltip as object),
+        formatter: (params: Array<{ dataIndex: number }>) => {
+          const i = params[0]?.dataIndex ?? 0;
+          const s = slots[i];
+          if (!s) return "";
+          return `<strong>${labels[i]}</strong>${s.kind ? ` · ${s.kind}` : ""}<br/>` +
+            (price[i] != null ? `Import ${price[i]!.toFixed(1)}p/kWh<br/>` : "") +
+            `PV planned ${pvPlanned[i].toFixed(2)} kWh<br/>` +
+            (pvActual[i] != null ? `PV actual ${pvActual[i]!.toFixed(2)} kWh<br/>` : "") +
+            (load[i] != null ? `Load ${load[i]!.toFixed(2)} kWh` : "");
+        },
+      },
+      xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
+      yAxis: [
+        { ...(base.yAxis as object), name: "kWh", nameTextStyle: { color: t.textDim, fontSize: 10 } },
+        {
+          ...(base.yAxis as object),
+          name: "p/kWh", position: "right",
+          nameTextStyle: { color: t.textDim, fontSize: 10 },
+          splitLine: { show: false },
+          axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}p" },
+        },
+      ],
+      series: [
+        {
+          name: "PV planned", type: "line", smooth: true, showSymbol: false,
+          data: pvPlanned, lineStyle: { color: t.pv, width: 1.5, type: "dashed" },
+          areaStyle: { color: areaGradient(t.pv, 0.16, 0.02) }, z: 2,
+          markArea: bands.length ? { silent: true, data: bands } : undefined,
+          markLine: nowIdx >= 0 ? {
+            silent: true, symbol: "none",
+            lineStyle: { color: t.textDim, width: 1, type: "dotted" },
+            label: { show: true, formatter: "now", color: t.textMute, fontSize: 10 },
+            data: [{ xAxis: nowIdx }],
+          } : undefined,
+        },
+        {
+          name: "PV actual", type: "line", smooth: true, showSymbol: false, connectNulls: false,
+          data: pvActual, lineStyle: { color: t.pv, width: 2.5 },
+          areaStyle: { color: areaGradient(t.pv, 0.32, 0.04) }, z: 3,
+        },
+        {
+          name: "Load forecast", type: "line", smooth: true, showSymbol: false,
+          data: load, lineStyle: { color: t.house, width: 1.5, type: "dashed" }, z: 2,
+        },
+        {
+          name: "Import price", type: "line", step: "middle", showSymbol: false,
+          yAxisIndex: 1, data: price, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8 }, z: 1,
+        },
+      ],
+    }, { notMerge: true });
+  }, [pv, theme]);
+
+  const acc = pv?.accuracy;
+
+  return (
+    <div class="today-plan">
+      {acc && (
+        <div class="today-plan-acc">
+          <span>PV today so far: <strong>{acc.actual_kwh.toFixed(1)}</strong> kWh actual vs <strong>{acc.forecast_kwh.toFixed(1)}</strong> planned</span>
+          <span class="today-plan-acc-sep">·</span>
+          <span title="Mean absolute error per slot, and forecast bias (positive = forecast under-predicted).">
+            MAE {acc.mae_kwh.toFixed(2)} kWh · bias {acc.bias_kwh >= 0 ? "+" : ""}{acc.bias_kwh.toFixed(1)} kWh
+          </span>
+        </div>
+      )}
+      <div ref={ref} style={{ width: "100%", height: "300px" }} />
+      {!pv?.slots?.length && !loading && <p class="muted">No plan data for today yet.</p>}
+    </div>
+  );
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/ui/src/components/home/today-plan.css
+++ b/ui/src/components/home/today-plan.css
@@ -1,0 +1,22 @@
+.today-plan {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.today-plan-acc {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: var(--font-sm);
+  color: var(--text-dim);
+}
+
+.today-plan-acc strong {
+  color: var(--text);
+}
+
+.today-plan-acc-sep {
+  color: var(--text-mute);
+}

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -21,6 +21,8 @@ import type {
   TariffDashboardResponse,
   PeriodInsightsResponse,
   DaikinConsumptionResponse,
+  PvTodayResponse,
+  OptimizationInputsResponse,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -30,6 +32,9 @@ export const getSchedulerTimeline = () => getJson<SchedulerTimeline>("/scheduler
 export const getDecisionsLatest = () =>
   getJson<DispatchDecisionsResponse>("/optimization/decisions/latest");
 export const getMetrics = () => getJson<MetricsResponse>("/metrics");
+export const getPvToday = () => getJson<PvTodayResponse>("/pv/today");
+export const getOptimizationInputs = () =>
+  getJson<OptimizationInputsResponse>("/optimization/inputs");
 export const getDaikinStatus = () => getJson<DaikinDevice[]>("/daikin/status");
 export const getDaikinQuota = () => getJson<ApiQuotaResponse>("/daikin/quota");
 export const getFoxQuota = () => getJson<ApiQuotaResponse>("/foxess/quota");

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -108,6 +108,49 @@ export interface SchedulerTimeline {
   planned: TimelineSlot[];
 }
 
+/* ----- /pv/today ----- */
+
+export interface PvTodaySlot {
+  slot_utc: string;
+  pv_forecast_kwh: number;
+  pv_actual_kwh: number | null;
+  import_price_p?: number | null;
+  base_load_kwh?: number | null;
+  kind?: string | null;
+}
+
+export interface PvTodayAccuracy {
+  slots_compared: number;
+  forecast_kwh: number;
+  actual_kwh: number;
+  mae_kwh: number;
+  bias_kwh: number;
+}
+
+export interface PvTodayResponse {
+  date: string;
+  now_utc: string;
+  slots: PvTodaySlot[];
+  accuracy: PvTodayAccuracy | null;
+  forecast_kwh_day_total: number;
+}
+
+/* ----- /optimization/inputs ----- */
+
+export interface OptimizationInputSlot {
+  t_utc: string;
+  price_import_p?: number | null;
+  price_export_p?: number | null;
+  temp_c?: number | null;
+  solar_w_m2?: number | null;
+  base_load_kwh?: number | null;
+}
+
+export interface OptimizationInputsResponse {
+  slots: OptimizationInputSlot[];
+  thresholds?: { cheap_p?: number; peak_p?: number } | null;
+}
+
 /* ----- /optimization/decisions/{run_id} ----- */
 
 export interface DispatchDecision {

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -15,6 +15,7 @@ import {
   getDaikinStatus,
   getDaikinQuota,
   getTariffDashboard,
+  getPvToday,
 } from "../lib/endpoints";
 import { Widget } from "../components/common/Widget";
 import { Spinner } from "../components/common/Spinner";
@@ -33,6 +34,12 @@ import "../components/home/home.css";
 // the hero + money tiles paint immediately and the chart streams in after.
 const EnergyChartWidget = lazy(() =>
   import("../components/home/EnergyChartWidget").then((m) => ({ default: m.EnergyChartWidget })),
+);
+
+// Combined "today's plan" chart also owns echarts — lazy-load alongside the
+// energy chart so the hero + money tiles paint first.
+const TodayPlanWidget = lazy(() =>
+  import("../components/home/TodayPlanWidget").then((m) => ({ default: m.TodayPlanWidget })),
 );
 
 function lastMonths(n: number): string[] {
@@ -74,6 +81,7 @@ export default function Landing() {
   const now = usePoll(getCockpitNow, 20_000);
   const metrics = usePoll(getMetrics, 5 * 60_000);
   const timeline = usePoll(getSchedulerTimeline, 5 * 60_000);
+  const pvToday = usePoll(getPvToday, 5 * 60_000);
 
   // Fetch-once endpoints — refresh on tab return, otherwise no churn.
   const agile = useFetch(getAgileToday, []);
@@ -124,6 +132,16 @@ export default function Landing() {
         <Widget title="Heating" icon="♨" tone="thermal" size="medium"
                 action={<RefreshAction onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} loading={daikin.loading} title="Re-fetch Daikin (cached server-side ~30min)" />}>
           <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data} />
+        </Widget>
+      </div>
+
+      {/* ── PLAN ───────────────────────────────────────────────────── */}
+      <div class="widget-grid widget-band">
+        <Widget title="Today's plan" icon="🗓" tone="plan" size="wide"
+                badge={pvToday.data?.forecast_kwh_day_total != null ? `${pvToday.data.forecast_kwh_day_total.toFixed(1)} kWh PV planned` : undefined}>
+          <Suspense fallback={<Spinner label="Loading plan…" />}>
+            <TodayPlanWidget pv={pvToday.data} loading={pvToday.loading} />
+          </Suspense>
         </Widget>
       </div>
 


### PR DESCRIPTION
## Context
Phase **P2** of the UI UX review. Two pains addressed:
- **Tab-switching** to cross-reference tariff slot prices × battery charge/discharge windows × load forecast.
- **No planned-vs-realised PV** view, no daily PV accuracy.

## Backend — `GET /api/v1/pv/today` (new, `src/api/routers/pv.py`)
Per 30-min UTC slot for the day, returns a single **full-day, server-aligned** payload:
- `pv_forecast_kwh` — the LP's *own* calibrated conversion (`weather.forecast_to_lp_inputs(...).pv_kwh_per_slot`), so the planned line matches what the optimizer plans against.
- `pv_actual_kwh` — trapezoidal roll-up of `pv_realtime_history.solar_power_kw` via new `db.half_hourly_solar_kwh_for_day` (mirrors the export/import roll-ups; `solar_power_kw` added to the column whitelist).
- `import_price_p`, `base_load_kwh`, `kind` — Agile price, residual load forecast, and dispatch classification per slot.
- `accuracy` — running MAE + bias over elapsed slots; `forecast_kwh_day_total`.

Centralising every series here (server controls ISO formatting) means the frontend does **zero cross-endpoint key-matching** — the original draft sourced price/kind from `/scheduler/timeline` and silently failed on a `Z` vs `+00:00` mismatch and a `price_p` vs `price_import_p` field-name mismatch (caught in review).

## Frontend — `TodayPlanWidget` (new, lazy echarts)
One chart on a shared slot axis: import price (right axis) · charge/discharge background bands · load-forecast line · PV planned-vs-realised areas · "now" marker · accuracy header. Added to a new **PLAN** band on Home below Live power. Lazy-loaded so it shares the existing echarts chunk (4 kB widget chunk; echarts stays out of the main bundle).

DST-safe: bands reference slot **index**, not the local `HH:MM` label; the now-marker is guarded to the day's window.

## Verification
- `pytest tests/test_pv_today_endpoint.py` (roll-up integrates to ~kWh, response shape, accuracy maths, future-day → no realised, bad-date → 400) + `test_db_fox_rollup`/`test_db_load_profile` green.
- `npx tsc -b --noEmit` clean; `vite build` clean (TodayPlanWidget split into its own chunk).
- Independent Plan-agent review: 2 HIGH (key/field mismatch) + 1 MED (partial-day) + 2 LOW — all resolved by the single-source design + index bands + guarded marker.

## Next phases
P3 heating controls · P4 LP load knob + workbench UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)