### PR TITLE
fix(lp,dhw,fox): negative-tariff release — drain economics, boost/warmup, 60°C cap, Fox in-flight, dedup

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -761,6 +761,15 @@ class Config:
     DHW_NEGATIVE_PRICE_BOOST_C: float = float(
         os.getenv("DHW_NEGATIVE_PRICE_BOOST_C", "65")
     )
+    # When a negative-price boost window opens within this many minutes of the
+    # daily warmup start, the warmup is DEFERRED past the boost (chaining
+    # consecutive early boosts) instead of pre-heating to NORMAL at a positive
+    # price right before the free boost-to-MAX. The warmup then resumes its
+    # hold-at-NORMAL role after the boost (tank coasts down from the boost temp).
+    # A boost later than this lead leaves the warmup intact. 0 disables.
+    DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES: int = int(
+        os.getenv("DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES", "120")
+    )
     # Forecast night-temperature bias (minimal #324 implementation).
     # Open Meteo's grid coverage (~10 km) over-estimates the W4 1DZ
     # microclimate's overnight outdoor temperature by ~3 °C in the household's
@@ -921,19 +930,18 @@ class Config:
     LP_PLUNGE_PREP_HOURS: int = int(os.getenv("LP_PLUNGE_PREP_HOURS", "12"))
 
     # Pre-negative ACTIVE pre-positioning: within LP_PLUNGE_PREP_HOURS of a
-    # negative window, actively DRAIN the battery to the grid (force export,
+    # negative window, ALLOW the battery to drain to the grid (force export,
     # selling high) so it has maximum headroom to absorb paid import during the
-    # negative window. Only fires when selling-now beats buying-back-during-
-    # negative by LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE (round-trip adjusted), and
-    # never below the export SoC floor. This DELIBERATELY reverses the standard
-    # "no battery export in normal/guests" rule (PR D) for the pre-negative
-    # window only — set false to disable.
+    # negative window. This only sets *eligibility* — the LP objective decides
+    # whether and how much to drain (export revenue net of cycle penalty and
+    # buy-back cost); there is no economic threshold gate. This DELIBERATELY
+    # reverses the standard "no battery export in normal/guests" rule (PR D)
+    # for the pre-negative window only — set false to disable.
+    # NOTE: LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE was REMOVED — it was an arbitrary
+    # 2p cliff that could toggle drain availability on small export-rate moves.
     LP_PRE_NEGATIVE_PREP_ENABLED: bool = (
         os.getenv("LP_PRE_NEGATIVE_PREP_ENABLED", "true").strip().lower()
         in ("1", "true", "yes", "on")
-    )
-    LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE: float = float(
-        os.getenv("LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE", "2.0")
     )
     # Pre-cool the DHW tank for this many hours before a negative window: don't
     # re-warm it (let it coast to setback) so it has maximum headroom to absorb

--- a/src/config.py
+++ b/src/config.py
@@ -485,7 +485,15 @@ class Config:
         os.getenv("APPLIANCE_DEFAULT_BASE_LOAD_KW", "0.4")
     )
 
-    DHW_TEMP_MAX_C: float = float(os.getenv("DHW_TEMP_MAX_C", "65"))
+    # Max tank temperature (°C) — the physical ceiling for EVERYTHING: the LP
+    # tank-variable bound, the soft per-slot ceiling, every setpoint we command,
+    # and the cap on the firmware legionella lift. The heat pump AND the
+    # firmware legionella cycle both top out here; Onecta rejects any setpoint
+    # above it ("Max tank temperature is 60°C", client.py:306), which made the
+    # old 65 °C negative-price boost silently FAIL (tank got no extra heat). The
+    # app's "powerful"/immersion button can momentarily push higher, but we
+    # never command that. Was 65 → now 60 to match the hardware.
+    DHW_TEMP_MAX_C: float = float(os.getenv("DHW_TEMP_MAX_C", "60"))
     # Plunge-only ceiling (≥ DHW_TEMP_COMFORT_C and ≤ DHW_TEMP_MAX_C is allowed only when price < 0).
     # DHW_TEMP_COMFORT_C + DHW_TEMP_NORMAL_C are runtime-tunable via
     # /api/v1/settings (#52) — see the @property definitions below.
@@ -752,24 +760,24 @@ class Config:
     DHW_TEMP_SETBACK_C: float = float(
         os.getenv("DHW_TEMP_SETBACK_C", "37")
     )
-    # Tank temperature during negative-price slots (Outgoing Agile < 0 p/kWh).
-    # Sole permitted exception to the fixed schedule — grid is paying us to
-    # consume, so load the tank to MAX. Default raised 60 → 65 (= DHW_TEMP_MAX_C;
-    # heat is free money during negative price). The LP now also BUDGETS this
-    # heat-up energy (forecast_dhw_load_per_slot ramp) so it plans the extra
-    # import. Clamped to DHW_TEMP_MAX_C in dhw_policy.
+    # Commandable SETPOINT during negative-price slots (import price < 0 p/kWh):
+    # the tank target we WRITE to the heat pump. Grid is paying us to consume, so
+    # we drive the setpoint to its max. MUST stay ≤ the device's heat-pump
+    # setpoint ceiling (60 °C) — Onecta rejects anything higher
+    # ("Max tank temperature is 60°C", client.py:306), which made every boost
+    # write FAIL (the tank got NO extra heat). Was 65 → now 60. The tank can
+    # still reach 65 physically via the app's "powerful"/immersion button or the
+    # legionella cycle (that's DHW_TEMP_MAX_C), but those are not commanded here.
+    # The LP also BUDGETS this heat-up energy (forecast_dhw_load_per_slot ramp).
     DHW_NEGATIVE_PRICE_BOOST_C: float = float(
-        os.getenv("DHW_NEGATIVE_PRICE_BOOST_C", "65")
+        os.getenv("DHW_NEGATIVE_PRICE_BOOST_C", "60")
     )
-    # When a negative-price boost window opens within this many minutes of the
-    # daily warmup start, the warmup is DEFERRED past the boost (chaining
-    # consecutive early boosts) instead of pre-heating to NORMAL at a positive
-    # price right before the free boost-to-MAX. The warmup then resumes its
-    # hold-at-NORMAL role after the boost (tank coasts down from the boost temp).
-    # A boost later than this lead leaves the warmup intact. 0 disables.
-    DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES: int = int(
-        os.getenv("DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES", "120")
-    )
+    # NOTE: the leading-warmup defer (a boost SUPERSEDES the warmup that would
+    # otherwise pre-heat at a positive price right before it) is driven by
+    # LP_PRE_NEGATIVE_PRECOOL_HOURS below — the SAME window the LP's energy
+    # forecast (forecast_dhw_load_per_slot) uses to pre-cool. Sharing one knob
+    # keeps the fired tank actions and the LP's budgeted DHW import consistent
+    # by construction (no separate DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES).
     # Forecast night-temperature bias (minimal #324 implementation).
     # Open Meteo's grid coverage (~10 km) over-estimates the W4 1DZ
     # microclimate's overnight outdoor temperature by ~3 °C in the household's

