### PR TITLE
feat(ui): heating control cards + tank plan; tariff to bottom

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1372,6 +1372,39 @@ async def foxess_quota():
     return get_refresh_stats_extended()
 
 
+@app.get("/api/v1/daikin/dhw-schedule")
+async def daikin_dhw_schedule():
+    """Today's deterministic DHW tank plan (dhw_policy) — the programmed
+    warmup / setback / boost rows with their times + tank targets. Pure
+    schedule generation; **zero Daikin quota** (no device read). Powers the
+    Heating widget's "tank plan" list.
+    """
+    from datetime import datetime as _dt
+    from zoneinfo import ZoneInfo
+    from .. import dhw_policy
+
+    try:
+        tz = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
+    except Exception:
+        tz = timezone.utc
+    today_local = _dt.now(tz).date()
+    mode = (getattr(config, "OPTIMIZATION_PRESET", "normal") or "normal").strip().lower()
+    rows_out: list[dict] = []
+    try:
+        rows = dhw_policy.generate_daily_tank_schedule(today_local)
+        for r in rows:
+            params = r.get("params") or {}
+            rows_out.append({
+                "action_type": r.get("action_type"),
+                "start_utc": r.get("start_time"),
+                "end_utc": r.get("end_time"),
+                "tank_temp_c": params.get("tank_temp"),
+            })
+    except Exception as e:
+        logger.warning("dhw-schedule: generation failed (%s)", e)
+    return {"mode": mode, "rows": rows_out}
+
+
 @app.get("/api/v1/daikin/consumption")
 async def daikin_consumption(
     period: str = "week",

--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -136,25 +136,6 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
     except Exception as e:
         logger.warning("pv/today: dispatch kinds failed (%s)", e)
 
-    # --- Heating plan: the deterministic dhw_policy tank trajectory the LP
-    # pins to (warmup rise during the day, setback fall after the evening
-    # showers). tank_target_c[i] = predicted tank °C at the START of slot i;
-    # dhw_load_kwh[i] = predicted heat-pump electric draw for DHW that slot.
-    # Lets the Home "Today's plan" overlay the heating plan without a 2nd call.
-    tank_c_per_slot: list[float | None] = [None] * _SLOTS_PER_DAY
-    dhw_kwh_per_slot: list[float | None] = [None] * _SLOTS_PER_DAY
-    try:
-        from ... import dhw_policy
-
-        e_dhw, tank_traj = dhw_policy.forecast_dhw_load_per_slot(slot_starts)
-        for i in range(_SLOTS_PER_DAY):
-            if i < len(tank_traj):
-                tank_c_per_slot[i] = round(float(tank_traj[i]), 2)
-            if i < len(e_dhw):
-                dhw_kwh_per_slot[i] = round(float(e_dhw[i]), 4)
-    except Exception as e:  # vacation mode / policy off → no heating-plan line
-        logger.warning("pv/today: dhw policy forecast unavailable (%s)", e)
-
     slots_out: list[dict[str, Any]] = []
     acc_f = acc_a = 0.0
     acc_abs = 0.0
@@ -177,8 +158,6 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
             "import_price_p": price_by_start.get(key),
             "base_load_kwh": round(float(bl), 4) if bl is not None else None,
             "kind": kind_by.get(key),
-            "tank_target_c": tank_c_per_slot[i],
-            "dhw_load_kwh": dhw_kwh_per_slot[i],
         })
         if elapsed and a is not None:
             compared += 1

--- a/tests/test_pv_today_endpoint.py
+++ b/tests/test_pv_today_endpoint.py
@@ -51,9 +51,7 @@ def test_pv_today_shape_and_accuracy():
     assert len(resp["slots"]) == 48
     # Every slot carries the full overlay key set; forecast is 0 (no provider
     # in test); price/load/kind are null (no rates/profile/runs seeded).
-    # tank_target_c / dhw_load_kwh come from the dhw_policy heating-plan forecast.
-    expected_keys = {"slot_utc", "pv_forecast_kwh", "pv_actual_kwh", "import_price_p",
-                     "base_load_kwh", "kind", "tank_target_c", "dhw_load_kwh"}
+    expected_keys = {"slot_utc", "pv_forecast_kwh", "pv_actual_kwh", "import_price_p", "base_load_kwh", "kind"}
     assert all(set(s) == expected_keys for s in resp["slots"])
     assert all(s["pv_forecast_kwh"] == 0.0 for s in resp["slots"])
 

