### PR TITLE
feat(ui): UX improvements P1–P4 (integration)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -117,6 +117,7 @@ from .models import (
 from .routers import appliances as appliances_router
 from .routers import dispatch as dispatch_router
 from .routers import energy_providers as energy_providers_router
+from .routers import pv as pv_router
 from .routers import workbench as workbench_router
 
 
@@ -282,6 +283,7 @@ app.include_router(energy_providers_router.router)
 app.include_router(workbench_router.router)
 app.include_router(dispatch_router.router)
 app.include_router(appliances_router.router)
+app.include_router(pv_router.router)
 
 # Mount the FastMCP streamable-HTTP transport at /mcp, guarded by a bearer
 # token. Replaces the legacy stdio subprocess (`bin/mcp`) for OpenClaw in

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1168,6 +1168,9 @@ async def optimization_inputs(horizon_hours: int | None = None):
         flat = fox_mean if fox_mean is not None else db.mean_consumption_kwh_from_execution_logs(limit=profile_limit)
     except Exception:
         flat = 0.4
+    # Operator load scale — mirrors the multiplier the optimizer applies to the
+    # residual profile, so this view matches the plan (no-op at default 1.0).
+    _load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
 
     # --- Initial state (quota-safe: no Daikin refresh) ----------------------
     try:
@@ -1293,7 +1296,9 @@ async def optimization_inputs(horizon_hours: int | None = None):
             hr_local = t.hour
             min_local = 30 if t.minute >= 30 else 0
         # S10.8 (#175): half-hour bucket lookup; falls back to flat mean.
-        bl = float(load_profile.get((hr_local, min_local), flat))
+        # Apply the operator load scale so this debug view matches what the LP
+        # actually plans against (no-op at the default 1.0).
+        bl = float(load_profile.get((hr_local, min_local), flat)) * _load_scale
         slots_out.append({
             "t_utc": iso.replace("+00:00", "Z"),
             "price_import_p": price_i,

--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -1,0 +1,181 @@
+"""PV planned-vs-realised endpoint.
+
+``GET /api/v1/pv/today`` returns, per 30-min UTC slot for the day, the
+*planned* PV (the calibrated forecast the LP plans against) and the *realised*
+PV (trapezoidal roll-up of ``pv_realtime_history.solar_power_kw``), plus a
+running accuracy summary over the slots already elapsed. Powers the Home
+"Today's plan" overlay (planned vs realised solar). Read-only, SQLite +
+forecast cache only — no cloud writes.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException
+
+from ... import db
+from ...config import config
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["pv"])
+
+_SLOTS_PER_DAY = 48  # 30-min slots
+_SLOT_MINUTES = 30
+
+
+def _iso_z(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _norm_z(iso: str) -> str:
+    """Normalise any UTC ISO string to the ``...Z`` form used as the slot key."""
+    try:
+        return _iso_z(datetime.fromisoformat(iso.replace("Z", "+00:00")))
+    except (ValueError, TypeError):
+        return iso
+
+
+@router.get("/api/v1/pv/today")
+async def get_pv_today(date: str | None = None) -> dict[str, Any]:
+    """Per-slot planned (forecast) vs realised PV for the UTC calendar day.
+
+    Query params:
+      * ``date`` — optional ``YYYY-MM-DD`` (UTC day). Defaults to today UTC.
+
+    Response:
+      * ``date`` — the UTC day rendered.
+      * ``now_utc`` — server time (the boundary between realised and future).
+      * ``slots[]`` — one per 30-min slot: ``{slot_utc, pv_forecast_kwh,
+        pv_actual_kwh}``. ``pv_actual_kwh`` is ``null`` for future slots (and
+        for past slots with no telemetry) so the UI doesn't plot a zero.
+      * ``accuracy`` — over elapsed slots: ``{slots_compared, forecast_kwh,
+        actual_kwh, mae_kwh, bias_kwh}`` (bias = actual − forecast; positive =
+        forecast under-predicted). ``null`` when nothing has elapsed yet.
+      * ``forecast_kwh_day_total`` — full-day forecast sum (kWh).
+    """
+    # Resolve the target UTC day (mirrors /api/v1/execution/today).
+    if date:
+        try:
+            d = _date_from_iso(date)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="date must be YYYY-MM-DD")
+    else:
+        d = datetime.now(UTC).date()
+
+    day_start = datetime(d.year, d.month, d.day, tzinfo=UTC)
+    slot_starts = [day_start + timedelta(minutes=_SLOT_MINUTES * i) for i in range(_SLOTS_PER_DAY)]
+    now = datetime.now(UTC)
+
+    # --- Planned PV: the LP's exact forecast→kWh conversion (calibration
+    # tables + W/m²→kW + 0.5h), so the planned line matches what the optimizer
+    # plans against. Default pv_scale (no today-factor) — this is the
+    # calibrated forecast, not a post-hoc re-fit.
+    forecast_kwh: list[float] = [0.0] * _SLOTS_PER_DAY
+    try:
+        from ... import weather
+
+        fc = weather.fetch_forecast(hours=48)
+        series = weather.forecast_to_lp_inputs(fc, slot_starts)
+        pv = series.pv_kwh_per_slot
+        for i in range(min(_SLOTS_PER_DAY, len(pv))):
+            forecast_kwh[i] = round(float(pv[i]), 4)
+    except Exception as e:  # forecast provider down / no cache — degrade gracefully
+        logger.warning("pv/today: forecast unavailable (%s); planned line will be zero", e)
+
+    # --- Realised PV: trapezoidal roll-up of pv_realtime_history (same helper
+    # the PnL export valuation uses), keyed by UTC half-hour slot ISO.
+    try:
+        actual_map = db.half_hourly_solar_kwh_for_day(d)
+    except Exception as e:
+        logger.warning("pv/today: realised roll-up failed (%s)", e)
+        actual_map = {}
+
+    # --- Full-day overlays so the chart needs only this one endpoint (no
+    # client-side key-matching across differently-formatted ISO strings):
+    #   import price (Agile, per slot), residual load forecast (per slot),
+    #   and the dispatch kind (charge/discharge classification per slot).
+    price_by_start: dict[str, float] = {}
+    try:
+        tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+        if tariff:
+            for r in db.get_rates_for_period(tariff, day_start, day_start + timedelta(days=1)):
+                price_by_start[_norm_z(r["valid_from"])] = float(r["value_inc_vat"])
+    except Exception as e:
+        logger.warning("pv/today: import-rate lookup failed (%s)", e)
+
+    load_profile: dict[tuple[int, int], float] = {}
+    try:
+        load_profile = db.half_hourly_residual_load_profile_kwh()
+    except Exception as e:
+        logger.warning("pv/today: load profile failed (%s)", e)
+    try:
+        tz = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
+    except Exception:
+        tz = UTC  # type: ignore[assignment]
+
+    kind_by: dict[str, str] = {}
+    try:
+        rid = db.find_latest_optimizer_run_id()
+        if rid is not None:
+            for dec in db.get_dispatch_decisions(rid):
+                k = dec.get("dispatched_kind") or dec.get("lp_kind")
+                stu = dec.get("slot_time_utc")
+                if k and stu:
+                    kind_by[_norm_z(stu)] = k
+    except Exception as e:
+        logger.warning("pv/today: dispatch kinds failed (%s)", e)
+
+    slots_out: list[dict[str, Any]] = []
+    acc_f = acc_a = 0.0
+    acc_abs = 0.0
+    compared = 0
+    for i, st in enumerate(slot_starts):
+        key = _iso_z(st)
+        f = forecast_kwh[i]
+        slot_end = st + timedelta(minutes=_SLOT_MINUTES)
+        elapsed = slot_end <= now
+        # Realised only exists for elapsed slots with telemetry; future slots
+        # (and gaps) stay null so the chart draws a clean planned-only line.
+        a_raw = actual_map.get(key)
+        a: float | None = round(float(a_raw), 4) if (elapsed and a_raw is not None) else None
+        local = st.astimezone(tz)
+        bl = load_profile.get((local.hour, local.minute))
+        slots_out.append({
+            "slot_utc": key,
+            "pv_forecast_kwh": f,
+            "pv_actual_kwh": a,
+            "import_price_p": price_by_start.get(key),
+            "base_load_kwh": round(float(bl), 4) if bl is not None else None,
+            "kind": kind_by.get(key),
+        })
+        if elapsed and a is not None:
+            compared += 1
+            acc_f += f
+            acc_a += a
+            acc_abs += abs(a - f)
+
+    accuracy: dict[str, Any] | None = None
+    if compared > 0:
+        accuracy = {
+            "slots_compared": compared,
+            "forecast_kwh": round(acc_f, 3),
+            "actual_kwh": round(acc_a, 3),
+            "mae_kwh": round(acc_abs / compared, 4),
+            "bias_kwh": round(acc_a - acc_f, 3),  # +ve = forecast under-predicted
+        }
+
+    return {
+        "date": d.isoformat(),
+        "now_utc": _iso_z(now),
+        "slots": slots_out,
+        "accuracy": accuracy,
+        "forecast_kwh_day_total": round(sum(forecast_kwh), 3),
+    }
+
+
+def _date_from_iso(s: str) -> date:
+    return date.fromisoformat(s)

--- a/src/api/routers/workbench.py
+++ b/src/api/routers/workbench.py
@@ -59,7 +59,7 @@ def _profile_path(name: str) -> Path:
 async def workbench_schema():
     """Return the override whitelist with metadata for the editor."""
     return {
-        "groups": ["comfort", "battery", "hardware", "penalty", "solver", "schedule", "mode"],
+        "groups": ["comfort", "battery", "hardware", "penalty", "solver", "schedule", "mode", "load"],
         "fields": lp_overrides.schema_for_response(),
     }
 

--- a/src/config.py
+++ b/src/config.py
@@ -1215,6 +1215,14 @@ class Config:
     def LP_SOC_FINAL_KWH(self, value: float) -> None:
         self._rt_set("LP_SOC_FINAL_KWH", float(value))
 
+    @property
+    def LP_LOAD_SCALE_FACTOR(self) -> float:
+        return float(self._rt_get("LP_LOAD_SCALE_FACTOR"))
+
+    @LP_LOAD_SCALE_FACTOR.setter
+    def LP_LOAD_SCALE_FACTOR(self, value: float) -> None:
+        self._rt_set("LP_LOAD_SCALE_FACTOR", float(value))
+
     # --- PR B — shower demand model -------------------------------------
     @property
     def DHW_SHOWER_DURATION_MIN(self) -> float:

--- a/src/db.py
+++ b/src/db.py
@@ -3072,7 +3072,7 @@ def _half_hourly_grid_kwh_for_day(
 ) -> dict[str, float]:
     """Shared trapezoidal-integration over ``pv_realtime_history.<column>`` for
     ``day``, keyed by ISO half-hour slot start (UTC). ``column`` must be one of
-    ``grid_export_kw`` / ``grid_import_kw`` (caller-vetted).
+    ``grid_export_kw`` / ``grid_import_kw`` / ``solar_power_kw`` (caller-vetted).
 
     Each sample-pair's energy is assigned to the bucket containing the EARLIER
     sample (matching :func:`compute_fox_energy_daily_from_realtime`). Slots with
@@ -3082,7 +3082,7 @@ def _half_hourly_grid_kwh_for_day(
     from collections import defaultdict
     from datetime import datetime as _dt
 
-    if column not in ("grid_export_kw", "grid_import_kw"):
+    if column not in ("grid_export_kw", "grid_import_kw", "solar_power_kw"):
         raise ValueError(f"unsupported column: {column}")
 
     day_iso = day.isoformat()
@@ -3156,6 +3156,21 @@ def half_hourly_grid_export_kwh_for_day(
     Octopus Outgoing rates (issue #207).
     """
     return _half_hourly_grid_kwh_for_day(day, "grid_export_kw", max_gap_seconds=max_gap_seconds)
+
+
+def half_hourly_solar_kwh_for_day(
+    day: date,
+    *,
+    max_gap_seconds: int = 1800,
+) -> dict[str, float]:
+    """Per-slot realised solar (PV generation) kWh for ``day``, keyed by ISO
+    half-hour slot start (UTC).
+
+    Trapezoidal integration of ``pv_realtime_history.solar_power_kw``. See
+    :func:`_half_hourly_grid_kwh_for_day` for mechanics. Powers the
+    ``GET /api/v1/pv/today`` planned-vs-realised overlay.
+    """
+    return _half_hourly_grid_kwh_for_day(day, "solar_power_kw", max_gap_seconds=max_gap_seconds)
 
 
 def half_hourly_grid_import_kwh_for_day(

--- a/src/runtime_settings.py
+++ b/src/runtime_settings.py
@@ -435,6 +435,21 @@ SCHEMA: dict[str, SettingSpec] = {
             "BATTERY_CAPACITY_KWH."
         ),
     ),
+    "LP_LOAD_SCALE_FACTOR": SettingSpec(
+        key="LP_LOAD_SCALE_FACTOR",
+        type_name="float",
+        env_default=_float_env("LP_LOAD_SCALE_FACTOR", "1.0"),
+        min_value=0.5,
+        max_value=2.0,
+        description=(
+            "Operator multiplier on the residual house-load forecast the LP "
+            "plans against. 1.0 = as-measured (default, no-op). Nudge down "
+            "(e.g. 0.7 when away) or up (e.g. 1.3 for guests) to shift the "
+            "plan's demand assumption without re-learning the profile. Applies "
+            "to the residual profile only — explicit appliance loads are "
+            "unaffected."
+        ),
+    ),
     # Legionella thermal-shock awareness. The Daikin Onecta firmware fires the
     # cycle autonomously on a user-configured day/hour (set in the Onecta app);
     # the LP cannot command it. These knobs let the LP *predict* the resulting

--- a/src/scheduler/lp_overrides.py
+++ b/src/scheduler/lp_overrides.py
@@ -257,6 +257,19 @@ WHITELIST: dict[str, OverrideSpec] = {
         description="passive = firmware autonomous (LP load-follows HP); active = LP schedules tank + LWT.",
         group="mode", promotable=True,
     ),
+    # --- Load forecast
+    "LP_LOAD_SCALE_FACTOR": OverrideSpec(
+        key="LP_LOAD_SCALE_FACTOR",
+        config_attr="LP_LOAD_SCALE_FACTOR",
+        type_name="float", min_value=0.5, max_value=2.0,
+        description=(
+            "Multiplier on the residual house-load forecast the LP plans "
+            "against. 1.0 = as-measured. Lower when away, raise for guests — "
+            "shifts the plan's demand assumption without re-learning the "
+            "profile. Appliance loads are unaffected."
+        ),
+        group="load", promotable=True,
+    ),
 }
 
 

--- a/src/scheduler/lp_simulation.py
+++ b/src/scheduler/lp_simulation.py
@@ -58,11 +58,14 @@ def _build_load_profile(slot_starts_utc: list[datetime]) -> list[float]:
     flat_from_log = db.mean_consumption_kwh_from_execution_logs(limit=limit)
     fox_mean = db.mean_fox_load_kwh_per_slot(limit=60)
     flat = fox_mean if fox_mean is not None else flat_from_log
+    # Operator load scale — mirror _run_optimizer_lp so the Workbench Simulate
+    # actually reflects LP_LOAD_SCALE_FACTOR (no-op at the default 1.0).
+    load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
     out: list[float] = []
     for s in slot_starts_utc:
         local = s.astimezone(ZoneInfo(config.BULLETPROOF_TIMEZONE))
         bucket = (local.hour, 30 if local.minute >= 30 else 0)
-        out.append(profile.get(bucket, flat))
+        out.append(profile.get(bucket, flat) * load_scale)
     return out
 
 

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1350,6 +1350,13 @@ def _run_optimizer_lp(
             return "peak"
         return "standard"
 
+    # Operator load-forecast scale (workbench/runtime-tunable). Multiplies the
+    # residual house-load profile so the user can nudge the plan's demand
+    # assumption up/down (e.g. "we'll be away → 0.7", "guests → 1.3"). Default
+    # 1.0 is a bit-identical no-op (v * 1.0 == v), so the LP regression
+    # baseline is unaffected. Applies to the residual profile only — explicit
+    # appliance dispatch loads (below) are added at their true kWh.
+    _load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
     base_load = []
     for s in slots:
         _local = s.start_utc.astimezone(tz)
@@ -1359,7 +1366,9 @@ def _run_optimizer_lp(
         v = _load_profile.get((_hm[0], _hm[1], _kind))
         if v is None:
             v = _load_profile.get(_hm, _flat)
-        base_load.append(v)
+        base_load.append(v * _load_scale)
+    if _load_scale != 1.0:
+        logger.info("LP base_load: operator load scale %.2f applied to residual profile", _load_scale)
     residual_base_load = list(base_load)
     appliance_profile_kwh = [0.0] * len(base_load)
 

--- a/tests/test_lp_load_scale.py
+++ b/tests/test_lp_load_scale.py
@@ -1,0 +1,85 @@
+"""LP_LOAD_SCALE_FACTOR — operator load-forecast multiplier.
+
+Covers the runtime-tunable knob wiring (config / SCHEMA / workbench whitelist)
+and that /optimization/inputs reflects the scale (no-op at 1.0).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src import db, runtime_settings as rts
+from src.config import config
+from src.scheduler import lp_overrides
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db.config, "DB_PATH", str(db_path))
+    db.init_db()
+    rts.clear_cache()
+    config._overrides.clear()
+    yield db_path
+    rts.clear_cache()
+    config._overrides.clear()
+
+
+def test_knob_is_registered_everywhere():
+    assert "LP_LOAD_SCALE_FACTOR" in rts.SCHEMA
+    assert "LP_LOAD_SCALE_FACTOR" in lp_overrides.WHITELIST
+    assert "LP_LOAD_SCALE_FACTOR" in lp_overrides.promotable_keys()
+    # New "load" group surfaces for the workbench UI.
+    assert any(s.group == "load" for s in lp_overrides.WHITELIST.values())
+
+
+def test_default_is_one_and_round_trips():
+    assert config.LP_LOAD_SCALE_FACTOR == 1.0
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.3)
+    assert config.LP_LOAD_SCALE_FACTOR == 1.3
+    # Range guard 0.5..2.0
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("LP_LOAD_SCALE_FACTOR", 0.1)
+    with pytest.raises(rts.SettingValidationError):
+        rts.set_setting("LP_LOAD_SCALE_FACTOR", 3.0)
+
+
+def _base_loads_from_inputs() -> list[float]:
+    from src.api.main import optimization_inputs
+    resp = asyncio.run(optimization_inputs())
+    return [s["base_load_kwh"] for s in resp["slots"] if s["base_load_kwh"] is not None]
+
+
+def test_optimization_inputs_scales_base_load(monkeypatch):
+    # Constant residual profile so the scale is unambiguous.
+    profile = {(h, m): 0.5 for h in range(24) for m in (0, 30)}
+    monkeypatch.setattr(db, "half_hourly_residual_load_profile_kwh", lambda *a, **k: profile)
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.0)
+    base = _base_loads_from_inputs()
+    assert base, "expected slots from /optimization/inputs"
+    assert all(abs(v - 0.5) < 1e-6 for v in base), "1.0 must be a no-op"
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 2.0)
+    scaled = _base_loads_from_inputs()
+    assert all(abs(v - 1.0) < 1e-6 for v in scaled), "2.0 must double the residual load"
+
+
+def test_simulation_load_builder_scales(monkeypatch):
+    """The Workbench Simulate path (run_lp_simulation → _build_load_profile)
+    MUST honour the scale, else the headline knob is inert in the UI."""
+    from datetime import UTC, datetime, timedelta
+    from src.scheduler import lp_simulation
+
+    profile = {(h, m): 0.5 for h in range(24) for m in (0, 30)}
+    monkeypatch.setattr(db, "half_hourly_residual_load_profile_kwh", lambda *a, **k: profile)
+    starts = [datetime(2026, 6, 1, 0, 0, tzinfo=UTC) + timedelta(minutes=30 * i) for i in range(8)]
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.0)
+    base = lp_simulation._build_load_profile(starts)
+    assert all(abs(v - 0.5) < 1e-6 for v in base), "1.0 no-op"
+
+    rts.set_setting("LP_LOAD_SCALE_FACTOR", 1.5)
+    scaled = lp_simulation._build_load_profile(starts)
+    assert all(abs(v - 0.75) < 1e-6 for v in scaled), "1.5 must scale the simulate base load"

--- a/tests/test_pv_today_endpoint.py
+++ b/tests/test_pv_today_endpoint.py
@@ -1,0 +1,83 @@
+"""GET /api/v1/pv/today — planned-vs-realised PV roll-up + accuracy."""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.api.routers import pv as pv_router
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db.config, "DB_PATH", str(db_path))
+    db.init_db()
+    # No network / forecast provider in tests — degrade planned line to zero
+    # so the test isolates the realised roll-up + accuracy maths.
+    import src.weather as weather
+    monkeypatch.setattr(weather, "fetch_forecast", lambda hours=48: [])
+    yield db_path
+
+
+def _seed_constant_solar(day, hour_utc: int, kw: float, *, minutes=(0, 15, 30, 45, 60)):
+    """Insert constant-kW solar samples across one hour of ``day`` (UTC)."""
+    for m in minutes:
+        ts = datetime(day.year, day.month, day.day, hour_utc, 0, tzinfo=UTC) + timedelta(minutes=m)
+        db.save_pv_realtime_sample(
+            ts.isoformat().replace("+00:00", "Z"),
+            solar_power_kw=kw,
+            source="test",
+        )
+
+
+def test_solar_rollup_integrates_to_kwh():
+    day = (datetime.now(UTC) - timedelta(days=1)).date()
+    _seed_constant_solar(day, 10, 3.0)  # 3 kW held for one hour → ~3 kWh
+    rollup = db.half_hourly_solar_kwh_for_day(day)
+    total = sum(rollup.values())
+    assert 2.5 <= total <= 3.5, f"expected ~3 kWh integrated, got {total}"
+
+
+def test_pv_today_shape_and_accuracy():
+    day = (datetime.now(UTC) - timedelta(days=1)).date()  # fully elapsed
+    _seed_constant_solar(day, 10, 3.0)
+
+    resp = asyncio.run(pv_router.get_pv_today(date=day.isoformat()))
+
+    assert resp["date"] == day.isoformat()
+    assert len(resp["slots"]) == 48
+    # Every slot carries the full overlay key set; forecast is 0 (no provider
+    # in test); price/load/kind are null (no rates/profile/runs seeded).
+    expected_keys = {"slot_utc", "pv_forecast_kwh", "pv_actual_kwh", "import_price_p", "base_load_kwh", "kind"}
+    assert all(set(s) == expected_keys for s in resp["slots"])
+    assert all(s["pv_forecast_kwh"] == 0.0 for s in resp["slots"])
+
+    realised = [s["pv_actual_kwh"] for s in resp["slots"] if s["pv_actual_kwh"] is not None]
+    assert realised, "expected at least one slot with realised PV"
+    assert 2.5 <= sum(realised) <= 3.5
+
+    acc = resp["accuracy"]
+    assert acc is not None
+    assert acc["slots_compared"] >= 1
+    assert acc["forecast_kwh"] == 0.0
+    assert 2.5 <= acc["actual_kwh"] <= 3.5
+    # Forecast is zero, so bias (actual − forecast) == realised total, and MAE
+    # is the mean realised kWh per compared slot.
+    assert acc["bias_kwh"] == pytest.approx(acc["actual_kwh"], abs=1e-6)
+
+
+def test_pv_today_future_day_has_no_realised():
+    day = (datetime.now(UTC) + timedelta(days=1)).date()  # all slots in the future
+    resp = asyncio.run(pv_router.get_pv_today(date=day.isoformat()))
+    assert len(resp["slots"]) == 48
+    assert all(s["pv_actual_kwh"] is None for s in resp["slots"])
+    assert resp["accuracy"] is None
+
+
+def test_pv_today_rejects_bad_date():
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException):
+        asyncio.run(pv_router.get_pv_today(date="not-a-date"))

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -11,6 +11,7 @@ import Landing from "./routes/landing";
 // here means a visitor who never opens /plan never downloads echarts.
 const Plan = lazy(() => import("./routes/plan"));
 const Settings = lazy(() => import("./routes/settings"));
