### PR TITLE
fix(dhw): tank negative-boost on import-negative (not export)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1403,21 +1403,21 @@ async def daikin_dhw_schedule():
     mode = (getattr(config, "OPTIMIZATION_PRESET", "normal") or "normal").strip().lower()
     warmup_hour = int(getattr(config, "DHW_WARMUP_START_HOUR_LOCAL", 13))
     rows_out: list[dict] = []
+    import_tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
     for offset in (0, 1):
         day = today_local + _td(days=offset)
-        outgoing = None
-        if (config.OCTOPUS_EXPORT_TARIFF_CODE or "").strip():
+        agile = None
+        if import_tariff:
             try:
                 ds = _dt(day.year, day.month, day.day, warmup_hour, 0, tzinfo=tz)
                 de = ds + _td(days=1)
-                outgoing = _db.get_agile_export_rates_in_range(
-                    ds.astimezone(UTC).isoformat().replace("+00:00", "Z"),
-                    de.astimezone(UTC).isoformat().replace("+00:00", "Z"),
-                )
+                # Negative boost fires on negative IMPORT (Agile) price (the
+                # plunge), matching the LP forecast — see lp_dispatch writer.
+                agile = _db.get_rates_for_period(import_tariff, ds.astimezone(UTC), de.astimezone(UTC))
             except Exception as e:
-                logger.debug("dhw-schedule: outgoing rates unavailable for %s: %s", day, e)
+                logger.debug("dhw-schedule: import rates unavailable for %s: %s", day, e)
         try:
-            rows = dhw_policy.generate_daily_tank_schedule(day, outgoing_rates=outgoing)
+            rows = dhw_policy.generate_daily_tank_schedule(day, agile_rates=agile)
             for r in rows:
                 params = r.get("params") or {}
                 rows_out.append({

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -69,20 +69,20 @@ def _make_action(
 
 
 def _detect_negative_windows(
-    outgoing_rates: list[dict[str, Any]] | None,
+    agile_rates: list[dict[str, Any]] | None,
     horizon_start_utc: datetime,
     horizon_end_utc: datetime,
 ) -> list[tuple[datetime, datetime]]:
     """Group consecutive negative-price 30-min slots into contiguous windows.
 
-    ``outgoing_rates`` is a list of dicts with at least ``valid_from`` (ISO
+    ``agile_rates`` is a list of dicts with at least ``valid_from`` (ISO
     UTC) and ``value_inc_vat`` (pence/kWh). Returns list of (start, end)
     UTC datetime tuples; empty when no negative slots in horizon.
     """
-    if not outgoing_rates:
+    if not agile_rates:
         return []
     neg_slot_starts: list[datetime] = []
-    for r in outgoing_rates:
+    for r in agile_rates:
         try:
             ts_raw = r.get("valid_from") or r.get("slot_time_utc")
             rate = float(r.get("value_inc_vat", r.get("rate_p", 999)))
@@ -118,7 +118,7 @@ def _detect_negative_windows(
 def generate_daily_tank_schedule(
     target_date_local: date,
     *,
-    outgoing_rates: list[dict[str, Any]] | None = None,
+    agile_rates: list[dict[str, Any]] | None = None,
     mode: str | None = None,
 ) -> list[dict[str, Any]]:
     """Generate tank action rows for the local calendar day starting at
@@ -131,7 +131,7 @@ def generate_daily_tank_schedule(
 
     Args:
         target_date_local: anchor day in local TZ
-        outgoing_rates: optional list of {valid_from, value_inc_vat}; used
+        agile_rates: optional list of {valid_from, value_inc_vat}; used
             to detect negative-price windows for boost overrides
         mode: optimization preset; defaults to ``config.OPTIMIZATION_PRESET``
 
@@ -217,7 +217,7 @@ def generate_daily_tank_schedule(
     # duration of any negative-priced contiguous window within the horizon.
     horizon_start = warmup_start.astimezone(UTC)
     horizon_end = next_warmup.astimezone(UTC)
-    neg_windows = _detect_negative_windows(outgoing_rates, horizon_start, horizon_end)
+    neg_windows = _detect_negative_windows(agile_rates, horizon_start, horizon_end)
     for nw_start, nw_end in neg_windows:
         rows.append(_make_action(
             action_type="tank_negative_boost",
@@ -464,7 +464,7 @@ def forecast_dhw_load_per_slot(
 def write_daily_tank_schedule(
     target_date_local: date | None = None,
     *,
-    outgoing_rates: list[dict[str, Any]] | None = None,
+    agile_rates: list[dict[str, Any]] | None = None,
     mode: str | None = None,
     clear_existing: bool = True,
 ) -> int:
@@ -477,7 +477,7 @@ def write_daily_tank_schedule(
 
     Args:
         target_date_local: defaults to today in local TZ
-        outgoing_rates: optional, for negative-price detection
+        agile_rates: optional, for negative-price detection
         mode: optional override; defaults to ``config.OPTIMIZATION_PRESET``
         clear_existing: when True, calls ``db.clear_actions_in_range`` over
             the warmup window before upserting
@@ -490,7 +490,7 @@ def write_daily_tank_schedule(
 
     rows = generate_daily_tank_schedule(
         target_date_local,
-        outgoing_rates=outgoing_rates,
+        agile_rates=agile_rates,
         mode=mode,
     )
     if not rows:

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -822,18 +822,24 @@ def write_daikin_from_lp_plan(
                 tzinfo=tz_local_local,
             )
             day_end_local = day_start_local + timedelta(days=1)
+            # Negative-price boost fires on negative IMPORT (Agile) price — "paid
+            # to import → load the tank". Must match the LP forecast (1A keys on
+            # the import price_line); the export/Outgoing rate is a different
+            # tariff and is rarely negative when import plunges.
+            import_tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
             try:
-                outgoing = get_agile_export_rates_in_range(
-                    day_start_local.astimezone(_UTC_T).isoformat().replace("+00:00", "Z"),
-                    day_end_local.astimezone(_UTC_T).isoformat().replace("+00:00", "Z"),
-                )
+                agile = db.get_rates_for_period(
+                    import_tariff,
+                    day_start_local.astimezone(_UTC_T),
+                    day_end_local.astimezone(_UTC_T),
+                ) if import_tariff else None
             except Exception as _e:
-                logger.debug("dhw_policy: outgoing rates unavailable for %s: %s", day, _e)
-                outgoing = None
+                logger.debug("dhw_policy: import rates unavailable for %s: %s", day, _e)
+                agile = None
             try:
                 n = dhw_policy.write_daily_tank_schedule(
                     target_date_local=day,
-                    outgoing_rates=outgoing,
+                    agile_rates=agile,
                     clear_existing=False,  # already cleared widely above
                 )
                 rows_total += n

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -126,7 +126,7 @@ def test_negative_price_single_slot_overlay():
         {"valid_from": neg_slot_utc, "value_inc_vat": -5.0, "tariff_code": "AGILE-OUTGOING"},
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert len(boost) == 1
@@ -142,7 +142,7 @@ def test_consecutive_negative_slots_merged_into_window():
         {"valid_from": "2026-06-01T15:00:00Z", "value_inc_vat": -1.2},
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert len(boost) == 1
@@ -160,7 +160,7 @@ def test_non_contiguous_negative_slots_emit_separate_windows():
         {"valid_from": "2026-06-01T15:30:00Z", "value_inc_vat": -2.0},
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert len(boost) == 2
@@ -173,7 +173,7 @@ def test_positive_outgoing_rates_do_not_trigger_boost():
         {"valid_from": "2026-06-01T15:00:00Z", "value_inc_vat": 20.0},
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     assert all(r["action_type"] != "tank_negative_boost" for r in rows)
 
@@ -186,16 +186,16 @@ def test_negative_slot_outside_horizon_ignored():
         {"valid_from": "2026-06-01T10:00:00Z", "value_inc_vat": -5.0},
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert boost == []
 
 
 def test_outgoing_rates_none_no_crash():
-    """outgoing_rates=None just yields warmup+setback, no boost; doesn't crash."""
+    """agile_rates=None just yields warmup+setback, no boost; doesn't crash."""
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=None, mode="normal",
+        date(2026, 6, 1), agile_rates=None, mode="normal",
     )
     assert len(rows) == 2
     assert all(r["action_type"] in ("tank_warmup", "tank_setback") for r in rows)
@@ -205,7 +205,7 @@ def test_outgoing_rate_zero_does_not_trigger_boost():
     """Rate=0 is not strictly negative; no boost."""
     outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": 0.0}]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert boost == []
@@ -220,7 +220,7 @@ def test_malformed_outgoing_rate_skipped():
         {"valid_from": "2026-06-01T15:00:00Z", "value_inc_vat": -1.0},  # good
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     # Only the one good negative rate emits a boost
@@ -236,7 +236,7 @@ def test_write_daily_tank_schedule_persists_rows():
     """write_daily_tank_schedule upserts rows into action_schedule."""
     n = dhw_policy.write_daily_tank_schedule(
         target_date_local=date(2026, 6, 1),
-        outgoing_rates=None,
+        agile_rates=None,
         mode="normal",
         clear_existing=False,
     )
@@ -334,7 +334,7 @@ def test_negative_boost_temp_override(monkeypatch):
     monkeypatch.setattr(config, "DHW_NEGATIVE_PRICE_BOOST_C", 65.0, raising=False)
     outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0}]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = next(r for r in rows if r["action_type"] == "tank_negative_boost")
     assert boost["params"]["tank_temp"] == 65
@@ -376,7 +376,7 @@ def test_negative_boost_uses_powerful():
     """Negative-price boost loads tank fast — tank_powerful=True."""
     outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0}]
     rows = dhw_policy.generate_daily_tank_schedule(
-        date(2026, 6, 1), outgoing_rates=outgoing, mode="normal",
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = next(r for r in rows if r["action_type"] == "tank_negative_boost")
     assert boost["params"]["tank_powerful"] is True

--- a/tests/test_dhw_policy_bugfixes.py
+++ b/tests/test_dhw_policy_bugfixes.py
@@ -95,7 +95,7 @@ def test_negative_slot_in_overnight_setback_window_detected():
     ).isoformat().replace("+00:00", "Z")
     outgoing = [{"valid_from": neg_slot_utc, "value_inc_vat": -5.0}]
     rows = dhw_policy.generate_daily_tank_schedule(
-        today, outgoing_rates=outgoing, mode="normal",
+        today, agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert len(boost) == 1, (
@@ -116,7 +116,7 @@ def test_negative_slot_at_horizon_end_excluded():
     ).astimezone(UTC).isoformat().replace("+00:00", "Z")
     outgoing = [{"valid_from": boundary_utc, "value_inc_vat": -3.0}]
     rows = dhw_policy.generate_daily_tank_schedule(
-        today, outgoing_rates=outgoing, mode="normal",
+        today, agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert boost == []  # at horizon end (exclusive); belongs to next day

--- a/tests/test_dhw_schedule_endpoint.py
+++ b/tests/test_dhw_schedule_endpoint.py
@@ -14,19 +14,18 @@ def test_dhw_schedule_two_days_with_negative_boost(monkeypatch):
     import src.db as db
     from src.api import main
 
-    monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE", "E-1R-AGILE-OUTGOING", raising=False)
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE-FLEX", raising=False)
     monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "normal", raising=False)
 
-    # Negative slot tomorrow ~15:00 UTC (inside tomorrow's warmup horizon).
+    # Negative IMPORT slot tomorrow ~15:00 UTC (inside tomorrow's warmup horizon).
     tomorrow = (datetime.now(UTC) + timedelta(days=1)).date()
     neg = datetime(tomorrow.year, tomorrow.month, tomorrow.day, 15, 0, tzinfo=UTC)
 
-    def _fake_rates(a, b):
-        # Return the negative slot only when the requested range covers it.
-        if a <= neg.isoformat().replace("+00:00", "Z") < b:
+    def _fake_rates(tariff, a, b):  # get_rates_for_period(tariff, from_dt, to_dt)
+        if a <= neg < b:
             return [{"valid_from": neg.isoformat().replace("+00:00", "Z"), "value_inc_vat": -4.0}]
         return []
-    monkeypatch.setattr(db, "get_agile_export_rates_in_range", _fake_rates)
+    monkeypatch.setattr(db, "get_rates_for_period", _fake_rates)
 
     resp = asyncio.run(main.daikin_dhw_schedule())
     rows = resp["rows"]
@@ -44,7 +43,7 @@ def test_dhw_schedule_no_rates_no_boost(monkeypatch):
     import src.db as db
     from src.api import main
 
-    monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE", "E-1R-AGILE-OUTGOING", raising=False)
-    monkeypatch.setattr(db, "get_agile_export_rates_in_range", lambda a, b: [])
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE-FLEX", raising=False)
+    monkeypatch.setattr(db, "get_rates_for_period", lambda tariff, a, b: [])
     resp = asyncio.run(main.daikin_dhw_schedule())
     assert not [r for r in resp["rows"] if r["action_type"] == "tank_negative_boost"]

--- a/tests/test_realistic_day_scenarios.py
+++ b/tests/test_realistic_day_scenarios.py
@@ -232,7 +232,7 @@ def test_scenario_negative_price_emits_boost():
                         tzinfo=UTC).isoformat().replace("+00:00", "Z")
     outgoing = [{"valid_from": neg_slot, "value_inc_vat": -3.5}]
     rows = dhw_policy.generate_daily_tank_schedule(
-        tomorrow, outgoing_rates=outgoing, mode="normal",
+        tomorrow, agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert len(boost) == 1

--- a/tests/test_winter_scenarios.py
+++ b/tests/test_winter_scenarios.py
@@ -235,7 +235,7 @@ def test_w3_winter_negative_price_still_emits_boost():
     neg_slot_utc = datetime(2026, 12, 15, 2, 0, tzinfo=UTC).isoformat().replace("+00:00", "Z")
     outgoing = [{"valid_from": neg_slot_utc, "value_inc_vat": -8.0}]
     rows = dhw_policy.generate_daily_tank_schedule(
-        schedule_day, outgoing_rates=outgoing, mode="normal",
+        schedule_day, agile_rates=outgoing, mode="normal",
     )
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert len(boost) == 1

--- a/ui/src/components/cockpit/LivePowerWidget.tsx
+++ b/ui/src/components/cockpit/LivePowerWidget.tsx
@@ -176,7 +176,7 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
 interface ForcedWindow { kind: string; start_utc: string; end_utc: string; slot_count: number; }
 function upcomingForcedWindows(timeline: SchedulerTimeline, limit: number): ForcedWindow[] {
   const out: ForcedWindow[] = [];
-  const interesting = new Set(["cheap", "negative", "peak_export"]);
+  const interesting = new Set(["cheap", "negative", "peak_export", "pre_negative_export"]);
   let current: ForcedWindow | null = null;
   for (const s of timeline.planned || []) {
     const k = (s.dispatched_kind || s.lp_kind || "").toLowerCase();
@@ -206,6 +206,7 @@ function labelForKind(k: string | undefined): string {
     case "cheap":         return "Force charge";
     case "negative":      return "Force charge";
     case "peak_export":   return "Force discharge";
+    case "pre_negative_export": return "Drain (pre-neg)";
     default:              return k || "?";
   }
 }


### PR DESCRIPTION
Live-on-prod fix. The LP forecast budgeted the tank boost (keys on negative IMPORT price), but the Daikin `tank_negative_boost` action + badge keyed on negative OUTGOING/export rates. Today import plunged negative while export had 0 negatives → no boost action written (phantom boost, no badge). Now the boost schedule detects negatives from the IMPORT Agile rates, consistent with the LP. Also surfaces the `pre_negative_export` drain in the battery badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)