--- a/ui/src/components/home/HeatingControls.tsx
+++ b/ui/src/components/home/HeatingControls.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "preact/hooks";
 import type { DaikinDevice, ActionResult } from "../../lib/types";
-import { setTankTemperature, setTankPower, setLwtOffset } from "../../lib/endpoints";
+import { setTankTemperature, setTankPower, setLwtOffset, setClimatePower } from "../../lib/endpoints";
 import { Toggle } from "../common/Inputs";
 import { Modal } from "../common/Modal";
+import { Icon } from "../common/Icon";
 import { toast } from "../../lib/toast";
 
 interface HeatingControlsProps {
@@ -20,10 +21,11 @@ function clamp(v: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, v));
 }
 
-// Manual Daikin controls, modelled on the Onecta app: tank-target dial stepper,
-// DHW power, LWT offset. Locked by default (the heat pump runs on dhw_policy);
-// unlocking requires a confirmation modal — that consent is the gate, so the
-// individual controls then apply directly (no per-action confirm).
+// Manual Daikin controls, modelled on the Onecta app and split into two cards —
+// Climate (space-heating power + leaving-water offset) and Tank/DHW (power +
+// target). Locked by default (the heat pump runs on dhw_policy); unlocking
+// needs a confirmation modal — that consent is the gate, so the controls then
+// apply directly (no per-action confirm).
 export function HeatingControls({ dev, controlMode, onChanged }: HeatingControlsProps) {
   const active = (dev?.control_mode ?? controlMode) === "active";
   const [unlocked, setUnlocked] = useState(false);
@@ -55,7 +57,10 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
     }
   };
 
-  const dhwOn = dev?.tank_power ?? false;
+  // Correct power semantics: climate_on / dhw_on are what /daikin/status serves
+  // (tank_power is legacy and never populated → it always read OFF before).
+  const climateOn = dev?.climate_on ?? dev?.is_on ?? false;
+  const tankOn = dev?.dhw_on ?? dev?.tank_power ?? false;
 
   return (
     <div class="heating-controls">
@@ -77,31 +82,46 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
         )}
       </div>
 
-      <div class="heating-control-row">
-        <label class="heating-control-label">Tank target</label>
-        <Stepper value={tankTarget} unit="°C" disabled={!editable || busy}
-                 onStep={(d) => setTankTarget((v) => clamp(v + d, TANK_MIN, TANK_MAX))} />
-        <button class="btn btn--sm" disabled={!editable || busy || tankTarget === dev?.tank_target}
-                onClick={() => run(`Tank set to ${tankTarget}°C`, () => setTankTemperature(tankTarget))}>
-          Apply
-        </button>
-      </div>
+      <div class="heating-controls-cards">
+        {/* Climate (space heating) — power + leaving-water offset */}
+        <section class="hc-card">
+          <header class="hc-card-head">
+            <span class="hc-card-icon"><Icon name="power-live" size={14} /></span>
+            <span class="hc-card-title">Climate</span>
+            <span class={`hc-card-state${climateOn ? " is-on" : ""}`}>{climateOn ? "ON" : "OFF"}</span>
+            <Toggle value={climateOn} ariaLabel="Climate power"
+                    onChange={(next) => editable && run(`Climate ${next ? "ON" : "OFF"}`, () => setClimatePower(next))} />
+          </header>
+          <div class="hc-card-body">
+            <span class="hc-card-label">Water offset</span>
+            <Stepper value={lwt} unit="°" step={0.5} disabled={!editable || busy}
+                     onStep={(d) => setLwt((v) => clamp(Math.round((v + d) * 2) / 2, LWT_MIN, LWT_MAX))} />
+            <button class="btn btn--sm hc-apply" disabled={!editable || busy || lwt === dev?.lwt_offset}
+                    onClick={() => run(`LWT offset ${lwt >= 0 ? "+" : ""}${lwt}`, () => setLwtOffset(lwt))}>
+              Apply
+            </button>
+          </div>
+        </section>
 
