### PR TITLE
feat(ui): scope tariff comparison to the period navigator

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3312,11 +3312,22 @@ async def tariffs_dashboard(req: TariffDashboardRequest):
     tariffs, identifying the winner for each period. The current tariff (Octopus
     Flexible by default) is flagged as baseline.
     """
+    from datetime import date as _date
+
     from ..energy.tariff_engine import get_tariff_comparison_dashboard
+    window_from = window_to = None
+    if req.start_date and req.end_date:
+        try:
+            window_from = _date.fromisoformat(req.start_date)
+            window_to = _date.fromisoformat(req.end_date)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="start_date/end_date must be YYYY-MM-DD")
     data = get_tariff_comparison_dashboard(
         months_back=req.months_back,
         granularity=req.granularity,
         max_tariffs=req.max_tariffs,
+        window_from=window_from,
+        window_to=window_to,
     )
     if not data.get("ok"):
         return TariffDashboardResponse(ok=False, error=data.get("error", "Unknown error"))

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -589,9 +589,14 @@ class ListAvailableTariffsResponse(BaseModel):
 
 
 class TariffDashboardRequest(BaseModel):
-    months_back: int = Field(default=1, ge=1, le=12, description="Months of usage data")
+    months_back: int = Field(default=1, ge=1, le=12, description="Months of usage data (used when start_date/end_date are absent)")
     granularity: str = Field(default="daily", pattern=r"^(daily|weekly|monthly)$")
     max_tariffs: int = Field(default=10, ge=1, le=20)
+    # Optional explicit usage window (inclusive ISO dates) — when both are set
+    # the comparison replays the catalogue over exactly this window instead of
+    # the trailing months_back. Lets the UI period navigator drive the widget.
+    start_date: str | None = Field(default=None, description="YYYY-MM-DD inclusive start")
+    end_date: str | None = Field(default=None, description="YYYY-MM-DD inclusive end")
 
 
 class TariffPeriodCosts(BaseModel):

--- a/src/energy/tariff_engine.py
+++ b/src/energy/tariff_engine.py
@@ -143,8 +143,18 @@ def _simulate_day_cost_pence(
 
 # ── Granular period comparison ───────────────────────────────────────────────
 
-def _get_daily_usage(months_back: int = 1) -> list[dict]:
+def _get_daily_usage(
+    months_back: int = 1,
+    *,
+    window_from: date | None = None,
+    window_to: date | None = None,
+) -> list[dict]:
     """Get per-day import/export kWh.
+
+    When ``window_from``/``window_to`` (inclusive local dates) are both given,
+    usage is gathered for exactly that window — this is how the UI period
+    navigator scopes the tariff comparison. Otherwise the trailing
+    ``months_back`` window is used.
 
     Priority:
     1. Octopus smart meter day-aggregated consumption (authenticated)
