### PR TITLE
fix(energy): trim current-month chart_data to elapsed days

### DIFF
--- a/src/energy/monthly.py
+++ b/src/energy/monthly.py
@@ -692,13 +692,14 @@ def get_period_insights(
         except Exception:
             raise
         energy = _foxess_to_energy_summary(y, m, totals)
-        # Standing charge must cover the same day-window as the energy: elapsed
-        # days for the current (partial) month, full month for a past month.
-        # len(daily) == days with Fox data; clamp to today.day to be robust to
-        # any trailing zero-padded days the breakdown might include.
-        n_days = len(daily)
+        # For the current (partial) month Fox returns a full-month daily
+        # breakdown with zero-padded future days. Trim to elapsed days so the
+        # standing-charge day-count, chart_data length, and the UI's per-day
+        # math (standing ÷ chart_data.length) all agree. Past months keep the
+        # full month.
         if (y, m) == (today.year, today.month):
-            n_days = min(n_days, today.day)
+            daily = [r for r in daily if r.get("date", "") <= today.isoformat()]
+        n_days = len(daily)
         cost = _best_cost(energy, n_days=n_days)
         daikin_heating = _get_daikin_heating_kwh(y, m)
         heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(

--- a/tests/test_monthly_cost_proration.py
+++ b/tests/test_monthly_cost_proration.py
@@ -134,11 +134,16 @@ def test_period_month_current_prorates_standing(monkeypatch):
 
 
 def test_period_month_current_clamps_zero_padded_days(monkeypatch):
-    """Even if Fox zero-pads to a full month, standing clamps to today.day."""
+    """Fox zero-pads the current month to a full breakdown — we trim chart_data
+    to elapsed days so standing, day-count, and the UI per-day math all agree."""
     today = date.today()
     _patch_client(monkeypatch, _FakeClient(days_with_data=today.day, pad_to_full=True))
     out = monthly.get_period_insights("month", month_str=today.strftime("%Y-%m"))
+    # chart_data trimmed to elapsed days (not the full padded month).
+    assert len(out.chart_data) == today.day
     assert out.insights.cost.standing_charge_pence == pytest.approx(today.day * 50.0)
+    # The UI invariant: standing / chart_data.length == standing_per_day.
+    assert out.insights.cost.standing_charge_pence / len(out.chart_data) == pytest.approx(50.0)
 
 
 def test_period_month_past_bills_full_month(monkeypatch):


### PR DESCRIPTION
Follow-up to #452. Live-data verification surfaced a gap: the current-month Fox daily breakdown returns **zero-padded to a full month** (30/31 rows). #452 correctly clamped the standing-charge *total* to elapsed days, but `chart_data` still carried the full month, so the UI's per-day math (`standing ÷ chart_data.length`) divided by 30 and **under-stated** the per-day standing (£0.04/day instead of £0.62/day on June 2).

Fix: trim the daily breakdown to `date ≤ today` for the current month, so the standing total, the day-count, and the UI bars all agree. Past months keep the full month.

Verified on prod (2026-06): standing `124.44p / 2 elapsed days = 62.22 p/day` ✅; net `£1.25`, `delta_vs_fixed −£0.42` consistent.

Test updated to assert `len(chart_data) == elapsed days` and the `standing / chart_data.length == standing_per_day` invariant under a zero-padded fake client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)