-      <div class="heating-control-row">
-        <label class="heating-control-label">DHW power</label>
-        <Toggle value={dhwOn} ariaLabel="DHW power"
-                onChange={(next) => editable && run(`DHW ${next ? "ON" : "OFF"}`, () => setTankPower(next))} />
-        <span class="heating-control-state">{dhwOn ? "ON" : "OFF"}</span>
-      </div>
-
-      <div class="heating-control-row">
-        <label class="heating-control-label">LWT offset</label>
-        <Stepper value={lwt} unit="" step={0.5} disabled={!editable || busy}
-                 onStep={(d) => setLwt((v) => clamp(Math.round((v + d) * 2) / 2, LWT_MIN, LWT_MAX))} />
-        <button class="btn btn--sm" disabled={!editable || busy || lwt === dev?.lwt_offset}
-                onClick={() => run(`LWT offset ${lwt >= 0 ? "+" : ""}${lwt}`, () => setLwtOffset(lwt))}>
-          Apply
-        </button>
+        {/* Tank (DHW) — power + target */}
+        <section class="hc-card">
+          <header class="hc-card-head">
+            <span class="hc-card-icon"><Icon name="schedule" size={14} /></span>
+            <span class="hc-card-title">Tank</span>
+            <span class={`hc-card-state${tankOn ? " is-on" : ""}`}>{tankOn ? "ON" : "OFF"}</span>
+            <Toggle value={tankOn} ariaLabel="Tank power"
+                    onChange={(next) => editable && run(`Tank ${next ? "ON" : "OFF"}`, () => setTankPower(next))} />
+          </header>
+          <div class="hc-card-body">
+            <span class="hc-card-label">Target</span>
+            <Stepper value={tankTarget} unit="°C" disabled={!editable || busy}
+                     onStep={(d) => setTankTarget((v) => clamp(v + d, TANK_MIN, TANK_MAX))} />
+            <button class="btn btn--sm hc-apply" disabled={!editable || busy || tankTarget === dev?.tank_target}
+                    onClick={() => run(`Tank set to ${tankTarget}°C`, () => setTankTemperature(tankTarget))}>
+              Apply
+            </button>
+          </div>
+        </section>
       </div>
 
       <Modal open={confirmingUnlock} onClose={() => setConfirmingUnlock(false)} width="sm"

--- a/ui/src/components/home/HeatingWidget.tsx
+++ b/ui/src/components/home/HeatingWidget.tsx
@@ -9,7 +9,8 @@ import type {
 } from "../../lib/types";
 import { useState, useEffect } from "preact/hooks";
 import { kwh, relTime } from "../../lib/format";
-import { forceRefreshDaikin } from "../../lib/endpoints";
+import { forceRefreshDaikin, getDhwSchedule } from "../../lib/endpoints";
+import type { DhwScheduleRow } from "../../lib/types";
 import { Pill } from "../common/Pill";
 import { Gauge } from "../common/Gauge";
 import { RadialGauge } from "../common/RadialGauge";
@@ -84,7 +85,16 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
   // status via the tank/space rows themselves (ON/OFF), not a "mode" chip.
   const tankTemp = state.tank_c ?? dev?.tank_temp ?? null;
   const tankTarget = dev?.tank_target ?? null;
-  const tankPower = dev?.tank_power ?? null;
+  // dhw_on is what /daikin/status serves; tank_power is legacy (never populated).
+  const tankPower = dev?.dhw_on ?? dev?.tank_power ?? null;
+
+  // Today's deterministic tank plan (times + targets) — dhw_policy, zero quota.
+  const [schedule, setSchedule] = useState<DhwScheduleRow[]>([]);
+  useEffect(() => {
+    let alive = true;
+    getDhwSchedule().then((r) => { if (alive) setSchedule(r.rows || []); }).catch(() => {});
+    return () => { alive = false; };
+  }, []);
 
   // LWT: latest execution slot first, then live cockpit state.
   const lwtFromExec = latestExecValue(execution, (s) => s.daikin_lwt_c);
@@ -175,6 +185,22 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
         </div>
       )}
 