@@ -152,8 +162,22 @@ def _get_daily_usage(months_back: int = 1) -> list[dict]:
     3. Synthetic defaults
     """
     today = date.today()
-    period_to = datetime.now(UTC)
-    period_from = period_to - timedelta(days=months_back * 31)
+    explicit_window = window_from is not None and window_to is not None
+    if explicit_window:
+        # Clamp the end to today (no future data) and bound the fetch range.
+        window_to = min(window_to, today)
+        period_from = datetime(window_from.year, window_from.month, window_from.day, tzinfo=UTC)
+        period_to = datetime(window_to.year, window_to.month, window_to.day, 23, 59, 59, tzinfo=UTC)
+    else:
+        period_to = datetime.now(UTC)
+        period_from = period_to - timedelta(days=months_back * 31)
+
+    def _in_window(d: date) -> bool:
+        if d > today:
+            return False
+        if explicit_window:
+            return window_from <= d <= window_to
+        return True
 
     # --- Source 1: Octopus day-aggregated consumption ---
     if config.OCTOPUS_API_KEY and (config.OCTOPUS_MPAN_IMPORT or config.OCTOPUS_MPAN_1):
@@ -201,7 +225,7 @@ def _get_daily_usage(months_back: int = 1) -> list[dict]:
                 )
                 for ds in all_dates:
                     d = date.fromisoformat(ds)
-                    if d <= today:
+                    if _in_window(d):
                         daily_all.append({
                             "date": ds,
                             "import_kwh": import_by_date.get(ds, 0.0),
@@ -222,13 +246,25 @@ def _get_daily_usage(months_back: int = 1) -> list[dict]:
         from ..foxess.client import FoxESSClient
         client = FoxESSClient(**config.foxess_client_kwargs())
         daily_all = []
+        # Months to fetch: the calendar months overlapping the requested window
+        # (explicit) or the trailing months_back (default).
+        months: list[tuple[int, int]] = []
+        if explicit_window:
+            cur = date(window_from.year, window_from.month, 1)
+            last = date(window_to.year, window_to.month, 1)
+            while cur <= last:
+                months.append((cur.year, cur.month))
+                cur = date(cur.year + 1, 1, 1) if cur.month == 12 else date(cur.year, cur.month + 1, 1)
+        else:
+            for offset in range(months_back):
+                m = today.month - offset
+                y = today.year
+                while m <= 0:
+                    m += 12
+                    y -= 1
+                months.append((y, m))
         months_done: set[tuple[int, int]] = set()
-        for offset in range(months_back):
-            m = today.month - offset
-            y = today.year
-            while m <= 0:
-                m += 12
-                y -= 1
+        for (y, m) in months:
             key = (y, m)
             if key in months_done:
                 continue
@@ -237,7 +273,7 @@ def _get_daily_usage(months_back: int = 1) -> list[dict]:
                 _totals, daily = client.get_energy_month_daily_breakdown(y, m)
                 for row in daily:
                     d = date.fromisoformat(row["date"])
-                    if d <= today:
+                    if _in_window(d):
                         daily_all.append({**row, "source": "foxess"})
             except Exception:
                 continue
@@ -255,14 +291,19 @@ def _get_daily_usage(months_back: int = 1) -> list[dict]:
         "No real usage data available — using synthetic defaults (8.5/2.0 kWh/day)"
     )
     daily_all = []
-    for i in range(months_back * 30):
-        d = today - timedelta(days=i)
-        daily_all.append({
-            "date": d.isoformat(),
-            "import_kwh": 8.5,
-            "export_kwh": 2.0,
-            "source": "synthetic",
-        })
+    if explicit_window:
+        d = window_from
+        while d <= window_to:
+            daily_all.append({
+                "date": d.isoformat(), "import_kwh": 8.5, "export_kwh": 2.0, "source": "synthetic",
+            })
+            d += timedelta(days=1)
+    else:
+        for i in range(months_back * 30):
+            d = today - timedelta(days=i)
+            daily_all.append({
+                "date": d.isoformat(), "import_kwh": 8.5, "export_kwh": 2.0, "source": "synthetic",
+            })
     daily_all.sort(key=lambda r: r["date"])
     return daily_all
 
@@ -338,6 +379,8 @@ def compare_tariffs_granular(
     *,
     months_back: int = 1,
     granularity: str = "daily",  # daily | weekly | monthly
+    window_from: date | None = None,
+    window_to: date | None = None,
 ) -> dict:
     """Compare tariffs at daily/weekly/monthly granularity.
 
@@ -349,7 +392,7 @@ def compare_tariffs_granular(
         "usage": {total_import_kwh, total_export_kwh, total_days}
     }
     """
-    daily_data = _get_daily_usage(months_back)
+    daily_data = _get_daily_usage(months_back, window_from=window_from, window_to=window_to)
     if not daily_data:
         return {"granularity": granularity, "periods": [], "totals": [], "usage": {}}
 
@@ -682,10 +725,15 @@ def get_tariff_comparison_dashboard(
     months_back: int = 1,
     granularity: str = "daily",
     max_tariffs: int = 10,
+    window_from: date | None = None,
+    window_to: date | None = None,
 ) -> dict:
     """Full dashboard payload: granular comparison + totals + recommendation.
 
