### PR TITLE
fix(daikin): route consumption reads through cache (read-burst root fix)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1432,10 +1432,6 @@ class Config:
     DAIKIN_REFRESH_MIN_INTERVAL_SECONDS: int = int(
         os.getenv("DAIKIN_REFRESH_MIN_INTERVAL_SECONDS", "90")
     )
-    # Temporary diagnostic: log the caller stack on every Daikin device read
-    # (client.get_devices). Used to pinpoint the residual read-burst source.
-    # Off by default; flip in prod .env for a capture window, then remove.
-    DAIKIN_TRACE_READS: bool = os.getenv("DAIKIN_TRACE_READS", "false").lower() == "true"
     # Minimum interval between explicit "force refresh" calls (UI refresh button, CLI --force-refresh).
     # 5 min: long enough to stop button-mashing through the ~200/day quota, short
     # enough that an operator who genuinely needs fresh state isn't stuck waiting.

--- a/src/daikin/client.py
+++ b/src/daikin/client.py
@@ -11,9 +11,7 @@ Usage:
 """
 import datetime as _datetime  # noqa: F401 — used in type hint of get_daily_consumption_from_cache
 import json
-import logging
 import time
-import traceback
 import urllib.error
 import urllib.request
 
@@ -21,8 +19,6 @@ from ..api_quota import record_call, should_block
 from ..config import config
 from .auth import get_valid_access_token
 from .models import DaikinDevice, DaikinStatus, SetpointRange
-
-logger = logging.getLogger(__name__)
 
 
 class DaikinError(Exception):
@@ -137,18 +133,6 @@ class DaikinClient:
 
     def get_devices(self) -> list[DaikinDevice]:
         """List all gateway devices."""
-        # Temporary diagnostic (DAIKIN_TRACE_READS): every Daikin READ funnels
-        # through here → _get. Logging the caller chain on each call pinpoints
-        # the burst source (the ~10-29-read clusters that pass under the 90s
-        # throttle floor). Off by default; flip the .env flag to capture, then
-        # remove. Compact: skip the two innermost frames (this method + caller
-        # shim), keep the next ~8.
-        if getattr(config, "DAIKIN_TRACE_READS", False):
-            # Full stack (deep under the scheduler thread pool), then the
-            # INNERMOST ~12 frames — those nearest get_devices are the real
-            # app caller. stack[-1] is this method itself, so end at -1.
-            stack = traceback.format_stack()
-            logger.warning("DAIKIN_READ_CALLER ↓\n%s", "".join(stack[-13:-1]))
         data = self._get("/gateway-devices")
         devices = []
         for gw in data if isinstance(data, list) else []:
@@ -334,15 +318,20 @@ class DaikinClient:
         self._patch(self._dhw_path(device, "powerfulMode"), {"value": "on" if on else "off"})
 
     def get_heating_consumption_kwh(
-        self, year: int, month: int
+        self, year: int, month: int, devices: list[DaikinDevice] | None = None
     ) -> float | None:
         """
         Get heating electrical consumption (kWh) for a given month from Daikin when available.
         Onecta exposes this for some devices (e.g. Altherma) via electricalConsumption.
         Returns None if not available or on error.
+
+        Pass ``devices`` (e.g. the cached service-layer payload) to read the
+        consumption out of an already-fetched device list — avoids a fresh
+        ``get_devices()`` wire read (the energy-insights read-burst fix).
         """
         try:
-            devices = self.get_devices()
+            if devices is None:
+                devices = self.get_devices()
             total = 0.0
             for device in devices:
                 val = self._device_heating_kwh_for_month(device, year, month)
@@ -562,13 +551,19 @@ class DaikinClient:
                 b["dhw_kwh"] = round(b["dhw_kwh"], 3)
         return out
 
-    def get_heating_daily_kwh(self, year: int, month: int) -> list[float] | None:
+    def get_heating_daily_kwh(
+        self, year: int, month: int, devices: list[DaikinDevice] | None = None
+    ) -> list[float] | None:
         """
         Get daily heating consumption (kWh) for the month when available.
         Returns list of 28–31 values (index 0 = day 1). None if not available.
