### PR TITLE
feat: LP load-forecast knob + Workbench UI (P4)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1168,6 +1168,9 @@ async def optimization_inputs(horizon_hours: int | None = None):
         flat = fox_mean if fox_mean is not None else db.mean_consumption_kwh_from_execution_logs(limit=profile_limit)
     except Exception:
         flat = 0.4
+    # Operator load scale — mirrors the multiplier the optimizer applies to the
+    # residual profile, so this view matches the plan (no-op at default 1.0).
+    _load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
 
     # --- Initial state (quota-safe: no Daikin refresh) ----------------------
     try:
@@ -1293,7 +1296,9 @@ async def optimization_inputs(horizon_hours: int | None = None):
             hr_local = t.hour
             min_local = 30 if t.minute >= 30 else 0
         # S10.8 (#175): half-hour bucket lookup; falls back to flat mean.
-        bl = float(load_profile.get((hr_local, min_local), flat))
+        # Apply the operator load scale so this debug view matches what the LP
+        # actually plans against (no-op at the default 1.0).
+        bl = float(load_profile.get((hr_local, min_local), flat)) * _load_scale
         slots_out.append({
             "t_utc": iso.replace("+00:00", "Z"),
             "price_import_p": price_i,

--- a/src/api/routers/workbench.py
+++ b/src/api/routers/workbench.py
@@ -59,7 +59,7 @@ def _profile_path(name: str) -> Path:
 async def workbench_schema():
     """Return the override whitelist with metadata for the editor."""
     return {
-        "groups": ["comfort", "battery", "hardware", "penalty", "solver", "schedule", "mode"],
+        "groups": ["comfort", "battery", "hardware", "penalty", "solver", "schedule", "mode", "load"],
         "fields": lp_overrides.schema_for_response(),
     }
 

--- a/src/config.py
+++ b/src/config.py
@@ -1215,6 +1215,14 @@ class Config:
     def LP_SOC_FINAL_KWH(self, value: float) -> None:
         self._rt_set("LP_SOC_FINAL_KWH", float(value))
 
+    @property
+    def LP_LOAD_SCALE_FACTOR(self) -> float:
+        return float(self._rt_get("LP_LOAD_SCALE_FACTOR"))
+
+    @LP_LOAD_SCALE_FACTOR.setter
+    def LP_LOAD_SCALE_FACTOR(self, value: float) -> None:
+        self._rt_set("LP_LOAD_SCALE_FACTOR", float(value))
+
     # --- PR B — shower demand model -------------------------------------
     @property
     def DHW_SHOWER_DURATION_MIN(self) -> float:

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -435,6 +435,21 @@ SCHEMA: dict[str, SettingSpec] = {
             "BATTERY_CAPACITY_KWH."
         ),
     ),
+    "LP_LOAD_SCALE_FACTOR": SettingSpec(
+        key="LP_LOAD_SCALE_FACTOR",
+        type_name="float",
+        env_default=_float_env("LP_LOAD_SCALE_FACTOR", "1.0"),
+        min_value=0.5,
+        max_value=2.0,
+        description=(
+            "Operator multiplier on the residual house-load forecast the LP "
+            "plans against. 1.0 = as-measured (default, no-op). Nudge down "
+            "(e.g. 0.7 when away) or up (e.g. 1.3 for guests) to shift the "
+            "plan's demand assumption without re-learning the profile. Applies "
+            "to the residual profile only — explicit appliance loads are "
+            "unaffected."
+        ),
+    ),
     # Legionella thermal-shock awareness. The Daikin Onecta firmware fires the
     # cycle autonomously on a user-configured day/hour (set in the Onecta app);
     # the LP cannot command it. These knobs let the LP *predict* the resulting

--- a/src/scheduler/lp_overrides.py
+++ b/src/scheduler/lp_overrides.py
@@ -257,6 +257,19 @@ WHITELIST: dict[str, OverrideSpec] = {
         description="passive = firmware autonomous (LP load-follows HP); active = LP schedules tank + LWT.",
         group="mode", promotable=True,
     ),
+    # --- Load forecast
+    "LP_LOAD_SCALE_FACTOR": OverrideSpec(
+        key="LP_LOAD_SCALE_FACTOR",
+        config_attr="LP_LOAD_SCALE_FACTOR",
+        type_name="float", min_value=0.5, max_value=2.0,
+        description=(
+            "Multiplier on the residual house-load forecast the LP plans "
+            "against. 1.0 = as-measured. Lower when away, raise for guests — "
+            "shifts the plan's demand assumption without re-learning the "
+            "profile. Appliance loads are unaffected."
+        ),
+        group="load", promotable=True,
+    ),
 }
 
 

