### PR TITLE
feat(ui): motion override — stop OS Reduce-Motion freezing the signature animations

### DIFF
--- a/ui/src/components/cockpit/LivePowerWidget.tsx
+++ b/ui/src/components/cockpit/LivePowerWidget.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "preact/hooks";
 import { PowerFlow } from "./PowerFlow";
 import { Icon, type IconName } from "../common/Icon";
 import { useAnimatedNumber } from "../../lib/useAnimatedNumber";
+import { reducedMotion } from "../../lib/motion";
 import { kw, kwh, pct } from "../../lib/format";
 import type { CockpitState, CockpitNow, SchedulerTimeline, ExecutionTodayResponse, AgileTodayResponse, MetricsResponse } from "../../lib/types";
 import "./cockpit.css";
@@ -16,10 +17,7 @@ interface LivePowerWidgetProps {
   metrics: MetricsResponse | null;
 }
 
-const RM =
-  typeof window !== "undefined" &&
-  typeof window.matchMedia === "function" &&
-  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const RM = reducedMotion();
 
 // The instrument panel: a hero NET grid-power number anchors the surface,
 // the live power-flow is the centerpiece, everything else (action verb,

--- a/ui/src/components/cockpit/PowerFlow.tsx
+++ b/ui/src/components/cockpit/PowerFlow.tsx
@@ -1,4 +1,5 @@
 import { watts } from "../../lib/format";
+import { reducedMotion } from "../../lib/motion";
 import type { CockpitState } from "../../lib/types";
 import type { JSX } from "preact";
 import "./cockpit.css";
@@ -20,10 +21,8 @@ interface PowerFlowProps {
 const ACTIVATION_W = 50;
 
 // Reduced motion — freeze particles into static proportional connector lines.
-const RM =
-  typeof window !== "undefined" &&
-  typeof window.matchMedia === "function" &&
-  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+// Honours the in-app motion override (default on), not just the OS setting.
+const RM = reducedMotion();
 
 const NODES = {
   pv:    { x: 110, y: 80 },

--- a/ui/src/components/cockpit/live-power.css
+++ b/ui/src/components/cockpit/live-power.css
@@ -287,6 +287,4 @@
 }
 .livepower-fox-debug strong { color: var(--text-dim); font-weight: 700; }
 
-@media (prefers-reduced-motion: reduce) {
-  .livepower-hero-num { animation: none; transform: none; }
-}
+:root.hem-reduce-motion .livepower-hero-num { animation: none; transform: none; }

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -223,7 +223,5 @@
   background: var(--bg-card-2);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .hero-bg { animation: none; }
-  .hero-headline--enter { animation: none; transform: none; }
-}
+:root.hem-reduce-motion .hero-bg { animation: none; }
+:root.hem-reduce-motion .hero-headline--enter { animation: none; transform: none; }