+
+        Pass ``devices`` to read from an already-fetched payload (cache) instead
+        of a fresh wire read — see :meth:`get_heating_consumption_kwh`.
         """
         try:
-            devices = self.get_devices()
+            if devices is None:
+                devices = self.get_devices()
             # Sum daily from all devices (usually one)
             result: list[float] = []
             for device in devices:

--- a/src/daikin/service.py
+++ b/src/daikin/service.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from ..api_quota import quota_remaining, record_call, should_block
+from ..api_quota import quota_remaining, should_block
 from ..config import config
 from .client import DaikinClient, DaikinError
 from .models import DaikinDevice
@@ -673,6 +673,27 @@ def set_weather_regulation(enabled: bool, actor: str = "api") -> None:
 # v10.2 — daikin_consumption_daily sync (deferred Epic #70 minimal first cut)
 # ---------------------------------------------------------------------------
 
+def heating_consumption_kwh(year: int, month: int, *, actor: str = "energy_insights") -> float | None:
+    """Monthly heating kWh, read from the CACHED device payload (30-min TTL) —
+    the consumption figures live inside the gateway-devices response, so this
+    never needs its own wire read when the cache is warm. This is the fix for
+    the energy-insights read-burst: ``/energy/period`` etc. previously spun up a
+    fresh client and hit ``get_devices()`` on every call."""
+    result = get_cached_devices(allow_refresh=True, actor=actor)
+    if not result.devices:
+        return None
+    return _get_or_create_client().get_heating_consumption_kwh(year, month, devices=result.devices)
+
+
+def heating_daily_kwh(year: int, month: int, *, actor: str = "energy_insights") -> list[float] | None:
+    """Per-day heating kWh for the month, from the cached device payload. See
+    :func:`heating_consumption_kwh`."""
+    result = get_cached_devices(allow_refresh=True, actor=actor)
+    if not result.devices:
+        return None
+    return _get_or_create_client().get_heating_daily_kwh(year, month, devices=result.devices)
+
+
 def sync_daikin_daily(date_obj) -> dict | None:
     """Populate ``daikin_consumption_daily`` for the given date.
 
@@ -700,9 +721,10 @@ def sync_daikin_daily(date_obj) -> dict | None:
     source = "unknown"
     try:
         if not should_block("daikin"):
-            client = _get_or_create_client()
-            daily = client.get_heating_daily_kwh(date_obj.year, date_obj.month)
-            record_call("daikin", "read", ok=True)
+            # Cached read — the transport records its own quota on a real fetch,
+            # so no manual record_call here (that double-counted), and a warm
+            # cache means zero extra reads.
+            daily = heating_daily_kwh(date_obj.year, date_obj.month, actor="daikin_daily_sync")
             if daily:
                 idx = date_obj.day - 1
                 if 0 <= idx < len(daily):
@@ -712,7 +734,6 @@ def sync_daikin_daily(date_obj) -> dict | None:
                         source = "onecta"
     except Exception as exc:
         logger.debug("sync_daikin_daily Onecta path failed for %s: %s", iso, exc)
-        record_call("daikin", "read", ok=False)
 
     # Path 2: telemetry integral fallback. daikin_telemetry.fetched_at is
     # stored as epoch seconds (float), so bound the range in epoch.

--- a/src/energy/monthly.py
+++ b/src/energy/monthly.py
@@ -238,21 +238,24 @@ def _best_cost(energy: MonthlyEnergySummary) -> MonthlyCostSummary:
 
 
 def _get_daikin_heating_kwh(year: int, month: int) -> float | None:
-    """Get heating electrical consumption (kWh) for the month from Daikin when available. Returns None if not configured or not exposed."""
+    """Get heating electrical consumption (kWh) for the month from Daikin when available. Returns None if not configured or not exposed.
+
+    Routes through the cached service layer (30-min device TTL) instead of a
+    fresh client — energy insights are built/polled often, and a raw client
+    here wire-read on every call (the read-burst root cause)."""
     try:
-        from ..daikin.client import DaikinClient
-        client = DaikinClient()
-        return client.get_heating_consumption_kwh(year, month)
+        from ..daikin import service as daikin_service
+        return daikin_service.heating_consumption_kwh(year, month)
     except Exception:
         return None
 
 
 def _get_daikin_heating_daily_kwh(year: int, month: int) -> list[float] | None:
-    """Get daily heating (kWh) for the month from Daikin when available. List length = days in month."""
+    """Get daily heating (kWh) for the month from Daikin when available. List
+    length = days in month. Cached service read — see :func:`_get_daikin_heating_kwh`."""
     try:
-        from ..daikin.client import DaikinClient
-        client = DaikinClient()
-        return client.get_heating_daily_kwh(year, month)
+        from ..daikin import service as daikin_service
+        return daikin_service.heating_daily_kwh(year, month)
     except Exception:
         return None
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2540,8 +2540,11 @@ def build_mcp() -> FastMCP:
         fc = [{"time": f.time_utc.isoformat(), "temp_c": f.temperature_c} for f in fetch_forecast(hours=48)]
         daikin = None
         try:
+            # Cached read (30-min TTL) — this MCP tool is user-callable; a direct
+            # client.get_devices() here bypassed the cache/throttle/quota guard.
+            from .daikin import service as _daikin_svc
             c = _daikin_client()
-            devs = c.get_devices()
+            devs = _daikin_svc.get_cached_devices(allow_refresh=False, actor="mcp_weather").devices
             if devs:
                 daikin = _device_status_dict(c, devs[0])
         except Exception as e:

--- a/tests/test_daikin_daily_cache.py
+++ b/tests/test_daikin_daily_cache.py
@@ -7,7 +7,6 @@ Two-path sync_daikin_daily:
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
-from unittest.mock import patch
 
 import pytest
 
@@ -20,21 +19,23 @@ def _init_db():
     db.init_db()
 
 
-class _FakeDaikinClient:
-    def __init__(self, daily_kwh: list | None = None):
-        self.daily_kwh = daily_kwh
-        self.calls: list[tuple[int, int]] = []
+def _stub_heating_daily(monkeypatch, daily: list | None):
+    """Stub the cached service read used by sync_daikin_daily (post read-burst
+    fix it goes through ``heating_daily_kwh`` instead of a raw client)."""
+    calls: list[tuple[int, int]] = []
 
-    def get_heating_daily_kwh(self, year: int, month: int):
-        self.calls.append((year, month))
-        return self.daily_kwh
+    def _fake(year: int, month: int, *, actor: str = "energy_insights"):
+        calls.append((year, month))
+        return daily
+
+    monkeypatch.setattr(daikin_svc, "heating_daily_kwh", _fake)
+    return calls
 
 
 def test_onecta_path_records_source(monkeypatch):
     daily = [0.0] * 30
     daily[14] = 12.5  # day 15 (idx 14)
-    fake = _FakeDaikinClient(daily_kwh=daily)
-    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    _stub_heating_daily(monkeypatch, daily)
     monkeypatch.setattr(daikin_svc, "should_block", lambda _v: False)
 
     row = daikin_svc.sync_daikin_daily(date(2024, 11, 15))
@@ -46,9 +47,7 @@ def test_onecta_path_records_source(monkeypatch):
 
 def test_onecta_zero_falls_back_to_telemetry_integral(monkeypatch):
     """Onecta returns the day but value is 0 → fall back to telemetry."""
-    daily = [0.0] * 30
-    fake = _FakeDaikinClient(daily_kwh=daily)
-    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    _stub_heating_daily(monkeypatch, [0.0] * 30)
     monkeypatch.setattr(daikin_svc, "should_block", lambda _v: False)
 
     # Seed daikin_telemetry: 4 ticks across the day with cold outdoor temps.
@@ -75,8 +74,7 @@ def test_onecta_zero_falls_back_to_telemetry_integral(monkeypatch):
 
 
 def test_no_data_returns_none(monkeypatch):
-    fake = _FakeDaikinClient(daily_kwh=None)
-    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    _stub_heating_daily(monkeypatch, None)
     monkeypatch.setattr(daikin_svc, "should_block", lambda _v: False)
 
     row = daikin_svc.sync_daikin_daily(date(2024, 11, 15))
@@ -85,11 +83,10 @@ def test_no_data_returns_none(monkeypatch):
 
 def test_quota_blocked_skips_onecta_path(monkeypatch):
     """When Daikin quota is exhausted, Onecta path is skipped entirely."""
-    fake = _FakeDaikinClient(daily_kwh=[10.0] * 30)
-    monkeypatch.setattr(daikin_svc, "_get_or_create_client", lambda: fake)
+    calls = _stub_heating_daily(monkeypatch, [10.0] * 30)
     monkeypatch.setattr(daikin_svc, "should_block", lambda _v: True)  # blocked!
 
     row = daikin_svc.sync_daikin_daily(date(2024, 11, 15))
     # No telemetry seeded → returns None; importantly Onecta was never called.
     assert row is None
-    assert fake.calls == [], "must not call Daikin client when quota blocked"
+    assert calls == [], "must not read Daikin when quota blocked"

--- a/tests/test_daikin_quota_fallback.py
+++ b/tests/test_daikin_quota_fallback.py
@@ -106,6 +106,44 @@ def test_quota_status_exposes_force_refresh_cooldown(monkeypatch):
     assert 295.0 <= locked["force_refresh_available_in_seconds"] <= 300.0
 
 
