### PR TITLE
feat(ui): plan heating curve + rate-tier background + flow motion

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -136,6 +136,25 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
     except Exception as e:
         logger.warning("pv/today: dispatch kinds failed (%s)", e)
 
+    # --- Heating plan: the deterministic dhw_policy tank trajectory the LP
+    # pins to (warmup rise during the day, setback fall after the evening
+    # showers). tank_target_c[i] = predicted tank °C at the START of slot i;
+    # dhw_load_kwh[i] = predicted heat-pump electric draw for DHW that slot.
+    # Lets the Home "Today's plan" overlay the heating plan without a 2nd call.
+    tank_c_per_slot: list[float | None] = [None] * _SLOTS_PER_DAY
+    dhw_kwh_per_slot: list[float | None] = [None] * _SLOTS_PER_DAY
+    try:
+        from ... import dhw_policy
+
+        e_dhw, tank_traj = dhw_policy.forecast_dhw_load_per_slot(slot_starts)
+        for i in range(_SLOTS_PER_DAY):
+            if i < len(tank_traj):
+                tank_c_per_slot[i] = round(float(tank_traj[i]), 2)
+            if i < len(e_dhw):
+                dhw_kwh_per_slot[i] = round(float(e_dhw[i]), 4)
+    except Exception as e:  # vacation mode / policy off → no heating-plan line
+        logger.warning("pv/today: dhw policy forecast unavailable (%s)", e)
+
     slots_out: list[dict[str, Any]] = []
     acc_f = acc_a = 0.0
     acc_abs = 0.0
@@ -158,6 +177,8 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
             "import_price_p": price_by_start.get(key),
             "base_load_kwh": round(float(bl), 4) if bl is not None else None,
             "kind": kind_by.get(key),
+            "tank_target_c": tank_c_per_slot[i],
+            "dhw_load_kwh": dhw_kwh_per_slot[i],
         })
         if elapsed and a is not None:
             compared += 1

--- a/tests/test_pv_today_endpoint.py
+++ b/tests/test_pv_today_endpoint.py
@@ -51,7 +51,9 @@ def test_pv_today_shape_and_accuracy():
     assert len(resp["slots"]) == 48
     # Every slot carries the full overlay key set; forecast is 0 (no provider
     # in test); price/load/kind are null (no rates/profile/runs seeded).
-    expected_keys = {"slot_utc", "pv_forecast_kwh", "pv_actual_kwh", "import_price_p", "base_load_kwh", "kind"}
+    # tank_target_c / dhw_load_kwh come from the dhw_policy heating-plan forecast.
+    expected_keys = {"slot_utc", "pv_forecast_kwh", "pv_actual_kwh", "import_price_p",
+                     "base_load_kwh", "kind", "tank_target_c", "dhw_load_kwh"}
     assert all(set(s) == expected_keys for s in resp["slots"])
     assert all(s["pv_forecast_kwh"] == 0.0 for s in resp["slots"])
 