--- a/ui/src/components/settings/settings.css
+++ b/ui/src/components/settings/settings.css
@@ -125,10 +125,8 @@
 .mode-segment-btn:hover { color: var(--text); }
 .mode-segment-btn.is-active { color: #fff; }
 .mode-segment-icon { display: inline-flex; }
-@media (prefers-reduced-motion: reduce) {
-  .mode-segment-thumb { transition: none; }
-  .mode-consequence { animation: none; }
-}
+:root.hem-reduce-motion .mode-segment-thumb { transition: none; }
+:root.hem-reduce-motion .mode-consequence { animation: none; }
 
 .mode-switcher-footnote {
   display: flex;

--- a/ui/src/components/shell/MotionToggle.tsx
+++ b/ui/src/components/shell/MotionToggle.tsx
@@ -1,0 +1,35 @@
+import { useState } from "preact/hooks";
+import { motionPref, setMotionPref, type MotionPref } from "../../lib/motion";
+import "./theme-toggle.css";
+
+const NEXT: Record<MotionPref, MotionPref> = { on: "auto", auto: "off", off: "on" };
+const META: Record<MotionPref, { icon: string; title: string }> = {
+  on:   { icon: "✨", title: "Motion: on (click for auto/system)" },
+  auto: { icon: "🌀", title: "Motion: auto — follows your OS Reduce-Motion (click to turn off)" },
+  off:  { icon: "⏸", title: "Motion: off (click to turn on)" },
+};
+
+// Cycles on → auto → off. Default is "on" (overrides OS Reduce-Motion) since the
+// signature power-flow/hero/chart animations are the point of this dashboard.
+// Reload on change so every module-load motion gate re-evaluates.
+export function MotionToggle() {
+  const [p, setP] = useState<MotionPref>(motionPref());
+  const meta = META[p];
+  return (
+    <button
+      type="button"
+      class="theme-toggle"
+      title={meta.title}
+      aria-label={meta.title}
+      onClick={() => {
+        const n = NEXT[p];
+        setMotionPref(n);
+        setP(n);
+        location.reload();
+      }}
+    >
+      <span class="theme-toggle-icon" aria-hidden="true">{meta.icon}</span>
+      <span class="theme-toggle-label">{p}</span>
+    </button>
+  );
+}

--- a/ui/src/components/shell/TopNav.tsx
+++ b/ui/src/components/shell/TopNav.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "wouter-preact";
 import { ThemeToggle } from "./ThemeToggle";
+import { MotionToggle } from "./MotionToggle";
 
 const tabs = [
   { href: "/", label: "Home" },
@@ -26,6 +27,7 @@ export function TopNav() {
             </Link>
           ))}
         </nav>
+        <MotionToggle />
         <ThemeToggle />
       </div>
     </header>

--- a/ui/src/lib/charts.ts
+++ b/ui/src/lib/charts.ts
@@ -4,6 +4,7 @@
 // it into its own chunk).
 
 import * as echarts from "echarts/core";
+import { reducedMotion } from "./motion";
 import {
   LineChart,
   BarChart,
@@ -68,13 +69,10 @@ export function chartTheme() {
   };
 }
 
-// Detected once — drives ECharts animation:false under reduced motion.
+// Drives ECharts animation:false under reduced motion — honours the in-app
+// motion override (default on), not just the OS setting.
 function prefersReducedMotion(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches
-  );
+  return reducedMotion();
 }
 
 // #rrggbb + alpha → rgba() string (ECharts canvas doesn't accept color-mix()).

--- a/ui/src/lib/motion.ts
+++ b/ui/src/lib/motion.ts
@@ -1,0 +1,43 @@
+// Motion preference. The signature power-flow / hero / chart animations are the
+// point of this UI, but they were gated purely on the OS `prefers-reduced-
+// motion` — so a desktop with "Reduce Motion" on (often enabled unknowingly,
+// or via battery savers) froze the whole experience. This adds an explicit
+// override stored in localStorage, defaulting to ON for this personal
+// dashboard. "auto" follows the OS; "off" forces reduced.
+export type MotionPref = "on" | "auto" | "off";
+
+const KEY = "hem.motion";
+
+export function motionPref(): MotionPref {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (v === "on" || v === "auto" || v === "off") return v;
+  } catch { /* ignore */ }
+  return "on"; // default: motion on (overrides OS reduce-motion)
+}
+
+export function setMotionPref(p: MotionPref): void {
+  try { localStorage.setItem(KEY, p); } catch { /* ignore */ }
+  applyMotionClass();
+}
+
+function osReduced(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+// The single source of truth used by every animation gate (JS + CSS class).
+export function reducedMotion(): boolean {
+  const p = motionPref();
+  if (p === "on") return false;
+  if (p === "off") return true;
+  return osReduced(); // "auto"
+}
+
+// Toggle the html class so the CSS reduce-motion rules apply only when OUR
+// logic says reduced — not whenever the OS says so (which the override beats).
+export function applyMotionClass(): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("hem-reduce-motion", reducedMotion());
+}

--- a/ui/src/lib/useAnimatedNumber.ts
+++ b/ui/src/lib/useAnimatedNumber.ts
@@ -1,13 +1,10 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import { reducedMotion } from "./motion";
 
