### PR TITLE
Cockpit overhaul: coherent surfaces, Journal, day-to-now, load split

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -409,6 +409,28 @@ async def api_v1_schedule_history(limit: int = 200):
     return {"action_log": db.get_action_logs(limit=limit)}
 
 
+@app.get("/api/v1/action-log")
+async def api_v1_action_log(
+    device: str | None = None,
+    trigger: str | None = None,
+    limit: int = 200,
+    days: int | None = None,
+):
+    """Executed-action journal (tank / Fox battery / appliances).
+
+    Reads ``action_log`` — the source of truth for what actually fired. Optional
+    ``device`` (daikin|fox|appliance), ``trigger``, and ``days`` (only entries
+    from the last N days). Powers the Report/Journal UI tab.
+    """
+    since = None
+    if days is not None and days > 0:
+        since = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    entries = await asyncio.to_thread(
+        db.get_action_logs, device, trigger, limit, since
+    )
+    return {"entries": entries}
+
+
 @app.get("/api/v1/weather")
 async def api_v1_weather():
     # Blocking (Open-Meteo HTTP + Daikin read) — offload so it doesn't stall
@@ -519,7 +541,17 @@ async def cockpit_now():
     day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     day_end = day_start + _td(days=1)
     import_rows = db.get_rates_for_period(tariff, day_start, day_end) if tariff else []
-    export_rows = db.get_rates_for_period(export_tariff, day_start, day_end) if export_tariff else []
+    # Export (Outgoing Agile) rates live in their OWN table — get_rates_for_period
+    # only reads agile_rates (import), so the export tariff is never found there.
+    # Use the dedicated getter the PnL/LP already rely on (issue: export p showed
+    # blank on the cockpit). Same row shape (valid_from/valid_to/value_inc_vat).
+    export_rows = (
+        db.get_agile_export_rates_in_range(
+            day_start.isoformat().replace("+00:00", "Z"),
+            day_end.isoformat().replace("+00:00", "Z"),
+        )
+        if export_tariff else []
+    )
 
     def _price_at(rows: list, t: _dt) -> tuple[float | None, str | None, str | None]:
         iso_t = t.isoformat().replace("+00:00", "Z")