--- a/ui/src/components/cockpit/PowerFlow.tsx
+++ b/ui/src/components/cockpit/PowerFlow.tsx
@@ -145,9 +145,13 @@ function BackgroundEdge({ href }: { href: string }) {
 
 function ActiveEdge({ pathId, w, colorVar }: { pathId: string; w: number; colorVar: string }) {
   if (w < ACTIVATION_W) return null;
-  // kW → speed + density + size. Faster + denser + slightly larger = more power.
-  const dur = Math.max(0.7, Math.min(2.6, 3200 / w));
-  const particleCount = w > 2000 ? 4 : w > 1000 ? 3 : w > 400 ? 2 : 1;
+  // kW → speed + density + size. Particle travel time ∝ 1/power, so higher
+  // flow = visibly faster particles. Wide range (0.5s–3.0s) and a low fast-end
+  // clamp so a >4 kW import/export streams noticeably quicker than 2 kW, which
+  // is quicker than 1 kW (operator-requested proportional motion).
+  //   ~800 W → 3.0s · 1 kW → 2.4s · 2 kW → 1.2s · 4 kW → 0.6s · ≥4.8 kW → 0.5s
+  const dur = Math.max(0.5, Math.min(3.0, 2400 / w));
+  const particleCount = w > 3000 ? 5 : w > 2000 ? 4 : w > 1000 ? 3 : w > 400 ? 2 : 1;
   const r = 3 + Math.min(1.5, w / 3000);
   const glowOpacity = 0.35 + Math.min(0.25, w / 4000);
 

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -203,13 +203,11 @@ export function EnergyChartWidget({ execution }: EnergyChartWidgetProps) {
           <span class="echart-foot-grp">
             <strong>Sources</strong>&nbsp;
             <span class="echart-tok echart-tok-solar">{fmt(summary.solar)} solar</span> ·
-            <span class="echart-tok echart-tok-disc">{fmt(summary.discharge)} discharge</span> ·
             <span class="echart-tok echart-tok-imp">{fmt(summary.import)} import</span>
           </span>
           <span class="echart-foot-grp">
             <strong>Sinks</strong>&nbsp;
             <span class="echart-tok echart-tok-load">{fmt(summary.load)} load</span> ·
-            <span class="echart-tok echart-tok-chg">{fmt(summary.charge)} charge</span> ·
             <span class="echart-tok echart-tok-exp">{fmt(summary.export)} export</span>
           </span>
           {daikinTotals && (daikinTotals.kwh_total || 0) > 0 && (
@@ -220,7 +218,7 @@ export function EnergyChartWidget({ execution }: EnergyChartWidgetProps) {
                 <> · <span class="echart-tok-mute">{fmt(daikinTotals.kwh_heating)} heating</span></>
               )}
               {daikinTotals.kwh_dhw > 0 && (
-                <> · <span class="echart-tok-mute">{fmt(daikinTotals.kwh_dhw)} DHW</span></>
+                <> · <span class="echart-tok-mute">{fmt(daikinTotals.kwh_dhw)} tank</span></>
               )}
             </span>
           )}
@@ -242,7 +240,7 @@ export function EnergyChartWidget({ execution }: EnergyChartWidgetProps) {
               <>
                 <span class="echart-tok echart-tok-daikin">{fmt(daikinTotals.kwh_total)} Daikin</span>
                 {daikinTotals.kwh_heating > 0 && <span class="echart-tok-mute"> ({fmt(daikinTotals.kwh_heating)} heat)</span>}
-                {daikinTotals.kwh_dhw > 0 && <span class="echart-tok-mute"> ({fmt(daikinTotals.kwh_dhw)} DHW)</span>}
+                {daikinTotals.kwh_dhw > 0 && <span class="echart-tok-mute"> ({fmt(daikinTotals.kwh_dhw)} tank)</span>}
                 {" · "}
               </>
             )}
@@ -315,7 +313,9 @@ function optionForPeriod(
     ...base,
     legend: {
       ...(base.legend as object),
-      data: ["Solar", "Discharge", "Grid Import", "Charge", "Grid Export", "Load", "Daikin heating", "Daikin DHW"],
+      // Per operator request: only solar, grid import/export, load + the two
+      // Daikin slices. Battery charge/discharge bars intentionally dropped.
+      data: ["Solar", "Grid Import", "Grid Export", "Load", "Daikin heating", "Daikin tank"],
     },
     xAxis: { ...(base.xAxis as object), data: labels },
     yAxis: [{ ...(base.yAxis as object), name: "kWh", nameTextStyle: { color: t.textMute, fontSize: 10 } }],
@@ -329,9 +329,7 @@ function optionForPeriod(
           data: [{ yAxis: 0 }], label: { show: false },
         },
       },
-      seriesBar("Discharge",   points.map((p) => round1(p.discharge_kwh)),  t.batt,        "house"),
       seriesBar("Grid Import", points.map((p) => round1(p.import_kwh)),     t.importColor, "house"),
-      seriesBar("Charge",      points.map((p) => -round1(p.charge_kwh)),    t.batt,        "out", true),
       seriesBar("Grid Export", points.map((p) => -round1(p.export_kwh)),    t.exportColor, "out", true),
       {
         name: "Load",
@@ -358,7 +356,7 @@ function optionForPeriod(
         emphasis: { focus: "series" },
       },
       {
-        name: "Daikin DHW",
+        name: "Daikin tank",
         type: "line",
         data: daikinDhwLine,
         smooth: 0.3,
@@ -454,7 +452,7 @@ function optionForDay(
 
   return {
     ...base,
-    legend: { ...(base.legend as object), data: ["Daikin DHW", "Daikin heating", "Residual", "Realised grid cost"] },
+    legend: { ...(base.legend as object), data: ["Daikin tank", "Daikin heating", "Residual", "Realised grid cost"] },
     // Quiet ghost note — per-slot solar/import/export genuinely unavailable
     // (#424). A text annotation, NOT a fabricated series/markArea.
     graphic: [{
@@ -474,7 +472,7 @@ function optionForDay(
     ],
     series: [
       {
-        name: "Daikin DHW",
+        name: "Daikin tank",
         type: "bar",
         stack: "load",
         data: dhwPerSlot,

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -1,31 +1,33 @@
 import { useEffect, useRef } from "preact/hooks";
 import { makeChart, baseOption, chartTheme, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
 import { useResolvedTheme } from "../../lib/theme";
+import { reducedMotion } from "../../lib/motion";
 import type { PvTodayResponse } from "../../lib/types";
 import "./today-plan.css";
 
 interface TodayPlanWidgetProps {
   pv: PvTodayResponse | null;
   loading: boolean;
+  // Tariff-tier thresholds (p/kWh) for the cheap/peak background shading. From
+  // /metrics — same thresholds the rest of the app classifies bands with.
+  cheapThresholdP?: number | null;
+  peakThresholdP?: number | null;
 }
-
-// Slot kinds that mean the battery is being FILLED (cheap/free energy in) vs
-// EMPTIED to the grid. Mirrors DispatchPlanStrip's colour buckets so the bands
-// read the same across the app.
-const CHARGE_KINDS = new Set(["negative", "cheap", "solar_charge", "solar_preheat", "charge"]);
-const DISCHARGE_KINDS = new Set(["peak_export", "peak", "discharge"]);
 
 function localHM(iso: string): string {
   const d = new Date(iso);
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
+type Tier = "negative" | "cheap" | "peak" | null;
+
 // One chart that answers "what's the plan today?" without tab-switching:
-// import price + charge/discharge windows + load forecast + PV planned vs
-// realised, all on a shared 30-min slot axis. Price on the right axis (p/kWh),
-// energy on the left (kWh). All series come from /pv/today — a single
+// import price + cheap/peak rate windows (background) + load forecast + the
+// heating plan (tank-temp trajectory) + PV planned (background) vs realised
+// (foreground). PV/load/DHW on the left kWh axis, price on the right p axis,
+// tank °C on a second right axis. All series come from /pv/today — one
 // full-day, server-aligned source (no client-side ISO key-matching).
-export function TodayPlanWidget({ pv, loading }: TodayPlanWidgetProps) {
+export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }: TodayPlanWidgetProps) {
   const ref = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
   const theme = useResolvedTheme();
@@ -54,32 +56,46 @@ export function TodayPlanWidget({ pv, loading }: TodayPlanWidgetProps) {
     const pvActual = slots.map((s) => (s.pv_actual_kwh == null ? null : round2(s.pv_actual_kwh)));
     const load = slots.map((s) => (s.base_load_kwh == null ? null : round2(s.base_load_kwh)));
     const price = slots.map((s) => (s.import_price_p == null ? null : s.import_price_p));
+    const tank = slots.map((s) => (s.tank_target_c == null ? null : round2(s.tank_target_c)));
+    const hasTank = tank.some((v) => v != null);
 
-    // Charge/discharge background bands — contiguous runs of charge/discharge
-    // kinds. markArea references the slot INDEX (DST-safe; two slots can share
-    // a local HH:MM label on the autumn clock change).
+    // --- Rate-tier background bands. Classify each slot by import price into
+    // negative / cheap / peak (standard → no shade), then shade contiguous
+    // runs. Thresholds come from /metrics; if absent, fall back to this day's
+    // own price distribution (33rd pct = cheap, 75th = peak).
+    const known = price.filter((p): p is number => p != null).slice().sort((a, b) => a - b);
+    const pct = (q: number) => (known.length ? known[Math.min(known.length - 1, Math.floor(q * known.length))] : null);
+    const cheapAt = cheapThresholdP ?? pct(0.33);
+    const peakAt = peakThresholdP ?? pct(0.75);
+    const tierOf = (p: number | null): Tier => {
+      if (p == null) return null;
+      if (p < 0) return "negative";
+      if (cheapAt != null && p <= cheapAt) return "cheap";
+      if (peakAt != null && p >= peakAt) return "peak";
+      return null;
+    };
+    const tierColor = (k: Tier): string =>
+      k === "negative" ? t.neg : k === "cheap" ? t.cheap : t.peak;
+    // markArea references slot INDEX (DST-safe; two slots can share a label).
     const bands: Array<[{ xAxis: number; itemStyle: object }, { xAxis: number }]> = [];
     let runStart = -1;
-    let runKind: "charge" | "discharge" | null = null;
+    let runTier: Tier = null;
     const flush = (endIdx: number) => {
-      if (runStart < 0 || runKind == null) return;
-      const color = runKind === "charge" ? t.cheap : t.peak;
+      if (runStart < 0 || runTier == null) return;
       bands.push([
-        { xAxis: runStart, itemStyle: { color: withAlpha(color, 0.22) } },
+        { xAxis: runStart, itemStyle: { color: withAlpha(tierColor(runTier), runTier === "peak" ? 0.16 : 0.20) } },
         { xAxis: endIdx },
       ]);
     };
-    slots.forEach((s, i) => {
-      const k = s.kind || undefined;
-      const cur: "charge" | "discharge" | null =
-        k && CHARGE_KINDS.has(k) ? "charge" : k && DISCHARGE_KINDS.has(k) ? "discharge" : null;
-      if (cur !== runKind) {
-        if (runKind != null) flush(i - 1);
-        runKind = cur;
+    slots.forEach((_, i) => {
+      const cur = tierOf(price[i]);
+      if (cur !== runTier) {
+        if (runTier != null) flush(i - 1);
+        runTier = cur;
         runStart = cur != null ? i : -1;
       }
     });
-    if (runKind != null) flush(slots.length - 1);
+    if (runTier != null) flush(slots.length - 1);
 
     // "Now" marker — only when now falls within this day's slots.
     const nowMs = pv.now_utc ? new Date(pv.now_utc).getTime() : Date.now();
@@ -90,64 +106,102 @@ export function TodayPlanWidget({ pv, loading }: TodayPlanWidgetProps) {
       const idx = slots.findIndex((s) => new Date(s.slot_utc).getTime() > nowMs);
       nowIdx = idx <= 0 ? slots.length - 1 : idx - 1;
     }
+    const animate = !reducedMotion();
 
     chartRef.current.setOption({
       ...base,
-      grid: { left: 48, right: 52, top: 28, bottom: 28, containLabel: true },
-      legend: { ...(base.legend as object), show: true },
+      // Extra right margin for the second (°C) axis; legend pinned bottom so it
+      // never collides with the top axis labels or the plot.
+      grid: { left: 16, right: hasTank ? 64 : 44, top: 16, bottom: 44, containLabel: true },
+      legend: {
+        ...(base.legend as object),
+        show: true, top: undefined, right: undefined, bottom: 4, left: "center",
+        data: ["PV actual", "PV planned", "Load forecast", "Heating plan (tank °C)", "Import price"]
+          .filter((n) => hasTank || n !== "Heating plan (tank °C)"),
+      },
       tooltip: {
         ...(base.tooltip as object),
         formatter: (params: Array<{ dataIndex: number }>) => {
           const i = params[0]?.dataIndex ?? 0;
           const s = slots[i];
           if (!s) return "";
-          return `<strong>${labels[i]}</strong>${s.kind ? ` · ${s.kind}` : ""}<br/>` +
+          const tier = tierOf(price[i]);
+          return `<strong>${labels[i]}</strong>${tier ? ` · ${tier}` : ""}<br/>` +
             (price[i] != null ? `Import ${price[i]!.toFixed(1)}p/kWh<br/>` : "") +
             `PV planned ${pvPlanned[i].toFixed(2)} kWh<br/>` +
             (pvActual[i] != null ? `PV actual ${pvActual[i]!.toFixed(2)} kWh<br/>` : "") +
-            (load[i] != null ? `Load ${load[i]!.toFixed(2)} kWh` : "");
+            (load[i] != null ? `Load ${load[i]!.toFixed(2)} kWh<br/>` : "") +
+            (tank[i] != null ? `Tank target ${tank[i]!.toFixed(0)}°C` : "");
         },
       },
       xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
       yAxis: [
-        { ...(base.yAxis as object), name: "kWh", nameTextStyle: { color: t.textDim, fontSize: 10 } },
+        { ...(base.yAxis as object), axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}" } },
         {
           ...(base.yAxis as object),
-          name: "p/kWh", position: "right",
-          nameTextStyle: { color: t.textDim, fontSize: 10 },
-          splitLine: { show: false },
+          position: "right", splitLine: { show: false },
           axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}p" },
+        },
+        {
+          ...(base.yAxis as object),
+          position: "right", offset: 40, splitLine: { show: false },
+          min: 35, max: 62,
+          axisLabel: { color: withAlpha(t.thermal, 0.85), fontSize: 10, formatter: "{value}°" },
         },
       ],
       series: [
+        // Rate-tier shading lives on a silent baseline series (z below all).
         {
-          name: "PV planned", type: "line", smooth: true, showSymbol: false,
-          data: pvPlanned, lineStyle: { color: t.pv, width: 1.5, type: "dashed" },
-          areaStyle: { color: areaGradient(t.pv, 0.16, 0.02) }, z: 2,
+          name: "_bands", type: "line", data: pvPlanned.map(() => null), silent: true,
           markArea: bands.length ? { silent: true, data: bands } : undefined,
           markLine: nowIdx >= 0 ? {
             silent: true, symbol: "none",
-            lineStyle: { color: t.textDim, width: 1, type: "dotted" },
-            label: { show: true, formatter: "now", color: t.textMute, fontSize: 10 },
+            lineStyle: { color: t.text, width: 1.5, type: "solid", opacity: 0.5 },
+            label: { show: false },
             data: [{ xAxis: nowIdx }],
           } : undefined,
+          z: 0,
+        },
+        // PV planned — Open-Meteo forecast in the BACKGROUND: dim, dashed, flat fill.
+        // `color` set so the legend swatch matches the line (ECharts colours the
+        // legend marker from series.color/itemStyle, NOT lineStyle).
+        {
+          name: "PV planned", type: "line", smooth: true, showSymbol: false, color: t.textDim,
+          data: pvPlanned, lineStyle: { color: t.textDim, width: 1, type: "dashed", opacity: 0.7 },
+          areaStyle: { color: withAlpha(t.textDim, 0.06) }, z: 2,
+        },
+        // PV actual — realised in the FOREGROUND: vivid PV colour, thick, gradient fill.
+        {
+          name: "PV actual", type: "line", smooth: true, showSymbol: false, connectNulls: false, color: t.pv,
+          data: pvActual, lineStyle: { color: t.pv, width: 2.75 },
+          areaStyle: { color: areaGradient(t.pv, 0.34, 0.04) }, z: 4,
         },
         {
-          name: "PV actual", type: "line", smooth: true, showSymbol: false, connectNulls: false,
-          data: pvActual, lineStyle: { color: t.pv, width: 2.5 },
-          areaStyle: { color: areaGradient(t.pv, 0.32, 0.04) }, z: 3,
+          name: "Load forecast", type: "line", smooth: true, showSymbol: false, color: t.grid,
+          data: load, lineStyle: { color: t.grid, width: 1.5, type: "dashed" }, z: 3,
         },
+        ...(hasTank ? [{
+          name: "Heating plan (tank °C)", type: "line", smooth: true, showSymbol: false, color: t.thermal,
+          yAxisIndex: 2, data: tank, connectNulls: true,
+          lineStyle: { color: t.thermal, width: 2, cap: "round" },
+          z: 3,
+        }] : []),
         {
-          name: "Load forecast", type: "line", smooth: true, showSymbol: false,
-          data: load, lineStyle: { color: t.grid, width: 1.5, type: "dashed" }, z: 2,
+          name: "Import price", type: "line", step: "middle", showSymbol: false, color: t.importColor,
+          yAxisIndex: 1, data: price, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.75 }, z: 1,
         },
-        {
-          name: "Import price", type: "line", step: "middle", showSymbol: false,
-          yAxisIndex: 1, data: price, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8 }, z: 1,
-        },
+        // Blinking "now" — a pulsing ripple at the current slot on the baseline.
+        ...(nowIdx >= 0 ? [{
+          name: "_now", type: "effectScatter", silent: true,
+          coordinateSystem: "cartesian2d", symbolSize: 10, z: 6,
+          showEffectOn: "render",
+          rippleEffect: { period: animate ? 2.4 : 0, scale: animate ? 3.2 : 1, brushType: "stroke" },
+          itemStyle: { color: t.accent, shadowBlur: 8, shadowColor: t.accent },
+          data: [[nowIdx, 0]],
+        }] : []),
       ],
     }, { notMerge: true });
-  }, [pv, theme]);
+  }, [pv, theme, cheapThresholdP, peakThresholdP]);
 
   const acc = pv?.accuracy;
 
@@ -162,11 +216,12 @@ export function TodayPlanWidget({ pv, loading }: TodayPlanWidgetProps) {
           </span>
         </div>
       )}
-      <div ref={ref} style={{ width: "100%", height: "300px" }} />
+      <div ref={ref} style={{ width: "100%", height: "320px" }} />
       <div class="today-plan-bands">
-        <span class="today-plan-band today-plan-band--charge">charge / cheap / solar window</span>
-        <span class="today-plan-band today-plan-band--discharge">discharge / peak-export window</span>
-        <span class="today-plan-band-hint">shaded bands = LP dispatch plan</span>
+        <span class="today-plan-band today-plan-band--cheap">cheap rate</span>
+        <span class="today-plan-band today-plan-band--peak">peak rate</span>
+        <span class="today-plan-band today-plan-band--neg">negative price</span>
+        <span class="today-plan-band-hint">shaded = tariff tier · ◉ now</span>
       </div>
       {!pv?.slots?.length && !loading && <p class="muted">No plan data for today yet.</p>}
     </div>

--- a/ui/src/components/home/today-plan.css
+++ b/ui/src/components/home/today-plan.css
@@ -42,6 +42,7 @@
   height: 12px;
   border-radius: 3px;
 }
-.today-plan-band--charge::before { background: color-mix(in srgb, var(--cheap) 35%, transparent); }
-.today-plan-band--discharge::before { background: color-mix(in srgb, var(--peak) 35%, transparent); }
+.today-plan-band--cheap::before { background: color-mix(in srgb, var(--cheap) 35%, transparent); }
+.today-plan-band--peak::before { background: color-mix(in srgb, var(--peak) 35%, transparent); }
+.today-plan-band--neg::before { background: color-mix(in srgb, var(--neg-price, #2563eb) 35%, transparent); }
 .today-plan-band-hint { margin-left: auto; }

--- a/ui/src/lib/charts.ts
+++ b/ui/src/lib/charts.ts
@@ -9,6 +9,7 @@ import {
   LineChart,
   BarChart,
   PieChart,
+  EffectScatterChart,
 } from "echarts/charts";
 import {
   GridComponent,
@@ -27,6 +28,7 @@ echarts.use([
   LineChart,
   BarChart,
   PieChart,
+  EffectScatterChart,
   GridComponent,
   TooltipComponent,
   LegendComponent,
@@ -61,6 +63,7 @@ export function chartTheme() {
     peak: cssVar("--peak", "#f59e0b"),
     neg: cssVar("--neg-price", "#2563eb"),
     pv: cssVar("--pv", "#fbbf24"),
+    thermal: cssVar("--thermal", "#fb923c"),
     batt: cssVar("--batt", "#10b981"),
     grid: cssVar("--grid", "#60a5fa"),
     house: cssVar("--house", "#c084fc"),

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -117,6 +117,10 @@ export interface PvTodaySlot {
   import_price_p?: number | null;
   base_load_kwh?: number | null;
   kind?: string | null;
+  // Heating plan: dhw_policy tank-temp trajectory (°C at slot start) + planned
+  // DHW heat-pump energy that slot. null when vacation mode / policy off.
+  tank_target_c?: number | null;
+  dhw_load_kwh?: number | null;
 }
 
 export interface PvTodayAccuracy {

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -136,7 +136,9 @@ export default function Landing() {
         <Widget title="Today's plan" icon="🗓" tone="plan" size="wide"
                 badge={pvToday.data?.forecast_kwh_day_total != null ? `${pvToday.data.forecast_kwh_day_total.toFixed(1)} kWh PV planned` : undefined}>
           <Suspense fallback={<Spinner label="Loading plan…" />}>
-            <TodayPlanWidget pv={pvToday.data} loading={pvToday.loading} />
+            <TodayPlanWidget pv={pvToday.data} loading={pvToday.loading}
+                             cheapThresholdP={metrics.data?.cheap_threshold_pence}
+                             peakThresholdP={metrics.data?.peak_threshold_pence} />
           </Suspense>
         </Widget>
       </div>


### PR DESCRIPTION
## What

Home UX pass on the plan/flow surfaces, per operator feedback.

### Today's plan chart (`TodayPlanWidget` + `/pv/today`)
- **Heating plan shown** — `/pv/today` now returns the dhw_policy tank-temp
  trajectory (`tank_target_c`) + planned DHW energy (`dhw_load_kwh`) per slot
  (pure physics, **zero Daikin quota** — polled every 5 min). Drawn as a quiet
  thermal line on its own °C axis: warmup rise ~13:00, after-shower setback fall.
- **Open-Meteo forecast → background, actuals → foreground** — PV planned is now
  a dim dashed background line+flat fill; PV actual is the vivid `--pv` foreground
  with a gradient fill.
- **Background = cheap/peak rate tiers** — the dispatch charge/discharge bands are
  replaced by tariff-tier shading (cheap / peak / negative) using the `/metrics`
  thresholds (falls back to the day's own price distribution if absent).
- **"now" blinks** — a pulsing `effectScatter` ripple at the current slot (period 0
  under reduced-motion) + a brighter vertical now-line.
- **Captions no longer overlap the chart** — legend moved to the bottom-centre,
  y-axis `name` labels dropped (they collided with the legend + right axis); units
  now live in the legend names + axis-label formatters. Legend swatch colours
  fixed to match the lines (ECharts colours the marker from `series.color`, not
  `lineStyle.color`).

### Energy flow chart (`EnergyChartWidget`)
- Restricted to the six series requested: **Solar, Grid Import, Grid Export, Load,
  Daikin heating, Daikin tank**. Battery **Charge/Discharge bars dropped** (and the
  matching foot tokens); "Daikin DHW" renamed **"Daikin tank"** throughout.

### Live power flow (`PowerFlow`)
- Particle speed now scales clearly with flow: `dur = clamp(0.5s, 3.0s, 2400/W)`
  (~1 kW → 2.4 s, 2 kW → 1.2 s, 4 kW → 0.6 s) + one more particle above 3 kW, so a
  >4 kW import/export visibly streams faster than 2 kW / 1 kW.

## Verification
- `npx tsc -b --noEmit` clean; `npm run build` clean.
- `/pv/today` test updated for the two new slot keys; `pytest test_pv_today_endpoint.py` green.
- Today's-plan layout verified via headless-Chromium render (axes/legend/overlap/
  rate bands/tank line/now-ripple all correct).

## Note
Dropping battery charge/discharge from the energy-flow history is a deliberate
info trade per the explicit "only display [these 6]" request — easy to add back.
