### PR TITLE
chore(daikin): trace read callers (flag-gated diagnostic)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1432,6 +1432,10 @@ class Config:
     DAIKIN_REFRESH_MIN_INTERVAL_SECONDS: int = int(
         os.getenv("DAIKIN_REFRESH_MIN_INTERVAL_SECONDS", "90")
     )
+    # Temporary diagnostic: log the caller stack on every Daikin device read
+    # (client.get_devices). Used to pinpoint the residual read-burst source.
+    # Off by default; flip in prod .env for a capture window, then remove.
+    DAIKIN_TRACE_READS: bool = os.getenv("DAIKIN_TRACE_READS", "false").lower() == "true"
     # Minimum interval between explicit "force refresh" calls (UI refresh button, CLI --force-refresh).
     # 5 min: long enough to stop button-mashing through the ~200/day quota, short
     # enough that an operator who genuinely needs fresh state isn't stuck waiting.

--- a/src/daikin/client.py
+++ b/src/daikin/client.py
@@ -11,7 +11,9 @@ Usage:
 """
 import datetime as _datetime  # noqa: F401 — used in type hint of get_daily_consumption_from_cache
 import json
+import logging
 import time
+import traceback
 import urllib.error
 import urllib.request
 
@@ -19,6 +21,8 @@ from ..api_quota import record_call, should_block
 from ..config import config
 from .auth import get_valid_access_token
 from .models import DaikinDevice, DaikinStatus, SetpointRange
+
+logger = logging.getLogger(__name__)
 
 
 class DaikinError(Exception):
@@ -133,6 +137,15 @@ class DaikinClient:
 
     def get_devices(self) -> list[DaikinDevice]:
         """List all gateway devices."""
+        # Temporary diagnostic (DAIKIN_TRACE_READS): every Daikin READ funnels
+        # through here → _get. Logging the caller chain on each call pinpoints
+        # the burst source (the ~10-29-read clusters that pass under the 90s
+        # throttle floor). Off by default; flip the .env flag to capture, then
+        # remove. Compact: skip the two innermost frames (this method + caller
+        # shim), keep the next ~8.
+        if getattr(config, "DAIKIN_TRACE_READS", False):
+            stack = traceback.format_stack(limit=12)[:-1]
+            logger.warning("DAIKIN_READ_CALLER ↓\n%s", "".join(stack[-9:]))
         data = self._get("/gateway-devices")
         devices = []
         for gw in data if isinstance(data, list) else []:


### PR DESCRIPTION
## What

Temporary diagnostic to pinpoint the residual Daikin read-burst source.

After the storm was contained (#435/#442/#443), prod still shows **90–115 reads/day**
(under the 180 budget, never blocking) in **~10–29-read clusters** at various hours.
These pass *under* the 90 s `_do_refresh` throttle (cadence ~2 min > 90 s floor) and
the throttle logs 0 trips — so the caller is unidentified (either bypasses
`_do_refresh` via a direct `client.get_devices()`, or is just spaced over 90 s).

`client.get_devices()` is the **single funnel** every Daikin read passes through
(it's the only `_get` caller). This adds a caller-stack log there, gated by a new
`DAIKIN_TRACE_READS` flag (default **off** — no behaviour change):

```python
if config.DAIKIN_TRACE_READS:
    logger.warning("DAIKIN_READ_CALLER ↓\n%s", compact_stack)
```

## How it's used
1. Deploy (flag off by default).
2. Set `DAIKIN_TRACE_READS=true` in prod `.env`, restart.
3. Wait for the next cluster (~hourly), `journalctl`/`docker logs` grep
   `DAIKIN_READ_CALLER` → the stack reveals the looping caller.
4. Route that path through `service.get_cached_devices()` (or fix its cadence),
   then remove this diagnostic.

Backend-only — UI image unchanged.