-// Read the OS reduced-motion preference once at module load. Under reduce we
-// skip the tween entirely and snap straight to the target — the count-up is
-// cosmetic; the final displayed figure must equal the formatter output exactly
-// in BOTH modes (accuracy guardrail — no parallel rounding path).
-const PREFERS_REDUCED_MOTION =
-  typeof window !== "undefined" &&
-  typeof window.matchMedia === "function" &&
-  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+// Under reduced motion we skip the tween and snap to the target — the count-up
+// is cosmetic; the final displayed figure must equal the formatter output
+// exactly in BOTH modes (accuracy guardrail). Honours the in-app motion
+// override (default on), evaluated at tween time (see PREFERS check below).
 
 // Smoothly tween a numeric value when it changes — for the hero counters
 // and lifetime stats so refreshes feel alive instead of snapping. Uses
@@ -45,7 +42,7 @@ export function useAnimatedNumber(
     if (lastTargetRef.current === target) return;
 
     // Reduced motion — snap to the exact value, no tween.
-    if (PREFERS_REDUCED_MOTION) {
+    if (reducedMotion()) {
       if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
       setDisplay(target);

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,9 +3,14 @@ import { App } from "./app";
 // Boot the theme system early so it applies the right class before the first
 // paint (avoids a flash of wrong-theme).
 import "./lib/theme";
+import { applyMotionClass } from "./lib/motion";
 import "./styles/tokens.css";
 import "./styles/base.css";
 import "./styles/shell.css";
+
+// Set the reduce-motion html class before first paint so the CSS animation
+// gates match the motion preference (default: on, overriding the OS setting).
+applyMotionClass();
 
 const root = document.getElementById("app");
 if (!root) throw new Error("#app missing from index.html");

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -114,17 +114,18 @@ code, pre {
  * instant. Number tweens snap via useAnimatedNumber's own guard. Power-flow
  * particles freeze into static proportional lines (handled in PowerFlow).
  * Hover lift is kept but capped to 1px (non-vestibular, aids affordance). */
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.001ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.001ms !important;
-    scroll-behavior: auto !important;
-  }
-  .widget { animation: none !important; opacity: 1 !important; transform: none !important; }
-  .widget:hover { transform: translateY(-1px); }
-  body::before { animation: none !important; }
-  .live-pulse { animation: none !important; opacity: 1 !important; }
+/* Reduce-motion is driven by the `.hem-reduce-motion` html class (set from the
+   in-app motion preference, default ON) — NOT the raw OS media query — so the
+   override can win. See src/lib/motion.ts. */
+:root.hem-reduce-motion *,
+:root.hem-reduce-motion *::before,
+:root.hem-reduce-motion *::after {
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.001ms !important;
+  scroll-behavior: auto !important;
 }
+:root.hem-reduce-motion .widget { animation: none !important; opacity: 1 !important; transform: none !important; }
+:root.hem-reduce-motion .widget:hover { transform: translateY(-1px); }
+:root.hem-reduce-motion body::before { animation: none !important; }
+:root.hem-reduce-motion .live-pulse { animation: none !important; opacity: 1 !important; }


### PR DESCRIPTION
## Why
"No motions on desktop." Diagnosed: the power-flow particles (SVG animateMotion), hero count-up tweens, and echarts morph **all gate on the OS prefers-reduced-motion** (4 JS consts + 4 CSS @media blocks). Verified in **headless Chromium** that the motion code works (mpath href animates fine) — so the browser is reporting reduce-motion = true (OS accessibility / battery savers), freezing the whole signature UX by design.

## Fix
New src/lib/motion.ts with an explicit preference, **default ON** (personal dashboard; motion is the point):
- 4 JS gates now call reducedMotion() (PowerFlow, useAnimatedNumber, charts.ts, LivePowerWidget).
- 4 CSS @media (prefers-reduced-motion) blocks re-scoped to :root.hem-reduce-motion (class set at boot from the pref), so the override beats the raw OS query.
- MotionToggle in the top nav: on -> auto (follow OS) -> off.

## Verify
tsc + vite build clean. After deploy: motion shows by default regardless of OS Reduce-Motion; nav toggle sets auto/off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
