### PR TITLE
fix(daikin): read circuit-breaker — stop the quota self-storm

### DIFF
--- a/src/daikin/client.py
+++ b/src/daikin/client.py
@@ -15,7 +15,7 @@ import time
 import urllib.error
 import urllib.request
 
-from ..api_quota import record_call
+from ..api_quota import record_call, should_block
 from ..config import config
 from .auth import get_valid_access_token
 from .models import DaikinDevice, DaikinStatus, SetpointRange
@@ -56,6 +56,17 @@ class DaikinClient:
             pass
 
     def _get(self, path: str) -> dict | list:
+        # Soft-cap circuit breaker on the READ path. Once the daily Daikin
+        # budget is exhausted (or the failure circuit is open), stop issuing
+        # network reads entirely and fail fast locally. Without this, a caller
+        # that retries on failure keeps hitting Daikin's hard ~200/day limit —
+        # every 429 is recorded, self-perpetuating the overage (the read-storm
+        # incident: 528 calls/24h, 358 failing). Cold-start / _do_refresh already
+        # honour should_block; this closes the bypass for direct reads
+        # (e.g. /weather, get_status). Do NOT record — no network call is made,
+        # so it consumes no quota and the rolling window can slide back down.
+        if should_block("daikin"):
+            raise DaikinError("daikin daily quota soft-cap reached — read skipped")
         url = f"{self.BASE_URL}{path}"
         max_429 = max(0, int(config.DAIKIN_HTTP_429_MAX_RETRIES))
         for auth_try in range(2):

--- a/tests/test_daikin.py
+++ b/tests/test_daikin.py
@@ -104,6 +104,18 @@ class TestDaikinClient(unittest.TestCase):
         self.assertEqual(devices[0].temperature.set_point, 21.0)
         self.assertEqual(devices[0].temperature.room_temperature, 19.5)
 
+    def test_get_skips_network_when_quota_blocked(self):
+        """Read circuit breaker: once should_block('daikin') is true, _get must
+        fail fast WITHOUT a network call, so a retrying caller can't keep
+        hammering Daikin's hard limit (the read-storm incident)."""
+        from src.daikin.client import DaikinError
+        client = DaikinClient()
+        with patch("src.daikin.client.should_block", return_value=True), \
+             patch("urllib.request.urlopen") as mock_urlopen:
+            with self.assertRaises(DaikinError):
+                client._get("/gateway-devices")
+            mock_urlopen.assert_not_called()
+
     @patch.object(DaikinClient, "_patch")
     @patch.object(DaikinClient, "_get")
     def test_set_temperature(self, mock_get, mock_patch):


### PR DESCRIPTION
## Incident (found while diagnosing the empty heating widget)
Prod `api_call_log`: **528 Daikin reads/24h vs a 180/day budget, 358 failing**, in bursts ~1.5s apart on scheduler-event hours. `quota_used_24h: 540, blocked: true` → `/daikin/status` returns `[]` → the heating widget shows "—" and the lock (gated on `control_mode` from a device) is hidden.

## Root cause
`client._get` (READ path) raises on 429 with **no backoff** (429 retries are 0 by config), so a caller that retries on failure keeps hitting Daikin's hard ~200/day limit — **every 429 is recorded, self-perpetuating the overage**. The cold-start path and `_do_refresh` honour `should_block('daikin')`, but **direct reads bypassed it**. The ~170 *successful* reads/day are within budget; the 358 fails are the whole problem.

## Fix
Gate `_get` on `should_block('daikin')`: once the daily budget is exhausted (or the failure circuit is open), reads **fail fast locally, no network call, no quota recorded** — breaking the self-perpetuation. Self-heals as the 24h rolling window slides back under budget.

## Test
`test_get_skips_network_when_quota_blocked` — asserts `_get` raises `DaikinError` and `urlopen` is **not** called when `should_block` is true. `tests/test_daikin.py` green (13 passed).

## Follow-up (separate, now quota-harmless)
The upstream caller that retries reads ~1.5s apart in bursts still spins (fails fast locally now) — worth finding + a per-caller backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)