--- a/src/config.py
+++ b/src/config.py
@@ -1102,6 +1102,13 @@ class Config:
     # is wasted budget against the 8-group hardware cap. Setting this False reverts to the
     # original behaviour (every LP window becomes a Fox group, including SelfUse gaps).
     FOX_SKIP_TRIVIAL_SELFUSE_GROUPS: bool = os.getenv("FOX_SKIP_TRIVIAL_SELFUSE_GROUPS", "true").lower() in ("1", "true", "yes")
+    # On a mid-slot re-upload, bridge the in-progress half-hour slot with the
+    # previously-uploaded work mode so a live ForceCharge/ForceDischarge isn't
+    # dropped to the firmware's SelfUse default (the plan horizon starts at the
+    # NEXT boundary for Daikin quota integrity, but a Fox upload replaces the
+    # whole schedule). Fixes force-charge silently stopping mid negative-price
+    # slot. Set false to roll back to the bare next-boundary schedule.
+    FOX_PRESERVE_INFLIGHT_GROUP: bool = os.getenv("FOX_PRESERVE_INFLIGHT_GROUP", "true").lower() in ("1", "true", "yes")
 
     # Event-driven MPC ("Waze recalculating") — see Epic #73.
     # Kill switch: setting this False disables drift + forecast triggers (cron MPC continues).

