### PR TITLE
perf(dashboard): unblock event loop + lazy below-the-fold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ agent_apply_v2.log
 backups/
 .claude/
 _scratch/
+.gstack/

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -411,6 +411,12 @@ async def api_v1_schedule_history(limit: int = 200):
 
 @app.get("/api/v1/weather")
 async def api_v1_weather():
+    # Blocking (Open-Meteo HTTP + Daikin read) — offload so it doesn't stall
+    # the event loop and serialize every other dashboard request.
+    return await asyncio.to_thread(_api_v1_weather_sync)
+
+
+def _api_v1_weather_sync():
     from ..weather import fetch_forecast
 
     fc = fetch_forecast(hours=48)
@@ -2451,7 +2457,7 @@ async def energy_monthly(month: str):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     try:
-        insights = get_monthly_insights(year, month_num)
+        insights = await asyncio.to_thread(get_monthly_insights, year, month_num)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -2527,7 +2533,7 @@ async def energy_period(
     if period in ("day", "week") and (len(date) != 10 or date[4] != "-" or date[7] != "-"):
         raise HTTPException(status_code=400, detail="Use date=YYYY-MM-DD")
     try:
-        out = get_period_insights(period, date_str=date, month_str=month, year=year)
+        out = await asyncio.to_thread(get_period_insights, period, date_str=date, month_str=month, year=year)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -2650,7 +2656,7 @@ async def energy_report(
     if period in ("day", "week") and date and (len(date) != 10 or date[4] != "-" or date[7] != "-"):
         raise HTTPException(status_code=400, detail="Use date=YYYY-MM-DD")
     try:
-        out = get_period_insights(period, date_str=date, month_str=month, year=year)
+        out = await asyncio.to_thread(get_period_insights, period, date_str=date, month_str=month, year=year)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -2729,7 +2735,7 @@ async def energy_insights():
         )
     from datetime import date
     today = date.today()
-    insights = get_monthly_insights(today.year, today.month)
+    insights = await asyncio.to_thread(get_monthly_insights, today.year, today.month)
     if insights is None:
         return EnergyInsightsTextResponse(
             summary="Monthly data is temporarily unavailable. Try again later."
@@ -3322,7 +3328,8 @@ async def tariffs_dashboard(req: TariffDashboardRequest):
             window_to = _date.fromisoformat(req.end_date)
         except ValueError:
             raise HTTPException(status_code=400, detail="start_date/end_date must be YYYY-MM-DD")
-    data = get_tariff_comparison_dashboard(
+    data = await asyncio.to_thread(
+        get_tariff_comparison_dashboard,
         months_back=req.months_back,
         granularity=req.granularity,
         max_tariffs=req.max_tariffs,

--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -9,6 +9,7 @@ forecast cache only — no cloud writes.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
@@ -85,7 +86,9 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
     try:
         from ... import weather
 
-        fc = weather.fetch_forecast(hours=48)
+        # Open-Meteo HTTP — offload so it doesn't block the event loop and
+        # serialize the other dashboard requests behind it.
+        fc = await asyncio.to_thread(weather.fetch_forecast, hours=48)
         series = weather.forecast_to_lp_inputs(fc, slot_starts, pv_scale=1.0)
         pv = series.pv_kwh_per_slot
         for i in range(min(_SLOTS_PER_DAY, len(pv))):

--- a/ui/src/lib/poll.ts
+++ b/ui/src/lib/poll.ts
@@ -121,3 +121,25 @@ export function useFetch<T>(
 
   return { data, error, loading, refresh };
 }
+
+// useAfterPaint returns false on first render, then flips true once the browser
+// is idle after the initial paint. Gate below-the-fold / non-critical fetches
+// on it so the hero + live power paint first and the heavy Fox/Octopus calls
+// (lifetime rollup, tariff comparison) stream in a beat later instead of
+// competing with the critical above-the-fold data.
+export function useAfterPaint(timeoutMs = 1500): boolean {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const w = window as unknown as {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+      cancelIdleCallback?: (id: number) => void;
+    };
+    if (w.requestIdleCallback) {
+      const id = w.requestIdleCallback(() => setReady(true), { timeout: timeoutMs });
+      return () => w.cancelIdleCallback?.(id);
+    }
+    const id = window.setTimeout(() => setReady(true), 200);
+    return () => clearTimeout(id);
+  }, [timeoutMs]);
+  return ready;
+}

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 import { lazy, Suspense } from "preact/compat";
-import { usePoll, useFetch } from "../lib/poll";
+import { usePoll, useFetch, useAfterPaint } from "../lib/poll";
 import {
   getCockpitNow,
   getMetrics,
@@ -50,10 +50,11 @@ function lastMonths(n: number): string[] {
   return out;
 }
 
-function useMonthlyHistory(n: number) {
+function useMonthlyHistory(n: number, enabled = true) {
   const [data, setData] = useState<MonthlyEnergy[]>([]);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
+    if (!enabled) return;
     let alive = true;
     setLoading(true);
     Promise.all(lastMonths(n).map((m) => getEnergyMonthly(m).catch(() => null))).then((r) => {
@@ -62,7 +63,7 @@ function useMonthlyHistory(n: number) {
       setLoading(false);
     });
     return () => { alive = false; };
-  }, [n]);
+  }, [n, enabled]);
   return { data, loading };
 }
 
@@ -82,12 +83,19 @@ export default function Landing() {
   const timeline = usePoll(getSchedulerTimeline, 5 * 60_000);
   const pvToday = usePoll(getPvToday, 5 * 60_000);
 
+  // Non-critical, below-the-fold data waits until the browser is idle after
+  // first paint — keeps the heavy Fox/Octopus rollups (lifetime, tariff) from
+  // competing with the above-the-fold hero / live-power / plan data.
+  const deferred = useAfterPaint();
+
   // Fetch-once endpoints — refresh on tab return, otherwise no churn.
   const agile = useFetch(getAgileToday, []);
   const weather = useFetch(getWeather, []);
   const execution = useFetch(getExecutionToday, []);
   const report = useFetch(() => getEnergyReport(new Date().toISOString().slice(0, 10)), []);
-  const monthly = useMonthlyHistory(6);
+  // Lifetime rollup = 6 sequential /energy/monthly calls — deferred (it's a
+  // small stats strip low in the hero, not the headline).
+  const monthly = useMonthlyHistory(6, deferred);
   // Daikin cached read — no refresh=true, so no live cloud call (30-min cache TTL).
   const daikin = useFetch(getDaikinStatus, []);
   const daikinQuota = useFetch(getDaikinQuota, []);
@@ -101,10 +109,11 @@ export default function Landing() {
   // Tariff comparison scoped to the SAME window as the navigator — the
   // catalogue replay + usage now cover exactly the selected period, so its
   // realised current-tariff row + fixed shadow (from periodInsights) line up.
-  const tariffDash = useFetch(() => {
-    const w = periodDateRange(period);
-    return getTariffDashboard(1, "daily", 8, w);
-  }, [period.gran, period.anchor]);
+  // Deferred (bottom of page + heaviest single call): only fetch once idle.
+  const tariffDash = useFetch(
+    () => (deferred ? getTariffDashboard(1, "daily", 8, periodDateRange(period)) : Promise.resolve(null)),
+    [deferred, period.gran, period.anchor],
+  );
 
   if (now.loading && !now.data) {
     return <div class="home"><Spinner label="Loading dashboard…" /></div>;
@@ -167,7 +176,7 @@ export default function Landing() {
         <Widget title="Tariff comparison" icon="📊" tone="savings" size="wide"
                 badge={tariffDash.data?.usage?.total_days ? `last ${tariffDash.data.usage.total_days}d of your usage` : undefined}
                 action={<RefreshAction onRefresh={tariffDash.refresh} loading={tariffDash.loading} />}>
-          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={tariffDash.loading} metrics={metrics.data} period={periodInsights.data} periodLoading={periodInsights.loading} />
+          <TariffComparisonWidget dashboard={tariffDash.data} dashboardLoading={!deferred || tariffDash.loading} metrics={metrics.data} period={periodInsights.data} periodLoading={periodInsights.loading} />
         </Widget>
       </div>
     </div>


### PR DESCRIPTION
Ships the dashboard load-speed fix (paused earlier pending the PV work, now rebased onto main).

## Problem
The home dashboard fanned out ~20 API calls that **serialized**: the Fox/Octopus-backed endpoints were `async def` but ran synchronous blocking cloud I/O directly on the single event loop, so every request queued behind them (full load 20–40s; completion times climbed ~1s apart).

## Fix
- **Event-loop offload**: wrap the blocking cloud-I/O work in the heavy handlers in `await asyncio.to_thread(...)` so they run concurrently — `energy_monthly`, `energy_period`, `energy_report`, `energy_insights`, `tariffs_dashboard`, `weather`, `pv/today`. Kept handlers `async def` (NOT converted to `def`) because the MCP server + tests reuse them as coroutines.
- **Lazy below-the-fold**: new `useAfterPaint()` defers the heaviest non-critical fetches (6-call lifetime rollup + tariff comparison) until the browser is idle, so the hero + live power paint first.

## Notes
- Rebased onto current main; integrates cleanly with the period-navigator + committed-plan-PV work (e.g. tariff fetch is both `deferred`-gated and `periodDateRange`-scoped).
- 51 targeted tests pass (incl. MCP cockpit parity, pv/today); `tsc` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)