+const Workbench = lazy(() => import("./routes/workbench"));
 
 export function App() {
   return (
@@ -22,6 +23,7 @@ export function App() {
             <Route path="/" component={Landing} />
             <Route path="/plan" component={Plan} />
             <Route path="/settings" component={Settings} />
+            <Route path="/workbench" component={Workbench} />
             <Route>
               <div class="page-padded">
                 <h1>Not found</h1>

--- a/ui/src/components/common/inputs.css
+++ b/ui/src/components/common/inputs.css
@@ -164,3 +164,7 @@
 .btn--ghost {
   background: transparent;
 }
+.btn--sm {
+  padding: 4px 10px;
+  font-size: var(--font-sm);
+}

--- a/ui/src/components/home/HeatingControls.tsx
+++ b/ui/src/components/home/HeatingControls.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "preact/hooks";
+import type { DaikinDevice, DaikinOperationMode, ActionResult } from "../../lib/types";
+import { setTankTemperature, setTankPower, setLwtOffset, setDaikinMode } from "../../lib/endpoints";
+import { NumberInput, Select, Toggle } from "../common/Inputs";
+import { Modal } from "../common/Modal";
+import { toast } from "../../lib/toast";
+
+interface HeatingControlsProps {
+  dev: DaikinDevice | null;
+  onChanged: () => void;
+}
+
+interface PendingAction {
+  label: string;
+  run: () => Promise<ActionResult>;
+}
+
+const MODES: DaikinOperationMode[] = ["heating", "cooling", "auto", "fan_only", "dry"];
+
+// Manual Daikin controls (tank target / DHW power / LWT offset / mode). All
+// writes are gated server-side by DAIKIN_CONTROL_MODE=active; when passive the
+// panel renders disabled with an explanation. Each write is confirmed in a
+// modal first, then sent with skip_confirmation:true.
+export function HeatingControls({ dev, onChanged }: HeatingControlsProps) {
+  const active = dev?.control_mode === "active";
+  const [tankTarget, setTankTarget] = useState<number>(dev?.tank_target ?? 45);
+  const [lwt, setLwt] = useState<number>(dev?.lwt_offset ?? 0);
+  const [pending, setPending] = useState<PendingAction | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Re-sync the editable fields when the device's confirmed values change
+  // (e.g. after a successful write refreshes status, or the optimizer writes
+  // externally). Daikin status is fetch-once (not polled), so this never
+  // clobbers mid-typing during normal use.
+  useEffect(() => {
+    if (dev?.tank_target != null) setTankTarget(dev.tank_target);
+  }, [dev?.tank_target]);
+  useEffect(() => {
+    if (dev?.lwt_offset != null) setLwt(dev.lwt_offset);
+  }, [dev?.lwt_offset]);
+
+  const confirm = (label: string, run: () => Promise<ActionResult>) => setPending({ label, run });
+
+  const runPending = async () => {
+    if (!pending) return;
+    setBusy(true);
+    try {
+      const res = await pending.run();
+      toast.success(res.message || "Done");
+      onChanged();
+    } catch (e) {
+      toast.error("Daikin command failed", e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+      setPending(null);
+    }
+  };
+
+  const dhwOn = dev?.tank_power ?? false;
+  const mode = (dev?.mode as DaikinOperationMode) || "heating";
+  // If the device reports a mode outside the known union, surface it as an
+  // extra option so the Select shows the real state instead of a blank.
+  const modeOptions: DaikinOperationMode[] = MODES.includes(mode) ? MODES : [...MODES, mode];
+
+  return (
+    <div class="heating-controls">
+      <div class="heating-controls-head">
+        <span class="heating-controls-title">Controls</span>
+        {dev && !active && (
+          <span class="heating-controls-passive" title="HEM is in passive mode — it observes Daikin but never writes. Set DAIKIN_CONTROL_MODE to active in Settings to drive the heat pump from here.">
+            passive · read-only
+          </span>
+        )}
+      </div>
+
+      <div class="heating-control-row">
+        <label class="heating-control-label">Tank target</label>
+        <NumberInput value={tankTarget} onChange={setTankTarget} min={30} max={65} step={1} ariaLabel="Tank target °C" />
+        <button class="btn btn--sm" disabled={!active || busy}
+                onClick={() => confirm(`Set DHW tank target to ${tankTarget}°C?`, () => setTankTemperature(tankTarget))}>
+          Set
+        </button>
+      </div>
+
+      <div class="heating-control-row">
+        <label class="heating-control-label">DHW power</label>
+        <Toggle value={dhwOn} ariaLabel="DHW power"
+                onChange={(next) => active && confirm(`Turn DHW tank ${next ? "ON" : "OFF"}?`, () => setTankPower(next))} />
+        <span class="heating-control-state">{dhwOn ? "ON" : "OFF"}</span>
+      </div>
+
+      <div class="heating-control-row">
+        <label class="heating-control-label">LWT offset</label>
+        <NumberInput value={lwt} onChange={setLwt} min={-10} max={10} step={0.5} ariaLabel="LWT offset" />
+        <button class="btn btn--sm" disabled={!active || busy}
+                onClick={() => confirm(`Set leaving-water offset to ${lwt >= 0 ? "+" : ""}${lwt}?`, () => setLwtOffset(lwt))}>
+          Set
+        </button>
+      </div>
+
+      <div class="heating-control-row">
+        <label class="heating-control-label">Mode</label>
+        <Select<DaikinOperationMode> value={mode} options={modeOptions} ariaLabel="Operation mode"
+                onChange={(m) => active && m !== mode && confirm(`Set Daikin mode to ${m}?`, () => setDaikinMode(m))} />
+      </div>
+
+      <Modal open={pending != null} onClose={() => !busy && setPending(null)} title="Confirm Daikin command" width="sm"
+             footer={
+               <>
+                 <button class="btn btn--ghost" disabled={busy} onClick={() => setPending(null)}>Cancel</button>
+                 <button class="btn btn--primary" disabled={busy} onClick={runPending}>{busy ? "Sending…" : "Confirm"}</button>
+               </>
+             }>
+        <p>{pending?.label}</p>
+        <p class="muted heating-controls-hint">This writes directly to the heat pump via Onecta.</p>
+      </Modal>
+    </div>
+  );
+}

--- a/ui/src/components/home/HeatingWidget.tsx
+++ b/ui/src/components/home/HeatingWidget.tsx
@@ -9,6 +9,7 @@ import type {
 } from "../../lib/types";
 import { tempC, kwh, relTime } from "../../lib/format";
 import { Pill } from "../common/Pill";
+import { HeatingControls } from "./HeatingControls";
 import "./heating.css";
 
 interface HeatingWidgetProps {
@@ -18,13 +19,15 @@ interface HeatingWidgetProps {
   report: EnergyReport | null;
   weather: WeatherResponse | null;
   execution: ExecutionTodayResponse | null;
+  // Re-fetch Daikin status + quota after a manual control write.
+  onRefresh?: () => void;
 }
 
 // Tank / outdoor / LWT + Daikin mode + cache freshness + quota.
 // Outdoor temp + LWT now prefer /execution/today (logged Daikin readings,
 // no live API call) over the cached /daikin/status — same data freshness,
 // zero quota cost.
-export function HeatingWidget({ state, daikin, daikinQuota, report, weather, execution }: HeatingWidgetProps) {
+export function HeatingWidget({ state, daikin, daikinQuota, report, weather, execution, onRefresh }: HeatingWidgetProps) {
   const dev = daikin && daikin.length > 0 ? daikin[0] : null;
   // No cooling on this system — only heating + DHW. We surface compressor
   // status via the tank/space rows themselves (ON/OFF), not a "mode" chip.
@@ -143,6 +146,8 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
           </div>
         </div>
       )}
+
+      <HeatingControls dev={dev} onChanged={() => onRefresh?.()} />
     </div>
   );
 }

--- a/ui/src/components/home/TariffComparisonWidget.tsx
+++ b/ui/src/components/home/TariffComparisonWidget.tsx
@@ -14,6 +14,12 @@ interface TariffComparisonWidgetProps {
   // (from /energy/period) bills measured grid import at the half-hourly
   // Agile rate per slot — the actual money out the door.
   monthPeriod: PeriodInsightsResponse | null;
+  // Whether the /energy/period fetch that feeds `monthPeriod` is still
+  // in-flight. The dashboard and monthPeriod are independent fetches: if the
+  // dashboard lands first we must NOT render the current tariff's projected
+  // total — it would flash a wrong (over-stated) number until the realised
+  // cost arrives and overwrites it. Hold the skeleton until BOTH have settled.
+  monthPeriodLoading: boolean;
 }
 
 // Default SEG floor used when a fixed-tariff doesn't expose its own outgoing
@@ -30,8 +36,10 @@ const SEG_EXPORT_FALLBACK_P = 4.0;
 // BG Fixed v58 row is computed client-side using the same real-usage block
 // + the configured FIXED_TARIFF_* rates from /metrics. No annual-from-daily
 // extrapolation; pure replay over the same window as the Octopus rows.
-export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, monthPeriod }: TariffComparisonWidgetProps) {
-  if (dashboardLoading) {
+export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, monthPeriod, monthPeriodLoading }: TariffComparisonWidgetProps) {
+  // Gate on BOTH fetches: the current tariff's realised total comes from
+  // monthPeriod, so rendering before it settles flashes the projected number.
+  if (dashboardLoading || monthPeriodLoading) {
     return <div class="tcomp"><div class="tcomp-skel skel" /></div>;
   }
   if (!dashboard?.ok || !dashboard.totals?.length) {

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef } from "preact/hooks";
+import { makeChart, baseOption, chartTheme, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
+import { useResolvedTheme } from "../../lib/theme";
+import type { PvTodayResponse } from "../../lib/types";
+import "./today-plan.css";
+
+interface TodayPlanWidgetProps {
+  pv: PvTodayResponse | null;
+  loading: boolean;
+}
+
+// Slot kinds that mean the battery is being FILLED (cheap/free energy in) vs
+// EMPTIED to the grid. Mirrors DispatchPlanStrip's colour buckets so the bands
+// read the same across the app.
+const CHARGE_KINDS = new Set(["negative", "cheap", "solar_charge", "solar_preheat", "charge"]);
+const DISCHARGE_KINDS = new Set(["peak_export", "peak", "discharge"]);
+
+function localHM(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+// One chart that answers "what's the plan today?" without tab-switching:
+// import price + charge/discharge windows + load forecast + PV planned vs
+// realised, all on a shared 30-min slot axis. Price on the right axis (p/kWh),
+// energy on the left (kWh). All series come from /pv/today — a single
+// full-day, server-aligned source (no client-side ISO key-matching).
+export function TodayPlanWidget({ pv, loading }: TodayPlanWidgetProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+  const theme = useResolvedTheme();
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const ch = makeChart(ref.current);
+    chartRef.current = ch;
+    const onResize = () => ch.resize();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      ch.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current || !pv?.slots?.length) return;
+    const t = chartTheme();
+    const base = baseOption();
+    const slots = pv.slots;
+    const labels = slots.map((s) => localHM(s.slot_utc));
+
+    const pvPlanned = slots.map((s) => round2(s.pv_forecast_kwh));
+    const pvActual = slots.map((s) => (s.pv_actual_kwh == null ? null : round2(s.pv_actual_kwh)));
+    const load = slots.map((s) => (s.base_load_kwh == null ? null : round2(s.base_load_kwh)));
+    const price = slots.map((s) => (s.import_price_p == null ? null : s.import_price_p));
+
+    // Charge/discharge background bands — contiguous runs of charge/discharge
+    // kinds. markArea references the slot INDEX (DST-safe; two slots can share
+    // a local HH:MM label on the autumn clock change).
+    const bands: Array<[{ xAxis: number; itemStyle: object }, { xAxis: number }]> = [];
+    let runStart = -1;
+    let runKind: "charge" | "discharge" | null = null;
+    const flush = (endIdx: number) => {
+      if (runStart < 0 || runKind == null) return;
+      const color = runKind === "charge" ? t.cheap : t.peak;
+      bands.push([
+        { xAxis: runStart, itemStyle: { color: withAlpha(color, 0.1) } },
+        { xAxis: endIdx },
+      ]);
+    };
+    slots.forEach((s, i) => {
+      const k = s.kind || undefined;
+      const cur: "charge" | "discharge" | null =
+        k && CHARGE_KINDS.has(k) ? "charge" : k && DISCHARGE_KINDS.has(k) ? "discharge" : null;
+      if (cur !== runKind) {
+        if (runKind != null) flush(i - 1);
+        runKind = cur;
+        runStart = cur != null ? i : -1;
+      }
+    });
+    if (runKind != null) flush(slots.length - 1);
+
+    // "Now" marker — only when now falls within this day's slots.
+    const nowMs = pv.now_utc ? new Date(pv.now_utc).getTime() : Date.now();
+    const firstMs = new Date(slots[0].slot_utc).getTime();
+    const lastMs = new Date(slots[slots.length - 1].slot_utc).getTime() + 30 * 60_000;
+    let nowIdx = -1;
+    if (nowMs >= firstMs && nowMs < lastMs) {
+      const idx = slots.findIndex((s) => new Date(s.slot_utc).getTime() > nowMs);
+      nowIdx = idx <= 0 ? slots.length - 1 : idx - 1;
+    }
+
+    chartRef.current.setOption({
+      ...base,
+      grid: { left: 48, right: 52, top: 28, bottom: 28, containLabel: true },
+      legend: { ...(base.legend as object), show: true },
+      tooltip: {
+        ...(base.tooltip as object),
+        formatter: (params: Array<{ dataIndex: number }>) => {
+          const i = params[0]?.dataIndex ?? 0;
+          const s = slots[i];
+          if (!s) return "";
+          return `<strong>${labels[i]}</strong>${s.kind ? ` · ${s.kind}` : ""}<br/>` +
+            (price[i] != null ? `Import ${price[i]!.toFixed(1)}p/kWh<br/>` : "") +
+            `PV planned ${pvPlanned[i].toFixed(2)} kWh<br/>` +
+            (pvActual[i] != null ? `PV actual ${pvActual[i]!.toFixed(2)} kWh<br/>` : "") +
+            (load[i] != null ? `Load ${load[i]!.toFixed(2)} kWh` : "");
+        },
+      },
+      xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
+      yAxis: [
+        { ...(base.yAxis as object), name: "kWh", nameTextStyle: { color: t.textDim, fontSize: 10 } },
+        {
+          ...(base.yAxis as object),
+          name: "p/kWh", position: "right",
+          nameTextStyle: { color: t.textDim, fontSize: 10 },
+          splitLine: { show: false },
+          axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}p" },
+        },
+      ],
+      series: [
+        {
+          name: "PV planned", type: "line", smooth: true, showSymbol: false,
+          data: pvPlanned, lineStyle: { color: t.pv, width: 1.5, type: "dashed" },
+          areaStyle: { color: areaGradient(t.pv, 0.16, 0.02) }, z: 2,
+          markArea: bands.length ? { silent: true, data: bands } : undefined,
+          markLine: nowIdx >= 0 ? {
+            silent: true, symbol: "none",
+            lineStyle: { color: t.textDim, width: 1, type: "dotted" },
+            label: { show: true, formatter: "now", color: t.textMute, fontSize: 10 },
+            data: [{ xAxis: nowIdx }],
+          } : undefined,
+        },
+        {
+          name: "PV actual", type: "line", smooth: true, showSymbol: false, connectNulls: false,
+          data: pvActual, lineStyle: { color: t.pv, width: 2.5 },
+          areaStyle: { color: areaGradient(t.pv, 0.32, 0.04) }, z: 3,
+        },
+        {
+          name: "Load forecast", type: "line", smooth: true, showSymbol: false,
+          data: load, lineStyle: { color: t.house, width: 1.5, type: "dashed" }, z: 2,
+        },
+        {
+          name: "Import price", type: "line", step: "middle", showSymbol: false,
+          yAxisIndex: 1, data: price, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8 }, z: 1,
+        },
+      ],
+    }, { notMerge: true });
+  }, [pv, theme]);
+
+  const acc = pv?.accuracy;
+
+  return (
+    <div class="today-plan">
+      {acc && (
+        <div class="today-plan-acc">
+          <span>PV today so far: <strong>{acc.actual_kwh.toFixed(1)}</strong> kWh actual vs <strong>{acc.forecast_kwh.toFixed(1)}</strong> planned</span>
+          <span class="today-plan-acc-sep">·</span>
+          <span title="Mean absolute error per slot, and forecast bias (positive = forecast under-predicted).">
+            MAE {acc.mae_kwh.toFixed(2)} kWh · bias {acc.bias_kwh >= 0 ? "+" : ""}{acc.bias_kwh.toFixed(1)} kWh
+          </span>
+        </div>
+      )}
+      <div ref={ref} style={{ width: "100%", height: "300px" }} />
+      {!pv?.slots?.length && !loading && <p class="muted">No plan data for today yet.</p>}
+    </div>
+  );
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/ui/src/components/home/heating.css
+++ b/ui/src/components/home/heating.css
@@ -76,3 +76,44 @@
 .heating-split-dot--space { background: var(--accent); }
 .heating-split-name { color: var(--text-dim); }
 .heating-split-value { font-weight: 700; }