--- a/src/db.py
+++ b/src/db.py
@@ -1282,6 +1282,51 @@ def upsert_action(
     with _lock:
         conn = get_connection()
         try:
+            # Genuine upsert on the natural key (device, action_type, start_time).
+            # Without this the function was a plain INSERT, so every re-plan that
+            # re-emitted the same slot created a duplicate row — and because
+            # clear_actions_in_range only removes *pending* rows in range, an
+            # already-fired (completed) or in-flight row for the same slot was
+            # never cleared, so the re-emit produced a past-dated pending dup
+            # that fired again. Observed in prod: ~18 identical tank_warmup rows
+            # in one day. Rule:
+            #   * existing pending+future row  → refresh it (pick up new params)
+            #   * existing completed/failed/in-flight row → SKIP (already handled;
+            #     never recreate a past or actively-firing action)
+            existing = conn.execute(
+                """SELECT id, status, start_time, end_time FROM action_schedule
+                   WHERE device = ? AND action_type = ? AND start_time = ?
+                   ORDER BY id DESC""",
+                (device, action_type, start_time),
+            ).fetchall()
+            if existing:
+                now_iso = created
+                refreshable = None
+                for row in existing:
+                    in_flight = (
+                        row["status"] == "pending"
+                        and row["start_time"] <= now_iso < (row["end_time"] or "")
+                    )
+                    if row["status"] == "pending" and not in_flight:
+                        refreshable = row
+                        break
+                if refreshable is not None:
+                    conn.execute(
+                        """UPDATE action_schedule
+                           SET date = ?, end_time = ?, params = ?, status = ?,
+                               restore_action_id = ?, created_at = ?
+                           WHERE id = ?""",
+                        (
+                            plan_date, end_time, params_json, status,
+                            restore_action_id, created, refreshable["id"],
+                        ),
+                    )
+                    conn.commit()
+                    return int(refreshable["id"])
+                # Only completed/failed/in-flight rows exist for this slot —
+                # the action is already handled; do not create a duplicate.
+                conn.commit()
+                return int(existing[0]["id"])
             cur = conn.execute(
                 """INSERT INTO action_schedule
                    (date, start_time, end_time, device, action_type, params, status,

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -203,9 +203,17 @@ def generate_daily_tank_schedule(
     # falls below normal_c. A boost LATER in the day (beyond the lead window of
     # the warmup start) leaves the warmup intact: the afternoon still needs hot
     # water before that boost arrives.
+    #
+    # The lead window is LP_PRE_NEGATIVE_PRECOOL_HOURS — deliberately the SAME
+    # window the LP's energy forecast (forecast_dhw_load_per_slot) uses to
+    # pre-cool: the forecast zeroes warmup energy for slots within precool_hours
+    # before a negative window, so deferring the fired warmup over exactly that
+    # window keeps the actions and the budgeted DHW import consistent. (The LP
+    # suppresses the warmup-start slot iff boost_start <= warmup_start +
+    # precool — identical to this defer condition.)
     effective_warmup_start_utc = warmup_start_utc
-    defer_lead = timedelta(minutes=int(
-        getattr(config, "DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES", 120)
+    defer_lead = timedelta(hours=max(
+        0.0, float(getattr(config, "LP_PRE_NEGATIVE_PRECOOL_HOURS", 3.0))
     ))
     if neg_windows and defer_lead > timedelta(0):
         for nw_start, nw_end in sorted(neg_windows):

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -186,38 +186,64 @@ def generate_daily_tank_schedule(
         warmup_hour, 0, tzinfo=tz,
     )
 
+    # Negative-price boost windows are the sole permitted exception to the fixed
+    # schedule. Detect them FIRST so they can genuinely SUPERSEDE the leading
+    # warmup (not just sit alongside it): we must never pre-heat to normal_c at a
+    # positive price right before a free, paid-to-import boost to boost_c.
+    warmup_start_utc = warmup_start.astimezone(UTC)
+    setback_start_utc = setback_start.astimezone(UTC)
+    next_warmup_utc = next_warmup.astimezone(UTC)
+    neg_windows = _detect_negative_windows(agile_rates, warmup_start_utc, next_warmup_utc)
+
+    # If a boost window opens at/near the warmup start, defer the warmup past it
+    # (chaining consecutive boosts that each fall within the lead window of the
+    # running start). The boost does the heating during the paid window; the
+    # warmup then resumes its hold-at-normal_c role afterwards — the tank simply
+    # coasts down from boost_c, so no positive-price heating happens until it
+    # falls below normal_c. A boost LATER in the day (beyond the lead window of
+    # the warmup start) leaves the warmup intact: the afternoon still needs hot
+    # water before that boost arrives.
+    effective_warmup_start_utc = warmup_start_utc
+    defer_lead = timedelta(minutes=int(
+        getattr(config, "DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES", 120)
+    ))
+    if neg_windows and defer_lead > timedelta(0):
+        for nw_start, nw_end in sorted(neg_windows):
+            if nw_start <= effective_warmup_start_utc + defer_lead:
+                effective_warmup_start_utc = max(effective_warmup_start_utc, nw_end)
+            else:
+                break
+
     rows: list[dict[str, Any]] = []
 
     if mode == "guests":
         # Single 24h warmup row — no setback during guest visits because of
-        # potential morning showers.
-        rows.append(_make_action(
-            action_type="tank_warmup",
-            start_utc=warmup_start.astimezone(UTC),
-            end_utc=next_warmup.astimezone(UTC),
-            tank_temp_c=normal_c,
-        ))
+        # potential morning showers. Skip entirely if a boost chain has deferred
+        # the start past the window end.
+        if effective_warmup_start_utc < next_warmup_utc:
+            rows.append(_make_action(
+                action_type="tank_warmup",
+                start_utc=effective_warmup_start_utc,
+                end_utc=next_warmup_utc,
+                tank_temp_c=normal_c,
+            ))
     else:
-        # Normal mode: warmup → setback → next-day warmup pattern
-        rows.append(_make_action(
-            action_type="tank_warmup",
-            start_utc=warmup_start.astimezone(UTC),
-            end_utc=setback_start.astimezone(UTC),
-            tank_temp_c=normal_c,
-        ))
+        # Normal mode: warmup → setback → next-day warmup pattern. The warmup is
+        # emitted only when it still has positive duration after any boost defer.
+        if effective_warmup_start_utc < setback_start_utc:
+            rows.append(_make_action(
+                action_type="tank_warmup",
+                start_utc=effective_warmup_start_utc,
+                end_utc=setback_start_utc,
+                tank_temp_c=normal_c,
+            ))
         rows.append(_make_action(
             action_type="tank_setback",
-            start_utc=setback_start.astimezone(UTC),
-            end_utc=next_warmup.astimezone(UTC),
+            start_utc=setback_start_utc,
+            end_utc=next_warmup_utc,
             tank_temp_c=setback_c,
         ))
 
-    # Negative-price boost windows — sole permitted exception to the fixed
-    # schedule. Override the underlying tank_warmup / tank_setback for the
-    # duration of any negative-priced contiguous window within the horizon.
-    horizon_start = warmup_start.astimezone(UTC)
-    horizon_end = next_warmup.astimezone(UTC)
-    neg_windows = _detect_negative_windows(agile_rates, horizon_start, horizon_end)
     for nw_start, nw_end in neg_windows:
         rows.append(_make_action(
             action_type="tank_negative_boost",

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -1184,9 +1184,89 @@ def _detect_overlapping_groups(
     return overlaps
 
 
+def _prepend_inflight_group(
+    groups: list[SchedulerGroup],
+    *,
+    now_local: datetime | None = None,
+) -> list[SchedulerGroup]:
+    """Re-assert the in-progress slot's work mode so a mid-slot re-upload can't
+    drop a live ForceCharge/ForceDischarge to the firmware's SelfUse default.
+
+    The plan window starts at the NEXT half-hour boundary (``_ceil_to_half_hour_utc``
+    — quota integrity for Daikin), but a Fox upload REPLACES the whole schedule.
+    So when a re-solve fires *mid-slot* (e.g. the ``negative_window_start``
+    trigger), the in-progress slot has no group and the firmware falls back to
+    SelfUse for its remainder — silently stopping force-charge during a paid
+    negative-price slot (observed 2026-06-04, upload left 13:34–14:00 BST bare).
+
+    We bridge ``[slot_start, next_boundary)`` with the work mode the PREVIOUSLY
+    uploaded schedule had for *now*, so whatever was decided for the live slot
+    survives the re-upload. Only active modes are carried (SelfUse is the
+    firmware default anyway). Issue #458 follow-up; ``FOX_PRESERVE_INFLIGHT_GROUP``
+    set false to roll back.
+    """
+    if not groups or not getattr(config, "FOX_PRESERVE_INFLIGHT_GROUP", True):
+        return groups
+    if len(groups) >= 8:
+        return groups  # no room under the Fox V3 8-group cap
+    tz = TZ()
+    now_local = now_local or datetime.now(tz)
+    now_min = now_local.hour * 60 + now_local.minute
+    slot_start_min = (now_min // 30) * 30          # floor to half-hour
+    slot_end_min = slot_start_min + 30             # exclusive end = next boundary
+
+    g0 = groups[0]
+    first_start_min = g0.start_hour * 60 + g0.start_minute
+    if first_start_min <= now_min:
+        return groups                              # first group already covers now
+    if first_start_min < slot_end_min:
+        return groups                              # would overlap the current slot
+    try:
+        prev = db.get_latest_fox_schedule_state()
+    except Exception as e:                          # never block an upload on this read
+        logger.debug("Fox in-flight preserve: prev-schedule read failed: %s", e)
+        return groups
+    if not prev or not prev.get("groups"):
+        return groups
+    carry = None
+    for pg in prev["groups"]:
+        try:
+            ps = int(pg["startHour"]) * 60 + int(pg["startMinute"])
+            pe = int(pg["endHour"]) * 60 + int(pg["endMinute"])  # inclusive :59
+        except (KeyError, TypeError, ValueError):
+            continue
+        if ps <= now_min <= pe:
+            carry = pg
+            break
+    if carry is None:
+        return groups
+    wm = carry.get("workMode")
+    if wm not in ("ForceCharge", "ForceDischarge", "Backup"):
+        return groups                              # SelfUse is the default — nothing to preserve
+    extra = carry.get("extraParam") or {}
+    sh, sm = divmod(slot_start_min, 60)
+    eh, em = divmod(slot_end_min - 1, 60)          # :59 inclusive-minute convention
+    bridge = SchedulerGroup(
+        start_hour=sh, start_minute=sm,
+        end_hour=eh, end_minute=em,
+        work_mode=wm,
+        min_soc_on_grid=int(extra.get("minSocOnGrid", config.MIN_SOC_RESERVE_PERCENT)),
+        fd_soc=extra.get("fdSoc"),
+        fd_pwr=extra.get("fdPwr"),
+        max_soc=extra.get("maxSoc"),
+    )
+    logger.info(
+        "Fox upload: re-asserting in-flight %s for current slot %02d:%02d-%02d:%02d "
+        "(horizon starts %02d:%02d) — prevents mid-slot SelfUse gap",
+        wm, sh, sm, eh, em, g0.start_hour, g0.start_minute,
+    )
+    return [bridge] + groups
+
+
 def upload_fox_if_operational(fox: FoxESSClient | None, groups: list[SchedulerGroup]) -> bool:
     fox_ok = False
     if fox and fox.api_key and not config.OPENCLAW_READ_ONLY:
+        groups = _prepend_inflight_group(groups)
         overlaps = _detect_overlapping_groups(groups)
         if overlaps:
             for i, j in overlaps:

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -636,13 +636,25 @@ def solve_lp(
     # absorb maximum import during the window. The LP objective + cycle penalty
     # decide whether/how much to drain (and the SoC reserve floors it). Gated by
     # a minimum export price so we never give energy away for headroom alone.
+    # Pre-negative drain ELIGIBILITY (not a decision): a positive-price slot is
+    # *allowed* to export battery→grid when a negative window sits within the
+    # prep horizon ahead. Whether — and how much — it actually drains is left
+    # entirely to the objective: export revenue (``-exp×export_rate``) net of
+    # the cycle penalty (``obj_cycle``) and the cost of buying the energy back.
+    # There is deliberately NO economic threshold gate here. The old
+    # ``export_rate >= LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE`` floor was an
+    # arbitrary 2p cliff that could flip a slot's drain availability on tiny
+    # export-rate moves near the threshold; the objective already declines to
+    # drain when it isn't worth it, and the ``export_rate < 0`` safety below
+    # forces ``exp == 0`` so we never pay to export.
     pre_neg_export = [False] * n
     if getattr(config, "LP_PRE_NEGATIVE_PREP_ENABLED", True) and not _vacation_mode:
         _prep_slots = int(max(0, int(getattr(config, "LP_PLUNGE_PREP_HOURS", 12))) * 2)
-        _drain_margin = float(getattr(config, "LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE", 2.0))
         if _prep_slots > 0:
             for i in range(n):
-                if price_line[i] < 0 or export_rate_line[i] < _drain_margin:
+                # Negative slots charge (paid to import) and have dis locked to
+                # 0 — never drain candidates.
+                if price_line[i] < 0:
                     continue
                 j_end = min(n, i + _prep_slots)
                 if any(price_line[j] < 0 for j in range(i, j_end)):

--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -969,7 +969,13 @@ def solve_lp(
             # firmware imposes — independent of where the LP's tank state
             # actually was at slot start.
             _normal_target = float(config.DHW_TEMP_NORMAL_C)
-            _delta_c = max(0.0, _leg_target_c - _normal_target)
+            # The tank can't physically exceed the ceiling (heat pump AND the
+            # firmware legionella cycle both top out at DHW_TEMP_MAX_C). Cap the
+            # modeled lift there: a configured target above the ceiling is
+            # unreachable and would otherwise force the tank past its hard bound
+            # → Infeasible. Keeps the solver robust to a misconfigured target.
+            _effective_leg_target = min(_leg_target_c, tank_hi)
+            _delta_c = max(0.0, _effective_leg_target - _normal_target)
             _thermal_kwh = (
                 float(config.DHW_TANK_LITRES) * float(config.DHW_WATER_CP)
                 * _delta_c / 3.6e6

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -798,7 +798,10 @@ def _daikin_params_for_kind(kind: str, peak_frost: bool) -> dict[str, Any]:
         return {
             "lwt_offset": config.LWT_OFFSET_MAX,
             "tank_powerful": True,
-            "tank_temp": config.DHW_TEMP_MAX_C,
+            # Commandable setpoint, NOT the physical ceiling — Onecta rejects
+            # setpoints above the heat-pump max (60 °C). tank_powerful=True still
+            # engages the immersion booster for max heat during the paid window.
+            "tank_temp": min(config.DHW_NEGATIVE_PRICE_BOOST_C, config.DHW_TEMP_MAX_C),
             "tank_power": True,
             "climate_on": True,
         }

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -318,20 +318,49 @@ def test_boost_chain_can_drop_guest_warmup_start():
     assert start == datetime(2026, 6, 1, 13, 0, tzinfo=UTC), start
 
 
-def test_warmup_override_disabled_by_zero_lead():
-    """Lead=0 disables the defer — warmup stays at 13:00 even with a boost at
-    the very next slot (rollback escape hatch)."""
+def test_warmup_override_disabled_by_zero_precool():
+    """precool_hours=0 disables both the LP pre-cool AND the schedule defer —
+    warmup stays at 13:00 even with a boost at the very next slot (rollback
+    escape hatch, and the two paths stay consistent: no pre-cool ⇒ no defer)."""
     outgoing = [{"valid_from": "2026-06-01T12:30:00Z", "value_inc_vat": -5.0}]
     import src.dhw_policy as _dp
     import pytest as _pytest
     with _pytest.MonkeyPatch.context() as mp:
-        mp.setattr(_dp.config, "DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES", 0, raising=False)
+        mp.setattr(_dp.config, "LP_PRE_NEGATIVE_PRECOOL_HOURS", 0.0, raising=False)
         rows = _dp.generate_daily_tank_schedule(
             date(2026, 6, 1), agile_rates=outgoing, mode="normal",
         )
     warmup = _warmup(rows)
     start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
     assert start.astimezone(TZ_LOCAL).hour == 13
+
+
+def test_schedule_defer_matches_lp_forecast_precool():
+    """Cross-path consistency: the warmup-start slot the SCHEDULE defers is the
+    same slot the LP ENERGY FORECAST pre-cools (zeroes warmup energy for). If
+    these ever diverge, the LP budgets DHW import for heating that won't fire
+    (or vice-versa) — the architectural drift this guard exists to catch."""
+    # Negative window opening one slot after the 13:00 BST (12:00 UTC) warmup.
+    outgoing = [{"valid_from": "2026-06-01T12:30:00Z", "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
+    )
+    warmup = _warmup(rows)
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    # SCHEDULE side: warmup deferred past the boost (not firing at 12:00 UTC).
+    assert start > datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+
+    # FORECAST side: same horizon + a price_line negative on the 12:30 slot.
+    slots = [datetime(2026, 6, 1, 12, 0, tzinfo=UTC) + i * timedelta(minutes=30)
+             for i in range(12)]
+    price_line = [5.0] * 12
+    price_line[1] = -5.0  # 12:30 UTC negative
+    e_dhw, _temps = dhw_policy.forecast_dhw_load_per_slot(
+        slots, mode="normal", price_line=price_line,
+    )
+    # The 12:00 UTC warmup-transition slot must be pre-cooled (no warmup energy
+    # budgeted) — consistent with the schedule deferring that warmup.
+    assert e_dhw[0] <= 0.05, f"LP still budgets leading warmup energy: {e_dhw[0]:.3f} kWh"
 
 
 # ---------------------------------------------------------------------------
@@ -436,15 +465,33 @@ def test_setback_temp_override(monkeypatch):
     assert setback["params"]["tank_temp"] == 40
 
 
-def test_negative_boost_temp_override(monkeypatch):
-    """DHW_NEGATIVE_PRICE_BOOST_C is tunable (e.g. could be 65 for max)."""
+def test_negative_boost_temp_clamped_to_device_max(monkeypatch):
+    """The boost target is clamped to DHW_TEMP_MAX_C (the device setpoint
+    ceiling). Requesting 65 must NOT emit a 65 °C setpoint — the heat pump
+    rejects anything above its max ("Max tank temperature is 60°C",
+    client.py:306), which made the whole boost write FAIL in prod (no heating
+    at all). This guard ensures we only ever write a setpoint the device
+    accepts."""
     monkeypatch.setattr(config, "DHW_NEGATIVE_PRICE_BOOST_C", 65.0, raising=False)
+    monkeypatch.setattr(config, "DHW_TEMP_MAX_C", 60.0, raising=False)
     outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0}]
     rows = dhw_policy.generate_daily_tank_schedule(
         date(2026, 6, 1), agile_rates=outgoing, mode="normal",
     )
     boost = next(r for r in rows if r["action_type"] == "tank_negative_boost")
-    assert boost["params"]["tank_temp"] == 65
+    assert boost["params"]["tank_temp"] == 60  # clamped to device max, not 65
+
+
+def test_negative_boost_temp_tunable_below_max(monkeypatch):
+    """A valid sub-max boost target passes through unchanged."""
+    monkeypatch.setattr(config, "DHW_NEGATIVE_PRICE_BOOST_C", 55.0, raising=False)
+    monkeypatch.setattr(config, "DHW_TEMP_MAX_C", 60.0, raising=False)
+    outgoing = [{"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
+    )
+    boost = next(r for r in rows if r["action_type"] == "tank_negative_boost")
+    assert boost["params"]["tank_temp"] == 55
 
 
 def test_normal_temp_override(monkeypatch):

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -22,11 +22,23 @@ from src.config import config
 TZ_LOCAL = ZoneInfo("Europe/London")
 
 
+class _FrozenDatetime(datetime):
+    """Pin ``dhw_policy``'s clock so the fixed 2026-06-01 anchor date is never
+    treated as "in the past" by the past-date guard. Kills the date-flake that
+    otherwise breaks the whole module once the wall clock passes 2026-06-01."""
+
+    @classmethod
+    def now(cls, tz=None):  # noqa: D401
+        base = datetime(2026, 6, 1, 10, 0, tzinfo=UTC)
+        return base.astimezone(tz) if tz is not None else base.replace(tzinfo=None)
+
+
 @pytest.fixture(autouse=True)
 def _isolated(monkeypatch, tmp_path):
     db_path = str(tmp_path / "test.db")
     monkeypatch.setenv("DB_PATH", db_path)
     monkeypatch.setattr(config, "DB_PATH", db_path, raising=False)
+    monkeypatch.setattr(dhw_policy, "datetime", _FrozenDatetime, raising=False)
     _db.init_db()
     monkeypatch.setattr(config, "DHW_FIXED_SCHEDULE_ENABLED", True, raising=False)
     monkeypatch.setattr(config, "DHW_WARMUP_START_HOUR_LOCAL", 13, raising=False)
@@ -225,6 +237,101 @@ def test_malformed_outgoing_rate_skipped():
     boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     # Only the one good negative rate emits a boost
     assert len(boost) == 1
+
+
+# ---------------------------------------------------------------------------
+# Boost-supersedes-warmup override (no positive-price pre-heat before a boost)
+# ---------------------------------------------------------------------------
+
+
+def _warmup(rows):
+    return next((r for r in rows if r["action_type"] == "tank_warmup"), None)
+
+
+def test_boost_near_warmup_start_defers_warmup():
+    """A boost opening shortly after the warmup start defers the warmup past it
+    — no pre-heating to NORMAL at a positive price right before the free boost.
+    Warmup start moves from 13:00 BST (12:00 UTC) to the boost end."""
+    # Negative slot at 12:30 UTC (13:30 BST) — 30 min after the 13:00 warmup.
+    outgoing = [{"valid_from": "2026-06-01T12:30:00Z", "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
+    )
+    warmup = _warmup(rows)
+    assert warmup is not None
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    # Deferred to the boost end (13:00 UTC = 14:00 BST), NOT the original 12:00 UTC.
+    assert start == datetime(2026, 6, 1, 13, 0, tzinfo=UTC), start
+    # Setback is untouched.
+    setback = next(r for r in rows if r["action_type"] == "tank_setback")
+    s_start = datetime.fromisoformat(setback["start_time"].replace("Z", "+00:00"))
+    assert s_start.astimezone(TZ_LOCAL).hour == 22
+
+
+def test_boost_far_from_warmup_start_keeps_warmup():
+    """A boost later than the lead window leaves the warmup intact — the
+    afternoon still needs hot water before that boost arrives."""
+    # Boost at 16:00 UTC (17:00 BST), well beyond the 120-min lead.
+    outgoing = [{"valid_from": "2026-06-01T16:00:00Z", "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
+    )
+    warmup = _warmup(rows)
+    assert warmup is not None
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    assert start.astimezone(TZ_LOCAL).hour == 13  # unchanged 13:00 BST
+    assert warmup["params"]["tank_temp"] == 45
+
+
+def test_interleaved_negative_window_chains_warmup_defer():
+    """The real prod case (2026-06-04): negatives at 12:30 / 13:30 / 14:00 UTC
+    with a positive slot at 13:00 between them. The warmup must defer past the
+    WHOLE early cluster (two boost windows chained) — no warmup at the positive
+    12:00 or 13:00 slots."""
+    outgoing = [
+        {"valid_from": "2026-06-01T12:30:00Z", "value_inc_vat": -0.34},
+        {"valid_from": "2026-06-01T13:00:00Z", "value_inc_vat": 0.77},  # positive gap
+        {"valid_from": "2026-06-01T13:30:00Z", "value_inc_vat": -1.30},
+        {"valid_from": "2026-06-01T14:00:00Z", "value_inc_vat": -0.86},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), agile_rates=outgoing, mode="normal",
+    )
+    boost = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    assert len(boost) == 2  # (12:30-13:00) and (13:30-14:30)
+    warmup = _warmup(rows)
+    assert warmup is not None
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    # Deferred past the last chained boost end: 14:30 UTC (15:30 BST).
+    assert start == datetime(2026, 6, 1, 14, 30, tzinfo=UTC), start
+
+
+def test_boost_chain_can_drop_guest_warmup_start():
+    """Guests mode: a near-start boost defers the single 24h warmup too."""
+    outgoing = [{"valid_from": "2026-06-01T12:30:00Z", "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 6, 1), agile_rates=outgoing, mode="guests",
+    )
+    warmup = _warmup(rows)
+    assert warmup is not None
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    assert start == datetime(2026, 6, 1, 13, 0, tzinfo=UTC), start
+
+
+def test_warmup_override_disabled_by_zero_lead():
+    """Lead=0 disables the defer — warmup stays at 13:00 even with a boost at
+    the very next slot (rollback escape hatch)."""
+    outgoing = [{"valid_from": "2026-06-01T12:30:00Z", "value_inc_vat": -5.0}]
+    import src.dhw_policy as _dp
+    import pytest as _pytest
+    with _pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_dp.config, "DHW_WARMUP_BOOST_OVERRIDE_LEAD_MINUTES", 0, raising=False)
+        rows = _dp.generate_daily_tank_schedule(
+            date(2026, 6, 1), agile_rates=outgoing, mode="normal",
+        )
+    warmup = _warmup(rows)
+    start = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
+    assert start.astimezone(TZ_LOCAL).hour == 13
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dhw_policy_bugfixes.py
+++ b/tests/test_dhw_policy_bugfixes.py
@@ -182,7 +182,8 @@ def test_fall_back_day_emits_correct_local_hours():
 
 def test_warmup_to_setback_duration_normal_day():
     """On a regular (non-DST) day, warmup window is exactly 9h."""
-    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    # Future BST date to clear the bug #5 past-date guard (cf. spring-forward test).
+    rows = dhw_policy.generate_daily_tank_schedule(date(2027, 6, 1), mode="normal")
     warmup = next(r for r in rows if r["action_type"] == "tank_warmup")
     s = datetime.fromisoformat(warmup["start_time"].replace("Z", "+00:00"))
     e = datetime.fromisoformat(warmup["end_time"].replace("Z", "+00:00"))
@@ -192,7 +193,8 @@ def test_warmup_to_setback_duration_normal_day():
 
 def test_setback_to_next_warmup_duration_normal_day():
     """Setback window is 15h on a regular day (22:00 → 13:00 next day)."""
-    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    # Future BST date to clear the bug #5 past-date guard (cf. spring-forward test).
+    rows = dhw_policy.generate_daily_tank_schedule(date(2027, 6, 1), mode="normal")
     setback = next(r for r in rows if r["action_type"] == "tank_setback")
     s = datetime.fromisoformat(setback["start_time"].replace("Z", "+00:00"))
     e = datetime.fromisoformat(setback["end_time"].replace("Z", "+00:00"))

--- a/tests/test_dhw_schedule_endpoint.py
+++ b/tests/test_dhw_schedule_endpoint.py
@@ -33,10 +33,13 @@ def test_dhw_schedule_two_days_with_negative_boost(monkeypatch):
     # Rows span two days (today + tomorrow).
     days = {r["start_utc"][:10] for r in rows if r.get("start_utc")}
     assert len(days) >= 2, f"expected today+tomorrow, got {days}"
-    # The negative window produced a boost row at MAX (65).
+    # The negative window produced a boost row at the commandable setpoint cap
+    # (DHW_NEGATIVE_PRICE_BOOST_C = 60 °C; the heat pump rejects higher). Note
+    # this is NOT DHW_TEMP_MAX_C (65, the physical/immersion ceiling).
     boosts = [r for r in rows if r["action_type"] == "tank_negative_boost"]
     assert boosts, "expected a tank_negative_boost row for the negative window"
-    assert boosts[0]["tank_temp_c"] == int(config.DHW_TEMP_MAX_C)
+    expected = int(round(min(config.DHW_NEGATIVE_PRICE_BOOST_C, config.DHW_TEMP_MAX_C)))
+    assert boosts[0]["tank_temp_c"] == expected
 
 
 def test_dhw_schedule_no_rates_no_boost(monkeypatch):

--- a/tests/test_fox_inflight_preserve.py
+++ b/tests/test_fox_inflight_preserve.py
@@ -1,0 +1,122 @@
+"""Issue #458 follow-up: a mid-slot Fox re-upload must not drop the in-progress
+slot's ForceCharge/ForceDischarge to the firmware's SelfUse default.
+
+The plan horizon starts at the NEXT half-hour boundary (Daikin quota integrity),
+but a Fox upload replaces the whole schedule — so without preservation the
+in-progress slot is left bare and the firmware falls back to SelfUse. During a
+negative (paid-import) slot that silently stops force-charge (observed in prod
+2026-06-04: upload left 13:34–14:00 BST uncovered)."""
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+from src.foxess.models import SchedulerGroup
+from src.scheduler.lp_dispatch import _prepend_inflight_group
+
+TZ = ZoneInfo("Europe/London")
+
+
+def _g(sh, sm, eh, em, mode="ForceCharge", **kw):
+    return SchedulerGroup(start_hour=sh, start_minute=sm, end_hour=eh, end_minute=em,
+                          work_mode=mode, **kw)
+
+
+def _prev(groups_api):
+    return {"groups": groups_api}
+
+
+@pytest.fixture(autouse=True)
+def _on(monkeypatch):
+    monkeypatch.setattr(app_config, "FOX_PRESERVE_INFLIGHT_GROUP", True, raising=False)
+
+
+def test_bridges_inflight_forcecharge(monkeypatch):
+    """Re-solve at 13:34 BST: horizon starts 14:00, previous schedule had
+    ForceCharge over 13:30–13:59 → a bridge group [13:30,13:59] ForceCharge is
+    prepended so the current negative slot keeps charging."""
+    now = datetime(2026, 6, 4, 13, 34, tzinfo=TZ)
+    prev = _prev([
+        {"startHour": 13, "startMinute": 30, "endHour": 13, "endMinute": 59,
+         "workMode": "ForceCharge",
+         "extraParam": {"minSocOnGrid": 10, "fdSoc": 100, "fdPwr": 5000}},
+    ])
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state", lambda: prev)
+    groups = [_g(14, 0, 14, 30, "ForceDischarge")]
+    out = _prepend_inflight_group(groups, now_local=now)
+    assert len(out) == 2
+    bridge = out[0]
+    assert bridge.work_mode == "ForceCharge"
+    assert (bridge.start_hour, bridge.start_minute) == (13, 30)
+    assert (bridge.end_hour, bridge.end_minute) == (13, 59)   # :59 inclusive convention
+    assert bridge.fd_soc == 100 and bridge.fd_pwr == 5000
+
+
+def test_no_bridge_when_first_group_already_covers_now(monkeypatch):
+    """If the first planned group already starts at/before now, nothing dropped."""
+    now = datetime(2026, 6, 4, 13, 34, tzinfo=TZ)
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state",
+                        lambda: _prev([{"startHour": 13, "startMinute": 0, "endHour": 13,
+                                        "endMinute": 59, "workMode": "ForceCharge",
+                                        "extraParam": {}}]))
+    groups = [_g(13, 30, 14, 30, "ForceCharge")]  # starts 13:30 <= 13:34
+    assert _prepend_inflight_group(groups, now_local=now) == groups
+
+
+def test_no_bridge_when_prev_was_selfuse(monkeypatch):
+    """SelfUse is the firmware default — nothing to re-assert."""
+    now = datetime(2026, 6, 4, 13, 34, tzinfo=TZ)
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state",
+                        lambda: _prev([{"startHour": 13, "startMinute": 30, "endHour": 13,
+                                        "endMinute": 59, "workMode": "SelfUse",
+                                        "extraParam": {"minSocOnGrid": 10}}]))
+    groups = [_g(14, 0, 14, 30, "ForceDischarge")]
+    assert _prepend_inflight_group(groups, now_local=now) == groups
+
+
+def test_no_bridge_when_no_prev_schedule(monkeypatch):
+    now = datetime(2026, 6, 4, 13, 34, tzinfo=TZ)
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state", lambda: None)
+    groups = [_g(14, 0, 14, 30, "ForceDischarge")]
+    assert _prepend_inflight_group(groups, now_local=now) == groups
+
+
+def test_flag_off_disables(monkeypatch):
+    monkeypatch.setattr(app_config, "FOX_PRESERVE_INFLIGHT_GROUP", False, raising=False)
+    now = datetime(2026, 6, 4, 13, 34, tzinfo=TZ)
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state",
+                        lambda: _prev([{"startHour": 13, "startMinute": 30, "endHour": 13,
+                                        "endMinute": 59, "workMode": "ForceCharge",
+                                        "extraParam": {}}]))
+    groups = [_g(14, 0, 14, 30, "ForceDischarge")]
+    assert _prepend_inflight_group(groups, now_local=now) == groups
+
+
+def test_no_bridge_at_group_cap(monkeypatch):
+    """At the Fox 8-group cap there's no room to prepend."""
+    now = datetime(2026, 6, 4, 13, 34, tzinfo=TZ)
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state",
+                        lambda: _prev([{"startHour": 13, "startMinute": 30, "endHour": 13,
+                                        "endMinute": 59, "workMode": "ForceCharge",
+                                        "extraParam": {}}]))
+    groups = [_g(14, 0, 14, 30, "ForceCharge")] * 8
+    assert len(_prepend_inflight_group(groups, now_local=now)) == 8
+
+
+def test_bridge_does_not_overlap_first_group(monkeypatch):
+    """The bridge ends exactly at the next boundary (:59 inclusive), never
+    overlapping the first planned group — overlap guard would otherwise refuse
+    the whole upload."""
+    from src.scheduler.lp_dispatch import _detect_overlapping_groups
+    now = datetime(2026, 6, 4, 13, 34, tzinfo=TZ)
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state",
+                        lambda: _prev([{"startHour": 13, "startMinute": 30, "endHour": 13,
+                                        "endMinute": 59, "workMode": "ForceCharge",
+                                        "extraParam": {"minSocOnGrid": 10}}]))
+    groups = [_g(14, 0, 14, 30, "ForceDischarge"), _g(14, 30, 15, 59, "ForceCharge")]
+    out = _prepend_inflight_group(groups, now_local=now)
+    assert _detect_overlapping_groups(out) == []

