### PR TITLE
fix(ui): clarify Live-power hero (BALANCED → SELF-SUPPLIED + caption)

### DIFF
--- a/ui/src/components/cockpit/LivePowerWidget.tsx
+++ b/ui/src/components/cockpit/LivePowerWidget.tsx
@@ -38,7 +38,12 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
   const gridKw = state.grid_kw;
   const importing = gridKw > 0.05;
   const exporting = gridKw < -0.05;
-  const netLabel = importing ? "IMPORTING" : exporting ? "EXPORTING" : "BALANCED";
+  const netLabel = importing ? "IMPORTING" : exporting ? "EXPORTING" : "SELF-SUPPLIED";
+  // One-line caption so the big kW number reads unambiguously as grid power,
+  // and "self-supplied" (formerly "balanced") is explained.
+  const netCaption = importing ? "drawn from the grid"
+    : exporting ? "sent to the grid"
+    : "no grid flow — solar + battery are covering the house";
   const netColor = importing ? "var(--import)" : exporting ? "var(--export)" : "var(--text-dim)";
   const netKwAnim = useAnimatedNumber(Math.abs(gridKw));
   const socAnim = useAnimatedNumber(socPct);
@@ -70,6 +75,7 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
           {netKwAnim != null ? netKwAnim.toFixed(2) : "—"}
           <span class="livepower-hero-unit">kW</span>
         </div>
+        <div class="livepower-hero-cap">{netCaption}</div>
       </div>
 
       {/* Quiet action verb — supporting copy beneath the hero */}

--- a/ui/src/components/cockpit/live-power.css
+++ b/ui/src/components/cockpit/live-power.css
@@ -288,3 +288,10 @@
 .livepower-fox-debug strong { color: var(--text-dim); font-weight: 700; }
 
 :root.hem-reduce-motion .livepower-hero-num { animation: none; transform: none; }
+
+/* Caption under the net-grid hero number — explains what the kW figure means. */
+.livepower-hero-cap {
+  margin-top: 2px;
+  font-size: var(--font-xs);
+  color: var(--text-mute);
+}


### PR DESCRIPTION
The Live-power hero number is net grid power, but the **BALANCED** label (shown when |grid| < 0.05 kW) next to a near-zero value read as cryptic. Renamed BALANCED → **SELF-SUPPLIED** and added a one-line caption so the kW figure is unambiguous: importing = 'drawn from the grid', exporting = 'sent to the grid', self-supplied = 'no grid flow — solar + battery are covering the house'. tsc + build clean.