-    This is the main entry point for the tariff dashboard.
+    This is the main entry point for the tariff dashboard. When
+    ``window_from``/``window_to`` are given, the comparison is scoped to that
+    exact window (driven by the UI period navigator); otherwise the trailing
+    ``months_back`` window is used.
     """
     from .octopus_products import get_available_tariffs
 
@@ -700,6 +748,8 @@ def get_tariff_comparison_dashboard(
         tariffs,
         months_back=months_back,
         granularity=granularity,
+        window_from=window_from,
+        window_to=window_to,
     )
 
     # Identify current tariff in totals and compute savings

--- a/tests/test_monthly_cost_proration.py
+++ b/tests/test_monthly_cost_proration.py
@@ -217,3 +217,37 @@ def test_usage_days_current_month_is_elapsed(monkeypatch):
     )
     imp, exp, days = tariff_engine._get_usage_data(months_back=1)
     assert days == today.day
+
+
+# ── tariff_engine windowed usage (period navigator) ──────────────────────────
+
+def test_daily_usage_explicit_window_filters_to_range(monkeypatch):
+    """An explicit window restricts daily usage to exactly that date range."""
+    from datetime import timedelta
+    # Force the Octopus + Fox paths off so we land on the synthetic generator,
+    # which deterministically emits one row per day in the window.
+    monkeypatch.setattr(config, "OCTOPUS_API_KEY", "", raising=False)
+    monkeypatch.setattr(config, "OCTOPUS_MPAN_IMPORT", "", raising=False)
+    monkeypatch.setattr(config, "OCTOPUS_MPAN_1", "", raising=False)
+    monkeypatch.setattr(tariff_engine.config, "foxess_client_kwargs", lambda: (_ for _ in ()).throw(RuntimeError("no fox")), raising=False)
+
+    today = date.today()
+    wf = today - timedelta(days=5)
+    wt = today - timedelta(days=2)
+    rows = tariff_engine._get_daily_usage(window_from=wf, window_to=wt)
+    dates = [date.fromisoformat(r["date"]) for r in rows]
+    assert dates == [wf + timedelta(days=i) for i in range(4)]  # wf..wt inclusive
+    assert all(wf <= d <= wt for d in dates)
+
+
+def test_daily_usage_window_clamps_future_to_today(monkeypatch):
+    from datetime import timedelta
+    monkeypatch.setattr(config, "OCTOPUS_API_KEY", "", raising=False)
+    monkeypatch.setattr(config, "OCTOPUS_MPAN_IMPORT", "", raising=False)
+    monkeypatch.setattr(config, "OCTOPUS_MPAN_1", "", raising=False)
+    monkeypatch.setattr(tariff_engine.config, "foxess_client_kwargs", lambda: (_ for _ in ()).throw(RuntimeError("no fox")), raising=False)
+
+    today = date.today()
+    rows = tariff_engine._get_daily_usage(window_from=today - timedelta(days=1), window_to=today + timedelta(days=10))
+    dates = [date.fromisoformat(r["date"]) for r in rows]
+    assert max(dates) == today  # never returns future days

--- a/ui/src/components/home/TariffComparisonWidget.tsx
+++ b/ui/src/components/home/TariffComparisonWidget.tsx
@@ -6,20 +6,19 @@ interface TariffComparisonWidgetProps {
   dashboard: TariffDashboardResponse | null;
   dashboardLoading: boolean;
   metrics: MetricsResponse | null;
-  // Real realised cost for the same calendar window — used to replace the
-  // current tariff's PROJECTED total. The dashboard engine bills total
-  // consumption at the tariff's average rate, which ignores the LP's
-  // battery-arbitrage on half-hourly tariffs (Agile) and over-states the
-  // current cost by ~30 % on solar+battery setups. The realised number
-  // (from /energy/period) bills measured grid import at the half-hourly
-  // Agile rate per slot — the actual money out the door.
-  monthPeriod: PeriodInsightsResponse | null;
-  // Whether the /energy/period fetch that feeds `monthPeriod` is still
-  // in-flight. The dashboard and monthPeriod are independent fetches: if the
-  // dashboard lands first we must NOT render the current tariff's projected
-  // total — it would flash a wrong (over-stated) number until the realised
-  // cost arrives and overwrites it. Hold the skeleton until BOTH have settled.
-  monthPeriodLoading: boolean;
+  // The navigator-selected period. Its realised net (from /energy/period —
+  // measured grid import × half-hourly Agile, the actual money out the door)
+  // replaces the current tariff's PROJECTED engine total, which bills total
+  // consumption at the avg rate and ignores battery arbitrage (over-states
+  // ~30% on solar+battery). Its backend fixed shadow drives the fixed row.
+  // Same window as the dashboard's catalogue replay → rows line up.
+  period: PeriodInsightsResponse | null;
+  // Whether the /energy/period fetch that feeds `period` is still in-flight.
+  // The dashboard and period are independent fetches: if the dashboard lands
+  // first we must NOT render the current tariff's projected total — it would
+  // flash a wrong (over-stated) number until the realised cost arrives and
+  // overwrites it. Hold the skeleton until BOTH have settled.
+  periodLoading: boolean;
 }
 
 // Tariff comparison anchored ENTIRELY on the household's real usage. The
@@ -31,10 +30,10 @@ interface TariffComparisonWidgetProps {
 // The fixed-tariff row uses the BACKEND-computed fixed shadow on the
 // monthPeriod cost (same metered kWh + day-window as the realised current
 // tariff), not a client recompute — so it can't drift from the current row.
-export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, monthPeriod, monthPeriodLoading }: TariffComparisonWidgetProps) {
+export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, period, periodLoading }: TariffComparisonWidgetProps) {
   // Gate on BOTH fetches: the current tariff's realised total comes from
   // monthPeriod, so rendering before it settles flashes the projected number.
-  if (dashboardLoading || monthPeriodLoading) {
+  if (dashboardLoading || periodLoading) {
     return <div class="tcomp"><div class="tcomp-skel skel" /></div>;
   }
   if (!dashboard?.ok || !dashboard.totals?.length) {
@@ -49,8 +48,8 @@ export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, m
   // a positive "unit rate" that's actually an export price. Treating them
   // as cheapest import would mislabel revenue as cost (see commit ec81a4b).
   const importOnly = dashboard.totals.filter((r) => isImportTariff(r));
-  const realisedMonthlyP = monthPeriod?.cost?.net_cost_pence ?? null;
-  const realisedDays = monthPeriod?.chart_data?.length ?? null;
+  const realisedMonthlyP = period?.cost?.net_cost_pence ?? null;
+  const realisedDays = period?.chart_data?.length ?? null;
   // Override the current tariff's projected totals with the real realised
   // ones. The engine's projection is consumption × avg rate (no battery-
   // arbitrage); the realised number is half-hourly grid_import × Agile_p.
@@ -75,7 +74,7 @@ export function TariffComparisonWidget({ dashboard, dashboardLoading, metrics, m
   // metered kWh + day-window as the realised current-tariff cost — no
   // Fox-vs-Octopus meter mixing, no client recompute that could drift).
   const ft = metrics?.fixed_tariff;
-  const fixedShadowP = monthPeriod?.cost?.fixed_shadow_pence ?? null;
+  const fixedShadowP = period?.cost?.fixed_shadow_pence ?? null;
   let bgRow: TariffTotalRow | null = null;
   if (ft?.label && fixedShadowP != null && realisedDays && realisedDays > 0) {
     const netP = fixedShadowP;

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -124,9 +124,19 @@ export const getAttributionDay = (date?: string) =>
   getJson<AttributionDay>(date ? `/attribution/day?date=${encodeURIComponent(date)}` : "/attribution/day");
 
 // POST /tariffs/dashboard — Octopus-tariff comparison engine, includes
-// standing charges + export earnings in the per-tariff costs.
-export const getTariffDashboard = (months_back = 1, granularity: "daily" | "weekly" | "monthly" = "monthly", max_tariffs = 8) =>
-  postJson<TariffDashboardResponse>("/tariffs/dashboard", { months_back, granularity, max_tariffs });
+// standing charges + export earnings in the per-tariff costs. Pass
+// start_date/end_date (inclusive YYYY-MM-DD) to scope to a navigator period;
+// omit them to use the trailing months_back window.
+export const getTariffDashboard = (
+  months_back = 1,
+  granularity: "daily" | "weekly" | "monthly" = "monthly",
+  max_tariffs = 8,
+  window?: { start: string; end: string },
+) =>
+  postJson<TariffDashboardResponse>("/tariffs/dashboard", {
+    months_back, granularity, max_tariffs,
+    ...(window ? { start_date: window.start, end_date: window.end } : {}),
+  });
 
 /* ----- Settings ----- */
 

--- a/ui/src/lib/period.ts
+++ b/ui/src/lib/period.ts
@@ -64,6 +64,32 @@ export function stepPeriod(dir: -1 | 1): void {
   selectedPeriod.value = { gran, anchor: next };
 }
 
+/** Inclusive [start, end] ISO date window for the selected period, end clamped
+ * to today (no future). Used to scope the tariff comparison to the navigator. */
+export function periodDateRange(p: PeriodState): { start: string; end: string } {
+  const t = todayISO();
+  const d = parse(p.anchor);
+  let start: Date;
+  let end: Date;
+  if (p.gran === "day") {
+    start = d; end = d;
+  } else if (p.gran === "week") {
+    start = new Date(d);
+    start.setDate(d.getDate() - ((d.getDay() + 6) % 7)); // Monday
+    end = new Date(start);
+    end.setDate(start.getDate() + 6);
+  } else if (p.gran === "month") {
+    start = new Date(d.getFullYear(), d.getMonth(), 1);
+    end = new Date(d.getFullYear(), d.getMonth() + 1, 0); // last day of month
+  } else {
+    start = new Date(d.getFullYear(), 0, 1);
+    end = new Date(d.getFullYear(), 11, 31);
+  }
+  const startISO = isoOf(start);
+  const endISO = isoOf(end);
+  return { start: startISO, end: endISO > t ? t : endISO };
+}
+
 /** Query params for getEnergyPeriod(). */
 export function periodFetchOpts(p: PeriodState): { date?: string; month?: string; year?: number } {
   if (p.gran === "month") return { month: p.anchor.slice(0, 7) };

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -20,7 +20,7 @@ import { Widget } from "../components/common/Widget";
 import { Spinner } from "../components/common/Spinner";
 import { RefreshAction } from "../components/common/RefreshAction";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
-import { usePeriod, periodFetchOpts } from "../lib/period";
+import { usePeriod, periodFetchOpts, periodDateRange } from "../lib/period";
 import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
 import { Hero } from "../components/home/Hero";
 import { HeatingWidget } from "../components/home/HeatingWidget";
@@ -91,21 +91,20 @@ export default function Landing() {
   // Daikin cached read — no refresh=true, so no live cloud call (30-min cache TTL).
   const daikin = useFetch(getDaikinStatus, []);
   const daikinQuota = useFetch(getDaikinQuota, []);
-  // Tariff comparison vs Octopus catalogue + the configured fixed tariff.
-  const tariffDash = useFetch(() => getTariffDashboard(1, "monthly", 8), []);
   // The shared period navigator drives the Hero headline + cost breakdown +
-  // energy chart. Re-fetch /energy/period whenever the selection changes.
+  // energy chart + tariff comparison. Re-fetch whenever the selection changes.
   const period = usePeriod();
   const periodInsights = useFetch(
     () => getEnergyPeriod(period.gran, periodFetchOpts(period)),
     [period.gran, period.anchor],
   );
-  // The tariff comparison is inherently a monthly/usage-window construct
-  // (the catalogue replay is monthly), so it stays pinned to the current month
-  // regardless of the navigator — its realised cost + fixed shadow come from
-  // this fetch.
-  const today = new Date().toISOString().slice(0, 10);
-  const monthPeriod = useFetch(() => getEnergyPeriod("month", { month: today.slice(0, 7) }), []);
+  // Tariff comparison scoped to the SAME window as the navigator — the
+  // catalogue replay + usage now cover exactly the selected period, so its
+  // realised current-tariff row + fixed shadow (from periodInsights) line up.
+  const tariffDash = useFetch(() => {
+    const w = periodDateRange(period);
+    return getTariffDashboard(1, "daily", 8, w);
+  }, [period.gran, period.anchor]);
 
   if (now.loading && !now.data) {
     return <div class="home"><Spinner label="Loading dashboard…" /></div>;
@@ -168,7 +167,7 @@ export default function Landing() {
         <Widget title="Tariff comparison" icon="📊" tone="savings" size="wide"
                 badge={tariffDash.data?.usage?.total_days ? `last ${tariffDash.data.usage.total_days}d of your usage` : undefined}
                 action={<RefreshAction onRefresh={tariffDash.refresh} loading={tariffDash.loading} />}>
-          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} monthPeriod={monthPeriod.data} monthPeriodLoading={monthPeriod.loading} />
+          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} period={periodInsights.data} periodLoading={periodInsights.loading} />
         </Widget>
       </div>
     </div>


### PR DESCRIPTION
Follow-up to #452/#453. The tariff-comparison widget was the one piece still pinned to the trailing month while the rest of the home page followed the navigator. Now it replays the Octopus catalogue + usage over **the same window the navigator selects**.

**Backend**
- `tariff_engine._get_daily_usage` takes an explicit `[window_from, window_to]` (inclusive local dates, end clamped to today); Octopus/Fox/synthetic sources all filter to it. Fox fallback iterates the months *overlapping the window* instead of `months_back`.
- `compare_tariffs_granular` + `get_tariff_comparison_dashboard` thread the window through; `POST /tariffs/dashboard` accepts optional `start_date`/`end_date`.

**Frontend**
- New `periodDateRange()` derives the inclusive window from the selected period.
- `landing.tsx` fetches the dashboard keyed on the navigator window and passes the navigator-selected period into the widget (drops the separate current-month fetch).
- `TariffComparisonWidget` props renamed `monthPeriod` → `period`; the realised current-tariff row + backend fixed shadow now share the dashboard's window, so the rows line up.

**Tests**: windowed `_get_daily_usage` (range filter + future clamp). `tsc` + `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)