--- a/tests/test_lp_legionella_cycle.py
+++ b/tests/test_lp_legionella_cycle.py
@@ -219,16 +219,17 @@ def test_legionella_disabled_does_not_force_tank() -> None:
 
 
 def test_legionella_high_target_still_feasible() -> None:
-    """PR E: legionella target above tank_hi (e.g. 70 °C target with tank_hi
-    = 65) no longer needs a constraint cap — the firmware-load floor on
-    ``e_dhw`` is capped at ``max_hp_kwh`` so the LP stays feasible. Tank
-    state is firmware's concern, not the LP's."""
+    """A legionella target ABOVE the tank ceiling (e.g. 70 °C with
+    DHW_TEMP_MAX_C = 60) must NOT make the solver infeasible. The tank can't
+    physically exceed the ceiling (heat pump + firmware both top out there),
+    so the modeled firmware lift is capped at the ceiling — a misconfigured
+    high target degrades gracefully instead of crashing the LP."""
     slots, plan = _solve_sunday_with_legionella(
         tank_initial=38.0, leg_day=6, leg_hour=13, leg_target=70.0,
         leg_duration_min=60,
     )
-    # LP must stay feasible (was the old failure mode pre-cap). With the
-    # new model, no tank constraint at all → trivially feasible.
+    # LP must stay feasible: the firmware lift is capped at tank_hi (60), so
+    # the forced e_dhw can't push the tank past its hard bound.
     assert plan.ok, plan.status
     # And the firmware-load floor still allocates kWh on cycle slots.
     tz = ZoneInfo("Europe/London")

