### PR TITLE
fix(daikin): hard anti-burst floor on device reads (root-cause for the read-storm)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1425,6 +1425,13 @@ class Config:
     DAIKIN_CIRCUIT_BREAKER_COOLDOWN_MINUTES: int = int(os.getenv("DAIKIN_CIRCUIT_BREAKER_COOLDOWN_MINUTES", "30"))
     # How long to serve device data from cache without refreshing (1800 s = 30 min)
     DAIKIN_DEVICES_CACHE_TTL_SECONDS: int = int(os.getenv("DAIKIN_DEVICES_CACHE_TTL_SECONDS", "1800"))
+    # Hard anti-burst floor between REAL Daikin device reads (any caller). Stops
+    # the read-storm sawtooth (#423 follow-up) — a tight loop gets the warm cache
+    # instead of hitting the wire. Distinct from the 30-min cache TTL and the
+    # force-refresh cooldown; this is the low-level _do_refresh guard.
+    DAIKIN_REFRESH_MIN_INTERVAL_SECONDS: int = int(
+        os.getenv("DAIKIN_REFRESH_MIN_INTERVAL_SECONDS", "90")
+    )
     # Minimum interval between explicit "force refresh" calls (UI refresh button, CLI --force-refresh)
     DAIKIN_FORCE_REFRESH_MIN_INTERVAL_SECONDS: int = int(
         os.getenv("DAIKIN_FORCE_REFRESH_MIN_INTERVAL_SECONDS", "1800")

--- a/src/daikin/service.py
+++ b/src/daikin/service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+import traceback
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -50,6 +51,14 @@ _cold_start_quota_logged: bool = False
 # this caused the 2026-05-27 22:00 UTC retry storm (#423).
 _cold_start_failed_at: float | None = None
 _COLD_START_BACKOFF_SECONDS: int = 600  # 10 min — bounds API attempts to ≤6/h
+
+# Anti-burst: a hard floor on how often a REAL Daikin device read can happen,
+# regardless of caller. The read-storm (#423 follow-up) was a caller hitting the
+# live-fetch path ~1s apart in bursts whenever quota freed up — a sawtooth that
+# kept quota pinned at the cap. This makes bursts structurally impossible: a
+# read within the window returns the warm cache instead of going to the wire.
+_last_refresh_monotonic: float = 0.0
+_refresh_throttle_logged: bool = False  # log the offending call stack once
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +106,7 @@ def _do_refresh(actor: str) -> list[DaikinDevice]:
     burning quota on 429s (#423 belt-and-braces).
     """
     global _devices_cache, _devices_fetched_monotonic, _devices_fetched_wall, _devices_stale
-    global _cold_start_quota_logged
+    global _cold_start_quota_logged, _last_refresh_monotonic, _refresh_throttle_logged
 
     if should_block("daikin"):
         # Raising means callers fall through to their stale-cache / empty
@@ -105,6 +114,28 @@ def _do_refresh(actor: str) -> list[DaikinDevice]:
         # the cache layer's own messaging surfaces the user-facing state.
         logger.debug("_do_refresh blocked: daikin soft cap exhausted (actor=%s)", actor)
         raise DaikinError("Daikin daily quota exhausted")
+
+    # Anti-burst floor: at most one real device read per
+    # DAIKIN_REFRESH_MIN_INTERVAL_SECONDS, regardless of caller. A tight read
+    # loop thus gets the warm cache instead of hammering the wire. Set BEFORE
+    # the fetch so a failing read still holds the window. First call (cache
+    # present) within the window logs the offending stack once, to pinpoint the
+    # looping caller without a separate instrumentation deploy.
+    now_m = time.monotonic()
+    min_iv = float(getattr(config, "DAIKIN_REFRESH_MIN_INTERVAL_SECONDS", 90))
+    if _last_refresh_monotonic and (now_m - _last_refresh_monotonic) < min_iv and _devices_cache is not None:
+        if not _refresh_throttle_logged:
+            _refresh_throttle_logged = True
+            logger.warning(
+                "Daikin _do_refresh throttled (%.1fs since last read < %.0fs floor, actor=%s) "
+                "— returning warm cache. Offending caller:\n%s",
+                now_m - _last_refresh_monotonic, min_iv, actor,
+                "".join(traceback.format_stack(limit=10)),
+            )
+        else:
+            logger.debug("Daikin _do_refresh throttled (actor=%s) — warm cache", actor)
+        return _devices_cache
+    _last_refresh_monotonic = now_m
 
     client = _get_or_create_client()
     devices = client.get_devices()

--- a/tests/test_daikin_quota_fallback.py
+++ b/tests/test_daikin_quota_fallback.py
@@ -39,7 +39,32 @@ def reset_service_state(monkeypatch):
     # must also reset or it leaks between tests and short-circuits the cold-start
     # fetch path into the backoff branch.
     monkeypatch.setattr(daikin_service, "_cold_start_failed_at", None, raising=False)
+    # Anti-burst refresh throttle globals.
+    monkeypatch.setattr(daikin_service, "_last_refresh_monotonic", 0.0, raising=False)
+    monkeypatch.setattr(daikin_service, "_refresh_throttle_logged", False, raising=False)
     yield
+
+
+def test_do_refresh_throttles_rapid_reads(monkeypatch):
+    """Anti-burst floor: two reads inside DAIKIN_REFRESH_MIN_INTERVAL_SECONDS hit
+    the API only ONCE — the second returns the warm cache. This is what
+    structurally kills the read-storm sawtooth regardless of the caller."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr(daikin_service, "should_block", lambda _v: False)
+    monkeypatch.setattr(daikin_service.config, "DAIKIN_REFRESH_MIN_INTERVAL_SECONDS", 300, raising=False)
+    monkeypatch.setattr(daikin_service, "_persist_daikin_telemetry_live", lambda _d: None)
+
+    sentinel = [object()]
+    mock_client = MagicMock()
+    mock_client.get_devices.return_value = sentinel
+    monkeypatch.setattr(daikin_service, "_get_or_create_client", lambda: mock_client)
+
+    first = daikin_service._do_refresh("test")
+    second = daikin_service._do_refresh("test")  # within 300s window → throttled
+
+    assert mock_client.get_devices.call_count == 1, "second rapid read must be throttled"
+    assert second is sentinel, "throttled call returns the warm cache"
 
 
 def _seed_live_row(age_seconds: float, *, tank: float = 50.0, indoor: float = 21.0) -> None:


### PR DESCRIPTION
Follow-up to the circuit-breaker (#435), which capped the damage but left the underlying loop: a **sawtooth** where whenever the 24h window slid under the 180 budget, a caller burst dozens of `get_devices` reads ~1s apart (prod: 58/h, 78/h) until it re-tripped the breaker — keeping quota pinned at the cap and the tank gauges "—".

**Structural fix:** a min-interval floor inside `_do_refresh` (the single device-read chokepoint) — at most one real read per `DAIKIN_REFRESH_MIN_INTERVAL_SECONDS` (default 90s), any caller; a read inside the window returns the warm cache. The first throttle-trip **logs the offending call stack once**, so the looping caller is pinpointed in prod (journalctl) without a separate instrumentation deploy — then we can fix it at source and/or relax the floor.

Test: two reads inside the window → API hit once. `tests/test_daikin*` green (19).