+      {schedule.length > 0 && (
+        <div class="heating-plan">
+          <div class="heating-plan-title">Tank plan · today</div>
+          <ul class="heating-plan-list">
+            {schedule.map((r, i) => (
+              <li key={i} class={`heating-plan-row heating-plan-row--${planKind(r.action_type)}`}>
+                <span class="heating-plan-dot" />
+                <span class="heating-plan-when">{planTime(r.start_utc)}</span>
+                <span class="heating-plan-label">{planLabel(r.action_type)}</span>
+                <span class="heating-plan-temp">{r.tank_temp_c != null ? `${r.tank_temp_c}°C` : "—"}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <HeatingControls dev={dev} controlMode={daikinQuota?.control_mode} onChanged={() => onRefresh?.()} />
 
       <Modal open={confirmingRefresh} onClose={() => { setConfirmingRefresh(false); setRefreshError(null); }} width="sm"
@@ -198,6 +224,25 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
       </Modal>
     </div>
   );
+}
+
+function planKind(action?: string | null): string {
+  if (action === "tank_setback") return "setback";
+  if (action === "tank_negative_boost") return "boost";
+  return "warmup";
+}
+function planLabel(action?: string | null): string {
+  switch (action) {
+    case "tank_setback": return "Setback";
+    case "tank_negative_boost": return "Boost (neg price)";
+    case "tank_warmup": return "Warmup";
+    default: return action || "—";
+  }
+}
+function planTime(iso?: string | null): string {
+  if (!iso) return "—";
+  try { return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }); }
+  catch { return "—"; }
 }
 
 function latestExecValue(

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -56,8 +56,6 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
     const pvActual = slots.map((s) => (s.pv_actual_kwh == null ? null : round2(s.pv_actual_kwh)));
     const load = slots.map((s) => (s.base_load_kwh == null ? null : round2(s.base_load_kwh)));
     const price = slots.map((s) => (s.import_price_p == null ? null : s.import_price_p));
-    const tank = slots.map((s) => (s.tank_target_c == null ? null : round2(s.tank_target_c)));
-    const hasTank = tank.some((v) => v != null);
 
     // --- Rate-tier background bands. Classify each slot by import price into
     // negative / cheap / peak (standard → no shade), then shade contiguous
@@ -110,14 +108,13 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
 
     chartRef.current.setOption({
       ...base,
-      // Extra right margin for the second (°C) axis; legend pinned bottom so it
-      // never collides with the top axis labels or the plot.
-      grid: { left: 16, right: hasTank ? 64 : 44, top: 16, bottom: 44, containLabel: true },
+      // Legend pinned bottom so it never collides with the top axis labels or
+      // the plot (the caption-overlap fix).
+      grid: { left: 16, right: 44, top: 16, bottom: 44, containLabel: true },
       legend: {
         ...(base.legend as object),
         show: true, top: undefined, right: undefined, bottom: 4, left: "center",
-        data: ["PV actual", "PV planned", "Load forecast", "Heating plan (tank °C)", "Import price"]
-          .filter((n) => hasTank || n !== "Heating plan (tank °C)"),
+        data: ["PV actual", "PV planned", "Load forecast", "Import price"],
       },
       tooltip: {
         ...(base.tooltip as object),
@@ -130,8 +127,7 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
             (price[i] != null ? `Import ${price[i]!.toFixed(1)}p/kWh<br/>` : "") +
             `PV planned ${pvPlanned[i].toFixed(2)} kWh<br/>` +
             (pvActual[i] != null ? `PV actual ${pvActual[i]!.toFixed(2)} kWh<br/>` : "") +
-            (load[i] != null ? `Load ${load[i]!.toFixed(2)} kWh<br/>` : "") +
-            (tank[i] != null ? `Tank target ${tank[i]!.toFixed(0)}°C` : "");
+            (load[i] != null ? `Load ${load[i]!.toFixed(2)} kWh` : "");
         },
       },
       xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
@@ -141,12 +137,6 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
           ...(base.yAxis as object),
           position: "right", splitLine: { show: false },
           axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}p" },
-        },
-        {
-          ...(base.yAxis as object),
-          position: "right", offset: 40, splitLine: { show: false },
-          min: 35, max: 62,
-          axisLabel: { color: withAlpha(t.thermal, 0.85), fontSize: 10, formatter: "{value}°" },
         },
       ],
       series: [
@@ -180,12 +170,6 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
           name: "Load forecast", type: "line", smooth: true, showSymbol: false, color: t.grid,
           data: load, lineStyle: { color: t.grid, width: 1.5, type: "dashed" }, z: 3,
         },
-        ...(hasTank ? [{
-          name: "Heating plan (tank °C)", type: "line", smooth: true, showSymbol: false, color: t.thermal,
-          yAxisIndex: 2, data: tank, connectNulls: true,
-          lineStyle: { color: t.thermal, width: 2, cap: "round" },
-          z: 3,
-        }] : []),
         {
           name: "Import price", type: "line", step: "middle", showSymbol: false, color: t.importColor,
           yAxisIndex: 1, data: price, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.75 }, z: 1,

--- a/ui/src/components/home/heating.css
+++ b/ui/src/components/home/heating.css
@@ -159,3 +159,79 @@
   font-weight: 600;
   color: var(--text);
 }