--- a/tests/test_lp_negative_prep.py
+++ b/tests/test_lp_negative_prep.py
@@ -61,7 +61,6 @@ def test_pre_negative_export_drains_battery(monkeypatch):
     drains the battery to the grid (export > PV) on pre-window slots."""
     monkeypatch.setattr(app_config, "LP_PRE_NEGATIVE_PREP_ENABLED", True)
     monkeypatch.setattr(app_config, "LP_PLUNGE_PREP_HOURS", 12)
-    monkeypatch.setattr(app_config, "LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE", 2.0)
     n = 24
     # Slots 0-7 positive import (15p), HIGH export (25p). Slots 8-9 negative (-8p).
     prices = [15.0] * 8 + [-8.0] * 2 + [15.0] * 14
@@ -90,16 +89,40 @@ def test_pre_negative_export_off_keeps_no_battery_export(monkeypatch):
     assert sum(plan.export_kwh) < 0.05, f"battery exported with flag off: {sum(plan.export_kwh):.3f}"
 
 
-def test_pre_negative_export_gated_by_margin(monkeypatch):
-    """Export price below the margin → no drain offered."""
+def test_pre_negative_export_drains_below_old_margin(monkeypatch):
+    """No arbitrary margin gate: a sub-2p export rate still drains when the
+    economics work out — selling now plus the paid refill during the negative
+    window beats the round-trip loss. The removed
+    ``LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE=2p`` cliff would have wrongly blocked
+    this and is exactly the kind of spurious toggle we eliminated."""
     monkeypatch.setattr(app_config, "LP_PRE_NEGATIVE_PREP_ENABLED", True)
     monkeypatch.setattr(app_config, "LP_PLUNGE_PREP_HOURS", 12)
-    monkeypatch.setattr(app_config, "LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE", 10.0)
-    prices = [15.0] * 8 + [-8.0] * 2 + [15.0] * 14
-    export = [3.0] * 24  # below 10p margin
+    # Battery near-full → no headroom to absorb the long negative window unless
+    # it drains first. Sell at 1.5p (below the old 2p gate), then get paid 8p to
+    # refill that freed capacity. The drained energy is recovered in-window, so
+    # the only cost is round-trip loss — comfortably beaten.
+    prices = [15.0] * 8 + [-8.0] * 4 + [15.0] * 12
+    export = [1.5] * 24
+    plan = _solve(prices, export, soc=9.5, pv=0.0)
+    assert plan.ok, plan.status
+    drained = sum(plan.export_kwh[i] for i in range(8))
+    assert drained > 0.3, f"sub-margin export should still drain on good economics, got {drained:.3f}"
+
+
+def test_pre_negative_export_declines_when_uneconomic(monkeypatch):
+    """The OBJECTIVE (not a threshold gate) decides: with a negligible export
+    value, a shallow negative window, and a heavy cycle penalty, draining loses
+    money so the LP declines — even though pre-negative export is *eligible*."""
+    monkeypatch.setattr(app_config, "LP_PRE_NEGATIVE_PREP_ENABLED", True)
+    monkeypatch.setattr(app_config, "LP_PLUNGE_PREP_HOURS", 12)
+    monkeypatch.setattr(app_config, "LP_CYCLE_PENALTY_PENCE_PER_KWH", 5.0)
+    prices = [15.0] * 8 + [-0.5] * 2 + [15.0] * 14  # shallow negative (tiny paid refill)
+    export = [0.2] * 24  # negligible export value
     plan = _solve(prices, export, soc=4.5, pv=0.0)
     assert plan.ok, plan.status
-    assert sum(plan.export_kwh) < 0.05, f"drained despite sub-margin export: {sum(plan.export_kwh):.3f}"
+    assert sum(plan.export_kwh) < 0.1, (
+        f"should not drain when the gain can't cover cycle cost: {sum(plan.export_kwh):.3f}"
+    )
 
 
 # ── 1C: never export when export price is negative ───────────────────────────

--- a/tests/test_upsert_action_dedup.py
+++ b/tests/test_upsert_action_dedup.py
@@ -1,0 +1,80 @@
+"""upsert_action must be a genuine upsert on (device, action_type, start_time).
+
+Before this, it was a plain INSERT: every re-plan that re-emitted the same slot
+created a duplicate row, and because clear_actions_in_range only removes pending
+in-range rows, an already-fired (completed) or in-flight row for the same slot
+was never cleared — so the re-emit produced a past-dated pending dup that fired
+again. Prod showed ~18 identical tank_warmup rows in a single day.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+
+
+@pytest.fixture(autouse=True)
+def _init_db() -> None:
+    db.init_db()
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _count(device, action_type, start_time) -> int:
+    rows = [r for r in db.schedule_for_date(start_time[:10].replace("Z", ""))
+            if r["device"] == device and r["action_type"] == action_type
+            and r["start_time"] == start_time]
+    return len(rows)
+
+
+def _mk(start, *, status="pending", temp=45, atype="tank_warmup"):
+    return db.upsert_action(
+        plan_date="2026-06-01",
+        start_time=_iso(start), end_time=_iso(start + timedelta(hours=9)),
+        device="daikin", action_type=atype, params={"tank_temp": temp}, status=status,
+    )
+
+
+def test_reemit_same_slot_does_not_duplicate() -> None:
+    start = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    id1 = _mk(start)
+    id2 = _mk(start)  # re-plan re-emits the identical pending slot
+    assert _count("daikin", "tank_warmup", _iso(start)) == 1
+    assert id1 == id2  # refreshed in place, not duplicated
+
+
+def test_reemit_refreshes_params_of_future_pending(monkeypatch) -> None:
+    monkeypatch.setattr(db, "_now_utc", lambda: datetime(2026, 6, 1, 6, 0, tzinfo=UTC))
+    start = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)  # future relative to now
+    _mk(start, temp=45)
+    _mk(start, temp=48)  # re-plan with a different target
+    rows = [r for r in db.schedule_for_date("2026-06-01")
+            if r["action_type"] == "tank_warmup" and r["start_time"] == _iso(start)]
+    assert len(rows) == 1
+    assert rows[0]["params"]["tank_temp"] == 48  # picked up the new params
+
+
+def test_completed_slot_is_not_recreated() -> None:
+    """A re-plan that re-emits an already-FIRED slot must NOT create a new
+    pending dup (the past dup that fired again in prod)."""
+    start = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    done = _mk(start, status="completed")
+    again = _mk(start, status="pending")  # re-plan re-emits it
+    assert again == done  # skipped — returns the existing completed row
+    rows = [r for r in db.schedule_for_date("2026-06-01")
+            if r["action_type"] == "tank_warmup" and r["start_time"] == _iso(start)]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "completed"  # untouched; no new pending dup
+
+
+def test_different_action_types_same_slot_coexist() -> None:
+    """warmup and negative_boost can legitimately share a start_time."""
+    start = datetime(2026, 6, 1, 12, 30, tzinfo=UTC)
+    _mk(start, atype="tank_warmup")
+    _mk(start, atype="tank_negative_boost", temp=60)
+    rows = [r for r in db.schedule_for_date("2026-06-01") if r["start_time"] == _iso(start)]
+    assert {r["action_type"] for r in rows} == {"tank_warmup", "tank_negative_boost"}


