### PR TITLE
perf(ui): enable nginx gzip — bundles were served uncompressed

### DIFF
--- a/ui/conf/nginx.conf.template
+++ b/ui/conf/nginx.conf.template
@@ -14,6 +14,23 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    # Compression — the JS/CSS/echarts bundles were served RAW (echarts alone
+    # is ~577 KB → ~193 KB gzipped). Without this the first load is slow and
+    # chart-heavy views feel janky. Runtime gzip (Vite emits no .gz files).
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types
+        text/plain
+        text/css
+        application/javascript
+        application/json
+        image/svg+xml
+        application/manifest+json
+        application/wasm;
+
     # Container-level health endpoint — used by docker compose healthcheck.
     location = /healthz {
         access_log off;


### PR DESCRIPTION
Diagnosed the slow loading: prod served the SPA's JS/CSS and the ~577 KB echarts chunk **uncompressed** (no `Content-Encoding` on assets). Added runtime gzip to `ui/conf/nginx.conf.template` (echarts ~577→193 KB, index ~87→30 KB).

Verified: deployed `index.html` is `no-cache` and references the latest hashed assets (0 `Workbench`, gauge styles present) — so the new UX **is** live; this is purely a compression gap. The power-flow/hero/chart motions are gated on `prefers-reduced-motion` (frozen by design when Reduce Motion is on, e.g. iOS Low Power Mode); gzip also removes load-jank that can read as 'static'.

UI-only nginx change → `ui-publish` rebuilds the UI image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)