### PR TITLE
fix(test): freeze clock in appliance battery-aware tests

### DIFF
--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -354,7 +354,7 @@ def _query_latest_lp_soc_trajectory(
                 )
                 if run_at.tzinfo is None:
                     run_at = run_at.replace(tzinfo=UTC)
-                age = datetime.now(UTC) - run_at
+                age = _now_utc() - run_at
                 if age > timedelta(hours=max_age_hours):
                     logger.info(
                         "appliance: LP run %s too stale (%.1fh > %.1fh) — "

--- a/tests/scheduler/test_appliance_battery_aware.py
+++ b/tests/scheduler/test_appliance_battery_aware.py
@@ -43,6 +43,11 @@ def _isolated(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "APPLIANCE_FALLBACK_SAFETY_MARGIN_KWH", 0.3, raising=False)
     monkeypatch.setattr(config, "BATTERY_CAPACITY_KWH", 10.0, raising=False)
     monkeypatch.setattr(config, "MIN_SOC_RESERVE_PERCENT", 15.0, raising=False)
+    # Freeze "now" just before the fixed test base (12:00) so the seeded LP
+    # trajectory (run_at = slots[0]) is always fresh — otherwise the staleness
+    # check compared the hardcoded 2026-06-01 base to the real clock and the
+    # picker fell back to cheapest-grid as soon as the date rolled past it.
+    monkeypatch.setattr(ad, "_now_utc", lambda: datetime(2026, 6, 1, 11, 0, tzinfo=UTC))
     yield
 
 
@@ -321,9 +326,9 @@ def test_lp_trajectory_too_stale_falls_back(monkeypatch):
     aid = _seed_appliance(typical_kw=1.0)
     base = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
     slots = [base + timedelta(minutes=30 * i) for i in range(8)]
-    # Seed a trajectory but with stale run_at (5 hours ago)
+    # Seed a trajectory but with stale run_at (5 hours before the frozen now).
     conn = sqlite3.connect(config.DB_PATH)
-    stale_run_at = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+    stale_run_at = (ad._now_utc() - timedelta(hours=5)).isoformat()
     conn.execute("INSERT INTO optimizer_log (run_at) VALUES (?)", (stale_run_at,))
     run_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
     for i, slot in enumerate(slots):


### PR DESCRIPTION
## What

Fixes a **date-dependent** flake in `test_appliance_battery_aware`: the tests
hardcode a `2026-06-01 12:00` base and seed an LP trajectory with
`run_at = slots[0]`, but the picker's staleness check compared it to the **real**
`datetime.now(UTC)` — so once the wall clock rolled past the hardcoded date, the
trajectory looked >max-age stale and the picker fell back to cheapest-grid,
breaking `test_battery_aware_prefers_earliest_when_battery_covers`.

## Fix
- **src (consistency):** `appliance_dispatch.py:357` used a raw `datetime.now(UTC)`
  for the LP-staleness age while the rest of the module uses the `_now_utc()`
  helper. Route it through `_now_utc()` (no prod behaviour change — same value;
  just makes the clock injectable, as the helper was designed for).
- **test:** the autouse fixture now freezes `ad._now_utc` to `2026-06-01 11:00`
  (just before the fixed base), so seeded trajectories are always fresh and the
  suite is deterministic regardless of the real date. `test_lp_trajectory_too_stale_falls_back`
  anchors its stale `run_at` to the same frozen clock.

## Verification
22/22 in the file, 154 passed across appliance/scheduler.