+
+/* --- Two-card control layout: Climate | Tank --- */
+.heating-controls-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+@media (max-width: 340px) {
+  .heating-controls-cards { grid-template-columns: 1fr; }
+}
+.hc-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 10px);
+  background: var(--bg-card-2);
+}
+.hc-card-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.hc-card-icon { display: inline-flex; color: var(--text-dim); }
+.hc-card-title { font-weight: 600; font-size: var(--font-sm); }
+.hc-card-state {
+  margin-left: auto;
+  font-size: var(--font-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+}
+.hc-card-state.is-on { color: var(--ok); }
+/* Vertical body so two cards sit side-by-side even in a ~380px medium widget. */
+.hc-card-body {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-2);
+}
+.hc-card-label {
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+}
+.hc-card-body .heating-stepper { justify-content: space-between; width: 100%; }
+.hc-apply { align-self: flex-end; }
+
+/* --- Tank plan (today's dhw_policy schedule) --- */
+.heating-plan {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px dashed var(--border);
+}
+.heating-plan-title {
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-2);
+}
+.heating-plan-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.heating-plan-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-sm);
+  font-variant-numeric: tabular-nums;
+}
+.heating-plan-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; background: var(--text-mute); }
+.heating-plan-row--warmup .heating-plan-dot { background: var(--pv, #fbbf24); }
+.heating-plan-row--setback .heating-plan-dot { background: var(--text-mute); }
+.heating-plan-row--boost .heating-plan-dot { background: var(--neg-price, #2563eb); }
+.heating-plan-when { color: var(--text); min-width: 3rem; }
+.heating-plan-label { color: var(--text-dim); flex: 1; }
+.heating-plan-temp { font-weight: 700; color: var(--text); }

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -21,6 +21,7 @@ import type {
   TariffDashboardResponse,
   PeriodInsightsResponse,
   DaikinConsumptionResponse,
+  DhwScheduleResponse,
   PvTodayResponse,
   OptimizationInputsResponse,
   ActionResult,
@@ -47,6 +48,8 @@ export const getDaikinStatus = () => getJson<DaikinDevice[]>("/daikin/status");
 export const forceRefreshDaikin = () => getJson<DaikinDevice[]>("/daikin/status?refresh=true");
 export const getDaikinQuota = () => getJson<ApiQuotaResponse>("/daikin/quota");
 export const getFoxQuota = () => getJson<ApiQuotaResponse>("/foxess/quota");
+// Today's deterministic DHW tank plan (times + targets). Zero Daikin quota.
+export const getDhwSchedule = () => getJson<DhwScheduleResponse>("/daikin/dhw-schedule");
 
 /* ----- Daikin controls (writes — require DAIKIN_CONTROL_MODE=active) -----
    The UI shows its own confirm dialog, then sends skip_confirmation:true so
@@ -56,6 +59,9 @@ export const setTankTemperature = (temperature: number) =>
   postJson<ActionResult>("/daikin/tank-temperature", { temperature });
 export const setTankPower = (on: boolean) =>
   postJson<ActionResult>("/daikin/tank-power", { on, skip_confirmation: true });
+// Climate (space-heating) zone power — mirrors tank-power.
+export const setClimatePower = (on: boolean) =>
+  postJson<ActionResult>("/daikin/power", { on, skip_confirmation: true });
 export const setLwtOffset = (offset: number) =>
   postJson<ActionResult>("/daikin/lwt-offset", { offset });
 export const setDaikinMode = (mode: DaikinOperationMode) =>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -117,10 +117,6 @@ export interface PvTodaySlot {
   import_price_p?: number | null;
   base_load_kwh?: number | null;
   kind?: string | null;
-  // Heating plan: dhw_policy tank-temp trajectory (°C at slot start) + planned
-  // DHW heat-pump energy that slot. null when vacation mode / policy off.
-  tank_target_c?: number | null;
-  dhw_load_kwh?: number | null;
 }
 
 export interface PvTodayAccuracy {
@@ -438,8 +434,25 @@ export interface DaikinDevice {
   weather_regulation?: boolean | null;
   control_mode?: string | null;
   state_summary?: string | null;
+  // is_on === climate (space-heating) onOffMode; prefer climate_on / dhw_on
+  // (unambiguous, what /daikin/status actually serves). tank_power is legacy
+  // and NOT populated by the status route — use dhw_on for the tank.
   is_on?: boolean | null;
+  climate_on?: boolean | null;
+  dhw_on?: boolean | null;
   tank_power?: boolean | null;
+}
+
+// Today's deterministic DHW tank plan — GET /api/v1/daikin/dhw-schedule.
+export interface DhwScheduleRow {
+  action_type?: string | null;   // tank_warmup | tank_setback | tank_negative_boost
+  start_utc?: string | null;
+  end_utc?: string | null;
+  tank_temp_c?: number | null;
+}
+export interface DhwScheduleResponse {
+  mode: string;
+  rows: DhwScheduleRow[];
 }
 
 // Daikin operation modes accepted by POST /daikin/mode.

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -143,21 +143,21 @@ export default function Landing() {
         </Widget>
       </div>
 
-      {/* ── MONEY ──────────────────────────────────────────────────── */}
-      <div class="widget-grid widget-band">
-        <Widget title="Tariff comparison" icon="📊" tone="savings" size="wide"
-                badge={tariffDash.data?.usage?.total_days ? `last ${tariffDash.data.usage.total_days}d of your usage` : undefined}
-                action={<RefreshAction onRefresh={tariffDash.refresh} loading={tariffDash.loading} />}>
-          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} monthPeriod={monthPeriod.data} monthPeriodLoading={monthPeriod.loading} />
-        </Widget>
-      </div>
-
       {/* ── ENERGY ─────────────────────────────────────────────────── */}
       <div class="widget-grid widget-band">
         <Widget title="Energy flow" icon="📈" tone="power" size="wide">
           <Suspense fallback={<Spinner label="Loading chart…" />}>
             <EnergyChartWidget execution={execution.data} />
           </Suspense>
+        </Widget>
+      </div>
+
+      {/* ── MONEY (bottom of page) ─────────────────────────────────── */}
+      <div class="widget-grid widget-band">
+        <Widget title="Tariff comparison" icon="📊" tone="savings" size="wide"
+                badge={tariffDash.data?.usage?.total_days ? `last ${tariffDash.data.usage.total_days}d of your usage` : undefined}
+                action={<RefreshAction onRefresh={tariffDash.refresh} loading={tariffDash.loading} />}>
+          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} monthPeriod={monthPeriod.data} monthPeriodLoading={monthPeriod.loading} />
         </Widget>
       </div>
     </div>


### PR DESCRIPTION
## What

Follow-up UX round on the Home surfaces, per operator notes.

### Heating widget
- **Tank plan shown here (not on the chart)** — new `GET /api/v1/daikin/dhw-schedule`
  returns today's dhw_policy rows (warmup / setback / negative-boost) with their
  **times + tank targets** (pure schedule gen, **zero Daikin quota**). Rendered as
  a compact "Tank plan · today" list (e.g. `13:00 Warmup 48°C` · `22:00 Setback 37°C`).
- **Controls redesigned into two side-by-side cards** — **Climate** (space-heating
  power toggle + leaving-water offset stepper) and **Tank** (DHW power toggle +
  target stepper), each with its own Apply. Replaces the cramped single-column rows
  where the DHW toggle sat awkwardly between the steppers.
- **Real bug fixed:** the power state read `dev.tank_power`, which `/daikin/status`
  **never populates** (the model serves `climate_on` / `dhw_on`) — so the DHW
  toggle always showed OFF. Now uses `dhw_on` (tank) and `climate_on` (climate).
- Added `setClimatePower` (`POST /daikin/power`) so the climate zone can be toggled.

### Today's plan chart
- **Heating-plan tank line removed** (moved to the Heating widget, above). The 3rd
  °C axis is gone; PV background/foreground, cheap/peak rate-tier shading, the
  blinking "now" ripple and the bottom legend (caption fix) all stay.

### Layout
- **Tariff comparison moved to the bottom** of the Home page (after Energy flow).

## Not changed (investigated, no bug)
- **Grid import** — prod's metered half-hourly import for yesterday was **1.496 kWh**
  (battery didn't fully cover overnight base load), so the chart's ~1.6 is correct.
- **Energy-flow export** is already a downward bar on the same y-axis, no offset.

## Verification
- `tsc` + `npm run build` clean; `pytest test_pv_today_endpoint.py` green (PV slot
  keys reverted to the original set); `daikin_dhw_schedule` smoke returns the
  warmup/setback rows.
- Controls + tank-plan layout verified side-by-side via headless-Chromium render.