+def test_heating_reads_route_through_cache(monkeypatch):
+    """Energy-insights heating reads pull from the CACHED device payload — no
+    fresh get_devices() wire read. This is the read-burst fix: /energy/period
+    etc. previously spun up a raw client and hit the wire on every call."""
+    from src.daikin.service import CachedDevices
+
+    sentinel = object()
+    monkeypatch.setattr(
+        daikin_service, "get_cached_devices",
+        lambda **kw: CachedDevices(devices=[sentinel], fetched_at_wall=None,
+                                   age_seconds=1.0, stale=False, source="cache"),
+    )
+
+    class _FakeClient:
+        def __init__(self):
+            self.wire_read = False
+            self.passed_consumption = "unset"
+            self.passed_daily = "unset"
+        def get_devices(self):
+            self.wire_read = True
+            return []
+        def get_heating_consumption_kwh(self, year, month, devices=None):
+            self.passed_consumption = devices
+            return 3.21
+        def get_heating_daily_kwh(self, year, month, devices=None):
+            self.passed_daily = devices
+            return [1.0, 2.0]
+
+    fc = _FakeClient()
+    monkeypatch.setattr(daikin_service, "_get_or_create_client", lambda: fc)
+
+    assert daikin_service.heating_consumption_kwh(2026, 6) == 3.21
+    assert daikin_service.heating_daily_kwh(2026, 6) == [1.0, 2.0]
+    assert fc.passed_consumption == [sentinel], "must feed cached devices to the client"
+    assert fc.passed_daily == [sentinel]
+    assert fc.wire_read is False, "must NOT trigger a fresh get_devices wire read"
+
+
 def _seed_live_row(age_seconds: float, *, tank: float = 50.0, indoor: float = 21.0) -> None:
     now = datetime.now(UTC)
     db.insert_daikin_telemetry({


### PR DESCRIPTION
## What — the residual Daikin read-burst, root-caused and fixed

The catastrophic storm was fixed earlier (#435/#442/#443), but prod still made
**90–115 reads/day in ~10–29-read clusters**. A flag-gated stack trace
(`DAIKIN_TRACE_READS`, now removed) captured the real callers — **25 of 29
traced reads** came from two consumption methods:

- `client.get_heating_consumption_kwh` (15×)
- `client.get_heating_daily_kwh` (10×)

**Root cause:** `energy/monthly.py` (`_get_daikin_heating_kwh` /
`_get_daikin_heating_daily_kwh`) spun up a **fresh `DaikinClient()`** and called
those methods, each doing a direct `get_devices()` **wire read that bypassed the
service cache, the 30-min TTL, the telemetry gate, and the 90s throttle**. These
feed `/energy/period`, `/energy/report`, the daily brief and MCP metrics — all
polled/fired repeatedly → the clusters. The #442/#443 fixes only covered the
*service-layer* read path, so this was never touched (which is exactly why the
burst survived every deploy). The consumption figures live **inside the
gateway-devices payload** (`_device_heating_kwh_for_month` parses `device.raw`,
no extra API call) — so reading them from the cached payload is correct.

## Fix
- `client.get_heating_consumption_kwh` / `get_heating_daily_kwh` gain an optional
  `devices=` param (default keeps `self.get_devices()` for CLI).
- New cached service wrappers `daikin_service.heating_consumption_kwh` /
  `heating_daily_kwh` read via `get_cached_devices` (30-min TTL) and feed the
  payload in — zero extra wire reads on a warm cache.
- `energy/monthly.py` + `sync_daikin_daily` route through the wrappers.
- `sync_daikin_daily` no longer double-counts the read (`record_call` was manual
  on top of the transport's own accounting).

## Cleanup (same bug class / leftovers)
- `mcp_server.get_weather_context` routed through `get_cached_devices` (was a
  direct user-callable wire read).
- Removed the temporary `DAIKIN_TRACE_READS` diagnostic + flag and the now-unused
  `logger`/`logging` (client) and `record_call` import (service).

## Verification
- New regression test: `heating_consumption_kwh`/`heating_daily_kwh` feed cached
  devices and never wire-read. `test_daikin_daily_cache` updated to the new seam.
- 264 passed across daikin/energy/mcp/insights.

Expected effect: auto reads drop from ~90–115/day to ~the 2-hourly refresh
baseline (#267) + LP cadence. Will confirm via `api_call_log` post-deploy.

(Deferred follow-up: the dead `scheduler/daikin.py` legacy tick + the overlapping
cache-age knobs — a separate cleanup PR with its own test updates.)