+
+/* --- Manual Daikin controls (P3) --- */
+.heating-controls {
+  margin-top: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.heating-controls-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.heating-controls-title {
+  font-size: var(--font-sm);
+  color: var(--text-dim);
+  font-weight: 600;
+}
+.heating-controls-passive {
+  font-size: var(--font-xs);
+  color: var(--warn);
+}
+.heating-control-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.heating-control-label {
+  flex: 0 0 5.5rem;
+  font-size: var(--font-sm);
+  color: var(--text-dim);
+}
+.heating-control-row .input { flex: 1; min-width: 0; }
+.heating-control-state {
+  font-size: var(--font-sm);
+  color: var(--text-mute);
+  min-width: 2rem;
+}
+.heating-controls-hint { font-size: var(--font-xs); }

--- a/ui/src/components/home/today-plan.css
+++ b/ui/src/components/home/today-plan.css
@@ -1,0 +1,22 @@
+.today-plan {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.today-plan-acc {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: var(--font-sm);
+  color: var(--text-dim);
+}
+
+.today-plan-acc strong {
+  color: var(--text);
+}
+
+.today-plan-acc-sep {
+  color: var(--text-mute);
+}

--- a/ui/src/components/shell/TopNav.tsx
+++ b/ui/src/components/shell/TopNav.tsx
@@ -4,6 +4,7 @@ import { ThemeToggle } from "./ThemeToggle";
 const tabs = [
   { href: "/", label: "Home" },
   { href: "/plan", label: "Plan" },
+  { href: "/workbench", label: "Workbench" },
   { href: "/settings", label: "Settings" },
 ];
 

--- a/ui/src/components/workbench/WorkbenchPlanChart.tsx
+++ b/ui/src/components/workbench/WorkbenchPlanChart.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "preact/hooks";
+import { makeChart, baseOption, chartTheme, barGradient, type EChartsType } from "../../lib/charts";
+import { useResolvedTheme } from "../../lib/theme";
+import type { WorkbenchSimSlot } from "../../lib/types";
+
+interface WorkbenchPlanChartProps {
+  slots: WorkbenchSimSlot[];
+}
+
+function localHM(iso: string | null): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+// Compact plan shape for a simulated LP run: grid import (up) / export (down)
+// bars + battery SoC trajectory (right axis) + import price in the tooltip.
+// Lets the operator see how a knob tweak reshapes the plan before promoting.
+export function WorkbenchPlanChart({ slots }: WorkbenchPlanChartProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+  const theme = useResolvedTheme();
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const ch = makeChart(ref.current);
+    chartRef.current = ch;
+    const onResize = () => ch.resize();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      ch.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current || !slots.length) return;
+    const t = chartTheme();
+    const base = baseOption();
+    const labels = slots.map((s) => localHM(s.t));
+    const imp = slots.map((s) => round2(s.import_kwh));
+    const exp = slots.map((s) => (s.export_kwh == null ? null : -(Math.round(s.export_kwh * 100) / 100)));
+    const soc = slots.map((s) => round2(s.soc_kwh));
+    const price = slots.map((s) => s.price_p);
+
+    chartRef.current.setOption({
+      ...base,
+      grid: { left: 44, right: 48, top: 24, bottom: 24, containLabel: true },
+      legend: { ...(base.legend as object), show: true },
+      tooltip: {
+        ...(base.tooltip as object),
+        formatter: (params: Array<{ dataIndex: number }>) => {
+          const i = params[0]?.dataIndex ?? 0;
+          return `<strong>${labels[i]}</strong><br/>` +
+            (price[i] != null ? `Price ${price[i]!.toFixed(1)}p/kWh<br/>` : "") +
+            `Import ${(imp[i] ?? 0).toFixed(2)} kWh<br/>` +
+            (exp[i] != null ? `Export ${(-exp[i]!).toFixed(2)} kWh<br/>` : "") +
+            (soc[i] != null ? `SoC ${soc[i]!.toFixed(2)} kWh` : "");
+        },
+      },
+      xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
+      yAxis: [
+        { ...(base.yAxis as object), name: "kWh", nameTextStyle: { color: t.textDim, fontSize: 10 } },
+        {
+          ...(base.yAxis as object),
+          name: "SoC", position: "right",
+          nameTextStyle: { color: t.textDim, fontSize: 10 },
+          splitLine: { show: false },
+          axisLabel: { color: t.textMute, fontSize: 10 },
+        },
+      ],
+      series: [
+        { name: "Import", type: "bar", stack: "grid", data: imp,
+          itemStyle: { color: barGradient(t.importColor), borderRadius: [2, 2, 0, 0] }, z: 1 },
+        { name: "Export", type: "bar", stack: "grid", data: exp,
+          itemStyle: { color: barGradient(t.exportColor), borderRadius: [0, 0, 2, 2] }, z: 1 },
+        { name: "SoC", type: "line", smooth: true, showSymbol: false, yAxisIndex: 1,
+          data: soc, lineStyle: { color: t.batt, width: 2 }, z: 3 },
+      ],
+    }, { notMerge: true });
+  }, [slots, theme]);
+
+  return <div ref={ref} style={{ width: "100%", height: "220px" }} />;
+}
+
+function round2(n: number | null): number | null {
+  return n == null ? null : Math.round(n * 100) / 100;
+}

