### PR TITLE
test(daikin): fix 2 stale tests from quota-safe caching refactor

### DIFF
--- a/tests/test_daikin_quota_fallback.py
+++ b/tests/test_daikin_quota_fallback.py
@@ -35,6 +35,10 @@ def reset_service_state(monkeypatch):
     monkeypatch.setattr(daikin_service, "_devices_fetched_wall", None, raising=False)
     monkeypatch.setattr(daikin_service, "_devices_stale", False, raising=False)
     monkeypatch.setattr(daikin_service, "_cold_start_quota_logged", False, raising=False)
+    # Cold-start backoff global (added with the quota-safe caching refactor) —
+    # must also reset or it leaks between tests and short-circuits the cold-start
+    # fetch path into the backoff branch.
+    monkeypatch.setattr(daikin_service, "_cold_start_failed_at", None, raising=False)
     yield
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -150,7 +150,13 @@ class TestMCPServerDaikinTools(unittest.IsolatedAsyncioTestCase):
             tank_target=48.0,
             weather_regulation=False,
         )
-        with patch("src.mcp_server._daikin_client", return_value=mock_client):
+        # The tool now reads devices from the quota-safe cache layer
+        # (daikin_service.get_cached_devices, #423) rather than calling the
+        # client directly — mock that seam too, else it hits the real cold-start
+        # path and returns a different device.
+        cached = MagicMock(devices=[dev], source="test", stale=False)
+        with patch("src.mcp_server._daikin_client", return_value=mock_client), \
+             patch("src.daikin.service.get_cached_devices", return_value=cached):
             _blocks, out = await mcp.call_tool("get_daikin_status", {})
         self.assertTrue(out["ok"])
         self.assertEqual(len(out["devices"]), 1)


### PR DESCRIPTION
Two tests passed on `main` but failed on `feat/ui-rebuild-vite-preact` — **stale tests from intentional refactors, no production regression** (verified the prod code paths are sound):

- **`test_get_daikin_status_ok`** — the MCP `get_daikin_status` tool now reads devices from `daikin_service.get_cached_devices` (#423 quota-safe cache) instead of the client directly. The test mocked only `_daikin_client`, so it hit the real cold-start path. Now mocks the `get_cached_devices` seam too.
- **`test_cold_start_quota_log_fires_once_then_suppressed`** — the `reset_service_state` autouse fixture didn't reset the new `_cold_start_failed_at` backoff global, so it leaked between tests and short-circuited call 1 into the backoff branch. Now reset.

Full suite green: **1382 passed, 3 skipped, 1 xfailed**.

Prereq for promoting `feat/ui-rebuild-vite-preact` → `main` with a green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)