--- a/src/scheduler/lp_simulation.py
+++ b/src/scheduler/lp_simulation.py
@@ -58,11 +58,14 @@ def _build_load_profile(slot_starts_utc: list[datetime]) -> list[float]:
     flat_from_log = db.mean_consumption_kwh_from_execution_logs(limit=limit)
     fox_mean = db.mean_fox_load_kwh_per_slot(limit=60)
     flat = fox_mean if fox_mean is not None else flat_from_log
+    # Operator load scale — mirror _run_optimizer_lp so the Workbench Simulate
+    # actually reflects LP_LOAD_SCALE_FACTOR (no-op at the default 1.0).
+    load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
     out: list[float] = []
     for s in slot_starts_utc:
         local = s.astimezone(ZoneInfo(config.BULLETPROOF_TIMEZONE))
         bucket = (local.hour, 30 if local.minute >= 30 else 0)
-        out.append(profile.get(bucket, flat))
+        out.append(profile.get(bucket, flat) * load_scale)
     return out
 
 

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1350,6 +1350,13 @@ def _run_optimizer_lp(
             return "peak"
         return "standard"
 
+    # Operator load-forecast scale (workbench/runtime-tunable). Multiplies the
+    # residual house-load profile so the user can nudge the plan's demand
+    # assumption up/down (e.g. "we'll be away → 0.7", "guests → 1.3"). Default
+    # 1.0 is a bit-identical no-op (v * 1.0 == v), so the LP regression
+    # baseline is unaffected. Applies to the residual profile only — explicit
+    # appliance dispatch loads (below) are added at their true kWh.
+    _load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
     base_load = []
     for s in slots:
         _local = s.start_utc.astimezone(tz)
@@ -1359,7 +1366,9 @@ def _run_optimizer_lp(
         v = _load_profile.get((_hm[0], _hm[1], _kind))
         if v is None:
             v = _load_profile.get(_hm, _flat)
-        base_load.append(v)
+        base_load.append(v * _load_scale)
+    if _load_scale != 1.0:
+        logger.info("LP base_load: operator load scale %.2f applied to residual profile", _load_scale)
     residual_base_load = list(base_load)
     appliance_profile_kwh = [0.0] * len(base_load)
 

--- a/tests/test_lp_load_scale.py
+++ b/tests/test_lp_load_scale.py
@@ -1,0 +1,85 @@
+"""LP_LOAD_SCALE_FACTOR — operator load-forecast multiplier.
+
+Covers the runtime-tunable knob wiring (config / SCHEMA / workbench whitelist)
+and that /optimization/inputs reflects the scale (no-op at 1.0).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src import db, runtime_settings as rts
+from src.config import config
+from src.scheduler import lp_overrides
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db.config, "DB_PATH", str(db_path))
+    db.init_db()
+    rts.clear_cache()
+    config._overrides.clear()
+    yield db_path
+    rts.clear_cache()
+    config._overrides.clear()
+
+
+def test_knob_is_registered_everywhere():
+    assert "LP_LOAD_SCALE_FACTOR" in rts.SCHEMA
+    assert "LP_LOAD_SCALE_FACTOR" in lp_overrides.WHITELIST
+    assert "LP_LOAD_SCALE_FACTOR" in lp_overrides.promotable_keys()
+    # New "load" group surfaces for the workbench UI.
+    assert any(s.group == "load" for s in lp_overrides.WHITELIST.values())
+
+
+def test_default_is_one_and_round_trips():
+    assert config.LP_LOAD_SCALE_FACTOR == 1.0
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.3)
+    assert config.LP_LOAD_SCALE_FACTOR == 1.3
+    # Range guard 0.5..2.0
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("LP_LOAD_SCALE_FACTOR", 0.1)
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("LP_LOAD_SCALE_FACTOR", 3.0)
+
+
+def _base_loads_from_inputs() -> list[float]:
+    from src.api.main import optimization_inputs
+    resp = asyncio.run(optimization_inputs())
+    return [s["base_load_kwh"] for s in resp["slots"] if s["base_load_kwh"] is not None]
+
+
+def test_optimization_inputs_scales_base_load(monkeypatch):
+    # Constant residual profile so the scale is unambiguous.
+    profile = {(h, m): 0.5 for h in range(24) for m in (0, 30)}
+    monkeypatch.setattr(db, "half_hourly_residual_load_profile_kwh", lambda *a, **k: profile)
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.0)
+    base = _base_loads_from_inputs()
+    assert base, "expected slots from /optimization/inputs"
+    assert all(abs(v - 0.5) < 1e-6 for v in base), "1.0 must be a no-op"
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 2.0)
+    scaled = _base_loads_from_inputs()
+    assert all(abs(v - 1.0) < 1e-6 for v in scaled), "2.0 must double the residual load"
+
+
+def test_simulation_load_builder_scales(monkeypatch):
+    """The Workbench Simulate path (run_lp_simulation → _build_load_profile)
+    MUST honour the scale, else the headline knob is inert in the UI."""
+    from datetime import UTC, datetime, timedelta
+    from src.scheduler import lp_simulation
+
+    profile = {(h, m): 0.5 for h in range(24) for m in (0, 30)}
+    monkeypatch.setattr(db, "half_hourly_residual_load_profile_kwh", lambda *a, **k: profile)
+    starts = [datetime(2026, 6, 1, 0, 0, tzinfo=UTC) + timedelta(minutes=30 * i) for i in range(8)]
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.0)
+    base = lp_simulation._build_load_profile(starts)
+    assert all(abs(v - 0.5) < 1e-6 for v in base), "1.0 no-op"
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.5)
+    scaled = lp_simulation._build_load_profile(starts)
+    assert all(abs(v - 0.75) < 1e-6 for v in scaled), "1.5 must scale the simulate base load"

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -11,6 +11,7 @@ import Landing from "./routes/landing";
 // here means a visitor who never opens /plan never downloads echarts.
 const Plan = lazy(() => import("./routes/plan"));
 const Settings = lazy(() => import("./routes/settings"));
+const Workbench = lazy(() => import("./routes/workbench"));
 
 export function App() {
   return (
@@ -22,6 +23,7 @@ export function App() {
             <Route path="/" component={Landing} />
             <Route path="/plan" component={Plan} />
             <Route path="/settings" component={Settings} />
+            <Route path="/workbench" component={Workbench} />
             <Route>
               <div class="page-padded">
                 <h1>Not found</h1>

--- a/ui/src/components/shell/TopNav.tsx
+++ b/ui/src/components/shell/TopNav.tsx
@@ -4,6 +4,7 @@ import { ThemeToggle } from "./ThemeToggle";
 const tabs = [
   { href: "/", label: "Home" },
   { href: "/plan", label: "Plan" },
+  { href: "/workbench", label: "Workbench" },
   { href: "/settings", label: "Settings" },
 ];
 

--- a/ui/src/components/workbench/WorkbenchPlanChart.tsx
+++ b/ui/src/components/workbench/WorkbenchPlanChart.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "preact/hooks";
+import { makeChart, baseOption, chartTheme, barGradient, type EChartsType } from "../../lib/charts";
+import { useResolvedTheme } from "../../lib/theme";
+import type { WorkbenchSimSlot } from "../../lib/types";
+
+interface WorkbenchPlanChartProps {
+  slots: WorkbenchSimSlot[];
+}
+
+function localHM(iso: string | null): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+// Compact plan shape for a simulated LP run: grid import (up) / export (down)
+// bars + battery SoC trajectory (right axis) + import price in the tooltip.
+// Lets the operator see how a knob tweak reshapes the plan before promoting.
+export function WorkbenchPlanChart({ slots }: WorkbenchPlanChartProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+  const theme = useResolvedTheme();
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const ch = makeChart(ref.current);
+    chartRef.current = ch;
+    const onResize = () => ch.resize();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      ch.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current || !slots.length) return;
+    const t = chartTheme();
+    const base = baseOption();
+    const labels = slots.map((s) => localHM(s.t));
+    const imp = slots.map((s) => round2(s.import_kwh));
+    const exp = slots.map((s) => (s.export_kwh == null ? null : -(Math.round(s.export_kwh * 100) / 100)));
+    const soc = slots.map((s) => round2(s.soc_kwh));
+    const price = slots.map((s) => s.price_p);
+
+    chartRef.current.setOption({
+      ...base,
+      grid: { left: 44, right: 48, top: 24, bottom: 24, containLabel: true },
+      legend: { ...(base.legend as object), show: true },
+      tooltip: {
+        ...(base.tooltip as object),
+        formatter: (params: Array<{ dataIndex: number }>) => {
+          const i = params[0]?.dataIndex ?? 0;
+          return `<strong>${labels[i]}</strong><br/>` +
+            (price[i] != null ? `Price ${price[i]!.toFixed(1)}p/kWh<br/>` : "") +
+            `Import ${(imp[i] ?? 0).toFixed(2)} kWh<br/>` +
+            (exp[i] != null ? `Export ${(-exp[i]!).toFixed(2)} kWh<br/>` : "") +
+            (soc[i] != null ? `SoC ${soc[i]!.toFixed(2)} kWh` : "");
+        },
+      },
+      xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
+      yAxis: [
+        { ...(base.yAxis as object), name: "kWh", nameTextStyle: { color: t.textDim, fontSize: 10 } },
+        {
+          ...(base.yAxis as object),
+          name: "SoC", position: "right",
+          nameTextStyle: { color: t.textDim, fontSize: 10 },
+          splitLine: { show: false },
+          axisLabel: { color: t.textMute, fontSize: 10 },
+        },
+      ],
+      series: [
+        { name: "Import", type: "bar", stack: "grid", data: imp,
+          itemStyle: { color: barGradient(t.importColor), borderRadius: [2, 2, 0, 0] }, z: 1 },
+        { name: "Export", type: "bar", stack: "grid", data: exp,
+          itemStyle: { color: barGradient(t.exportColor), borderRadius: [0, 0, 2, 2] }, z: 1 },
+        { name: "SoC", type: "line", smooth: true, showSymbol: false, yAxisIndex: 1,
+          data: soc, lineStyle: { color: t.batt, width: 2 }, z: 3 },
+      ],
+    }, { notMerge: true });
+  }, [slots, theme]);
+
+  return <div ref={ref} style={{ width: "100%", height: "220px" }} />;
+}
+
+function round2(n: number | null): number | null {
+  return n == null ? null : Math.round(n * 100) / 100;
+}

--- a/ui/src/components/workbench/workbench.css
+++ b/ui/src/components/workbench/workbench.css
@@ -1,0 +1,78 @@
+.wb { display: flex; flex-direction: column; gap: var(--space-5); padding-bottom: 6rem; }
+.wb-head h1 { margin: 0 0 var(--space-1); }
+
+.wb-group { display: flex; flex-direction: column; gap: var(--space-2); }
+.wb-group-title {
+  font-size: var(--font-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-mute);
+  margin: 0;
+}
+.wb-group--load {
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  background: var(--bg-card);
+}
+.wb-group--load .wb-group-title { color: var(--accent); }
+
+.wb-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-3);
+}
+.wb-field {
+  background: var(--bg-card-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.wb-field--edited { border-color: var(--warn); }
+.wb-field-head { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
+.wb-field-key { font-size: var(--font-sm); color: var(--text); }
+.wb-field-desc { font-size: var(--font-xs); margin: 0; }
+.wb-field-input .input { width: 100%; }
+
+.wb-bar {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  backdrop-filter: blur(12px);
+}
+.wb-bar-status { font-size: var(--font-sm); color: var(--text-dim); }
+.wb-bar-actions { display: flex; gap: var(--space-2); }
+
+.wb-sim {
+  background: var(--bg-card-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.wb-sim--err { border-color: var(--bad); }
+.wb-sim-head { display: flex; align-items: center; gap: var(--space-2); font-weight: 600; }
+.wb-sim-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: var(--space-3);
+}
+.wb-stat-value { font-size: var(--font-lg); color: var(--text); }
+.wb-stat-label { font-size: var(--font-xs); color: var(--text-mute); }
+.wb-sim-applied { font-size: var(--font-sm); margin: 0; }
+
+.wb-nonprom { font-size: var(--font-sm); }
+.wb-profile { display: flex; flex-direction: column; gap: var(--space-1); margin-top: var(--space-3); font-size: var(--font-sm); }
+.wb-profile .input { width: 100%; }

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -21,6 +21,10 @@ import type {
   TariffDashboardResponse,
   PeriodInsightsResponse,
   DaikinConsumptionResponse,
+  WorkbenchSchema,
+  WorkbenchSimulateResponse,
+  WorkbenchPromoteDiff,
+  WorkbenchPromoteResult,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -113,4 +117,28 @@ export async function applyBatch(
     headers,
   });
   return r.json() as Promise<ApplyBatchResponse>;
+}
+
+/* ----- Workbench (LP override editor) ----- */
+
+export const getWorkbenchSchema = () => getJson<WorkbenchSchema>("/workbench/schema");
+
+export const simulateWorkbench = (overrides: Record<string, unknown>) =>
+  postJson<WorkbenchSimulateResponse>("/workbench/simulate", { overrides });
+
+export const promoteSimulateWorkbench = (overrides: Record<string, unknown>) =>
+  postJson<WorkbenchPromoteDiff>("/workbench/promote/simulate", { overrides });
+
+export async function promoteWorkbench(
+  simulationId: string,
+  overrides: Record<string, unknown>,
+  profileName?: string,
+): Promise<WorkbenchPromoteResult> {
+  const headers = new Headers({ "Content-Type": "application/json", "X-Simulation-Id": simulationId });
+  const r = await hemFetch("/workbench/promote", {
+    method: "POST",
+    body: JSON.stringify({ overrides, profile_name: profileName }),
+    headers,
+  });
+  return r.json() as Promise<WorkbenchPromoteResult>;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -496,3 +496,63 @@ export interface MetricsResponse {
     standing_pence_per_day?: number | null;
   };
 }
+
+/* ----- /workbench (LP override editor) ----- */
+
+export interface WorkbenchField {
+  key: string;
+  config_attr: string;
+  type: string; // "float" | "int" | "str"
+  min?: number | null;
+  max?: number | null;
+  enum?: string[] | null;
+  description: string;
+  group: string;
+  promotable: boolean;
+  current: number | string | boolean | null;
+}
+
+export interface WorkbenchSchema {
+  groups: string[];
+  fields: WorkbenchField[];
+}
+
+export interface WorkbenchSimSlot {
+  t: string | null;
+  price_p: number | null;
+  import_kwh: number | null;
+  export_kwh: number | null;
+  battery_charge_kwh: number | null;
+  battery_discharge_kwh: number | null;
+  soc_kwh: number | null;
+}
+
+export interface WorkbenchSimulateResponse {
+  ok: boolean;
+  error?: string | null;
+  plan_date?: string | null;
+  objective_pence?: number | null;
+  status?: string | null;
+  slot_count?: number | null;
+  actual_mean_agile_pence?: number | null;
+  forecast_solar_kwh_horizon?: number | null;
+  mu_load_kwh_per_slot?: number | null;
+  applied_overrides: Record<string, unknown>;
+  ignored_overrides: Record<string, unknown>;
+  slots?: WorkbenchSimSlot[];
+}
+
+// ActionDiff shape from /workbench/promote/simulate. We render human_summary +
+// the non-promotable list; the detailed diff items vary, so keep them loose.
+export interface WorkbenchPromoteDiff {
+  simulation_id: string;
+  action?: string;
+  human_summary?: string;
+  non_promotable_overrides?: Record<string, unknown>;
+}
+
+export interface WorkbenchPromoteResult {
+  ok: boolean;
+  promoted: Array<{ key: string; ok: boolean; value?: unknown; error?: string }>;
+  profile_name?: string | null;
+}

--- a/ui/src/routes/workbench.tsx
+++ b/ui/src/routes/workbench.tsx
@@ -11,6 +11,7 @@ import { Spinner } from "../components/common/Spinner";
 import { NumberInput, Select } from "../components/common/Inputs";
 import { Modal } from "../components/common/Modal";
 import { Pill } from "../components/common/Pill";
+import { WorkbenchPlanChart } from "../components/workbench/WorkbenchPlanChart";
 import { toast } from "../lib/toast";
 import { gbp } from "../lib/format";
 import "../components/workbench/workbench.css";
@@ -206,6 +207,7 @@ function SimResult({ sim }: { sim: WorkbenchSimulateResponse }) {
         <Stat label="Mean load/slot" value={sim.mu_load_kwh_per_slot != null ? `${sim.mu_load_kwh_per_slot.toFixed(2)} kWh` : "—"} />
         <Stat label="Slots" value={String(sim.slot_count ?? "—")} />
       </div>
+      {sim.slots && sim.slots.length > 0 && <WorkbenchPlanChart slots={sim.slots} />}
       {applied.length > 0 && <p class="wb-sim-applied">Applied: <code>{applied.join(", ")}</code></p>}
       {ignored.length > 0 && <p class="muted">Ignored: {ignored.join(", ")}</p>}
     </div>

--- a/ui/src/routes/workbench.tsx
+++ b/ui/src/routes/workbench.tsx
@@ -1,0 +1,222 @@
+import { useState } from "preact/hooks";
+import { useFetch } from "../lib/poll";
+import {
+  getWorkbenchSchema,
+  simulateWorkbench,
+  promoteSimulateWorkbench,
+  promoteWorkbench,
+} from "../lib/endpoints";
+import type { WorkbenchField, WorkbenchSimulateResponse, WorkbenchPromoteDiff } from "../lib/types";
+import { Spinner } from "../components/common/Spinner";
+import { NumberInput, Select } from "../components/common/Inputs";
+import { Modal } from "../components/common/Modal";
+import { Pill } from "../components/common/Pill";
+import { toast } from "../lib/toast";
+import { gbp } from "../lib/format";
+import "../components/workbench/workbench.css";
+
+type OverrideVal = number | string;
+
+// Workbench — tune LP knobs, simulate the plan, promote the promotable subset
+// to prod (runtime_settings). Mirrors the backend /workbench/* flow. The load
+// knob (LP_LOAD_SCALE_FACTOR) is surfaced in its own group at the top.
+export default function Workbench() {
+  const schema = useFetch(getWorkbenchSchema, []);
+  const [overrides, setOverrides] = useState<Record<string, OverrideVal>>({});
+  const [sim, setSim] = useState<WorkbenchSimulateResponse | null>(null);
+  const [simBusy, setSimBusy] = useState(false);
+  const [diff, setDiff] = useState<WorkbenchPromoteDiff | null>(null);
+  const [promoteBusy, setPromoteBusy] = useState(false);
+  const [profileName, setProfileName] = useState("");
+
+  const dirty = Object.keys(overrides).length > 0;
+
+  const setVal = (key: string, v: OverrideVal) => setOverrides((o) => ({ ...o, [key]: v }));
+  const reset = () => { setOverrides({}); setSim(null); };
+
+  const runSimulate = async () => {
+    setSimBusy(true);
+    try {
+      setSim(await simulateWorkbench(overrides));
+    } catch (e) {
+      toast.error("Simulation failed", e instanceof Error ? e.message : String(e));
+    } finally {
+      setSimBusy(false);
+    }
+  };
+
+  const openPromote = async () => {
+    setPromoteBusy(true);
+    try {
+      setDiff(await promoteSimulateWorkbench(overrides));
+    } catch (e) {
+      toast.error("Nothing to promote", e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoteBusy(false);
+    }
+  };
+
+  const confirmPromote = async () => {
+    if (!diff) return;
+    setPromoteBusy(true);
+    try {
+      const res = await promoteWorkbench(diff.simulation_id, overrides, profileName.trim() || undefined);
+      const okCount = res.promoted.filter((p) => p.ok).length;
+      toast.success(`Promoted ${okCount} setting${okCount === 1 ? "" : "s"} to prod`);
+      setDiff(null);
+      setProfileName("");
+      reset();
+      schema.refresh();
+    } catch (e) {
+      toast.error("Promote failed", e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoteBusy(false);
+    }
+  };
+
+  if (schema.loading && !schema.data) {
+    return <div class="page-padded"><Spinner label="Loading workbench…" /></div>;
+  }
+  if (!schema.data) {
+    return (
+      <div class="page-padded">
+        <p class="muted">Workbench unavailable: {schema.error?.message || "no data"}</p>
+        <button class="btn" onClick={() => schema.refresh()}>Retry</button>
+      </div>
+    );
+  }
+
+  const fields = schema.data.fields;
+  // Render the load group first (the headline knob), then the rest in order.
+  const groupOrder = ["load", ...schema.data.groups.filter((g) => g !== "load")];
+  const byGroup = new Map<string, WorkbenchField[]>();
+  for (const f of fields) {
+    if (!byGroup.has(f.group)) byGroup.set(f.group, []);
+    byGroup.get(f.group)!.push(f);
+  }
+
+  return (
+    <div class="page-padded wb">
+      <header class="wb-head">
+        <h1>Workbench</h1>
+        <p class="muted">
+          Tune the LP planner, simulate the resulting plan, and promote the promotable
+          subset to production. Simulation never writes to hardware or the cloud.
+        </p>
+      </header>
+
+      {groupOrder.map((g) => {
+        const gf = byGroup.get(g);
+        if (!gf || !gf.length) return null;
+        return (
+          <section key={g} class={`wb-group${g === "load" ? " wb-group--load" : ""}`}>
+            <h2 class="wb-group-title">{g}</h2>
+            <div class="wb-fields">
+              {gf.map((f) => (
+                <FieldRow key={f.key} field={f}
+                          value={overrides[f.key] ?? (f.current as OverrideVal)}
+                          edited={overrides[f.key] !== undefined}
+                          onChange={(v) => setVal(f.key, v)} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+
+      <div class="wb-bar">
+        <span class="wb-bar-status">{dirty ? `${Object.keys(overrides).length} change(s)` : "no changes"}</span>
+        <div class="wb-bar-actions">
+          {dirty && <button class="btn btn--ghost" onClick={reset} disabled={simBusy || promoteBusy}>Reset</button>}
+          <button class="btn" onClick={runSimulate} disabled={!dirty || simBusy}>
+            {simBusy ? "Simulating…" : "Simulate"}
+          </button>
+          <button class="btn btn--primary" onClick={openPromote} disabled={!dirty || promoteBusy}>
+            Promote to prod…
+          </button>
+        </div>
+      </div>
+
+      {sim && <SimResult sim={sim} />}
+
+      <Modal open={diff != null} onClose={() => !promoteBusy && setDiff(null)} title="Promote to production" width="md"
+             footer={
+               <>
+                 <button class="btn btn--ghost" disabled={promoteBusy} onClick={() => setDiff(null)}>Cancel</button>
+                 <button class="btn btn--primary" disabled={promoteBusy} onClick={confirmPromote}>
+                   {promoteBusy ? "Promoting…" : "Confirm promote"}
+                 </button>
+               </>
+             }>
+        <p>{diff?.human_summary || "Promote the promotable overrides to runtime settings."}</p>
+        {diff?.non_promotable_overrides && Object.keys(diff.non_promotable_overrides).length > 0 && (
+          <p class="muted wb-nonprom">
+            Not promotable (simulation-only): {Object.keys(diff.non_promotable_overrides).join(", ")}
+          </p>
+        )}
+        <label class="wb-profile">
+          <span>Save as profile (optional)</span>
+          <input class="input" type="text" value={profileName} placeholder="e.g. away-week"
+                 onInput={(e) => setProfileName((e.currentTarget as HTMLInputElement).value)} />
+        </label>
+      </Modal>
+    </div>
+  );
+}
+
+function FieldRow({ field, value, edited, onChange }: {
+  field: WorkbenchField; value: OverrideVal; edited: boolean; onChange: (v: OverrideVal) => void;
+}) {
+  return (
+    <div class={`wb-field${edited ? " wb-field--edited" : ""}`}>
+      <div class="wb-field-head">
+        <code class="wb-field-key">{field.key}</code>
+        {field.promotable
+          ? <Pill tone="ok" title="Has a runtime_settings entry — can be promoted to prod">promotable</Pill>
+          : <Pill tone="dim" title="Simulation-only — no prod equivalent">sim-only</Pill>}
+        {edited && <Pill tone="warn">edited</Pill>}
+      </div>
+      <p class="wb-field-desc muted">{field.description}</p>
+      <div class="wb-field-input">
+        {field.enum
+          ? <Select value={String(value)} options={field.enum} onChange={(v) => onChange(v)} ariaLabel={field.key} />
+          : <NumberInput value={value} onChange={(n) => onChange(n)} min={field.min} max={field.max}
+                         step={field.type === "int" ? 1 : 0.1} ariaLabel={field.key} />}
+      </div>
+    </div>
+  );
+}
+
+function SimResult({ sim }: { sim: WorkbenchSimulateResponse }) {
+  if (!sim.ok) {
+    return <div class="wb-sim wb-sim--err"><strong>Simulation failed</strong><p class="muted">{sim.error || sim.status}</p></div>;
+  }
+  const obj = sim.objective_pence != null ? gbp(sim.objective_pence / 100) : "—";
+  const applied = Object.keys(sim.applied_overrides || {});
+  const ignored = Object.keys(sim.ignored_overrides || {});
+  return (
+    <div class="wb-sim">
+      <div class="wb-sim-head">
+        <span>Simulated plan</span>
+        <Pill tone={sim.status === "Optimal" ? "ok" : "warn"}>{sim.status}</Pill>
+      </div>
+      <div class="wb-sim-stats">
+        <Stat label="Objective" value={obj} hint="LP objective cost over the horizon" />
+        <Stat label="Mean Agile" value={sim.actual_mean_agile_pence != null ? `${sim.actual_mean_agile_pence.toFixed(1)}p` : "—"} />
+        <Stat label="Horizon solar" value={sim.forecast_solar_kwh_horizon != null ? `${sim.forecast_solar_kwh_horizon.toFixed(1)} kWh` : "—"} />
+        <Stat label="Mean load/slot" value={sim.mu_load_kwh_per_slot != null ? `${sim.mu_load_kwh_per_slot.toFixed(2)} kWh` : "—"} />
+        <Stat label="Slots" value={String(sim.slot_count ?? "—")} />
+      </div>
+      {applied.length > 0 && <p class="wb-sim-applied">Applied: <code>{applied.join(", ")}</code></p>}
+      {ignored.length > 0 && <p class="muted">Ignored: {ignored.join(", ")}</p>}
+    </div>
+  );
+}
+
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div class="wb-stat" title={hint}>
+      <div class="wb-stat-value">{value}</div>
+      <div class="wb-stat-label">{label}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Context
Phase **P4** (final) of the UI UX review. The user wanted to **fine-tune the LP by adding/reducing the load forecast**, and the existing `/workbench/*` backend (simulate→diff→promote) had **no UI**.

## Backend — `LP_LOAD_SCALE_FACTOR` (default 1.0, range 0.5–2.0)
Operator multiplier on the residual house-load profile the LP plans against (lower when away, higher for guests). Applied in **both** base-load builders so the nightly plan *and* the Workbench Simulate reflect it:
- `optimizer.py:_run_optimizer_lp` — `base_load.append(v * scale)` before appliance loads.
- `lp_simulation.py:_build_load_profile` — the path the Workbench `/simulate` uses.

`1.0` is a **bit-identical no-op** (`v*1.0`), so the LP regression baseline is unaffected. Wired through `config` (`@property`), `runtime_settings.SCHEMA`, `lp_overrides.WHITELIST` (new **load** group, `promotable=True`), and `/optimization/inputs` (debug view matches the plan).

## Frontend — Workbench tab
New lazy route + nav tab. Reads `/workbench/schema`, edits overrides grouped by `group` (load knob surfaced first), with two flows:
- **Simulate** → `/workbench/simulate` → plan summary card (objective £, status, mean Agile, horizon solar, mean load/slot, applied/ignored overrides). No hardware/cloud writes.
- **Promote** → `/workbench/promote/simulate` (diff + `simulation_id`) → confirm modal → `/workbench/promote` with `X-Simulation-Id`; optional profile save.

## Verification
- `pytest tests/test_lp_load_scale.py` (knob registration, range guard, **both** `/optimization/inputs` and the `run_lp_simulation` path scale; 1.0 no-op) + `tests/api/test_workbench.py` + `test_runtime_settings.py` green.
- `npx tsc -b --noEmit` + `vite build` clean (Workbench is its own 5.4 kB lazy chunk).
- Independent Plan-agent review caught a **HIGH**: `run_lp_simulation` built base load via a separate helper that ignored the scale → the knob was **inert in the UI that ships it**. Fixed in both paths + added a simulate-path test (the original test only covered `/optimization/inputs`, masking it). No-op bit-identity, no scenario double-scaling, and the promote `X-Simulation-Id` flow all confirmed.

## Phase series complete
P1 #428 (tariff flash) · P2 #429 (unified plan chart + PV planned/realised) · P3 #430 (heating controls) · **P4 (this)**. All branch off `feat/ui-rebuild-vite-preact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)