### PR TITLE
feat(ui): Hero month-outcome vs BG Fixed; plan ref/actual colours

### DIFF
--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -15,26 +15,50 @@ interface HeroProps {
   periodsLoading: boolean;
 }
 
-// The hero is the at-a-glance "where are we right now" surface. It bundles:
-//   1. Savings vs SVT (the biggest number on the screen)
-//   2. Comparison vs the previous BG Fixed contract
-//   3. Today's running DMA (£/day)
-//   4. Lifetime totals on Agile (folded in from the old Lifetime widget)
-//   5. Live "motion" — action verb + tariff band + import/export p/kWh
-// Numeric values are tweened via useAnimatedNumber so refreshes feel alive
-// rather than snapping.
-export function Hero({ metrics, metricsLoading, cockpit, agile, monthly, todayPeriod, monthPeriod, periodsLoading }: HeroProps) {
-  const daily = metrics?.pnl?.daily;
-  const today = daily?.delta_vs_svt_pounds ?? null;
-  const todayFixed = daily?.delta_vs_fixed_pounds ?? null;
-  const monthTotal = metrics?.pnl?.monthly?.delta_vs_svt_pounds ?? null;
+// SEG export floor used when comparing against a flat fixed tariff (which
+// wouldn't have Agile's outgoing rate). Matches TariffComparisonWidget.
+const SEG_EXPORT_FALLBACK_P = 4.0;
 
-  const dayOfMonth = new Date().getDate();
-  const monthDaily = monthTotal != null ? monthTotal / Math.max(1, dayOfMonth) : null;
+// The hero answers ONE question clearly: how is this month going on Agile vs the
+// household's real alternative (British Gas Fixed)?  We lead with the MONTH —
+// it's the figure backed by complete, metered data — because *today* only fills
+// in after the next-day Octopus backfill, so an intraday "today" headline would
+// be empty or estimated. Hierarchy:
+//   1. This month's real net bill (the big number)
+//   2. Saved vs BG Fixed + exported (the outcome line)
+//   3. Today so far — small, explicitly an estimate
+//   4. Lifetime totals on Agile
+//   5. The cost-composition chart (Today / 7d / Month)
+export function Hero({ metrics, cockpit, agile, monthly, todayPeriod, monthPeriod, periodsLoading }: HeroProps) {
+  const monthName = new Date().toLocaleDateString([], { month: "long" });
 
-  const sign = today == null ? "neutral" : today >= 0 ? "positive" : "negative";
+  // --- This month, real money ---
+  const monthNet = monthPeriod?.cost?.net_cost_pounds ?? null;          // £ out the door
+  const monthExport = monthPeriod?.cost?.export_earnings_pounds ?? null;
+  const cd = monthPeriod?.chart_data ?? [];
+  const monthDays = cd.length;
+  const monthImportKwh = cd.reduce((s, d) => s + (d.import_kwh ?? 0), 0);
+  const monthExportKwh = cd.reduce((s, d) => s + (d.export_kwh ?? 0), 0);
 
+  // --- Saved vs British Gas Fixed (computed client-side from the same real
+  // usage block + the configured FIXED_TARIFF_* rates — the engine's
+  // delta_vs_fixed uses a different MANUAL_TARIFF rate, so we don't use it). ---
+  const ft = metrics?.fixed_tariff;
+  let savedVsFixed: number | null = null;
+  if (ft?.label && ft.rate_pence && monthNet != null && monthDays > 0) {
+    const bgImport = monthImportKwh * ft.rate_pence / 100;
+    const bgStanding = monthDays * (ft.standing_pence_per_day ?? 0) / 100;
+    const bgExport = monthExportKwh * SEG_EXPORT_FALLBACK_P / 100;
+    const bgNet = bgImport + bgStanding - bgExport;
+    savedVsFixed = bgNet - monthNet;
+  }
+  const fixedLabel = ft?.label || "fixed tariff";
 
+  // --- Today so far — estimate only (realised lands next-day). The engine's
+  // daily fixed delta is the available "today savings" figure. ---
+  const todayEst = metrics?.pnl?.daily?.delta_vs_fixed_pounds ?? null;
+
+  // --- Lifetime totals on Agile (folded in from the old Lifetime widget) ---
   const activeMonths = monthly.filter(
     (m) => (m.cost?.net_cost_pounds ?? 0) !== 0 || (m.energy?.export_kwh ?? 0) > 0,
   );
@@ -48,55 +72,50 @@ export function Hero({ metrics, metricsLoading, cockpit, agile, monthly, todayPe
       }
     : null;
 
-  // Smooth tweens for every refreshing figure.
-  const todayAnim = useAnimatedNumber(today);
-  const todayFixedAnim = useAnimatedNumber(todayFixed);
-  const monthDailyAnim = useAnimatedNumber(monthDaily);
+  // Smooth tweens for the refreshing figures.
+  const monthNetAnim = useAnimatedNumber(monthNet);
+  const savedAnim = useAnimatedNumber(savedVsFixed);
+  const todayAnim = useAnimatedNumber(todayEst);
   const solarAnim = useAnimatedNumber(lifetime?.solar_kwh ?? null);
   const exportKwhAnim = useAnimatedNumber(lifetime?.export_kwh ?? null);
   const exportEarnAnim = useAnimatedNumber(lifetime?.export_earn ?? null);
   const totalCostAnim = useAnimatedNumber(lifetime?.total_cost ?? null);
-
-  // Export earnings — folded in from the removed standalone Exports widget.
-  const exportToday = todayPeriod?.cost?.export_earnings_pounds ?? null;
-  const exportMonth = monthPeriod?.cost?.export_earnings_pounds ?? null;
   const curExportP = agile?.current_export_p ?? cockpit?.current_slot?.price_export_p ?? null;
-  const exportTodayAnim = useAnimatedNumber(exportToday);
-  const exportMonthAnim = useAnimatedNumber(exportMonth);
 
   return (
-    <section class="hero" aria-label="Live status + savings overview">
+    <section class="hero" aria-label="This month's energy outcome">
       <div class="hero-bg" aria-hidden="true" />
 
       <div class="hero-main">
         <div class="hero-eyebrow">
           <span class="live-pulse hero-eyebrow-dot" />
-          Today · saved vs Standard Variable Tariff
+          {monthName} on Agile · net bill so far
         </div>
-        <div class={`hero-headline hero-headline--enter hero-headline--${sign}`}>
-          {todayAnim == null ? (metricsLoading ? <SkelHero /> : "—") : gbpSigned(todayAnim)}
+        {/* The big number is the BILL — kept neutral; the savings line below
+            carries the good/bad colour. */}
+        <div class="hero-headline hero-headline--enter">
+          {monthNetAnim == null ? (periodsLoading ? <SkelHero /> : "—") : gbp(monthNetAnim)}
         </div>
         <div class="hero-sublines">
-          {todayFixedAnim != null && (
+          {savedAnim != null && (
             <div class="hero-subline">
-              vs British Gas Fixed:&nbsp;
-              <strong class={todayFixedAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
-                {gbpSigned(todayFixedAnim)}
+              <strong class={savedAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
+                {savedAnim >= 0 ? "Saved " : "Cost "}{gbpSigned(savedAnim)}
               </strong>
+              &nbsp;vs {fixedLabel}
+              {monthExport != null && monthExport > 0 && (
+                <>&nbsp;·&nbsp;<strong class="hero-strong-pos">{gbp(monthExport)}</strong> exported</>
+              )}
             </div>
           )}
-          {monthDailyAnim != null && (
+          {todayAnim != null && (
             <div class="hero-subline hero-subline-dma">
-              This month's running average:&nbsp;
-              <strong class={monthDailyAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
-                {gbpSigned(monthDailyAnim)}/day
+              Today so far:&nbsp;
+              <strong class={todayAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
+                {gbpSigned(todayAnim)}
               </strong>
-            </div>
-          )}
-          {todayPeriod?.cost?.net_cost_pounds != null && (
-            <div class="hero-subline">
-              Today's bill so far:&nbsp;
-              <strong>{gbp(todayPeriod.cost.net_cost_pounds)}</strong>
+              &nbsp;vs {fixedLabel}
+              <span class="hero-est-tag" title="Estimate — today's metered cost confirms after the next-day Octopus backfill.">est</span>
             </div>
           )}
         </div>
@@ -105,24 +124,13 @@ export function Hero({ metrics, metricsLoading, cockpit, agile, monthly, todayPe
           <div class="hero-lifetime" title={`Sums across ${lifetime.months} active months on Agile`}>
             <div class="hero-lifetime-label">
               Lifetime on Agile · {lifetime.months} mo
+              {curExportP != null ? ` · export now ${curExportP.toFixed(1)}p/kWh` : ""}
             </div>
             <div class="hero-lifetime-stats">
               <HeroStat value={kwh(solarAnim ?? 0, 0)} label="solar produced" />
               <HeroStat value={kwh(exportKwhAnim ?? 0, 0)} label="exported" />
               <HeroStat value={gbp(exportEarnAnim ?? 0)} label="export earnings" />
               <HeroStat value={gbp(totalCostAnim ?? 0)} label="total bills" />
-            </div>
-          </div>
-        )}
-
-        {(exportToday != null || exportMonth != null) && (
-          <div class="hero-lifetime hero-export">
-            <div class="hero-lifetime-label">
-              Export earnings{curExportP != null ? ` · now ${curExportP.toFixed(1)}p/kWh` : ""}
-            </div>
-            <div class="hero-lifetime-stats">
-              <HeroStat value={gbp(exportTodayAnim ?? 0)} label="today" />
-              <HeroStat value={gbp(exportMonthAnim ?? 0)} label="this month" />
             </div>
           </div>
         )}

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -152,23 +152,26 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
           } : undefined,
           z: 0,
         },
-        // PV planned — Open-Meteo forecast in the BACKGROUND: dim, dashed, flat fill.
-        // `color` set so the legend swatch matches the line (ECharts colours the
-        // legend marker from series.color/itemStyle, NOT lineStyle).
+        // Colour scheme: each metric keeps ONE hue; the REFERENCE (forecast/
+        // planned) is the dim/dark, dashed version, the ACTUAL is the bright,
+        // solid one. So PV planned vs PV actual read as the same thing, dim→bright.
+        // `color` is set so the legend swatch matches the line (ECharts colours
+        // the legend marker from series.color, NOT lineStyle).
         {
-          name: "PV planned", type: "line", smooth: true, showSymbol: false, color: t.textDim,
-          data: pvPlanned, lineStyle: { color: t.textDim, width: 1, type: "dashed", opacity: 0.7 },
-          areaStyle: { color: withAlpha(t.textDim, 0.06) }, z: 2,
+          name: "PV planned", type: "line", smooth: true, showSymbol: false, color: withAlpha(t.pv, 0.45),
+          data: pvPlanned, lineStyle: { color: withAlpha(t.pv, 0.45), width: 1.25, type: "dashed" },
+          areaStyle: { color: withAlpha(t.pv, 0.05) }, z: 2,
         },
         // PV actual — realised in the FOREGROUND: vivid PV colour, thick, gradient fill.
         {
           name: "PV actual", type: "line", smooth: true, showSymbol: false, connectNulls: false, color: t.pv,
           data: pvActual, lineStyle: { color: t.pv, width: 2.75 },
-          areaStyle: { color: areaGradient(t.pv, 0.34, 0.04) }, z: 4,
+          areaStyle: { color: areaGradient(t.pv, 0.36, 0.04) }, z: 4,
         },
+        // Load forecast is a reference → dim, dashed (its own cool hue).
         {
-          name: "Load forecast", type: "line", smooth: true, showSymbol: false, color: t.grid,
-          data: load, lineStyle: { color: t.grid, width: 1.5, type: "dashed" }, z: 3,
+          name: "Load forecast", type: "line", smooth: true, showSymbol: false, color: withAlpha(t.grid, 0.5),
+          data: load, lineStyle: { color: withAlpha(t.grid, 0.5), width: 1.25, type: "dashed" }, z: 3,
         },
         {
           name: "Import price", type: "line", step: "middle", showSymbol: false, color: t.importColor,

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -124,6 +124,18 @@
  * inline colour; surrounding label stays dim so only the figure carries it. */
 .hero-strong-pos { color: var(--ok); font-weight: 600; }
 .hero-strong-neg { color: var(--bad); font-weight: 600; }
+/* "est" tag on the intraday today figure — quiet, italic, recessed. */
+.hero-est-tag {
+  margin-left: 6px;
+  padding: 1px 5px;
+  font-size: 0.6rem;
+  font-style: italic;
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  vertical-align: middle;
+}
 
 /* Lifetime strip — supporting context, fully monochrome. Hairline + space. */
 .hero-lifetime {


### PR DESCRIPTION
## What

Two Home clarity fixes per operator feedback.

### Hero — lead with one clear outcome
The Hero led with **today**, but today's realised data only lands after the
next-day Octopus backfill — so intraday it showed an *estimated* delta, the
bill subline vanished, and it stacked four framings (vs SVT / vs BG-Fixed /
running-avg/day / bill). Rebuilt around **one** question: *how is this month
going on Agile vs our real alternative (British Gas Fixed)?*

- **Big number** = this month's **real net bill so far** (from `/energy/period`
  month — complete, metered).
- **Outcome line** = `Saved +£X vs British Gas Fixed · £Y exported`. The BG-Fixed
  figure is computed client-side from `metrics.fixed_tariff` + the month's real
  usage (same method as the Tariff-comparison widget; the engine's
  `delta_vs_fixed` uses a different `MANUAL_TARIFF` rate, so it isn't reused).
- **Today** demoted to a small line, explicitly tagged `est` (tooltip: confirms
  after the next-day backfill).
- Headline is now **neutral** (it's the bill); the savings line carries the
  good/bad colour. Lifetime strip + cost-composition chart unchanged (the chart
  already shows Today as "—" when realised is null — honest, not broken).

### Today's plan — reference vs actual colour scheme
Each metric now keeps **one hue**; the **reference** (forecast/planned) is the
dim, dashed version and the **actual** is the bright, solid one — so PV planned
vs PV actual read as the same thing (dim → bright) instead of grey-vs-amber.
Load forecast dimmed to read as a reference too.

## Verification
- `tsc` + `npm run build` clean.
- Hero hierarchy + Today's-plan colours verified via headless-Chromium renders.

No backend change.