@@ -2742,6 +2774,32 @@ async def energy_report(
     return EnergyReportResponse(**resp.model_dump(), summary=summary)
 
 
+@app.get("/api/v1/energy/today-cumulative")
+async def energy_today_cumulative():
+    """Today's grid import/export so far — kWh + real money, to now.
+
+    For *today*, realised telemetry (``pv_realtime_history``) only exists up to
+    the current moment, so ``compute_daily_pnl(today)`` IS the day-to-now figure.
+    ``import_cost_gbp`` is the real-money import cost from measured grid traffic
+    × per-slot Agile rates — it goes **negative (a credit)** on negative-price
+    slots, which is exactly what the Live-power widget surfaces. No standing
+    charge here (this is the energy in/out, not the net bill).
+    """
+    from datetime import datetime as _dt
+    from zoneinfo import ZoneInfo
+    from src.analytics.pnl import compute_daily_pnl
+
+    today = _dt.now(ZoneInfo(config.BULLETPROOF_TIMEZONE)).date()
+    pnl = await asyncio.to_thread(compute_daily_pnl, today)
+    return {
+        "date": today.isoformat(),
+        "import_kwh": pnl.get("import_kwh", 0.0),
+        "export_kwh": pnl.get("export_kwh", 0.0),
+        "import_cost_gbp": pnl.get("import_cost_gbp", 0.0),
+        "export_revenue_gbp": pnl.get("export_revenue_gbp", 0.0),
+    }
+
+
 @app.get("/api/v1/energy/insights", response_model=EnergyInsightsTextResponse)
 async def energy_insights():
     """Short narrative summary for OpenClaw: this month cost and equivalent gas.
@@ -3885,7 +3943,15 @@ async def agile_today():
     day_end = day_start + timedelta(days=1)
 
     import_rows = _db.get_rates_for_period(tariff, day_start, day_end) if tariff else []
-    export_rows = _db.get_rates_for_period(export_tariff, day_start, day_end) if export_tariff else []
+    # Export rates live in agile_export_rates (not agile_rates) — use the
+    # dedicated getter so the Outgoing tariff actually resolves (was blank).
+    export_rows = (
+        _db.get_agile_export_rates_in_range(
+            day_start.isoformat().replace("+00:00", "Z"),
+            day_end.isoformat().replace("+00:00", "Z"),
+        )
+        if export_tariff else []
+    )
 
     def _slot_price_at(rows: list, t: datetime) -> float | None:
         iso_t = t.isoformat().replace("+00:00", "Z")
@@ -4239,6 +4305,23 @@ async def execution_today(date: str | None = None):
     total_load = 0.0
     total_daikin_kwh = 0.0
 
+    # Per-slot appliance load (planned/typical kW while a washer/dryer/dishwasher
+    # job is armed or running). This is an ESTIMATE (typical_kw × 0.5h), not a
+    # metered value, and only present for armed/running jobs — but it lets the UI
+    # peel appliances out of the residual so "base load" is genuinely base.
+    appliance_kw_by_slot: dict[str, float] = {}
+    if buckets:
+        try:
+            from ..scheduler.appliance_dispatch import appliance_load_profile_kw
+            _isos = sorted(buckets.keys())
+            _d0 = datetime.fromisoformat(_isos[0].replace("Z", "+00:00"))
+            _d1 = datetime.fromisoformat(_isos[-1].replace("Z", "+00:00")) + timedelta(minutes=30)
+            for _dt, _kw in appliance_load_profile_kw(_d0, _d1).items():
+                _key = _dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+                appliance_kw_by_slot[_key] = float(_kw)
+        except Exception:
+            logger.debug("execution_today: appliance profile unavailable", exc_info=True)
+
     for slot_iso in sorted(buckets.keys()):
         ticks = buckets[slot_iso]
         # Sum consumption across ticks in the slot (real per-tick from heartbeat)
@@ -4262,6 +4345,9 @@ async def execution_today(date: str | None = None):
             daikin_kw = float(get_daikin_heating_kw(outdoor)) if outdoor is not None else 0.0
             daikin_kwh = min(daikin_kw * SLOT_HOURS, load_kwh)
         residual_kwh = max(0.0, load_kwh - daikin_kwh)
+        # Split residual into appliance (estimated) + true base load.
+        appliance_kwh = min(appliance_kw_by_slot.get(slot_iso, 0.0) * SLOT_HOURS, residual_kwh)
+        base_load_kwh = max(0.0, residual_kwh - appliance_kwh)
         # Costs: re-derive from the slot's totals (don't trust per-tick fakes)
         cost = load_kwh * agile_p if agile_p is not None else 0.0
         svt_cost = load_kwh * svt_rate if svt_rate is not None else 0.0
@@ -4277,6 +4363,8 @@ async def execution_today(date: str | None = None):
             "consumption_kwh": round(load_kwh, 3),
             "daikin_kwh_est": round(daikin_kwh, 3),
             "residual_kwh": round(residual_kwh, 3),
+            "appliance_kwh_est": round(appliance_kwh, 3),
+            "base_load_kwh_est": round(base_load_kwh, 3),
             "cost_realised_p": round(cost, 2),
             "cost_daikin_p": round(cost_daikin, 2),
             "cost_residual_p": round(cost_residual, 2),

--- a/src/db.py
+++ b/src/db.py
@@ -2263,6 +2263,7 @@ def get_action_logs(
     device: str | None = None,
     trigger: str | None = None,
     limit: int = 200,
+    since: str | None = None,
 ) -> list[dict[str, Any]]:
     with _lock:
         conn = get_connection()
@@ -2275,6 +2276,9 @@ def get_action_logs(
             if trigger:
                 q += " AND trigger = ?"
                 args.append(trigger)
+            if since:
+                q += " AND timestamp >= ?"
+                args.append(since)
             q += " ORDER BY timestamp DESC LIMIT ?"
             args.append(limit)
             cur = conn.execute(q, args)

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -6,8 +6,9 @@ import { ToastHost } from "./components/common/Toast";
 import { Spinner } from "./components/common/Spinner";
 import Landing from "./routes/landing";
 
-// Settings is lazy — off the critical path (home is the default route).
+// Settings + Report are lazy — off the critical path (home is the default route).
 const Settings = lazy(() => import("./routes/settings"));
+const Report = lazy(() => import("./routes/report"));
 
 export function App() {
   return (
@@ -17,6 +18,7 @@ export function App() {
         <Suspense fallback={<div class="page-padded"><Spinner label="Loading…" /></div>}>
           <Switch>
             <Route path="/" component={Landing} />
+            <Route path="/report" component={Report} />
             <Route path="/settings" component={Settings} />
             <Route>
               <div class="page-padded">

--- a/ui/src/components/cockpit/LivePowerWidget.tsx
+++ b/ui/src/components/cockpit/LivePowerWidget.tsx
@@ -3,10 +3,9 @@ import { PowerFlow } from "./PowerFlow";
 import { Icon, type IconName } from "../common/Icon";
 import { useAnimatedNumber } from "../../lib/useAnimatedNumber";
 import { reducedMotion } from "../../lib/motion";
-import { kw, kwh, pct } from "../../lib/format";
-import type { CockpitState, CockpitNow, SchedulerTimeline, ExecutionTodayResponse, AgileTodayResponse, MetricsResponse, DhwScheduleRow } from "../../lib/types";
-import { TankScheduleBadges } from "../common/TankScheduleBadges";
-import { formatRelativeSlot, endLabelFor } from "../../lib/slotLabels";
+import { kw, kwh, pct, gbp } from "../../lib/format";
+import type { CockpitState, CockpitNow, SchedulerTimeline, ExecutionTodayResponse, AgileTodayResponse, MetricsResponse, DhwScheduleRow, TodayCumulativeResponse } from "../../lib/types";
+import { formatRelativeSlot, endLabelFor, tankLabelOf } from "../../lib/slotLabels";
 import "./cockpit.css";
 import "./live-power.css";
 
@@ -18,6 +17,7 @@ interface LivePowerWidgetProps {
   agile: AgileTodayResponse | null;
   metrics: MetricsResponse | null;
   dhwSchedule?: DhwScheduleRow[] | null;
+  todayCumulative?: TodayCumulativeResponse | null;
 }
 
 const RM = reducedMotion();
@@ -26,7 +26,7 @@ const RM = reducedMotion();
 // the live power-flow is the centerpiece, everything else (action verb,
 // battery SoC, Fox mode, tariff, scheduled windows) recedes to quiet
 // monochrome. Domain colour appears only on the flow + the focal-value tint.
-export function LivePowerWidget({ state, cockpit, timeline, execution, agile, metrics, dhwSchedule }: LivePowerWidgetProps) {
+export function LivePowerWidget({ state, cockpit, timeline, execution, agile, metrics, dhwSchedule, todayCumulative }: LivePowerWidgetProps) {
   const socPct = state.soc_pct ?? 0;
   const charging = state.battery_kw > 0.05;
   const discharging = state.battery_kw < -0.05;
@@ -58,11 +58,18 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
   const todayRange = computeTodayRange(execution);
   const nextEvent = nextSocEvent(timeline);
   const foxMode = cockpit.current_slot?.fox_mode ?? "—";
+  // SelfUse is the resting state already implied by the big net-power number up
+  // top — only surface the Fox mode pill when it's actively forcing the battery.
+  const foxActive = !["selfuse", "self_use", "idle", "—", ""].includes(foxMode.toLowerCase());
   const forced = timeline ? upcomingForcedWindows(timeline, 4) : [];
   const lpInfo = timeline ? { runId: timeline.run_id ?? null, runAt: timeline.run_at ?? null, planDate: timeline.plan_date ?? null } : null;
   const importP = agile?.current_import_p ?? null;
-  const exportP = agile?.current_export_p ?? null;
+  const exportP = agile?.current_export_p ?? cockpit.current_slot?.price_export_p ?? null;
   const importBand = classifyBand(importP, metrics?.cheap_threshold_pence, metrics?.peak_threshold_pence);
+  // What the system does NEXT — the soonest upcoming battery + tank actions,
+  // surfaced as one quiet line so "what's the plan about to do?" reads at a
+  // glance (tank chips moved to the Heating tile; this keeps tank awareness here).
+  const nextActions = buildNextActions(forced, dhwSchedule, cockpit.now_utc);
 
   return (
     <div class="livepower">
@@ -78,6 +85,17 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
           <span class="livepower-hero-unit">kW</span>
         </div>
         <div class="livepower-hero-cap">{netCaption}</div>
+        {nextActions.length > 0 && (
+          <div class="livepower-next" title="The next scheduled battery + tank actions">
+            <span class="livepower-next-label">Next</span>
+            {nextActions.map((a, i) => (
+              <span key={i} class="livepower-next-item" style={{ color: a.color }}>
+                <span class="livepower-next-dot" style={{ background: a.color }} />
+                {a.label} <span class="livepower-next-when">{a.when}</span>
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* The power-flow centerpiece + battery panel */}
@@ -118,22 +136,41 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
 
       {/* Secondary: tariff rates + Fox mode + scheduled windows + LP run */}
       <div class="livepower-fox">
-        <div class="livepower-fox-rates" title="Live Agile p/kWh — import is what you'd pay now, export is what you'd earn now">
+        <div class="livepower-fox-rates" title="Live Agile p/kWh + how much you've imported/exported so far today (to now)">
           <span class="livepower-fox-rate">
             <span class="livepower-fox-rate-label">Import</span>
             <span class={`livepower-fox-rate-value livepower-rate--band-${importBand}`}>{importP != null ? `${importP.toFixed(2)}p` : "—"}</span>
+            {todayCumulative && (
+              <span class="livepower-fox-rate-sub">
+                {kwh(todayCumulative.import_kwh)} today ·{" "}
+                {todayCumulative.import_cost_gbp < -0.005
+                  ? <span class="livepower-credit" title="Paid to import on negative-price slots">+{gbp(Math.abs(todayCumulative.import_cost_gbp))} credit</span>
+                  : <span>{gbp(todayCumulative.import_cost_gbp)}</span>}
+              </span>
+            )}
           </span>
           <span class="livepower-fox-rate">
             <span class="livepower-fox-rate-label">Export</span>
-            <span class="livepower-fox-rate-value livepower-rate--export">{exportP != null ? `${exportP.toFixed(2)}p` : "—"}</span>
+            {exportP != null
+              ? <span class="livepower-fox-rate-value livepower-rate--export">{exportP.toFixed(2)}p</span>
+              : <span class="livepower-fox-rate-value livepower-fox-rate-value--none">no export</span>}
+            {todayCumulative && (
+              <span class="livepower-fox-rate-sub">
+                {kwh(todayCumulative.export_kwh)} today ·{" "}
+                <span class="livepower-rate--export">{gbp(todayCumulative.export_revenue_gbp)}</span>
+              </span>
+            )}
           </span>
         </div>
+        {(foxActive || forced.length > 0) && (
         <div class="livepower-fox-row">
-          <span class="livepower-fox-label">Fox mode</span>
-          <span class={`livepower-fox-mode livepower-fox-mode--${foxMode.toLowerCase()}`}>
-            <span class="livepower-fox-mode-dot" />
-            {foxMode}
-          </span>
+          <span class="livepower-fox-label">Grid plan</span>
+          {foxActive && (
+            <span class={`livepower-fox-mode livepower-fox-mode--${foxMode.toLowerCase()}`}>
+              <span class="livepower-fox-mode-dot" />
+              {foxMode}
+            </span>
+          )}
           {forced.length > 0 && (
             <span class="livepower-fox-windows">
               {forced.map((w) => {
@@ -154,10 +191,8 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
               })}
             </span>
           )}
-          {dhwSchedule && dhwSchedule.length > 0 && (
-            <TankScheduleBadges rows={dhwSchedule} nowIso={cockpit.now_utc} limit={4} />
-          )}
         </div>
+        )}
         {lpInfo && (lpInfo.runId != null || lpInfo.runAt) && (
           <div class="livepower-fox-debug">
             <span title="Last LP run id + wall time + plan target date">
@@ -198,6 +233,52 @@ function upcomingForcedWindows(timeline: SchedulerTimeline, limit: number): Forc
   }
   if (current) out.push(current);
   return out.slice(0, limit);
+}
+
+interface NextAction { label: string; when: string; whenMs: number; color: string; }
+
+// Merge the soonest upcoming battery window + the next future tank action into
+// a single chronologically-ordered "Next" line (max 2 items). Reuses the same
+// kind/label vocabulary as the chips; the dot colour here is SEMANTIC (charge =
+// ok/green, drain = warn/amber), intentionally not the band hue the chips use.
+function buildNextActions(
+  forced: ForcedWindow[],
+  dhw: DhwScheduleRow[] | null | undefined,
+  nowIso: string | undefined,
+): NextAction[] {
+  const out: NextAction[] = [];
+  const rel = (iso: string) => {
+    const r = formatRelativeSlot(iso, nowIso);
+    return `${r.dayLabel ? r.dayLabel + " " : ""}${r.timeLabel}`;
+  };
+  if (forced.length > 0) {
+    const w = forced[0];
+    out.push({ label: labelForKind(w.kind), when: rel(w.start_utc), whenMs: Date.parse(w.start_utc),
+               color: kindColorVar(w.kind) });
+  }
+  const nowMs = nowIso ? Date.parse(nowIso) : Date.now();
+  const nextTank = (dhw || [])
+    .filter((r) => r.start_utc && Date.parse(r.start_utc) > nowMs)
+    .sort((a, b) => Date.parse(a.start_utc!) - Date.parse(b.start_utc!))[0];
+  if (nextTank?.start_utc) {
+    out.push({ label: tankLabelOf(nextTank.action_type), when: rel(nextTank.start_utc),
+               whenMs: Date.parse(nextTank.start_utc), color: "var(--warn)" });
+  }
+  // Drop any entry whose timestamp failed to parse (whenMs NaN) — a NaN in the
+  // comparator leaves the sort order undefined and could surface the wrong action.
+  return out.filter((a) => Number.isFinite(a.whenMs)).sort((a, b) => a.whenMs - b.whenMs).slice(0, 2);
+}
+
+// Battery window kind → the same semantic colour the rest of the surface uses
+// (charge = ok/green, discharge/drain = warn/amber).
+function kindColorVar(k: string | undefined): string {
+  switch ((k || "").toLowerCase()) {
+    case "cheap":
+    case "negative":            return "var(--ok)";
+    case "peak_export":
+    case "pre_negative_export": return "var(--warn)";
+    default:                    return "var(--text-dim)";
+  }
 }
 
 // Kind conveyed by the leading coloured dot + band colour — no emoji.

--- a/ui/src/components/cockpit/live-power.css
+++ b/ui/src/components/cockpit/live-power.css
@@ -214,6 +214,21 @@
 .livepower-rate--band-cheap    { color: var(--cheap); }
 .livepower-rate--band-peak     { color: var(--peak); }
 .livepower-rate--export        { color: var(--export); }
+/* No live export price — quiet, smaller, never reads as a live green value. */
+.livepower-fox-rate-value--none {
+  color: var(--text-mute);
+  font-size: var(--font-sm);
+  font-weight: 600;
+}
+/* "X.X kWh today · £Y" line under each live rate — day-to-now grid traffic. */
+.livepower-fox-rate-sub {
+  display: block;
+  margin-top: 2px;
+  font-size: var(--font-2xs);
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.livepower-credit { color: var(--ok); font-weight: 600; }
 
 .livepower-fox-row {
   display: flex;
@@ -294,4 +309,38 @@
   margin-top: 2px;
   font-size: var(--font-xs);
   color: var(--text-mute);
+}
+
+/* "Next" action summary — soonest battery + tank actions, one quiet line. */
+.livepower-next {
+  margin-top: var(--space-2);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-3);
+  font-size: var(--font-xs);
+  font-variant-numeric: tabular-nums;
+}
+.livepower-next-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--font-2xs);
+  font-weight: 600;
+  color: var(--text-mute);
+}
+.livepower-next-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-weight: 600;
+}
+.livepower-next-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+}
+.livepower-next-when {
+  color: var(--text-dim);
+  font-weight: 500;
 }

--- a/ui/src/components/common/Gauge.tsx
+++ b/ui/src/components/common/Gauge.tsx
@@ -1,3 +1,4 @@
+import type { ComponentChildren } from "preact";
 import "./gauge.css";
 
 interface GaugeProps {
@@ -7,8 +8,14 @@ interface GaugeProps {
   max: number;
   target?: number | null;
   unit?: string;
-  tone?: "thermal" | "cool" | "neutral";
+  tone?: "thermal" | "cool" | "neutral" | "warm" | "cold";
   sub?: string;
+  icon?: ComponentChildren;
+  // When true and unit is °C, show the Fahrenheit equivalent alongside.
+  showFahrenheit?: boolean;
+  // Override the tone gradient with an explicit fill colour (e.g. a continuous
+  // temperature→colour mapping). Takes precedence over `tone`.
+  fillColor?: string;
 }
 
 function clampFrac(v: number, min: number, max: number): number {
@@ -19,18 +26,23 @@ function clampFrac(v: number, min: number, max: number): number {
 // Horizontal bar gauge: track + fill to `value`, optional tick at `target`,
 // big readout above. Pure HTML/CSS — no canvas/SVG, so it renders correctly
 // everywhere and is cheap on the eager Home critical path.
-export function Gauge({ label, value, min, max, target, unit = "°C", tone = "thermal", sub }: GaugeProps) {
+export function Gauge({ label, value, min, max, target, unit = "°C", tone = "thermal", sub, icon, showFahrenheit, fillColor }: GaugeProps) {
   const has = value != null && Number.isFinite(value);
   const frac = has ? clampFrac(value as number, min, max) : 0;
   const targetFrac = target != null && Number.isFinite(target) ? clampFrac(target, min, max) : null;
+  const fahrenheit = has && showFahrenheit && unit === "°C"
+    ? `${Math.round((value as number) * 9 / 5 + 32)}°F` : null;
   return (
     <div class={`gauge gauge--${tone}`}>
       <div class="gauge-top">
-        <span class="gauge-label">{label}</span>
-        <span class="gauge-value">{has ? `${(value as number).toFixed(0)}${unit}` : "—"}</span>
+        <span class="gauge-label">{icon && <span class="gauge-icon">{icon}</span>}{label}</span>
+        <span class="gauge-value">
+          {has ? `${(value as number).toFixed(0)}${unit}` : "—"}
+          {fahrenheit && <span class="gauge-value-alt"> · {fahrenheit}</span>}
+        </span>
       </div>
       <div class="gauge-track">
-        <div class="gauge-fill" style={{ width: `${(frac * 100).toFixed(1)}%` }} />
+        <div class="gauge-fill" style={{ width: `${(frac * 100).toFixed(1)}%`, ...(fillColor ? { background: fillColor } : {}) }} />
         {targetFrac != null && (
           <div class="gauge-target" style={{ left: `${(targetFrac * 100).toFixed(1)}%` }}
                title={`target ${target!.toFixed(0)}${unit}`} />

--- a/ui/src/components/common/RefreshCountdown.tsx
+++ b/ui/src/components/common/RefreshCountdown.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "preact/hooks";
+import "./refresh-countdown.css";
+
+interface Props {
+  // From a usePoll() result: when the last fetch landed + the poll interval.
+  // Can also represent a cooldown window (lastFetchAt = cooldown start).
+  lastFetchAt: number | null;
+  intervalMs: number;
+  loading?: boolean;   // a fetch is in flight → spin
+  disabled?: boolean;  // not clickable (e.g. on cooldown) but not spinning
+  onRefresh?: () => void;
+  label?: string;
+}
+
+// A tiny ring that drains as the next auto-refresh approaches, with the seconds
+// remaining inside. Click to refresh now. Mirrors the data the cockpit already
+// polls on — purely presentational over usePoll's lastFetchAt/intervalMs.
+export function RefreshCountdown({ lastFetchAt, intervalMs, loading, disabled, onRefresh, label }: Props) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  if (!intervalMs || lastFetchAt == null) {
+    return (
+      <button class="refresh-cd refresh-cd--plain" onClick={onRefresh} title="Refresh now" disabled={loading || disabled}>
+        <span class={`refresh-cd-glyph${loading ? " spin" : ""}`}>↻</span>
+        {label && <span class="refresh-cd-label">{label}</span>}
+      </button>
+    );
+  }
+
+  const nextAt = lastFetchAt + intervalMs;
+  const leftMs = Math.max(0, nextAt - now);
+  const leftS = Math.ceil(leftMs / 1000);
+  const frac = Math.max(0, Math.min(1, leftMs / intervalMs)); // 1 → just refreshed
+  const R = 8, C = 2 * Math.PI * R;
+  const dash = C * frac;
+
+  return (
+    <button class="refresh-cd" onClick={onRefresh}
+            title={disabled
+              ? `Just refreshed — available again in ${leftS}s`
+              : `Auto-refreshes every ${Math.round(intervalMs / 1000)}s — click to refresh now`}
+            disabled={loading || disabled}>
+      <svg width="22" height="22" viewBox="0 0 22 22" class={loading ? "spin" : ""} aria-hidden="true">
+        <circle cx="11" cy="11" r={R} fill="none" stroke="var(--border-strong)" stroke-width="2" />
+        <circle cx="11" cy="11" r={R} fill="none" stroke="var(--accent)" stroke-width="2"
+                stroke-linecap="round" stroke-dasharray={`${dash} ${C}`}
+                transform="rotate(-90 11 11)" style={{ transition: "stroke-dasharray 1s linear" }} />
+      </svg>
+      <span class="refresh-cd-num">{loading ? "↻" : leftS}</span>
+      {label && <span class="refresh-cd-label">{label}</span>}
+    </button>
+  );
+}

--- a/ui/src/components/common/TankScheduleBadges.tsx
+++ b/ui/src/components/common/TankScheduleBadges.tsx
@@ -1,25 +1,12 @@
 import type { DhwScheduleRow } from "../../lib/types";
-import { formatRelativeSlot, endLabelFor } from "../../lib/slotLabels";
+import { formatRelativeSlot, endLabelFor, tankKindOf, tankLabelOf } from "../../lib/slotLabels";
 import "./tank-badges.css";
 
 // Heat-tank scheduling badges — "Warmup 13:00–22:00 · 45°C",
 // "Boost (neg) 02:00–04:00 · 65°C" — mirroring the battery force-charge flags.
 // Each dhw_policy row IS already a coalesced window (start/end/target), so no
 // merge is needed. Future-day rows render dimmed/dashed.
-
-function kindOf(a?: string | null): string {
-  if (a === "tank_setback") return "setback";
-  if (a === "tank_negative_boost") return "boost";
-  return "warmup";
-}
-function labelOf(a?: string | null): string {
-  switch (a) {
-    case "tank_setback": return "Setback";
-    case "tank_negative_boost": return "Boost (neg)";
-    case "tank_warmup": return "Warmup";
-    default: return a || "—";
-  }
-}
+// kind/label vocabulary is shared via lib/slotLabels (tankKindOf/tankLabelOf).
 
 interface Props {
   rows: DhwScheduleRow[] | null | undefined;
@@ -33,7 +20,7 @@ export function TankScheduleBadges({ rows, nowIso, limit }: Props) {
   return (
     <span class="tank-windows">
       {items.map((r, i) => {
-        const k = kindOf(r.action_type);
+        const k = tankKindOf(r.action_type);
         const start = formatRelativeSlot(r.start_utc ?? undefined, nowIso);
         const end = endLabelFor(r.end_utc ?? undefined, false);
         const range = `${start.timeLabel}–${end}`;
@@ -42,9 +29,9 @@ export function TankScheduleBadges({ rows, nowIso, limit }: Props) {
         return (
           <span key={i}
                 class={`tank-window tank-window--${k}${start.isToday ? "" : " tank-window--future"}`}
-                title={`${labelOf(r.action_type)} ${dayPfx}${range}${temp}`}>
+                title={`${tankLabelOf(r.action_type)} ${dayPfx}${range}${temp}`}>
             <span class="tank-window-dot" />
-            {labelOf(r.action_type)} {dayPfx}{range}{temp}
+            {tankLabelOf(r.action_type)} {dayPfx}{range}{temp}
           </span>
         );
       })}

--- a/ui/src/components/common/gauge.css
+++ b/ui/src/components/common/gauge.css
@@ -11,11 +11,22 @@
 .gauge-label {
   font-size: var(--font-sm);
   color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.gauge-icon {
+  display: inline-flex;
+  color: var(--text-mute);
 }
 .gauge-value {
   font-size: var(--font-lg);
   font-variant-numeric: tabular-nums;
   color: var(--text);
+}
+.gauge-value-alt {
+  font-size: var(--font-xs);
+  color: var(--text-mute);
 }
 .gauge-track {
   position: relative;
@@ -32,6 +43,9 @@
 .gauge--thermal .gauge-fill { background: linear-gradient(90deg, var(--pv), var(--warn)); }
 .gauge--cool .gauge-fill { background: linear-gradient(90deg, var(--grid), var(--accent)); }
 .gauge--neutral .gauge-fill { background: var(--text-mute); }
+/* Outdoor temperature tones — by how warm it actually is. */
+.gauge--cold .gauge-fill { background: linear-gradient(90deg, var(--grid), var(--accent)); }
+.gauge--warm .gauge-fill { background: linear-gradient(90deg, var(--warn), var(--peak-export, var(--bad))); }
 /* target marker sits ABOVE the fill — overflow on track clips it, so render
    it as a full-height notch via a thin high-contrast line that isn't clipped. */
 .gauge-track .gauge-target {

--- a/ui/src/components/common/refresh-countdown.css
+++ b/ui/src/components/common/refresh-countdown.css
@@ -1,0 +1,32 @@
+.refresh-cd {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  position: relative;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.refresh-cd:hover { color: var(--text); }
+.refresh-cd:disabled { cursor: default; opacity: 0.7; }
+.refresh-cd svg { display: block; }
+.refresh-cd-num {
+  position: absolute;
+  left: 11px;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 9px;
+  font-weight: 600;
+  pointer-events: none;
+}
+.refresh-cd-label { font-size: var(--font-2xs); }
+.refresh-cd--plain .refresh-cd-glyph { font-size: var(--font-md); }
+
+@keyframes refresh-cd-spin { to { transform: rotate(360deg); } }
+.refresh-cd .spin, .refresh-cd-glyph.spin { animation: refresh-cd-spin 0.8s linear infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .refresh-cd .spin, .refresh-cd-glyph.spin { animation: none; }
+}

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -206,9 +206,9 @@ export function EnergyChartWidget({ execution }: EnergyChartWidgetProps) {
       {granularity === "day" && dayHasSlots && (
         <div class="echart-flag">
           <span class="echart-flag-icon"><Icon name="schedule" size={14} /></span>
-          Day view: Daikin <strong>{daikinSourceLabel}</strong> / Residual stacked,
-          + <strong>realised grid cost</strong>. Per-slot solar / import / export
-          are not yet captured — see #424.
+          Day view: load split into Daikin (<strong>{daikinSourceLabel}</strong>),
+          appliances &amp; base, + <strong>realised grid cost</strong>. Per-slot
+          solar / import / export aren't captured yet — see #424.
         </div>
       )}
 
@@ -458,15 +458,23 @@ function optionForDay(
     // Fallback: whole physics estimate goes into Heating
     return round2(s.daikin_kwh_est ?? 0);
   });
-  const residualPerSlot = slots.map((s, i) => {
+  // Residual (load minus Daikin) splits into APPLIANCE (washer/dryer/dishwasher,
+  // estimated from armed jobs) + BASE load. Prefer the backend's per-slot
+  // appliance/base split; fall back to all-residual-as-base when absent.
+  const appliancePerSlot = slots.map((s) => round2(s.appliance_kwh_est ?? 0));
+  const basePerSlot = slots.map((s, i) => {
+    if (s.base_load_kwh_est != null) return round2(s.base_load_kwh_est);
     const load = s.consumption_kwh ?? 0;
     const daikin = (dhwPerSlot[i] ?? 0) + (heatingPerSlot[i] ?? 0);
-    return round2(Math.max(0, load - daikin));
+    return round2(Math.max(0, load - daikin - (appliancePerSlot[i] ?? 0)));
   });
+  const hasAppliance = appliancePerSlot.some((v) => v > 0);
 
   return {
     ...base,
-    legend: { ...(base.legend as object), data: ["Daikin tank", "Daikin heating", "Residual", "Realised grid cost"] },
+    legend: { ...(base.legend as object), data: hasAppliance
+      ? ["Daikin tank", "Daikin heating", "Appliances", "Base load", "Realised grid cost"]
+      : ["Daikin tank", "Daikin heating", "Base load", "Realised grid cost"] },
     // Quiet ghost note — per-slot solar/import/export genuinely unavailable
     // (#424). A text annotation, NOT a fabricated series/markArea.
     graphic: [{
@@ -502,11 +510,19 @@ function optionForDay(
         itemStyle: { color: barGradient(t.warn, 0.9, 0.5) },
         emphasis: { focus: "series" },
       },
-      {
-        name: "Residual",
+      ...(hasAppliance ? [{
+        name: "Appliances",
         type: "bar",
         stack: "load",
-        data: residualPerSlot,
+        data: appliancePerSlot,
+        itemStyle: { color: barGradient(t.accent, 0.85, 0.45) },
+        emphasis: { focus: "series" },
+      }] : []),
+      {
+        name: "Base load",
+        type: "bar",
+        stack: "load",
+        data: basePerSlot,
         // Top segment of the stack — rounds the crown so the bar reads as one.
         itemStyle: { color: barGradient(t.house, 0.75, 0.4), borderRadius: [3, 3, 0, 0] },
         emphasis: { focus: "series" },

--- a/ui/src/components/home/HeatingControls.tsx
+++ b/ui/src/components/home/HeatingControls.tsx
@@ -62,6 +62,11 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
   const climateOn = dev?.climate_on ?? dev?.is_on ?? false;
   const tankOn = dev?.dhw_on ?? dev?.tank_power ?? false;
 
+  // Require a KNOWN device value that differs — otherwise (value absent) we'd let
+  // an Apply fire a redundant no-op write to the heat pump, burning Daikin quota.
+  const tankChanged = editable && !busy && dev?.tank_target != null && tankTarget !== dev.tank_target;
+  const lwtChanged = editable && !busy && dev?.lwt_offset != null && lwt !== dev.lwt_offset;
+
   return (
     <div class="heating-controls">
       <div class="heating-controls-head">
@@ -71,18 +76,25 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
             passive · read-only
           </span>
         )}
-        {active && (
-          <button type="button"
-                  class={`heating-controls-lock${unlocked ? " heating-controls-lock--open" : ""}`}
-                  aria-pressed={unlocked}
-                  title={unlocked ? "Manual control enabled — click to lock" : "Locked — click to enable manual control"}
-                  onClick={() => (unlocked ? setUnlocked(false) : setConfirmingUnlock(true))}>
-            {unlocked ? "🔓 editing" : "🔒 locked"}
-          </button>
-        )}
       </div>
 
-      <div class="heating-controls-cards">
+      {active && (
+        <div class={`hc-lockbar${unlocked ? " hc-lockbar--open" : ""}`}>
+          <span class="hc-lockbar-icon" aria-hidden="true">{unlocked ? "🔓" : "🔒"}</span>
+          <span class="hc-lockbar-text">
+            {unlocked
+              ? "Manual control on — what you apply is written to the heat pump."
+              : "Locked — the tank follows the automatic schedule."}
+          </span>
+          <button type="button" class={`btn btn--sm${unlocked ? " btn--ghost" : " btn--primary"}`}
+                  aria-pressed={unlocked}
+                  onClick={() => (unlocked ? setUnlocked(false) : setConfirmingUnlock(true))}>
+            {unlocked ? "Re-lock" : "Take control"}
+          </button>
+        </div>
+      )}
+
+      <div class={`heating-controls-cards${active && !unlocked ? " is-locked" : ""}`}>
         {/* Climate (space heating) — power + leaving-water offset */}
         <section class="hc-card">
           <header class="hc-card-head">
@@ -94,12 +106,11 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
           </header>
           <div class="hc-card-body">
             <span class="hc-card-label">Water offset</span>
-            <Stepper value={lwt} unit="°" step={0.5} disabled={!editable || busy}
-                     onStep={(d) => setLwt((v) => clamp(Math.round((v + d) * 2) / 2, LWT_MIN, LWT_MAX))} />
-            <button class="btn btn--sm hc-apply" disabled={!editable || busy || lwt === dev?.lwt_offset}
-                    onClick={() => run(`LWT offset ${lwt >= 0 ? "+" : ""}${lwt}`, () => setLwtOffset(lwt))}>
-              Apply
-            </button>
+            <Slider value={lwt} min={LWT_MIN} max={LWT_MAX} step={0.5} current={dev?.lwt_offset}
+                    unit="°" tone="cool" disabled={!editable || busy}
+                    onInput={(v) => setLwt(clamp(Math.round(v * 2) / 2, LWT_MIN, LWT_MAX))} />
+            <ApplyBtn changed={lwtChanged} label={`Set ${lwt >= 0 ? "+" : ""}${lwt}°`}
+                      onClick={() => run(`LWT offset ${lwt >= 0 ? "+" : ""}${lwt}`, () => setLwtOffset(lwt))} />
           </div>
         </section>
 
@@ -114,12 +125,11 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
           </header>
           <div class="hc-card-body">
             <span class="hc-card-label">Target</span>
-            <Stepper value={tankTarget} unit="°C" disabled={!editable || busy}
-                     onStep={(d) => setTankTarget((v) => clamp(v + d, TANK_MIN, TANK_MAX))} />
-            <button class="btn btn--sm hc-apply" disabled={!editable || busy || tankTarget === dev?.tank_target}
-                    onClick={() => run(`Tank set to ${tankTarget}°C`, () => setTankTemperature(tankTarget))}>
-              Apply
-            </button>
+            <Slider value={tankTarget} min={TANK_MIN} max={TANK_MAX} step={1} current={dev?.tank_target}
+                    unit="°C" tone="thermal" disabled={!editable || busy}
+                    onInput={(v) => setTankTarget(clamp(Math.round(v), TANK_MIN, TANK_MAX))} />
+            <ApplyBtn changed={tankChanged} label={`Set ${tankTarget}°C`}
+                      onClick={() => run(`Tank set to ${tankTarget}°C`, () => setTankTemperature(tankTarget))} />
           </div>
         </section>
       </div>
@@ -143,17 +153,43 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
   );
 }
 
-// Onecta-style − value + stepper.
-function Stepper({ value, unit = "°C", step = 1, disabled, onStep }: {
-  value: number; unit?: string; step?: number; disabled?: boolean; onStep: (delta: number) => void;
+// Slider with a tick marking the device's CURRENT value, so you see where you're
+// dragging relative to where the unit is now. Native range for a11y + touch.
+function Slider({ value, min, max, step = 1, current, unit, tone = "thermal", disabled, onInput }: {
+  value: number; min: number; max: number; step?: number; current?: number | null;
+  unit: string; tone?: "thermal" | "cool"; disabled?: boolean; onInput: (v: number) => void;
 }) {
+  const fmt = (v: number) => (v % 1 === 0 ? String(v) : v.toFixed(1));
+  const pct = (v: number) => Math.max(0, Math.min(1, (v - min) / (max - min))) * 100;
+  const curValid = current != null && Number.isFinite(current);
   return (
-    <div class="heating-stepper">
-      <button type="button" class="heating-stepper-btn" disabled={disabled} aria-label="decrease"
-              onClick={() => onStep(-step)}>−</button>
-      <span class="heating-stepper-value">{value % 1 === 0 ? value : value.toFixed(1)}{unit}</span>
-      <button type="button" class="heating-stepper-btn" disabled={disabled} aria-label="increase"
-              onClick={() => onStep(step)}>+</button>
+    <div class={`hc-slider hc-slider--${tone}${disabled ? " is-disabled" : ""}`}>
+      <div class="hc-slider-rail">
+        <div class="hc-slider-fill" style={{ width: `${pct(value)}%` }} />
+        {curValid && (
+          <span class="hc-slider-cur" style={{ left: `${pct(current as number)}%` }}
+                title={`now ${fmt(current as number)}${unit}`} />
+        )}
+        <input class="hc-slider-input" type="range" min={min} max={max} step={step}
+               value={value} disabled={disabled} aria-label={`Set value (${unit})`}
+               onInput={(e) => onInput(Number((e.target as HTMLInputElement).value))} />
+      </div>
+      <div class="hc-slider-readout">
+        <span class="hc-slider-value">{fmt(value)}{unit}</span>
+        {curValid && value !== current && (
+          <span class="hc-slider-from">from {fmt(current as number)}{unit}</span>
+        )}
+      </div>
     </div>
+  );
+}
+
+// Apply button — primary + pending value when there's a change, quiet otherwise.
+function ApplyBtn({ changed, label, onClick }: { changed: boolean; label: string; onClick: () => void }) {
+  return (
+    <button class={`btn btn--sm hc-apply${changed ? " btn--primary hc-apply--ready" : ""}`}
+            disabled={!changed} onClick={onClick}>
+      {changed ? label : "Apply"}
+    </button>
   );
 }

--- a/ui/src/components/home/HeatingWidget.tsx
+++ b/ui/src/components/home/HeatingWidget.tsx
@@ -17,6 +17,7 @@ import { RadialGauge } from "../common/RadialGauge";
 import { Modal } from "../common/Modal";
 import { HeatingControls } from "./HeatingControls";
 import { TankScheduleBadges } from "../common/TankScheduleBadges";
+import { RefreshCountdown } from "../common/RefreshCountdown";
 import "./heating.css";
 
 interface HeatingWidgetProps {
@@ -66,9 +67,6 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
   }, [cooldownUntil]);
   const cooldownLeft = Math.max(0, Math.ceil((cooldownUntil - nowMs) / 1000));
   const onCooldown = cooldownLeft > 0;
-  const cooldownLabel = onCooldown
-    ? `↻ ${Math.floor(cooldownLeft / 60)}:${String(cooldownLeft % 60).padStart(2, "0")}`
-    : "↻ Live";
   async function doForceRefresh() {
     setRefreshing(true);
     setRefreshError(null);
@@ -100,7 +98,13 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
     getDhwSchedule().then((r) => { if (alive) setSelfSchedule(r.rows || []); }).catch(() => {});
     return () => { alive = false; };
   }, [dhwSchedule]);
-  const schedule = dhwSchedule ?? selfSchedule;
+  const scheduleAll = dhwSchedule ?? selfSchedule;
+  // Drop windows that have already finished — a boost/warmup that ran earlier
+  // today is noise here; show only what's ongoing or still upcoming.
+  const schedule = scheduleAll.filter((r) => {
+    const end = r.end_utc ? Date.parse(r.end_utc) : NaN;
+    return Number.isNaN(end) || end >= Date.now();
+  });
 
   // LWT: latest execution slot first, then live cockpit state.
   const lwtFromExec = latestExecValue(execution, (s) => s.daikin_lwt_c);
@@ -159,34 +163,33 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
             {quotaUsed}/{quotaBudget} · 24h
           </Pill>
         )}
-        <button class="btn btn--ghost btn--sm heating-refresh" disabled={refreshing || onCooldown}
-                title={onCooldown
-                  ? `Just refreshed — available again in ${cooldownLabel.replace("↻ ", "")}`
-                  : "Fetch live data from the heat pump now (uses one Daikin API call)"}
-                onClick={() => setConfirmingRefresh(true)}>
-          {refreshing ? "…" : cooldownLabel}
-        </button>
+        <RefreshCountdown
+          lastFetchAt={onCooldown ? cooldownUntil - forceIv * 1000 : null}
+          intervalMs={forceIv * 1000}
+          loading={refreshing}
+          disabled={onCooldown}
+          onRefresh={() => setConfirmingRefresh(true)}
+          label={onCooldown ? undefined : "Live"} />
       </div>
 
       <RadialGauge label={`Tank${tankPower != null ? (tankPower ? " · on" : " · off") : ""}`}
                    value={tankTemp} min={20} max={65} target={tankTarget} tone="thermal" />
       <div class="heating-gauges heating-gauges--secondary">
-        <Gauge label="Outdoor" value={outdoorTemp} min={-5} max={35} tone="cool"
+        <Gauge label="Outdoor" value={outdoorTemp} min={-5} max={40}
+               fillColor={tempColor(outdoorTemp)}
+               icon={<ThermometerIcon />} showFahrenheit
                sub={outdoorSource === "execution" ? "Daikin sensor (logged)"
                     : outdoorSource === "daikin" ? "Daikin sensor (live)"
                     : "Open-Meteo forecast"} />
-        <Gauge label="LWT" value={lwt} min={20} max={55} tone="thermal" sub="leaving water" />
+        <Gauge label="LWT" value={lwt} min={20} max={55} tone="thermal" showFahrenheit sub="leaving water" />
       </div>
 
       {totalHeatingKwh != null && (
         <div class="heating-split">
           <div class="heating-split-label">Today's heating energy</div>
-          <div class="heating-split-row">
-            <div class="heating-split-item">
-              <span class="heating-split-dot heating-split-dot--dhw" />
-              <span class="heating-split-name">Total estimate</span>
-              <span class="heating-split-value">{kwh(totalHeatingKwh)}</span>
-            </div>
+          <div class="heating-energy-value" title="Estimated total heat-pump electricity today (DHW + space, not split by the meter)">
+            {kwh(totalHeatingKwh)}
+            <span class="heating-energy-est">est</span>
           </div>
         </div>
       )}
@@ -220,6 +223,44 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
         {refreshError && <p class="heating-refresh-error">Live read failed: {refreshError}</p>}
       </Modal>
     </div>
+  );
+}
+
+// Continuous outdoor-temperature colour: light-blue (cold) → dark-blue → green
+// (mild, ~18°C) → yellow → red → purple (very hot). Interpolated in HSL along
+// the shortest hue path so the midpoints stay vivid (RGB lerp would go muddy).
+function tempColor(t: number | null): string | undefined {
+  if (t == null || !Number.isFinite(t)) return undefined;
+  // [temp, hue, sat%, light%]
+  const stops: [number, number, number, number][] = [
+    [0, 195, 90, 72],   // light blue
+    [10, 222, 78, 48],  // dark blue
+    [25, 48, 95, 55],   // yellow
+    [30, 6, 85, 55],    // red
+    [40, 285, 65, 55],  // purple
+  ];
+  const c = Math.max(stops[0][0], Math.min(stops[stops.length - 1][0], t));
+  let a = stops[0], b = stops[stops.length - 1];
+  for (let i = 0; i < stops.length - 1; i++) {
+    if (c >= stops[i][0] && c <= stops[i + 1][0]) { a = stops[i]; b = stops[i + 1]; break; }
+  }
+  const f = b[0] === a[0] ? 0 : (c - a[0]) / (b[0] - a[0]);
+  // Shortest-path hue interpolation.
+  let dh = b[1] - a[1];
+  if (dh > 180) dh -= 360;
+  if (dh < -180) dh += 360;
+  const h = ((a[1] + dh * f) % 360 + 360) % 360;
+  const s = a[2] + (b[2] - a[2]) * f;
+  const l = a[3] + (b[3] - a[3]) * f;
+  return `hsl(${h.toFixed(0)} ${s.toFixed(0)}% ${l.toFixed(0)}%)`;
+}
+
+function ThermometerIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M14 14.76V5a2 2 0 0 0-4 0v9.76a4 4 0 1 0 4 0z" />
+    </svg>
   );
 }
 

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -1,5 +1,5 @@
 import type { MetricsResponse, CockpitNow, AgileTodayResponse, MonthlyEnergy, PeriodInsightsResponse } from "../../lib/types";
-import { gbp, gbpSigned, kwh } from "../../lib/format";
+import { gbp, kwh } from "../../lib/format";
 import { useAnimatedNumber } from "../../lib/useAnimatedNumber";
 import { isCurrentPeriod, periodLabel, type PeriodState } from "../../lib/period";
 import { CostBreakdownChart } from "./CostBreakdownChart";
@@ -58,6 +58,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
         export_kwh: activeMonths.reduce((s, m) => s + (m.energy?.export_kwh ?? 0), 0),
         export_earn: activeMonths.reduce((s, m) => s + (m.cost?.export_earnings_pounds ?? 0), 0),
         total_cost: activeMonths.reduce((s, m) => s + (m.cost?.net_cost_pounds ?? 0), 0),
+        saved_vs_fixed: activeMonths.reduce((s, m) => s + (m.cost?.delta_vs_fixed_pounds ?? 0), 0),
       }
     : null;
 
@@ -69,6 +70,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   const exportKwhAnim = useAnimatedNumber(lifetime?.export_kwh ?? null);
   const exportEarnAnim = useAnimatedNumber(lifetime?.export_earn ?? null);
   const totalCostAnim = useAnimatedNumber(lifetime?.total_cost ?? null);
+  const savedVsFixedAnim = useAnimatedNumber(lifetime?.saved_vs_fixed ?? null);
 
   // Live-now strip — always current, ignores the period selector.
   const curImportP = cockpit?.current_slot?.price_import_p ?? null;
@@ -93,7 +95,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
           {savedAnim != null && (
             <div class="hero-subline">
               <strong class={savedAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
-                {savedAnim >= 0 ? "Saved " : "Cost "}{gbpSigned(savedAnim)}
+                {savedAnim >= 0 ? "Saved " : "Extra "}{gbp(Math.abs(savedAnim))}
               </strong>
               &nbsp;vs {fixedLabel}
               {periodExport != null && periodExport > 0 && (
@@ -105,7 +107,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
             <div class="hero-subline hero-subline-dma">
               Today so far:&nbsp;
               <strong class={todayAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
-                {gbpSigned(todayAnim)}
+                {todayAnim >= 0 ? "Saved " : "Extra "}{gbp(Math.abs(todayAnim))}
               </strong>
               &nbsp;vs {fixedLabel}
               <span class="hero-est-tag" title="Estimate — today's metered cost confirms after the next-day Octopus backfill.">est</span>
@@ -132,6 +134,12 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
               <HeroStat value={kwh(exportKwhAnim ?? 0, 0)} label="exported" />
               <HeroStat value={gbp(exportEarnAnim ?? 0)} label="export earnings" />
               <HeroStat value={gbp(totalCostAnim ?? 0)} label="total bills" />
+              <HeroStat
+                value={gbp(Math.abs(savedVsFixedAnim ?? 0))}
+                label={(savedVsFixedAnim ?? 0) >= 0 ? "saved vs fixed" : "extra vs fixed"}
+                tone={(savedVsFixedAnim ?? 0) >= 0 ? "pos" : "neg"}
+                title={`Net £ vs ${fixedLabel} across ${lifetime.months} active months on Agile`}
+              />
             </div>
           </div>
         )}
@@ -150,10 +158,10 @@ function SkelHero() {
   return <span class="skel-text" style={{ width: "8rem", height: "0.85em" }} />;
 }
 
-function HeroStat({ value, label }: { value: string; label: string }) {
+function HeroStat({ value, label, tone, title }: { value: string; label: string; tone?: "pos" | "neg"; title?: string }) {
   return (
-    <div class="hero-stat">
-      <div class="hero-stat-value">{value}</div>
+    <div class="hero-stat" title={title}>
+      <div class={`hero-stat-value${tone ? ` hero-stat-value--${tone}` : ""}`}>{value}</div>
       <div class="hero-stat-label">{label}</div>
     </div>
   );

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -2,12 +2,15 @@ import { useEffect, useRef } from "preact/hooks";
 import { makeChart, baseOption, chartTheme, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
 import { useResolvedTheme } from "../../lib/theme";
 import { reducedMotion } from "../../lib/motion";
-import type { PvTodayResponse } from "../../lib/types";
+import type { PvTodayResponse, ExecutionTodayResponse } from "../../lib/types";
 import "./today-plan.css";
 
 interface TodayPlanWidgetProps {
   pv: PvTodayResponse | null;
   loading: boolean;
+  // Execution slots — used to overlay MEASURED base load (consumption − daikin −
+  // appliance) against the forecast base-load line.
+  execution?: ExecutionTodayResponse | null;
   // Tariff-tier thresholds (p/kWh) for the cheap/peak background shading. From
   // /metrics — same thresholds the rest of the app classifies bands with.
   cheapThresholdP?: number | null;
@@ -19,7 +22,7 @@ function localHM(iso: string): string {
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
-type Tier = "negative" | "cheap" | "peak" | null;
+type Tier = "negative" | "cheap" | "standard" | "peak" | null;
 
 // One chart that answers "what's the plan today?" without tab-switching:
 // import price + cheap/peak rate windows (background) + load forecast + the
@@ -27,7 +30,7 @@ type Tier = "negative" | "cheap" | "peak" | null;
 // (foreground). PV/load/DHW on the left kWh axis, price on the right p axis,
 // tank °C on a second right axis. All series come from /pv/today — one
 // full-day, server-aligned source (no client-side ISO key-matching).
-export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }: TodayPlanWidgetProps) {
+export function TodayPlanWidget({ pv, loading, execution, cheapThresholdP, peakThresholdP }: TodayPlanWidgetProps) {
   const ref = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
   const theme = useResolvedTheme();
@@ -59,6 +62,16 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
     const pvForecastLive = slots.map((s) => round2(s.pv_forecast_kwh));
     const pvActual = slots.map((s) => (s.pv_actual_kwh == null ? null : round2(s.pv_actual_kwh)));
     const load = slots.map((s) => (s.base_load_kwh == null ? null : round2(s.base_load_kwh)));
+    // Measured base load (consumption − daikin − appliance), aligned to these
+    // slots by slot_utc — the actual to compare against the forecast `load`.
+    const execBase = new Map<string, number>();
+    for (const e of execution?.slots ?? []) {
+      if (e.slot_utc && e.base_load_kwh_est != null) execBase.set(e.slot_utc, e.base_load_kwh_est);
+    }
+    const loadActual = slots.map((s) => {
+      const v = execBase.get(s.slot_utc);
+      return v == null ? null : round2(v);
+    });
     const price = slots.map((s) => (s.import_price_p == null ? null : s.import_price_p));
 
     // --- Rate-tier background bands. Classify each slot by import price into
@@ -69,24 +82,41 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
     const pct = (q: number) => (known.length ? known[Math.min(known.length - 1, Math.floor(q * known.length))] : null);
     const cheapAt = cheapThresholdP ?? pct(0.33);
     const peakAt = peakThresholdP ?? pct(0.75);
+    // Every slot with a known price gets a tier — no blank gaps. Mid-priced
+    // slots are "standard" (a neutral wash) rather than nothing, so the band
+    // reads as a continuous tariff ribbon: paid / cheap / standard / peak.
     const tierOf = (p: number | null): Tier => {
       if (p == null) return null;
       if (p < 0) return "negative";
       if (cheapAt != null && p <= cheapAt) return "cheap";
       if (peakAt != null && p >= peakAt) return "peak";
-      return null;
+      return "standard";
     };
     const tierColor = (k: Tier): string =>
-      k === "negative" ? t.neg : k === "cheap" ? t.cheap : t.peak;
+      k === "negative" ? t.neg : k === "cheap" ? t.cheap : k === "peak" ? t.peak : t.textMute;
+    // Negative ("paid to import") is the rare money-maker → the only strong band
+    // (visible border, distinct blue). Cheap/peak are soft context washes;
+    // standard is the faintest neutral so it fills the gap without greying the
+    // plot. (The load line is greyed elsewhere, not by these bands.)
+    const tierFill = (k: Tier): object =>
+      k === "negative"
+        ? { color: withAlpha(t.neg, 0.26), borderColor: withAlpha(t.neg, 0.9), borderWidth: 1 }
+        : k === "standard"
+        ? { color: withAlpha(t.textMute, 0.05) }
+        : { color: withAlpha(tierColor(k), 0.10) };
     // markArea references slot INDEX (DST-safe; two slots can share a label).
     const bands: Array<[{ xAxis: number; itemStyle: object }, { xAxis: number }]> = [];
     let runStart = -1;
     let runTier: Tier = null;
+    // Expand each run by half a category cell on both sides so a SINGLE-slot
+    // tier (e.g. one 30-min negative window) still renders a full-width cell.
+    // Without this, runStart === endIdx → a zero-width band → invisible, which
+    // is why today's short negative windows weren't showing up.
     const flush = (endIdx: number) => {
       if (runStart < 0 || runTier == null) return;
       bands.push([
-        { xAxis: runStart, itemStyle: { color: withAlpha(tierColor(runTier), runTier === "peak" ? 0.16 : 0.20) } },
-        { xAxis: endIdx },
+        { xAxis: runStart - 0.5, itemStyle: tierFill(runTier) },
+        { xAxis: endIdx + 0.5 },
       ]);
     };
     slots.forEach((_, i) => {
@@ -110,16 +140,23 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
     }
     const animate = !reducedMotion();
 
+    // ONE projected-PV line: behind 'now' it's the committed plan we executed,
+    // ahead it's the live forecast — but drawn in a single uniform thin dotted
+    // light-yellow style so it reads as "the projection", with ACTUAL as the one
+    // bold line. (Past vs future is still distinguished in the hover tooltip.)
+    const mergeIdx = nowIdx; // -1 when 'now' is outside this day
+    const planLine = slots.map((_, i) =>
+      mergeIdx >= 0 && i > mergeIdx ? pvForecastLive[i] : (pvCommitted[i] ?? pvForecastLive[i]));
+
     chartRef.current.setOption({
       ...base,
       // Legend pinned bottom so it never collides with the top axis labels or
       // the plot (the caption-overlap fix).
-      grid: { left: 16, right: 44, top: 16, bottom: 44, containLabel: true },
-      legend: {
-        ...(base.legend as object),
-        show: true, top: undefined, right: undefined, bottom: 4, left: "center",
-        data: ["PV actual", "PV plan (committed)", "PV forecast (live)", "Load forecast", "Import price"],
-      },
+      grid: { left: 16, right: 44, top: 16, bottom: 24, containLabel: true },
+      // Legend removed — the lines are explained by the caption below the chart
+      // (bold = actual, dotted = projection) + the tier-band legend, so the
+      // floating legend over the plot was redundant clutter.
+      legend: { show: false },
       tooltip: {
         ...(base.tooltip as object),
         formatter: (params: Array<{ dataIndex: number }>) => {
@@ -127,12 +164,37 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
           const s = slots[i];
           if (!s) return "";
           const tier = tierOf(price[i]);
-          return `<strong>${labels[i]}</strong>${tier ? ` · ${tier}` : ""}<br/>` +
-            (price[i] != null ? `Import ${price[i]!.toFixed(1)}p/kWh<br/>` : "") +
-            (pvCommitted[i] != null ? `PV plan ${pvCommitted[i]!.toFixed(2)} kWh<br/>` : "") +
-            `PV forecast (live) ${pvForecastLive[i].toFixed(2)} kWh<br/>` +
-            (pvActual[i] != null ? `PV actual ${pvActual[i]!.toFixed(2)} kWh<br/>` : "") +
-            (load[i] != null ? `Load ${load[i]!.toFixed(2)} kWh` : "");
+          const isPast = nowIdx >= 0 && i <= nowIdx;
+          const planVal = isPast ? (pvCommitted[i] ?? pvForecastLive[i]) : pvForecastLive[i];
+          // A mini horizontal bar so plan vs actual compare at a glance — the
+          // "show the error graphically on hover" ask. All bars share one scale.
+          const scale = Math.max(0.01, planVal ?? 0, pvActual[i] ?? 0, load[i] ?? 0, loadActual[i] ?? 0);
+          const bar = (label: string, val: number | null, col: string, sub?: string) => {
+            if (val == null || !Number.isFinite(val)) return "";
+            const w = Math.round(Math.max(0, Math.min(1, val / scale)) * 78);
+            return `<div style="display:flex;align-items:center;gap:6px;margin-top:3px;">` +
+              `<span style="width:62px;color:${t.textMute};font-size:11px;">${label}</span>` +
+              `<span style="display:inline-block;width:${w}px;height:7px;border-radius:3px;background:${col};"></span>` +
+              `<span style="font-size:11px;color:${t.text};">${val.toFixed(2)}${sub || ""}</span></div>`;
+          };
+          // Miss readout (actual − committed plan), coloured by direction.
+          let missRow = "";
+          if (isPast && pvActual[i] != null && pvCommitted[i] != null) {
+            const miss = pvActual[i]! - pvCommitted[i]!;
+            const col = miss >= 0 ? t.cheap : t.importColor;
+            missRow = `<div style="margin-top:4px;font-size:11px;color:${col};">` +
+              `solar ${miss >= 0 ? "beat plan by +" : "fell short −"}${Math.abs(miss).toFixed(2)} kWh</div>`;
+          }
+          const head = `<strong>${labels[i]}</strong>${tier ? ` · ${tier}` : ""}` +
+            (price[i] != null ? ` · ${price[i]!.toFixed(1)}p/kWh` : "");
+          return head +
+            bar(isPast ? "PV plan" : "PV forecast", planVal, withAlpha(t.pv, 0.55)) +
+            bar("PV actual", pvActual[i], t.pv) +
+            missRow +
+            (load[i] != null || loadActual[i] != null
+              ? `<div style="margin-top:5px;border-top:1px solid ${withAlpha(t.textMute, 0.25)};padding-top:2px;"></div>` : "") +
+            bar("Load fcast", load[i], withAlpha(t.textMute, 0.5)) +
+            bar("Load actual", loadActual[i], withAlpha(t.textMute, 0.9));
         },
       },
       xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
@@ -157,36 +219,34 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
           } : undefined,
           z: 0,
         },
-        // Three PV lines share the PV hue, distinguished by treatment:
-        //   committed plan = dotted, mid-alpha (the frozen plan being executed)
-        //   live forecast  = dashed, dim (revises through the day)
-        //   actual         = solid, bright, filled (realised)
-        // `color` is set so the legend swatch matches the line (ECharts colours
-        // the legend marker from series.color, NOT lineStyle).
+        // PV plan/forecast — one thin dotted light-yellow projection line.
         {
-          name: "PV plan (committed)", type: "line", smooth: true, showSymbol: false,
-          connectNulls: false, color: withAlpha(t.pv, 0.7),
-          data: pvCommitted, lineStyle: { color: withAlpha(t.pv, 0.7), width: 1.5, type: "dotted" }, z: 3,
+          name: "PV plan", type: "line", smooth: true, showSymbol: false, connectNulls: false,
+          color: withAlpha(t.pv, 0.5),
+          data: planLine, lineStyle: { color: withAlpha(t.pv, 0.5), width: 1, type: "dotted" }, z: 3,
         },
-        {
-          name: "PV forecast (live)", type: "line", smooth: true, showSymbol: false, color: withAlpha(t.pv, 0.4),
-          data: pvForecastLive, lineStyle: { color: withAlpha(t.pv, 0.4), width: 1.25, type: "dashed" },
-          areaStyle: { color: withAlpha(t.pv, 0.05) }, z: 2,
-        },
-        // PV actual — realised in the FOREGROUND: vivid PV colour, thick, gradient fill.
+        // PV actual — the ONE bold line: vivid PV colour, thick, gradient fill.
         {
           name: "PV actual", type: "line", smooth: true, showSymbol: false, connectNulls: false, color: t.pv,
-          data: pvActual, lineStyle: { color: t.pv, width: 2.75 },
-          areaStyle: { color: areaGradient(t.pv, 0.36, 0.04) }, z: 4,
+          data: pvActual, lineStyle: { color: t.pv, width: 3 },
+          areaStyle: { color: areaGradient(t.pv, 0.46, 0.05) }, z: 4,
         },
-        // Load forecast is a reference → dim, dashed (its own cool hue).
+        // Load — neutral GREY (doesn't clash with PV yellow / price red).
+        // Forecast = dim dashed; ACTUAL (measured base load) = solid, mirroring
+        // the PV actual-vs-plan treatment so load reads the same way.
         {
-          name: "Load forecast", type: "line", smooth: true, showSymbol: false, color: withAlpha(t.grid, 0.5),
-          data: load, lineStyle: { color: withAlpha(t.grid, 0.5), width: 1.25, type: "dashed" }, z: 3,
+          name: "Load forecast", type: "line", smooth: true, showSymbol: false, color: withAlpha(t.textMute, 0.55),
+          data: load, lineStyle: { color: withAlpha(t.textMute, 0.45), width: 1.25, type: "dashed" }, z: 2,
         },
+        {
+          name: "Load actual", type: "line", smooth: true, showSymbol: false, connectNulls: false,
+          color: withAlpha(t.textMute, 0.95),
+          data: loadActual, lineStyle: { color: withAlpha(t.textMute, 0.9), width: 1.75 }, z: 3,
+        },
+        // Import price → dashed step (reads as a reference, not a hard line).
         {
           name: "Import price", type: "line", step: "middle", showSymbol: false, color: t.importColor,
-          yAxisIndex: 1, data: price, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.75 }, z: 1,
+          yAxisIndex: 1, data: price, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8, type: "dashed" }, z: 1,
         },
         // Blinking "now" — a pulsing ripple at the current slot on the baseline.
         ...(nowIdx >= 0 ? [{
@@ -199,34 +259,58 @@ export function TodayPlanWidget({ pv, loading, cheapThresholdP, peakThresholdP }
         }] : []),
       ],
     }, { notMerge: true });
-  }, [pv, theme, cheapThresholdP, peakThresholdP]);
+  }, [pv, execution, theme, cheapThresholdP, peakThresholdP]);
 
   const acc = pv?.accuracy;
+  // Plain-language accuracy: did solar come in above or below the forecast so
+  // far, and by how much. The per-slot detail (miss bar) is in the chart hover.
+  const biasWord = acc == null ? "" :
+    Math.abs(acc.bias_kwh) < 0.1 ? "tracking forecast"
+    : acc.bias_kwh > 0 ? `${acc.bias_kwh.toFixed(1)} kWh above forecast`
+    : `${Math.abs(acc.bias_kwh).toFixed(1)} kWh below forecast`;
+  const biasTone = acc == null ? "" : Math.abs(acc.bias_kwh) < 0.1 ? "" : acc.bias_kwh > 0 ? " today-plan-acc--pos" : " today-plan-acc--neg";
+
+  // Headline day total = solar ALREADY generated (actual, locked) + forecast for
+  // the slots still to come. Use actual ONLY for fully-elapsed slots; the current
+  // in-progress slot has just a partial actual (lower than its full-slot forecast),
+  // so counting that would make the headline DIP at every slot boundary — use the
+  // slot's forecast there instead. The realised part can't change, so only the
+  // shrinking remainder moves: steady, and the right magnitude.
+  const dayTotalNowMs = pv?.now_utc ? new Date(pv.now_utc).getTime() : Date.now();
+  const dayTotal = pv?.slots?.length
+    ? pv.slots.reduce((sum, s) => {
+        const elapsed = new Date(s.slot_utc).getTime() + 30 * 60_000 <= dayTotalNowMs;
+        const v = elapsed ? (s.pv_actual_kwh ?? s.pv_forecast_kwh) : s.pv_forecast_kwh;
+        return sum + (v ?? 0);
+      }, 0)
+    : (pv?.forecast_kwh_day_total ?? null);
 
   return (
     <div class="today-plan">
+      {dayTotal != null && (
+        <div class="today-plan-summary">
+          <span class="today-plan-summary-icon" aria-hidden="true">☀</span>
+          <span class="today-plan-summary-value">{dayTotal.toFixed(1)}<span class="today-plan-summary-unit"> kWh</span></span>
+          <span class="today-plan-summary-label">solar expected today (generated + forecast)</span>
+        </div>
+      )}
       {acc && (
         <div class="today-plan-acc">
-          <span>PV today so far: <strong>{acc.actual_kwh.toFixed(1)}</strong> kWh actual vs <strong>{acc.forecast_kwh.toFixed(1)}</strong> planned</span>
+          <span>Solar so far today: <strong>{acc.actual_kwh.toFixed(1)}</strong> kWh vs <strong>{acc.forecast_kwh.toFixed(1)}</strong> expected by now</span>
           <span class="today-plan-acc-sep">·</span>
-          <span title="Mean absolute error per slot, and forecast bias (positive = forecast under-predicted).">
-            MAE {acc.mae_kwh.toFixed(2)} kWh · bias {acc.bias_kwh >= 0 ? "+" : ""}{acc.bias_kwh.toFixed(1)} kWh
+          <span class={biasTone.trim()} title="Actual vs the forecast for the slots elapsed so far (not the full-day total in the card header). Hover any slot for its miss.">
+            {biasWord}
           </span>
         </div>
       )}
       <div ref={ref} style={{ width: "100%", height: "320px" }} />
-      <div class="today-plan-bands">
-        <span class="today-plan-band today-plan-band--cheap">cheap rate</span>
-        <span class="today-plan-band today-plan-band--peak">peak rate</span>
-        <span class="today-plan-band today-plan-band--neg">negative price</span>
-        <span class="today-plan-band-hint">shaded = tariff tier · ◉ now</span>
-      </div>
-      {pv?.plan_committed_at && (
+      {pv?.slots?.length ? (
         <p class="today-plan-note muted">
-          Committed plan from {localHM(pv.plan_committed_at)} (the line the system is executing);
-          the live forecast re-fetches from Quartz through the day, so it moves.
+          Bold line = actual solar; dotted = the plan (committed behind ◉ now,
+          live forecast ahead). Background shades the tariff tier — blue = paid
+          (negative), green = cheap, amber = peak. Hover a slot for its detail.
         </p>
-      )}
+      ) : null}
       {!pv?.slots?.length && !loading && <p class="muted">No plan data for today yet.</p>}
     </div>
   );

--- a/ui/src/components/home/heating.css
+++ b/ui/src/components/home/heating.css
@@ -36,27 +36,22 @@
   text-transform: uppercase;
   margin-bottom: var(--space-2);
 }
-.heating-split-row {
-  display: flex;
-  gap: var(--space-3);
-  flex-wrap: wrap;
-}
-.heating-split-item {
+.heating-energy-value {
   display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  font-size: var(--font-sm);
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: var(--font-lg);
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
+  color: var(--text);
 }
-.heating-split-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+.heating-energy-est {
+  font-size: var(--font-2xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-mute);
 }
-.heating-split-dot--dhw { background: var(--warn); }
-.heating-split-dot--space { background: var(--accent); }
-.heating-split-name { color: var(--text-dim); }
-.heating-split-value { font-weight: 700; }
 
 /* --- Manual Daikin controls (P3) --- */
 .heating-controls {
@@ -105,22 +100,6 @@
   flex-direction: column;
   gap: var(--space-3);
 }
-/* Lock affordance on the controls */
-.heating-controls-lock {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--font-xs);
-  padding: 2px 8px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: var(--bg-card-2);
-  color: var(--text-dim);
-  cursor: pointer;
-}
-.heating-controls-lock--open { color: var(--warn); border-color: var(--warn); }
-.heating-controls-lock:disabled { opacity: 0.5; cursor: not-allowed; }
-
 /* Secondary gauges (outdoor / LWT) below the tank dial */
 .heating-gauges--secondary {
   flex-direction: row;
@@ -129,36 +108,64 @@
 }
 .heating-gauges--secondary > * { flex: 1; min-width: 0; }
 
-/* Onecta-style − value + stepper */
-.heating-stepper {
-  display: inline-flex;
+/* Lock bar — explicit state + action for manual control */
+.hc-lockbar {
+  display: flex;
   align-items: center;
   gap: var(--space-2);
-  flex: 1;
-}
-.heating-stepper-btn {
-  width: 28px;
-  height: 28px;
-  border-radius: 999px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border);
+  border-radius: var(--radius, 10px);
   background: var(--bg-card-2);
-  color: var(--text);
-  font-size: 1.1rem;
-  line-height: 1;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  margin-bottom: var(--space-3);
 }
-.heating-stepper-btn:hover:not(:disabled) { background: var(--bg-card-3); border-color: var(--border-strong); }
-.heating-stepper-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.heating-stepper-value {
-  min-width: 3.2rem;
-  text-align: center;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
-  color: var(--text);
+.hc-lockbar--open {
+  border-color: color-mix(in srgb, var(--warn) 55%, transparent);
+  background: color-mix(in srgb, var(--warn) 8%, var(--bg-card-2));
 }
+.hc-lockbar-icon { font-size: var(--font-md); }
+.hc-lockbar-text { font-size: var(--font-xs); color: var(--text-dim); flex: 1; min-width: 0; }
+.hc-lockbar .btn { flex: none; }
+
+/* Slider control (replaces the −/+ stepper) */
+.hc-slider { display: flex; flex-direction: column; gap: 4px; width: 100%; }
+.hc-slider-rail { position: relative; height: 22px; display: flex; align-items: center; }
+.hc-slider-rail::before {
+  content: ""; position: absolute; left: 0; right: 0; height: 5px;
+  border-radius: 999px; background: var(--bg-card-3, var(--border));
+}
+.hc-slider-fill {
+  position: absolute; left: 0; height: 5px; border-radius: 999px; pointer-events: none;
+}
+.hc-slider--thermal .hc-slider-fill { background: linear-gradient(90deg, var(--pv), var(--warn)); }
+.hc-slider--cool .hc-slider-fill { background: linear-gradient(90deg, var(--grid), var(--accent)); }
+.hc-slider-cur {
+  position: absolute; top: 50%; width: 2px; height: 13px;
+  transform: translate(-50%, -50%); background: var(--text); opacity: 0.55;
+  border-radius: 1px; pointer-events: none;
+}
+.hc-slider-input {
+  position: absolute; left: 0; width: 100%; height: 22px; margin: 0;
+  -webkit-appearance: none; appearance: none; background: transparent; cursor: pointer;
+}
+.hc-slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none; width: 16px; height: 16px; border-radius: 50%;
+  background: var(--text); border: 2px solid var(--bg-card); cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.35);
+}
+.hc-slider-input::-moz-range-thumb {
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--text); border: 2px solid var(--bg-card); cursor: pointer;
+}
+.hc-slider.is-disabled { opacity: 0.55; }
+.hc-slider.is-disabled .hc-slider-input { cursor: not-allowed; }
+.hc-slider-readout {
+  display: flex; align-items: baseline; justify-content: flex-end; gap: var(--space-2);
+}
+.hc-slider-value { font-weight: 700; font-variant-numeric: tabular-nums; color: var(--text); }
+.hc-slider-from { font-size: var(--font-2xs); color: var(--text-mute); }
+
+.heating-controls-cards.is-locked { opacity: 0.55; }
 
 /* --- Two-card control layout: Climate | Tank --- */
 .heating-controls-cards {
@@ -204,8 +211,8 @@
   font-size: var(--font-xs);
   color: var(--text-dim);
 }
-.hc-card-body .heating-stepper { justify-content: space-between; width: 100%; }
-.hc-apply { align-self: flex-end; }
+.hc-apply { align-self: stretch; }
+.hc-apply--ready { font-weight: 600; }
 
 /* --- Tank plan (today's dhw_policy schedule) --- */
 .heating-plan {

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -153,7 +153,7 @@
 }
 .hero-lifetime-stats {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   gap: var(--space-3);
 }
 @media (max-width: 640px) {
@@ -178,6 +178,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.hero-stat-value--pos { color: var(--ok); }
+.hero-stat-value--neg { color: var(--bad); }
 .hero-stat-label {
   font-size: var(--font-2xs);
   color: var(--text-mute);

--- a/ui/src/components/home/today-plan.css
+++ b/ui/src/components/home/today-plan.css
@@ -4,6 +4,34 @@
   gap: var(--space-2);
 }
 
+.today-plan-summary {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
+}
+.today-plan-summary-icon {
+  font-size: var(--font-lg);
+  align-self: center;
+  filter: saturate(1.2);
+}
+.today-plan-summary-value {
+  font-size: var(--font-2xl);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--pv, #fbbf24);
+  font-variant-numeric: tabular-nums;
+}
+.today-plan-summary-unit {
+  font-size: var(--font-md);
+  font-weight: 600;
+  color: var(--text-dim);
+}
+.today-plan-summary-label {
+  font-size: var(--font-sm);
+  color: var(--text-mute);
+}
+
 .today-plan-acc {
   display: flex;
   flex-wrap: wrap;
@@ -20,29 +48,5 @@
 .today-plan-acc-sep {
   color: var(--text-mute);
 }
-
-/* Dispatch-band legend under the chart */
-.today-plan-bands {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-3);
-  font-size: var(--font-xs);
-  color: var(--text-mute);
-}
-.today-plan-band {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  color: var(--text-dim);
-}
-.today-plan-band::before {
-  content: "";
-  width: 12px;
-  height: 12px;
-  border-radius: 3px;
-}
-.today-plan-band--cheap::before { background: color-mix(in srgb, var(--cheap) 35%, transparent); }
-.today-plan-band--peak::before { background: color-mix(in srgb, var(--peak) 35%, transparent); }
-.today-plan-band--neg::before { background: color-mix(in srgb, var(--neg-price, #2563eb) 35%, transparent); }
-.today-plan-band-hint { margin-left: auto; }
+.today-plan-acc--pos { color: var(--ok); font-weight: 600; }
+.today-plan-acc--neg { color: var(--warn); font-weight: 600; }

--- a/ui/src/components/shell/TopNav.tsx
+++ b/ui/src/components/shell/TopNav.tsx
@@ -3,6 +3,7 @@ import { ThemeToggle } from "./ThemeToggle";
 
 const tabs = [
   { href: "/", label: "Home" },
+  { href: "/report", label: "Journal" },
   { href: "/settings", label: "Settings" },
 ];
 

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -30,6 +30,8 @@ import type {
   WorkbenchSimulateResponse,
   WorkbenchPromoteDiff,
   WorkbenchPromoteResult,
+  TodayCumulativeResponse,
+  ActionLogResponse,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -106,6 +108,16 @@ export const getEnergyReport = (date?: string, period: "day" | "month" = "day") 
   );
 export const getEnergyMonthly = (month: string) =>
   getJson<MonthlyEnergy>(`/energy/monthly?month=${encodeURIComponent(month)}`);
+export const getEnergyTodayCumulative = () =>
+  getJson<TodayCumulativeResponse>("/energy/today-cumulative");
+export const getActionLog = (opts?: { device?: string; days?: number; limit?: number }) => {
+  const p = new URLSearchParams();
+  if (opts?.device) p.set("device", opts.device);
+  if (opts?.days != null) p.set("days", String(opts.days));
+  if (opts?.limit != null) p.set("limit", String(opts.limit));
+  const qs = p.toString();
+  return getJson<ActionLogResponse>(`/action-log${qs ? `?${qs}` : ""}`);
+};
 
 // /energy/period — granular chart_data (day=1pt, week=7pts, month=≤31pts,
 // year=≤12pts). Per-point shape: { date, import_kwh, export_kwh,

--- a/ui/src/lib/poll.ts
+++ b/ui/src/lib/poll.ts
@@ -9,6 +9,9 @@ export interface PollState<T> {
   error: Error | null;
   loading: boolean;
   refresh: () => Promise<void>;
+  // Epoch ms of the last successful fetch (for "next refresh in Ns" UIs).
+  lastFetchAt: number | null;
+  intervalMs: number;
 }
 
 export function usePoll<T>(
@@ -19,6 +22,7 @@ export function usePoll<T>(
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [lastFetchAt, setLastFetchAt] = useState<number | null>(null);
   const fnRef = useRef(fn);
   fnRef.current = fn;
 
@@ -35,6 +39,7 @@ export function usePoll<T>(
       const next = await fnRef.current();
       if (!mountedRef.current) return;
       setData(next);
+      setLastFetchAt(Date.now());
       setError(null);
     } catch (e) {
       if (!mountedRef.current) return;
@@ -77,7 +82,7 @@ export function usePoll<T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [intervalMs, ...deps]);
 
-  return { data, error, loading, refresh };
+  return { data, error, loading, refresh, lastFetchAt, intervalMs };
 }
 
 // Fetch-once hook for endpoints we don't poll.
@@ -119,7 +124,7 @@ export function useFetch<T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 
-  return { data, error, loading, refresh };
+  return { data, error, loading, refresh, lastFetchAt: null, intervalMs: 0 };
 }
 
 // useAfterPaint returns false on first render, then flips true once the browser

--- a/ui/src/lib/slotLabels.ts
+++ b/ui/src/lib/slotLabels.ts
@@ -21,6 +21,22 @@ export function endLabelFor(iso: string | undefined, addSlot = true): string {
   }
 }
 
+// Tank (DHW) action vocabulary — shared by the tank schedule chips and the
+// Live-power "next action" summary so they always speak the same words/kinds.
+export function tankKindOf(action?: string | null): "warmup" | "setback" | "boost" {
+  if (action === "tank_setback") return "setback";
+  if (action === "tank_negative_boost") return "boost";
+  return "warmup";
+}
+export function tankLabelOf(action?: string | null): string {
+  switch (action) {
+    case "tank_setback": return "Setback";
+    case "tank_negative_boost": return "Boost (neg)";
+    case "tank_warmup": return "Warmup";
+    default: return action || "—";
+  }
+}
+
 export function formatRelativeSlot(iso: string | undefined, nowIso?: string | null): RelativeSlot {
   if (!iso) return { dayLabel: "", timeLabel: "—", isToday: false };
   try {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -207,6 +207,8 @@ export interface ExecutionSlot {
   consumption_kwh?: number | null;
   daikin_kwh_est?: number | null;
   residual_kwh?: number | null;
+  appliance_kwh_est?: number | null;   // estimated appliance load (armed jobs)
+  base_load_kwh_est?: number | null;    // residual − appliance = measured base load
   cost_realised_p?: number | null;
   cost_daikin_p?: number | null;
   cost_residual_p?: number | null;
@@ -463,6 +465,34 @@ export interface DhwScheduleRow {
 export interface DhwScheduleResponse {
   mode: string;
   rows: DhwScheduleRow[];
+}
+
+// GET /energy/today-cumulative — today's grid traffic so far (to now). Real-
+// money import cost goes NEGATIVE (a credit) on negative-price slots.
+export interface TodayCumulativeResponse {
+  date: string;
+  import_kwh: number;
+  export_kwh: number;
+  import_cost_gbp: number;       // <0 = we were paid to import (credit)
+  export_revenue_gbp: number;
+}
+
+// One executed action from action_log — GET /action-log.
+export interface ActionLogEntry {
+  id: number;
+  timestamp: string;
+  device: string;                // daikin | foxess | appliance
+  action: string;                // tank_warmup | max_heat | charge | washer_start | …
+  params: Record<string, unknown>;
+  result: string;                // success | failed | skipped
+  error_msg: string | null;
+  trigger: string | null;        // lp_dispatch | negative_window | user_manual | …
+  slot_kind: string | null;      // cheap | peak | negative | standard
+  agile_price_at_time: number | null;
+  actor?: string | null;
+}
+export interface ActionLogResponse {
+  entries: ActionLogEntry[];
 }
 
 // Daikin operation modes accepted by POST /daikin/mode.

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -16,10 +16,12 @@ import {
   getTariffDashboard,
   getPvToday,
   getDhwSchedule,
+  getEnergyTodayCumulative,
 } from "../lib/endpoints";
 import { Widget } from "../components/common/Widget";
 import { Spinner } from "../components/common/Spinner";
 import { RefreshAction } from "../components/common/RefreshAction";
+import { RefreshCountdown } from "../components/common/RefreshCountdown";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
 import { usePeriod, periodFetchOpts, periodDateRange } from "../lib/period";
 import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
@@ -102,6 +104,8 @@ export default function Landing() {
   const daikinQuota = useFetch(getDaikinQuota, []);
   // DHW tank plan (today+tomorrow) — shared by Heating + Live-power tank badges.
   const dhwSched = useFetch(getDhwSchedule, []);
+  // Today's grid import/export so far (kWh + real £, credit on negative slots).
+  const todayCum = usePoll(getEnergyTodayCumulative, 60_000);
   // The shared period navigator drives the Hero headline + cost breakdown +
   // energy chart + tariff comparison. Re-fetch whenever the selection changes.
   const period = usePeriod();
@@ -143,8 +147,9 @@ export default function Landing() {
       {/* ── LIVE ───────────────────────────────────────────────────── */}
       <div class="widget-grid widget-band">
         <Widget title="Live power" icon="⚡" tone="power" size="large"
-                badge={data.now_utc ? new Date(data.now_utc).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }) : undefined}>
-          <LivePowerWidget state={s} cockpit={data} timeline={timeline.data} execution={execution.data} agile={agile.data} metrics={metrics.data} dhwSchedule={dhwSched.data?.rows} />
+                badge={data.now_utc ? new Date(data.now_utc).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }) : undefined}
+                action={<RefreshCountdown lastFetchAt={now.lastFetchAt} intervalMs={now.intervalMs} loading={now.loading} onRefresh={() => void now.refresh()} />}>
+          <LivePowerWidget state={s} cockpit={data} timeline={timeline.data} execution={execution.data} agile={agile.data} metrics={metrics.data} dhwSchedule={dhwSched.data?.rows} todayCumulative={todayCum.data} />
         </Widget>
 
         <Widget title="Heating" icon="♨" tone="thermal" size="medium">
@@ -155,10 +160,10 @@ export default function Landing() {
 
       {/* ── PLAN ───────────────────────────────────────────────────── */}
       <div class="widget-grid widget-band">
-        <Widget title="Today's plan" icon="🗓" tone="plan" size="wide"
-                badge={pvToday.data?.forecast_kwh_day_total != null ? `${pvToday.data.forecast_kwh_day_total.toFixed(1)} kWh PV planned` : undefined}>
+        <Widget title="Today's plan" icon="🗓" tone="plan" size="wide">
           <Suspense fallback={<Spinner label="Loading plan…" />}>
             <TodayPlanWidget pv={pvToday.data} loading={pvToday.loading}
+                             execution={execution.data}
                              cheapThresholdP={metrics.data?.cheap_threshold_pence}
                              peakThresholdP={metrics.data?.peak_threshold_pence} />
           </Suspense>

--- a/ui/src/routes/report.css
+++ b/ui/src/routes/report.css
@@ -1,0 +1,101 @@
+.report-head h1 {
+  margin: 0 0 var(--space-1);
+  font-size: var(--font-2xl);
+}
+.report-head p { margin: 0 0 var(--space-4); }
+
+.report-filters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+.report-tabs, .report-range { display: flex; gap: var(--space-1); flex-wrap: wrap; }
+.report-tab {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  padding: 5px 12px;
+  border-radius: var(--radius-pill, 999px);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.report-tab:hover { color: var(--text); border-color: var(--border-strong); }
+.report-tab.active {
+  background: var(--accent-soft, var(--surface-2));
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.report-group { margin-bottom: var(--space-5); }
+.report-group-day {
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-mute);
+  margin: 0 0 var(--space-2);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--border);
+}
+.report-list { list-style: none; margin: 0; padding: 0; }
+
+.report-row {
+  display: grid;
+  grid-template-columns: 3.2rem 10px 5rem 1fr auto;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border-faint, var(--border));
+  font-size: var(--font-sm);
+}
+.report-time { color: var(--text-mute); font-variant-numeric: tabular-nums; }
+.report-dot { width: 8px; height: 8px; border-radius: 50%; }
+.report-dot--thermal { background: var(--warn); }
+.report-dot--power { background: var(--ok); }
+.report-dot--appliance { background: var(--accent); }
+.report-dot--neutral { background: var(--text-mute); }
+.report-device { color: var(--text-dim); font-weight: 600; }
+.report-action { color: var(--text); min-width: 0; }
+.report-hint { color: var(--text-mute); }
+.report-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  justify-self: end;
+  font-variant-numeric: tabular-nums;
+}
+.report-kind {
+  text-transform: capitalize;
+  color: var(--text-dim);
+  font-size: var(--font-2xs);
+}
+.report-price { color: var(--text-dim); font-size: var(--font-2xs); }
+.report-trigger { color: var(--text-mute); font-size: var(--font-2xs); }
+.report-err {
+  grid-column: 4 / -1;
+  color: var(--bad);
+  font-size: var(--font-2xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.report-error { color: var(--bad); }
+.report-empty { padding: var(--space-4) 0; }
+
+@media (max-width: 640px) {
+  .report-row {
+    grid-template-columns: 3rem 8px 1fr;
+    grid-template-areas:
+      "time dot action"
+      ".    .   meta";
+    row-gap: var(--space-1);
+  }
+  .report-time { grid-area: time; }
+  .report-device { display: none; }
+  .report-action { grid-area: action; }
+  .report-meta { grid-area: meta; justify-self: start; }
+}

--- a/ui/src/routes/report.tsx
+++ b/ui/src/routes/report.tsx
@@ -1,0 +1,168 @@
+import { useState } from "preact/hooks";
+import { useFetch } from "../lib/poll";
+import { getActionLog } from "../lib/endpoints";
+import { Spinner } from "../components/common/Spinner";
+import { Pill } from "../components/common/Pill";
+import { hhmm } from "../lib/format";
+import type { ActionLogEntry } from "../lib/types";
+import "./report.css";
+
+// Execution journal — what the system ACTUALLY did (tank / battery / appliances),
+// read straight from action_log. This is the audit trail: every fired, skipped
+// or failed action with its trigger, tariff context and result.
+
+type DeviceFilter = "all" | "daikin" | "foxess" | "appliance";
+const DEVICE_TABS: { key: DeviceFilter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "daikin", label: "Tank / heat pump" },
+  { key: "foxess", label: "Battery" },
+  { key: "appliance", label: "Appliances" },
+];
+const RANGES = [
+  { days: 1, label: "24h" },
+  { days: 7, label: "7 days" },
+  { days: 30, label: "30 days" },
+];
+
+function deviceLabel(d: string): string {
+  switch (d) {
+    case "daikin": return "Tank";
+    case "foxess": case "fox": return "Battery";
+    case "appliance": return "Appliance";
+    default: return d;
+  }
+}
+function deviceTone(d: string): "thermal" | "power" | "appliance" | "neutral" {
+  switch (d) {
+    case "daikin": return "thermal";
+    case "foxess": case "fox": return "power";
+    case "appliance": return "appliance";
+    default: return "neutral";
+  }
+}
+
+// Humanise the raw action verbs into something readable.
+function actionLabel(a: string): string {
+  const map: Record<string, string> = {
+    tank_warmup: "Tank warmup",
+    tank_setback: "Tank setback",
+    tank_negative_boost: "Tank boost (negative price)",
+    max_heat: "Tank max-heat",
+    pre_heat: "Tank pre-heat",
+    shutdown: "Tank shutdown",
+    restore: "Restore to baseline",
+    charge: "Battery force-charge",
+    discharge: "Battery force-discharge",
+    mode_switch: "Battery mode switch",
+    washer_start: "Washer start",
+    dryer_start: "Dryer start",
+    dishwasher_start: "Dishwasher start",
+    apply_safe_defaults: "Apply safe defaults",
+  };
+  return map[a] || a.replace(/_/g, " ");
+}
+function resultTone(r: string): "ok" | "bad" | "dim" {
+  if (r === "success") return "ok";
+  if (r === "failed") return "bad";
+  return "dim";
+}
+
+function localDay(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString([], { weekday: "short", day: "2-digit", month: "short" });
+  } catch { return iso.slice(0, 10); }
+}
+
+// Pick the most informative param to show inline (temp, offset, power, soc).
+function paramHint(p: Record<string, unknown>): string | null {
+  const bits: string[] = [];
+  if (typeof p.tank_temp === "number") bits.push(`${p.tank_temp}°C`);
+  if (typeof p.lwt_offset === "number" && p.lwt_offset !== 0) bits.push(`LWT ${p.lwt_offset > 0 ? "+" : ""}${p.lwt_offset}`);
+  if (typeof p.fdSoc === "number") bits.push(`→ ${p.fdSoc}%`);
+  if (typeof p.fdPwr === "number") bits.push(`${p.fdPwr}W`);
+  if (p.tank_powerful === true) bits.push("powerful");
+  return bits.length ? bits.join(" · ") : null;
+}
+
+export default function Report() {
+  const [device, setDevice] = useState<DeviceFilter>("all");
+  const [days, setDays] = useState(7);
+  const log = useFetch(
+    () => getActionLog({ device: device === "all" ? undefined : device, days, limit: 300 }),
+    [device, days],
+  );
+
+  const entries = log.data?.entries ?? [];
+  // Group by local day, preserving the DESC order the API returns.
+  const groups: { day: string; items: ActionLogEntry[] }[] = [];
+  for (const e of entries) {
+    const day = localDay(e.timestamp);
+    const last = groups[groups.length - 1];
+    if (last && last.day === day) last.items.push(e);
+    else groups.push({ day, items: [e] });
+  }
+
+  return (
+    <div class="page-padded report">
+      <header class="report-head">
+        <h1>Activity journal</h1>
+        <p class="muted">Everything the system actually did — tank, battery and appliances — with its trigger and result.</p>
+      </header>
+
+      <div class="report-filters">
+        <div class="report-tabs" role="tablist" aria-label="Device">
+          {DEVICE_TABS.map((t) => (
+            <button key={t.key} role="tab" aria-selected={device === t.key}
+                    class={`report-tab${device === t.key ? " active" : ""}`}
+                    onClick={() => setDevice(t.key)}>{t.label}</button>
+          ))}
+        </div>
+        <div class="report-range">
+          {RANGES.map((r) => (
+            <button key={r.days} class={`report-tab${days === r.days ? " active" : ""}`}
+                    onClick={() => setDays(r.days)}>{r.label}</button>
+          ))}
+        </div>
+      </div>
+
+      {log.loading && !log.data && <Spinner label="Loading journal…" />}
+      {log.error && <p class="report-error">Couldn't load the journal: {log.error.message}</p>}
+      {!log.loading && entries.length === 0 && (
+        <p class="muted report-empty">No actions recorded in this window.</p>
+      )}
+
+      {groups.map((g) => (
+        <section key={g.day} class="report-group">
+          <h2 class="report-group-day">{g.day}</h2>
+          <ul class="report-list">
+            {g.items.map((e) => {
+              const hint = paramHint(e.params || {});
+              return (
+                <li key={e.id} class="report-row">
+                  <span class="report-time">{hhmm(e.timestamp)}</span>
+                  <span class={`report-dot report-dot--${deviceTone(e.device)}`} />
+                  <span class="report-device">{deviceLabel(e.device)}</span>
+                  <span class="report-action">
+                    {actionLabel(e.action)}
+                    {hint && <span class="report-hint"> · {hint}</span>}
+                  </span>
+                  <span class="report-meta">
+                    {e.slot_kind && <span class="report-kind">{e.slot_kind}</span>}
+                    {e.agile_price_at_time != null && (
+                      <span class="report-price">{e.agile_price_at_time.toFixed(1)}p</span>
+                    )}
+                    {e.trigger && <span class="report-trigger" title="What scheduled this action">{e.trigger}</span>}
+                    <Pill tone={resultTone(e.result)}>{e.result}</Pill>
+                  </span>
+                  {e.error_msg && e.result !== "success" && (
+                    <span class="report-err" title={e.error_msg}>{e.error_msg}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -14,6 +14,15 @@ import preact from "@preact/preset-vite";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const apiTarget = env.VITE_DEV_API_TARGET || "http://localhost:8000";
+  // Optional split: route specific paths to a SECOND backend (e.g. local box
+  // running not-yet-deployed endpoints) while the rest hits VITE_DEV_API_TARGET.
+  // Comma-separated path prefixes in VITE_DEV_LOCAL_PATHS → VITE_DEV_LOCAL_API.
+  const localTarget = env.VITE_DEV_LOCAL_API || "http://localhost:8000";
+  const localPaths = (env.VITE_DEV_LOCAL_PATHS || "")
+    .split(",").map((p) => p.trim()).filter(Boolean);
+  const proxy: Record<string, { target: string; changeOrigin: boolean }> = {};
+  for (const p of localPaths) proxy[p] = { target: localTarget, changeOrigin: true };
+  proxy["/api"] = { target: apiTarget, changeOrigin: true };
 
   return {
     plugins: [preact()],
@@ -23,12 +32,7 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 5173,
       strictPort: true,
-      proxy: {
-        "/api": {
-          target: apiTarget,
-          changeOrigin: true,
-        },
-      },
+      proxy,
     },
     build: {
       outDir: "dist",


### PR DESCRIPTION
## Summary

A multi-pass overhaul of the cockpit driven by live-screenshot review, plus four backend additions. Everything is frontend except the four backend items, which need a deploy to render real data.

### Frontend (cockpit)
- **Hero** — verb-led money wording ("Saved £3.32" / "Extra £0.91", no contradictory "Cost −£"); new lifetime **"saved vs fixed"** stat.
- **Live power** — a prominent **"Next" action** line (soonest battery + tank); Fox-mode pill only when actively forcing (relabelled "Grid plan"); **import/export day-to-now** (kWh + £, with a green **credit** when the import price went negative); a **refresh countdown ring**; export tariff empty-state.
- **Today's plan** — one thin dotted projection (committed behind *now*, live forecast ahead) vs the bold actual line; **fixed single-slot negative bands** (were zero-width → invisible); every slot now a tariff tier (paid/cheap/standard/peak — no blank gaps); **graphical hover tooltip** (plan-vs-actual mini bars + miss); **stable full-day total** (generated + remaining forecast, no flicker); **load actual-vs-forecast** line; legend de-cluttered.
- **Heating** — continuous **outdoor-temp colour** (cold-blue → green → warm) + °F + thermometer; **slider** tank/LWT controls with a current-value tick, an explicit **lock bar**, and an Apply that shows the pending value; refresh countdown ring; collapsed the fake DHW/space split.
- **Energy flow** — day-view load split into **Daikin / Appliances / Base**.
- **New `/report` "Journal" tab** — executed-action timeline (tank / battery / appliances) with trigger, tariff context and result.

### Backend
- `GET /energy/today-cumulative` — today's grid import/export to-now (real £, **negative-price import = credit**).
- `GET /action-log` — executed-action journal (`db.get_action_logs` gains a `since` filter).
- `/execution/today` — per-slot `appliance_kwh_est` + `base_load_kwh_est` (powers the load split + the plan's load-actual line).
- **Bug fix:** `/agile/today` and `/cockpit/now` read the export rate from `agile_export_rates` (was `agile_rates`, which is import-only → export price always blank). Verified prod has the data.

### Review
Ran a multi-angle diff review; fixed a partial-current-slot dip in the day total, a NaN-sort guard in the Next line, a redundant-Daikin-write guard, a tooltip width clamp, an always-visible tariff key, a duplicate time formatter, and removed dead CSS. One maintainability nit (export-rate lookup duplicated across two endpoints — correct, but could be one helper) left as a follow-up.

### Notes
- `vite.config.ts` gains an optional env-driven split-proxy (no-op without the env vars).
- The four backend items only render real data after deploy.

Related: #461 (LWT offset reset), #462 (`pv_error_log` persistence). Tariff-comparison fairness audit tracked separately by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)