### PR TITLE
chore(daikin): remove dead legacy LWT tick + redundant cache knobs

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1457,13 +1457,6 @@ class Config:
         os.getenv("DAIKIN_2H_REFRESH_ENABLED", "true").strip().lower()
         in ("1", "true", "yes")
     )
-    # Phase 4.1 — per-caller cache staleness ceilings (seconds) so non-heartbeat paths reuse the cache.
-    DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS: int = int(
-        os.getenv("DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS", "600")
-    )
-    DAIKIN_LEGACY_TICK_CACHE_MAX_AGE_SECONDS: int = int(
-        os.getenv("DAIKIN_LEGACY_TICK_CACHE_MAX_AGE_SECONDS", "1200")
-    )
     # #55 — how old a live telemetry row can be before the LP wrapper falls back
     # to the physics estimator instead of returning the stale value.
     DAIKIN_TELEMETRY_MAX_STALENESS_SECONDS: int = int(

--- a/src/scheduler/__init__.py
+++ b/src/scheduler/__init__.py
@@ -5,7 +5,7 @@ when other packages import `src.scheduler.agile`.
 """
 
 from .agile import fetch_agile_rates, get_current_and_next_slots
-from .daikin import apply_scheduler_offset, compute_lwt_adjustment, run_daikin_scheduler_tick
+from .daikin import compute_lwt_adjustment
 
 
 def get_scheduler_status():
@@ -23,19 +23,11 @@ def resume_scheduler():
     return _resume_scheduler()
 
 
-def run_scheduler_tick():
-    from .runner import run_scheduler_tick as _run_scheduler_tick
-    return _run_scheduler_tick()
-
-
 __all__ = [
     "fetch_agile_rates",
     "get_current_and_next_slots",
     "compute_lwt_adjustment",
-    "apply_scheduler_offset",
-    "run_daikin_scheduler_tick",
     "get_scheduler_status",
     "pause_scheduler",
     "resume_scheduler",
-    "run_scheduler_tick",
 ]

--- a/src/scheduler/daikin.py
+++ b/src/scheduler/daikin.py
@@ -1,16 +1,15 @@
-"""Translate Agile rate forecast into Daikin LWT offset adjustments."""
-import logging
+"""LWT offset adjustment from the live Agile rate position.
+
+Only ``compute_lwt_adjustment`` survives — it feeds the scheduler-status display
+(``runner.get_scheduler_status`` → ``planned_lwt_adjustment``). The old
+``run_daikin_scheduler_tick`` / ``apply_scheduler_offset`` legacy LWT tick (only
+ever wired under ``not USE_BULLETPROOF_ENGINE``) was removed as dead code.
+"""
 from datetime import UTC, datetime
 
 from ..config import config
-from ..daikin import service as daikin_service
-from .agile import (
-    fetch_agile_rates,
-    get_current_and_next_slots,
-    utc_instant_in_scheduler_peak,
-)
+from .agile import utc_instant_in_scheduler_peak
 
-logger = logging.getLogger(__name__)
 
 def compute_lwt_adjustment(
     current_price_pence: float | None,
@@ -31,67 +30,3 @@ def compute_lwt_adjustment(
     ):
         return -min(2.0, preheat_boost)
     return 0.0
-
-
-def apply_scheduler_offset(
-    base_offset: float,
-    adjustment: float,
-    min_offset: float = -10,
-    max_offset: float = 10,
-) -> float:
-    """Clamp base_offset + adjustment to [min_offset, max_offset]."""
-    return max(min_offset, min(max_offset, base_offset + adjustment))
-
-
-def run_daikin_scheduler_tick(is_paused: bool) -> str | None:
-    """Fetch rates, compute LWT delta, set LWT offset via the cached service. Returns error message or None."""
-    if is_paused:
-        return None
-
-    if config.DAIKIN_CONTROL_MODE == "passive":
-        # Skip the rate fetch entirely — service.set_lwt_offset would raise anyway.
-        return None
-
-    if not config.OCTOPUS_TARIFF_CODE:
-        return "OCTOPUS_TARIFF_CODE not set"
-    if not config.SCHEDULER_ENABLED:
-        return None
-
-    rates = fetch_agile_rates()
-    if not rates:
-        return "No Agile rates fetched"
-
-    current, _next_cheap, current_price = get_current_and_next_slots(
-        rates,
-        cheap_threshold_pence=config.SCHEDULER_CHEAP_THRESHOLD_PENCE,
-        peak_start=config.SCHEDULER_PEAK_START,
-        peak_end=config.SCHEDULER_PEAK_END,
-    )
-    if current is None or current_price is None:
-        return None
-
-    adjustment = compute_lwt_adjustment(
-        current_price,
-        config.SCHEDULER_CHEAP_THRESHOLD_PENCE,
-        config.SCHEDULER_PEAK_START,
-        config.SCHEDULER_PEAK_END,
-        config.SCHEDULER_PREHEAT_LWT_BOOST,
-    )
-    try:
-        result = daikin_service.get_cached_devices(
-            allow_refresh=True,
-            max_age_seconds=config.DAIKIN_LEGACY_TICK_CACHE_MAX_AGE_SECONDS,
-            actor="legacy_lwt_tick",
-        )
-        if not result.devices:
-            return "No Daikin devices"
-        dev = result.devices[0]
-        # Use absolute target offset (no compounding with previous value)
-        new_offset = apply_scheduler_offset(adjustment, 0.0, -10, 10)
-        mode = dev.operation_mode or "heating"
-        daikin_service.set_lwt_offset(new_offset, mode=mode, actor="legacy_lwt_tick")
-        logger.info("Scheduler LWT offset set to %s (adjustment %s)", new_offset, adjustment)
-        return None
-    except Exception as e:
-        logger.exception("Scheduler Daikin tick failed")
-        return str(e)

--- a/src/scheduler/lp_initial_state.py
+++ b/src/scheduler/lp_initial_state.py
@@ -65,10 +65,10 @@ def read_lp_initial_state(
         if allow_daikin_refresh:
             state = daikin_service.get_lp_state_cached_or_estimated(actor="lp_init")
         else:
-            # Simulation: cache-only path; never burns Daikin quota.
+            # Simulation: cache-only path; never burns Daikin quota. Uses the
+            # canonical device-cache TTL (the per-caller LP_INIT knob was retired).
             result = daikin_service.get_cached_devices(
                 allow_refresh=False,
-                max_age_seconds=config.DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS,
                 actor="lp_init",
             )
             state = {

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -20,7 +20,7 @@ from ..notifier import (
 )
 from ..state_machine import heartbeat_repair_fox_scheduler, reconcile_daikin_schedule_for_date
 from .agile import fetch_agile_rates, get_current_and_next_slots
-from .daikin import compute_lwt_adjustment, run_daikin_scheduler_tick
+from .daikin import compute_lwt_adjustment
 
 logger = logging.getLogger(__name__)
 
@@ -415,11 +415,6 @@ def get_scheduler_status() -> dict:
             config.SCHEDULER_PREHEAT_LWT_BOOST,
         )
     return out
-
-
-def run_scheduler_tick() -> str | None:
-    """Run one legacy scheduler tick (Daikin LWT only)."""
-    return run_daikin_scheduler_tick(get_scheduler_paused())
 
 
 def _try_fox() -> FoxESSClient | None:
@@ -1776,12 +1771,6 @@ def start_background_scheduler() -> None:
 
         _background_scheduler = BackgroundScheduler()
         tz = ZoneInfo(config.BULLETPROOF_TIMEZONE if config.USE_BULLETPROOF_ENGINE else config.OPTIMIZATION_TIMEZONE)
-
-        if config.SCHEDULER_ENABLED and config.OCTOPUS_TARIFF_CODE and not config.USE_BULLETPROOF_ENGINE:
-            _background_scheduler.add_job(
-                run_scheduler_tick, "interval", minutes=30, id="agile_daikin"
-            )
-            logger.info("Agile Daikin scheduler started (every 30 min)")
 
         if config.USE_BULLETPROOF_ENGINE and config.OCTOPUS_TARIFF_CODE:
             _background_scheduler.add_job(

--- a/tests/test_daikin_passive_mode.py
+++ b/tests/test_daikin_passive_mode.py
@@ -93,19 +93,9 @@ def test_service_setters_passive_skip(passive_mode, fn_name: str, args: tuple) -
 # S2: scheduler tick
 # ---------------------------------------------------------------------------
 
-def test_scheduler_tick_passive_skip(passive_mode, monkeypatch: pytest.MonkeyPatch) -> None:
-    from src.scheduler import daikin as sched_daikin
-
-    # Ensure the rate-fetch path would otherwise be exercised so the early-return
-    # is the only reason no error is raised.
-    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "TEST")
-    monkeypatch.setattr(config, "SCHEDULER_ENABLED", True)
-    fake = MagicMock(side_effect=AssertionError("rates fetch should not run in passive"))
-    monkeypatch.setattr(sched_daikin, "fetch_agile_rates", fake)
-
-    result = sched_daikin.run_daikin_scheduler_tick(is_paused=False)
-    assert result is None
-    fake.assert_not_called()
+# (Removed test_scheduler_tick_passive_skip — the legacy run_daikin_scheduler_tick
+#  was deleted as dead code. Passive-mode write blocking is still covered by the
+#  service-setter + apply_scheduled + comfort-restore tests above.)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What — dead-code cleanup (deferred follow-up to #449)

Removes the dead legacy Daikin LWT tick and the redundant cache-age knobs the
read-burst audit surfaced. No behavioural change in prod (bulletproof engine).

### Removed
- **`scheduler/daikin.py:run_daikin_scheduler_tick`** + **`apply_scheduler_offset`** —
  the legacy Agile→LWT tick. It was only ever scheduled under
  `not USE_BULLETPROOF_ENGINE` (the `agile_daikin` interval job), which is dead in
  prod. `compute_lwt_adjustment` is **kept** (still feeds
  `get_scheduler_status().planned_lwt_adjustment`).
- **`runner.run_scheduler_tick`** wrapper + the `agile_daikin` job registration.
- **`scheduler/__init__`** exports for the above.
- **`DAIKIN_LEGACY_TICK_CACHE_MAX_AGE_SECONDS`** (only consumer was the tick).
- **`DAIKIN_LP_INIT_CACHE_MAX_AGE_SECONDS`** — redundant per-caller knob, used only
  on the LP *simulation* cache-only branch; collapsed to the canonical
  `DAIKIN_DEVICES_CACHE_TTL_SECONDS`.

### Tests
- Dropped `test_scheduler_tick_passive_skip` (tested the deleted tick). Passive-mode
  write-blocking is still covered by the service-setter / apply-scheduled /
  comfort-restore tests.
- `compute_lwt_adjustment` DST + peak-sync tests unchanged and green.

276 passed across scheduler/daikin/lp/runner/passive. (One pre-existing,
date-dependent failure in `test_appliance_battery_aware` — fails on clean main
too, unrelated.)