### PR DESCRIPTION
Five negative-tariff / tank fixes from auditing the release against **2026-06-04 prod data** (a live negative-window day). No commitment/penalty hacks — these remove arbitrary rules and match the actual hardware.

### 1. Drain decided by the objective, not a 2p cliff
Removed the `export_rate >= LP_PRE_NEGATIVE_EXPORT_MARGIN_PENCE` (2p) gate on pre-negative battery drain — a binary threshold that toggled drain *availability* on tiny export-rate moves (looked like flip-flopping). The LP objective already prices drain (export revenue − cycle penalty − buy-back); `export_rate < 0` safety forces `exp==0`. `pre_neg_export` is now pure eligibility. Config key removed.

### 2. Negative boost overrides the leading warmup
Was heating to 45°C at **+1.98p** then to max 30 min later. Now a boost within `LP_PRE_NEGATIVE_PRECOOL_HOURS` of the warmup start defers the warmup past it, reusing the **same** pre-cool window the LP energy forecast uses → fired actions and budgeted import stay consistent (cross-path consistency test added).

### 3. Tank setpoint capped at the device max (60°C) — was silently failing at 65
Prod showed **every** `tank_negative_boost` FAILING: `Max tank temperature is 60°C`. The heat pump AND firmware legionella cycle both cap at 60 (only the app's manual immersion reaches higher). `DHW_TEMP_MAX_C` + `DHW_NEGATIVE_PRICE_BOOST_C` 65→60; heuristic path writes `min(boost,max)`; legionella floor caps its lift at the ceiling so a stray target can't make the solver infeasible.

### 4. Fox force-charge no longer silently reverts to SelfUse mid-slot
The plan horizon starts at the next half-hour (Daikin quota integrity), but a Fox upload replaces the whole schedule — so a re-solve mid-slot left the in-progress negative slot bare → firmware SelfUse → force-charge stopped (prod: upload 1362 @13:34 BST left 13:34–14:00 uncovered). Now `_prepend_inflight_group` bridges the current slot with the previous schedule's work mode. New `FOX_PRESERVE_INFLIGHT_GROUP` flag (default on) to roll back.

### 5. Duplicate `action_schedule` rows
`upsert_action` was a plain INSERT — re-plans re-emitting an already-fired slot created past-dated pending dups that fired again (~18 identical `tank_warmup` in one prod day). Now a genuine upsert on `(device, action_type, start_time)`: refresh a future pending row, SKIP a completed/in-flight one.

## Tests
- `test_lp_negative_prep.py`, `test_dhw_policy.py` (warmup-override + cross-path consistency + clamp-to-device-max), `test_lp_legionella_cycle.py`, `test_fox_inflight_preserve.py`, `test_upsert_action_dedup.py`.
- Killed latent date-flakes in `test_dhw_policy*.py`. Remaining broad-run failures (passive-mode SSL, lp_infeasible ordering, pv_calibration_3d + tariff_aware date-flakes) are **pre-existing on main** and pass in isolation — none from this PR.

Tracked by #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