--- a/ui/src/components/workbench/workbench.css
+++ b/ui/src/components/workbench/workbench.css
@@ -1,0 +1,78 @@
+.wb { display: flex; flex-direction: column; gap: var(--space-5); padding-bottom: 6rem; }
+.wb-head h1 { margin: 0 0 var(--space-1); }
+
+.wb-group { display: flex; flex-direction: column; gap: var(--space-2); }
+.wb-group-title {
+  font-size: var(--font-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-mute);
+  margin: 0;
+}
+.wb-group--load {
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  padding: var(--space-3);
+  background: var(--bg-card);
+}
+.wb-group--load .wb-group-title { color: var(--accent); }
+
+.wb-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-3);
+}
+.wb-field {
+  background: var(--bg-card-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.wb-field--edited { border-color: var(--warn); }
+.wb-field-head { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
+.wb-field-key { font-size: var(--font-sm); color: var(--text); }
+.wb-field-desc { font-size: var(--font-xs); margin: 0; }
+.wb-field-input .input { width: 100%; }
+
+.wb-bar {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  backdrop-filter: blur(12px);
+}
+.wb-bar-status { font-size: var(--font-sm); color: var(--text-dim); }
+.wb-bar-actions { display: flex; gap: var(--space-2); }
+
+.wb-sim {
+  background: var(--bg-card-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.wb-sim--err { border-color: var(--bad); }
+.wb-sim-head { display: flex; align-items: center; gap: var(--space-2); font-weight: 600; }
+.wb-sim-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: var(--space-3);
+}
+.wb-stat-value { font-size: var(--font-lg); color: var(--text); }
+.wb-stat-label { font-size: var(--font-xs); color: var(--text-mute); }
+.wb-sim-applied { font-size: var(--font-sm); margin: 0; }
+
+.wb-nonprom { font-size: var(--font-sm); }
+.wb-profile { display: flex; flex-direction: column; gap: var(--space-1); margin-top: var(--space-3); font-size: var(--font-sm); }
+.wb-profile .input { width: 100%; }

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -21,6 +21,8 @@ import type {
   TariffDashboardResponse,
   PeriodInsightsResponse,
   DaikinConsumptionResponse,
+  ActionResult,
+  DaikinOperationMode,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -33,6 +35,19 @@ export const getMetrics = () => getJson<MetricsResponse>("/metrics");
 export const getDaikinStatus = () => getJson<DaikinDevice[]>("/daikin/status");
 export const getDaikinQuota = () => getJson<ApiQuotaResponse>("/daikin/quota");
 export const getFoxQuota = () => getJson<ApiQuotaResponse>("/foxess/quota");
+
+/* ----- Daikin controls (writes — require DAIKIN_CONTROL_MODE=active) -----
+   The UI shows its own confirm dialog, then sends skip_confirmation:true so
+   the backend doesn't return a separate pending-action step. A 409
+   PassiveModeLocked surfaces as a HemApiError the caller can toast. */
+export const setTankTemperature = (temperature: number) =>
+  postJson<ActionResult>("/daikin/tank-temperature", { temperature });
+export const setTankPower = (on: boolean) =>
+  postJson<ActionResult>("/daikin/tank-power", { on, skip_confirmation: true });
+export const setLwtOffset = (offset: number) =>
+  postJson<ActionResult>("/daikin/lwt-offset", { offset });
+export const setDaikinMode = (mode: DaikinOperationMode) =>
+  postJson<ActionResult>("/daikin/mode", { mode });
 
 // /daikin/consumption — Onecta-measured Daikin energy split by heating vs DHW.
 // SQLite read only — zero Daikin API quota. Granularities mirror /energy/period.

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -21,6 +21,8 @@ import type {
   TariffDashboardResponse,
   PeriodInsightsResponse,
   DaikinConsumptionResponse,
+  PvTodayResponse,
+  OptimizationInputsResponse,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -30,6 +32,9 @@ export const getSchedulerTimeline = () => getJson<SchedulerTimeline>("/scheduler
 export const getDecisionsLatest = () =>
   getJson<DispatchDecisionsResponse>("/optimization/decisions/latest");
 export const getMetrics = () => getJson<MetricsResponse>("/metrics");
+export const getPvToday = () => getJson<PvTodayResponse>("/pv/today");
+export const getOptimizationInputs = () =>
+  getJson<OptimizationInputsResponse>("/optimization/inputs");
 export const getDaikinStatus = () => getJson<DaikinDevice[]>("/daikin/status");
 export const getDaikinQuota = () => getJson<ApiQuotaResponse>("/daikin/quota");
 export const getFoxQuota = () => getJson<ApiQuotaResponse>("/foxess/quota");

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -21,6 +21,10 @@ import type {
   TariffDashboardResponse,
   PeriodInsightsResponse,
   DaikinConsumptionResponse,
+  WorkbenchSchema,
+  WorkbenchSimulateResponse,
+  WorkbenchPromoteDiff,
+  WorkbenchPromoteResult,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -113,4 +117,28 @@ export async function applyBatch(
     headers,
   });
   return r.json() as Promise<ApplyBatchResponse>;
+}
+
+/* ----- Workbench (LP override editor) ----- */
+
+export const getWorkbenchSchema = () => getJson<WorkbenchSchema>("/workbench/schema");
+
+export const simulateWorkbench = (overrides: Record<string, unknown>) =>
+  postJson<WorkbenchSimulateResponse>("/workbench/simulate", { overrides });
+
+export const promoteSimulateWorkbench = (overrides: Record<string, unknown>) =>
+  postJson<WorkbenchPromoteDiff>("/workbench/promote/simulate", { overrides });
+
+export async function promoteWorkbench(
+  simulationId: string,
+  overrides: Record<string, unknown>,
+  profileName?: string,
+): Promise<WorkbenchPromoteResult> {
+  const headers = new Headers({ "Content-Type": "application/json", "X-Simulation-Id": simulationId });
+  const r = await hemFetch("/workbench/promote", {
+    method: "POST",
+    body: JSON.stringify({ overrides, profile_name: profileName }),
+    headers,
+  });
+  return r.json() as Promise<WorkbenchPromoteResult>;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -387,11 +387,24 @@ export interface DaikinDevice {
   tank_target?: number | null;
   outdoor_temp?: number | null;
   lwt?: number | null;
+  lwt_offset?: number | null;
   weather_regulation?: boolean | null;
   control_mode?: string | null;
   state_summary?: string | null;
   is_on?: boolean | null;
   tank_power?: boolean | null;
+}
+
+// Daikin operation modes accepted by POST /daikin/mode.
+export type DaikinOperationMode = "heating" | "cooling" | "auto" | "fan_only" | "dry";
+
+// Shape returned by the Daikin write routes (ActionResult). When a route
+// requires confirmation and skip_confirmation is false it returns a different
+// (pending) shape — the UI always sends skip_confirmation:true after its own
+// confirm dialog, so it only ever sees this.
+export interface ActionResult {
+  success: boolean;
+  message: string;
 }
 
 // /daikin/quota + /foxess/quota — shared shape

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -108,6 +108,49 @@ export interface SchedulerTimeline {
   planned: TimelineSlot[];
 }
 
+/* ----- /pv/today ----- */
+
+export interface PvTodaySlot {
+  slot_utc: string;
+  pv_forecast_kwh: number;
+  pv_actual_kwh: number | null;
+  import_price_p?: number | null;
+  base_load_kwh?: number | null;
+  kind?: string | null;
+}
+
+export interface PvTodayAccuracy {
+  slots_compared: number;
+  forecast_kwh: number;
+  actual_kwh: number;
+  mae_kwh: number;
+  bias_kwh: number;
+}
+
+export interface PvTodayResponse {
+  date: string;
+  now_utc: string;
+  slots: PvTodaySlot[];
+  accuracy: PvTodayAccuracy | null;
+  forecast_kwh_day_total: number;
+}
+
+/* ----- /optimization/inputs ----- */
+
+export interface OptimizationInputSlot {
+  t_utc: string;
+  price_import_p?: number | null;
+  price_export_p?: number | null;
+  temp_c?: number | null;
+  solar_w_m2?: number | null;
+  base_load_kwh?: number | null;
+}
+
+export interface OptimizationInputsResponse {
+  slots: OptimizationInputSlot[];
+  thresholds?: { cheap_p?: number; peak_p?: number } | null;
+}
+
 /* ----- /optimization/decisions/{run_id} ----- */
 
 export interface DispatchDecision {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -496,3 +496,63 @@ export interface MetricsResponse {
     standing_pence_per_day?: number | null;
   };
 }
+
+/* ----- /workbench (LP override editor) ----- */
+
+export interface WorkbenchField {
+  key: string;
+  config_attr: string;
+  type: string; // "float" | "int" | "str"
+  min?: number | null;
+  max?: number | null;
+  enum?: string[] | null;
+  description: string;
+  group: string;
+  promotable: boolean;
+  current: number | string | boolean | null;
+}
+
+export interface WorkbenchSchema {
+  groups: string[];
+  fields: WorkbenchField[];
+}
+
+export interface WorkbenchSimSlot {
+  t: string | null;
+  price_p: number | null;
+  import_kwh: number | null;
+  export_kwh: number | null;
+  battery_charge_kwh: number | null;
+  battery_discharge_kwh: number | null;
+  soc_kwh: number | null;
+}
+
+export interface WorkbenchSimulateResponse {
+  ok: boolean;
+  error?: string | null;
+  plan_date?: string | null;
+  objective_pence?: number | null;
+  status?: string | null;
+  slot_count?: number | null;
+  actual_mean_agile_pence?: number | null;
+  forecast_solar_kwh_horizon?: number | null;
+  mu_load_kwh_per_slot?: number | null;
+  applied_overrides: Record<string, unknown>;
+  ignored_overrides: Record<string, unknown>;
+  slots?: WorkbenchSimSlot[];
+}
+
+// ActionDiff shape from /workbench/promote/simulate. We render human_summary +
+// the non-promotable list; the detailed diff items vary, so keep them loose.
+export interface WorkbenchPromoteDiff {
+  simulation_id: string;
+  action?: string;
+  human_summary?: string;
+  non_promotable_overrides?: Record<string, unknown>;
+}
+
+export interface WorkbenchPromoteResult {
+  ok: boolean;
+  promoted: Array<{ key: string; ok: boolean; value?: unknown; error?: string }>;
+  profile_name?: string | null;
+}

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -15,6 +15,7 @@ import {
   getDaikinStatus,
   getDaikinQuota,
   getTariffDashboard,
+  getPvToday,
 } from "../lib/endpoints";
 import { Widget } from "../components/common/Widget";
 import { Spinner } from "../components/common/Spinner";
@@ -33,6 +34,12 @@ import "../components/home/home.css";
 // the hero + money tiles paint immediately and the chart streams in after.
 const EnergyChartWidget = lazy(() =>
   import("../components/home/EnergyChartWidget").then((m) => ({ default: m.EnergyChartWidget })),
+);
+
+// Combined "today's plan" chart also owns echarts — lazy-load alongside the
+// energy chart so the hero + money tiles paint first.
+const TodayPlanWidget = lazy(() =>
+  import("../components/home/TodayPlanWidget").then((m) => ({ default: m.TodayPlanWidget })),
 );
 
 function lastMonths(n: number): string[] {
@@ -74,6 +81,7 @@ export default function Landing() {
   const now = usePoll(getCockpitNow, 20_000);
   const metrics = usePoll(getMetrics, 5 * 60_000);
   const timeline = usePoll(getSchedulerTimeline, 5 * 60_000);
+  const pvToday = usePoll(getPvToday, 5 * 60_000);
 
   // Fetch-once endpoints — refresh on tab return, otherwise no churn.
   const agile = useFetch(getAgileToday, []);
@@ -124,6 +132,16 @@ export default function Landing() {
         <Widget title="Heating" icon="♨" tone="thermal" size="medium"
                 action={<RefreshAction onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} loading={daikin.loading} title="Re-fetch Daikin (cached server-side ~30min)" />}>
           <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data} />
+        </Widget>
+      </div>
+
+      {/* ── PLAN ───────────────────────────────────────────────────── */}
+      <div class="widget-grid widget-band">
+        <Widget title="Today's plan" icon="🗓" tone="plan" size="wide"
+                badge={pvToday.data?.forecast_kwh_day_total != null ? `${pvToday.data.forecast_kwh_day_total.toFixed(1)} kWh PV planned` : undefined}>
+          <Suspense fallback={<Spinner label="Loading plan…" />}>
+            <TodayPlanWidget pv={pvToday.data} loading={pvToday.loading} />
+          </Suspense>
         </Widget>
       </div>
 

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -146,7 +146,7 @@ export default function Landing() {
         <Widget title="Tariff comparison" icon="📊" tone="savings" size="wide"
                 badge={tariffDash.data?.usage?.total_days ? `last ${tariffDash.data.usage.total_days}d of your usage` : undefined}
                 action={<RefreshAction onRefresh={tariffDash.refresh} loading={tariffDash.loading} />}>
-          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} monthPeriod={monthPeriod.data} />
+          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} monthPeriod={monthPeriod.data} monthPeriodLoading={monthPeriod.loading} />
         </Widget>
       </div>
 

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -123,7 +123,8 @@ export default function Landing() {
 
         <Widget title="Heating" icon="♨" tone="thermal" size="medium"
                 action={<RefreshAction onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} loading={daikin.loading} title="Re-fetch Daikin (cached server-side ~30min)" />}>
-          <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data} />
+          <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data}
+                         onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} />
         </Widget>
       </div>
 

--- a/ui/src/routes/workbench.tsx
+++ b/ui/src/routes/workbench.tsx
@@ -11,6 +11,7 @@ import { Spinner } from "../components/common/Spinner";
 import { NumberInput, Select } from "../components/common/Inputs";
 import { Modal } from "../components/common/Modal";
 import { Pill } from "../components/common/Pill";
+import { WorkbenchPlanChart } from "../components/workbench/WorkbenchPlanChart";
 import { toast } from "../lib/toast";
 import { gbp } from "../lib/format";
 import "../components/workbench/workbench.css";
@@ -206,6 +207,7 @@ function SimResult({ sim }: { sim: WorkbenchSimulateResponse }) {
         <Stat label="Mean load/slot" value={sim.mu_load_kwh_per_slot != null ? `${sim.mu_load_kwh_per_slot.toFixed(2)} kWh` : "—"} />
         <Stat label="Slots" value={String(sim.slot_count ?? "—")} />
       </div>
+      {sim.slots && sim.slots.length > 0 && <WorkbenchPlanChart slots={sim.slots} />}
       {applied.length > 0 && <p class="wb-sim-applied">Applied: <code>{applied.join(", ")}</code></p>}
       {ignored.length > 0 && <p class="muted">Ignored: {ignored.join(", ")}</p>}
     </div>

--- a/ui/src/routes/workbench.tsx
+++ b/ui/src/routes/workbench.tsx
@@ -1,0 +1,222 @@
+import { useState } from "preact/hooks";
+import { useFetch } from "../lib/poll";
+import {
+  getWorkbenchSchema,
+  simulateWorkbench,
+  promoteSimulateWorkbench,
+  promoteWorkbench,
+} from "../lib/endpoints";
+import type { WorkbenchField, WorkbenchSimulateResponse, WorkbenchPromoteDiff } from "../lib/types";
+import { Spinner } from "../components/common/Spinner";
+import { NumberInput, Select } from "../components/common/Inputs";
+import { Modal } from "../components/common/Modal";
+import { Pill } from "../components/common/Pill";
+import { toast } from "../lib/toast";
+import { gbp } from "../lib/format";
+import "../components/workbench/workbench.css";
+
+type OverrideVal = number | string;
+
+// Workbench — tune LP knobs, simulate the plan, promote the promotable subset
+// to prod (runtime_settings). Mirrors the backend /workbench/* flow. The load
+// knob (LP_LOAD_SCALE_FACTOR) is surfaced in its own group at the top.
+export default function Workbench() {
+  const schema = useFetch(getWorkbenchSchema, []);
+  const [overrides, setOverrides] = useState<Record<string, OverrideVal>>({});
+  const [sim, setSim] = useState<WorkbenchSimulateResponse | null>(null);
+  const [simBusy, setSimBusy] = useState(false);
+  const [diff, setDiff] = useState<WorkbenchPromoteDiff | null>(null);
+  const [promoteBusy, setPromoteBusy] = useState(false);
+  const [profileName, setProfileName] = useState("");
+
+  const dirty = Object.keys(overrides).length > 0;
+
+  const setVal = (key: string, v: OverrideVal) => setOverrides((o) => ({ ...o, [key]: v }));
+  const reset = () => { setOverrides({}); setSim(null); };
+
+  const runSimulate = async () => {
+    setSimBusy(true);
+    try {
+      setSim(await simulateWorkbench(overrides));
+    } catch (e) {
+      toast.error("Simulation failed", e instanceof Error ? e.message : String(e));
+    } finally {
+      setSimBusy(false);
+    }
+  };
+
+  const openPromote = async () => {
+    setPromoteBusy(true);
+    try {
+      setDiff(await promoteSimulateWorkbench(overrides));
+    } catch (e) {
+      toast.error("Nothing to promote", e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoteBusy(false);
+    }
+  };
+
+  const confirmPromote = async () => {
+    if (!diff) return;
+    setPromoteBusy(true);
+    try {
+      const res = await promoteWorkbench(diff.simulation_id, overrides, profileName.trim() || undefined);
+      const okCount = res.promoted.filter((p) => p.ok).length;
+      toast.success(`Promoted ${okCount} setting${okCount === 1 ? "" : "s"} to prod`);
+      setDiff(null);
+      setProfileName("");
+      reset();
+      schema.refresh();
+    } catch (e) {
+      toast.error("Promote failed", e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoteBusy(false);
+    }
+  };
+
+  if (schema.loading && !schema.data) {
+    return <div class="page-padded"><Spinner label="Loading workbench…" /></div>;
+  }
+  if (!schema.data) {
+    return (
+      <div class="page-padded">
+        <p class="muted">Workbench unavailable: {schema.error?.message || "no data"}</p>
+        <button class="btn" onClick={() => schema.refresh()}>Retry</button>
+      </div>
+    );
+  }
+
+  const fields = schema.data.fields;
+  // Render the load group first (the headline knob), then the rest in order.
+  const groupOrder = ["load", ...schema.data.groups.filter((g) => g !== "load")];
+  const byGroup = new Map<string, WorkbenchField[]>();
+  for (const f of fields) {
+    if (!byGroup.has(f.group)) byGroup.set(f.group, []);
+    byGroup.get(f.group)!.push(f);
+  }
+
+  return (
+    <div class="page-padded wb">
+      <header class="wb-head">
+        <h1>Workbench</h1>
+        <p class="muted">
+          Tune the LP planner, simulate the resulting plan, and promote the promotable
+          subset to production. Simulation never writes to hardware or the cloud.
+        </p>
+      </header>
+
+      {groupOrder.map((g) => {
+        const gf = byGroup.get(g);
+        if (!gf || !gf.length) return null;
+        return (
+          <section key={g} class={`wb-group${g === "load" ? " wb-group--load" : ""}`}>
+            <h2 class="wb-group-title">{g}</h2>
+            <div class="wb-fields">
+              {gf.map((f) => (
+                <FieldRow key={f.key} field={f}
+                          value={overrides[f.key] ?? (f.current as OverrideVal)}
+                          edited={overrides[f.key] !== undefined}
+                          onChange={(v) => setVal(f.key, v)} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+
+      <div class="wb-bar">
+        <span class="wb-bar-status">{dirty ? `${Object.keys(overrides).length} change(s)` : "no changes"}</span>
+        <div class="wb-bar-actions">
+          {dirty && <button class="btn btn--ghost" onClick={reset} disabled={simBusy || promoteBusy}>Reset</button>}
+          <button class="btn" onClick={runSimulate} disabled={!dirty || simBusy}>
+            {simBusy ? "Simulating…" : "Simulate"}
+          </button>
+          <button class="btn btn--primary" onClick={openPromote} disabled={!dirty || promoteBusy}>
+            Promote to prod…
+          </button>
+        </div>
+      </div>
+
+      {sim && <SimResult sim={sim} />}
+
+      <Modal open={diff != null} onClose={() => !promoteBusy && setDiff(null)} title="Promote to production" width="md"
+             footer={
+               <>
+                 <button class="btn btn--ghost" disabled={promoteBusy} onClick={() => setDiff(null)}>Cancel</button>
+                 <button class="btn btn--primary" disabled={promoteBusy} onClick={confirmPromote}>
+                   {promoteBusy ? "Promoting…" : "Confirm promote"}
+                 </button>
+               </>
+             }>
+        <p>{diff?.human_summary || "Promote the promotable overrides to runtime settings."}</p>
+        {diff?.non_promotable_overrides && Object.keys(diff.non_promotable_overrides).length > 0 && (
+          <p class="muted wb-nonprom">
+            Not promotable (simulation-only): {Object.keys(diff.non_promotable_overrides).join(", ")}
+          </p>
+        )}
+        <label class="wb-profile">
+          <span>Save as profile (optional)</span>
+          <input class="input" type="text" value={profileName} placeholder="e.g. away-week"
+                 onInput={(e) => setProfileName((e.currentTarget as HTMLInputElement).value)} />
+        </label>
+      </Modal>
+    </div>
+  );
+}
+
+function FieldRow({ field, value, edited, onChange }: {
+  field: WorkbenchField; value: OverrideVal; edited: boolean; onChange: (v: OverrideVal) => void;
+}) {
+  return (
+    <div class={`wb-field${edited ? " wb-field--edited" : ""}`}>
+      <div class="wb-field-head">
+        <code class="wb-field-key">{field.key}</code>
+        {field.promotable
+          ? <Pill tone="ok" title="Has a runtime_settings entry — can be promoted to prod">promotable</Pill>
+          : <Pill tone="dim" title="Simulation-only — no prod equivalent">sim-only</Pill>}
+        {edited && <Pill tone="warn">edited</Pill>}
+      </div>
+      <p class="wb-field-desc muted">{field.description}</p>
+      <div class="wb-field-input">
+        {field.enum
+          ? <Select value={String(value)} options={field.enum} onChange={(v) => onChange(v)} ariaLabel={field.key} />
+          : <NumberInput value={value} onChange={(n) => onChange(n)} min={field.min} max={field.max}
+                         step={field.type === "int" ? 1 : 0.1} ariaLabel={field.key} />}
+      </div>
+    </div>
+  );
+}
+
+function SimResult({ sim }: { sim: WorkbenchSimulateResponse }) {
+  if (!sim.ok) {
+    return <div class="wb-sim wb-sim--err"><strong>Simulation failed</strong><p class="muted">{sim.error || sim.status}</p></div>;
+  }
+  const obj = sim.objective_pence != null ? gbp(sim.objective_pence / 100) : "—";
+  const applied = Object.keys(sim.applied_overrides || {});
+  const ignored = Object.keys(sim.ignored_overrides || {});
+  return (
+    <div class="wb-sim">
+      <div class="wb-sim-head">
+        <span>Simulated plan</span>
+        <Pill tone={sim.status === "Optimal" ? "ok" : "warn"}>{sim.status}</Pill>
+      </div>
+      <div class="wb-sim-stats">
+        <Stat label="Objective" value={obj} hint="LP objective cost over the horizon" />
+        <Stat label="Mean Agile" value={sim.actual_mean_agile_pence != null ? `${sim.actual_mean_agile_pence.toFixed(1)}p` : "—"} />
+        <Stat label="Horizon solar" value={sim.forecast_solar_kwh_horizon != null ? `${sim.forecast_solar_kwh_horizon.toFixed(1)} kWh` : "—"} />
+        <Stat label="Mean load/slot" value={sim.mu_load_kwh_per_slot != null ? `${sim.mu_load_kwh_per_slot.toFixed(2)} kWh` : "—"} />
+        <Stat label="Slots" value={String(sim.slot_count ?? "—")} />
+      </div>
+      {applied.length > 0 && <p class="wb-sim-applied">Applied: <code>{applied.join(", ")}</code></p>}
+      {ignored.length > 0 && <p class="muted">Ignored: {ignored.join(", ")}</p>}
+    </div>
+  );
+}
+
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div class="wb-stat" title={hint}>
+      <div class="wb-stat-value">{value}</div>
+      <div class="wb-stat-label">{label}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this is
A single **conflict-free integration** of the four phased UI UX-review PRs (+ a Workbench re-plan chart follow-up), so the whole set can be merged in one go. The individual PRs (#428–#431) remain for granular review; this branch is the "merge everything" option.

Merges, in order: #428 → #429 → #430 → #431. The only conflicts were trivial import-list unions in `ui/src/lib/endpoints.ts` (resolved by keeping all imports). Combined tree verified.

## Included
- **P1 (#428)** — Tariff comparison no longer flashes the projected cost before the realised one (gate skeleton on both fetches).
- **P2 (#429)** — Unified **"Today's plan"** chart on Home (price + charge/discharge windows + load forecast + **PV planned vs realised** + accuracy) backed by a new `GET /api/v1/pv/today`.
- **P3 (#430)** — Manual **Daikin heating controls** (tank target / DHW power / LWT offset / mode) with confirm modal + passive/active gate.
- **P4 (#431)** — **`LP_LOAD_SCALE_FACTOR`** load-forecast knob (no-op at 1.0, applied in both base-load builders) + new **Workbench** tab (simulate→diff→promote).
- **Follow-up** — Workbench Simulate now renders a compact **plan-shape chart** (import/export bars + SoC trajectory) so a knob tweak's effect is visible before promoting.

## Verification
- `npx tsc -b --noEmit` + `vite build` clean on the merged tree (Workbench + TodayPlan are their own lazy echarts chunks).
- Backend: `pytest tests/test_pv_today_endpoint.py tests/test_lp_load_scale.py tests/api/test_workbench.py tests/test_runtime_settings.py` — 40 passed. LP regression baseline preserved (1.0 scale = bit-identical).
- Each phase was independently Plan-agent reviewed (see the per-phase PRs); HIGH findings fixed before landing.

## Merge options
- **This PR** — everything at once, conflict-free.
- **Or** the four individual PRs in order (#428→#431) — same result, finer-grained review; resolve the same `endpoints.ts` import union if merging individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)