### PR TITLE
fix(home): standing in Energy Flow eq, SEG export in monthly, robust solar accuracy

### DIFF
--- a/src/energy/monthly.py
+++ b/src/energy/monthly.py
@@ -163,7 +163,14 @@ def _compute_cost(energy: MonthlyEnergySummary, n_days: int | None = None) -> Mo
     is billed — the original behaviour, kept for completed past months.
     """
     import_rate = config.MANUAL_TARIFF_IMPORT_PENCE or 0.0
-    export_rate = config.MANUAL_TARIFF_EXPORT_PENCE or 0.0
+    # Export at the household's actual tariff. In seg_flat mode (default) that's
+    # the flat SEG rate, keeping the Octopus-unavailable fallback (e.g. "today"
+    # before backfill) consistent with _compute_cost_octopus + the Insights tab.
+    export_rate = (
+        (config.EXPORT_SEG_RATE_PENCE or 0.0)
+        if config.EXPORT_TARIFF_MODE != "outgoing_agile"
+        else (config.MANUAL_TARIFF_EXPORT_PENCE or 0.0)
+    )
     standing_per_day = config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0.0
     days = n_days if n_days is not None else monthrange(energy.year, energy.month)[1]
     import_cost_pence = energy.import_kwh * import_rate
@@ -256,10 +263,10 @@ def _compute_cost_octopus(
 
         import_kwh_metered = sum(s.consumption_kwh for s in import_slots)
 
-        # Export: use Octopus export consumption if available, billed at the
-        # per-slot Outgoing Agile rate (matching pnl.py:_realised_export_pence).
-        # Falls back to the flat manual export rate for unmatched slots / when
-        # no Outgoing tariff is configured.
+        # Export: use Octopus export consumption if available, valued by the
+        # tariff the household is ACTUALLY paid on (config.EXPORT_TARIFF_MODE) —
+        # flat Octopus SEG by default, per-slot Outgoing Agile when switched.
+        # Mirrors pnl.export_revenues_for_day so Home and Insights agree.
         export_earnings_pence = 0.0
         export_kwh_metered = 0.0
         if roles.export_mpan and roles.export_serial:
@@ -270,28 +277,39 @@ def _compute_cost_octopus(
                 period_to,
             )
             export_kwh_metered = sum(s.consumption_kwh for s in export_slots)
-            flat_export_rate = config.MANUAL_TARIFF_EXPORT_PENCE or 0.0
-            export_rate_by_start: dict[str, float] = {}
-            if config.OCTOPUS_EXPORT_TARIFF_CODE:
-                for r in db.get_agile_export_rates_in_range(
-                    period_from.isoformat(), period_to.isoformat()
-                ):
-                    ts = r.get("valid_from") or ""
-                    if ts:
-                        export_rate_by_start[ts[:16]] = float(r.get("value_inc_vat") or 0)
-            matched = 0
-            for slot in export_slots:
-                key = slot.interval_start.isoformat()[:16]
-                rate = export_rate_by_start.get(key)
-                if rate is not None:
-                    matched += 1
-                else:
-                    rate = flat_export_rate
-                export_earnings_pence += slot.consumption_kwh * rate
-            logger.info(
-                "Monthly export (Octopus %d-%02d): %.3f kWh -> %.2fp (%d/%d slots per-slot rate)",
-                year, month, export_kwh_metered, export_earnings_pence, matched, len(export_slots),
-            )
+            if config.EXPORT_TARIFF_MODE == "outgoing_agile":
+                # Variable Outgoing Agile — price each slot by its own rate,
+                # falling back to the flat manual rate for unmatched slots.
+                flat_export_rate = config.MANUAL_TARIFF_EXPORT_PENCE or 0.0
+                export_rate_by_start: dict[str, float] = {}
+                if config.OCTOPUS_EXPORT_TARIFF_CODE:
+                    for r in db.get_agile_export_rates_in_range(
+                        period_from.isoformat(), period_to.isoformat()
+                    ):
+                        ts = r.get("valid_from") or ""
+                        if ts:
+                            export_rate_by_start[ts[:16]] = float(r.get("value_inc_vat") or 0)
+                matched = 0
+                for slot in export_slots:
+                    key = slot.interval_start.isoformat()[:16]
+                    rate = export_rate_by_start.get(key)
+                    if rate is not None:
+                        matched += 1
+                    else:
+                        rate = flat_export_rate
+                    export_earnings_pence += slot.consumption_kwh * rate
+                logger.info(
+                    "Monthly export (Octopus %d-%02d, agile): %.3f kWh -> %.2fp (%d/%d slots per-slot rate)",
+                    year, month, export_kwh_metered, export_earnings_pence, matched, len(export_slots),
+                )
+            else:
+                # Flat Octopus Outgoing SEG (the household's real export tariff).
+                seg_rate = config.EXPORT_SEG_RATE_PENCE or 0.0
+                export_earnings_pence = export_kwh_metered * seg_rate
+                logger.info(
+                    "Monthly export (Octopus %d-%02d, seg_flat): %.3f kWh -> %.2fp @ %.2fp/kWh",
+                    year, month, export_kwh_metered, export_earnings_pence, seg_rate,
+                )
 
         days = n_days if n_days is not None else monthrange(year, month)[1]
         standing_pence = (config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0.0) * days

--- a/tests/test_monthly_cost_proration.py
+++ b/tests/test_monthly_cost_proration.py
@@ -31,6 +31,11 @@ def _fixed_tariff(monkeypatch):
     monkeypatch.setattr(config, "FIXED_TARIFF_LABEL", "Test Fixed", raising=False)
     monkeypatch.setattr(config, "FIXED_TARIFF_RATE_PENCE", 30.0, raising=False)
     monkeypatch.setattr(config, "FIXED_TARIFF_STANDING_PENCE_PER_DAY", 45.0, raising=False)
+    # Export tariff: pin deterministically so tests don't depend on prod .env.
+    # seg_flat is the household's actual mode; SEG rate matches the shadow's
+    # SEG_EXPORT_FALLBACK_PENCE constant so realised and shadow export agree.
+    monkeypatch.setattr(config, "EXPORT_TARIFF_MODE", "seg_flat", raising=False)
+    monkeypatch.setattr(config, "EXPORT_SEG_RATE_PENCE", monthly.SEG_EXPORT_FALLBACK_PENCE, raising=False)
     monkeypatch.setattr(config, "OCTOPUS_API_KEY", "", raising=False)  # force manual path
 
 
@@ -54,8 +59,10 @@ def test_compute_cost_prorates_to_n_days():
     e = _energy(2026, 1)
     cost = monthly._compute_cost(e, n_days=10)
     assert cost.standing_charge_pence == 10 * 50.0
-    # net = import×rate + standing − export×rate
-    assert cost.net_cost_pence == pytest.approx(100 * 20.0 + 10 * 50.0 - 40 * 5.0)
+    # net = import×rate + standing − export×SEG (seg_flat mode → SEG, not the 5p manual rate)
+    assert cost.net_cost_pence == pytest.approx(
+        100 * 20.0 + 10 * 50.0 - 40 * monthly.SEG_EXPORT_FALLBACK_PENCE
+    )
 
 
 def test_best_cost_threads_n_days(monkeypatch):
@@ -160,7 +167,7 @@ def test_period_month_past_bills_full_month(monkeypatch):
 # ── _compute_cost_octopus: per-slot Outgoing export billing ──────────────────
 
 def test_octopus_export_billed_per_slot(monkeypatch):
-    """Export revenue must use per-slot Outgoing Agile rates, not a flat rate."""
+    """In outgoing_agile mode, export revenue uses per-slot rates, not a flat rate."""
     from datetime import datetime, UTC
 
     import src.db as db_mod
@@ -170,6 +177,7 @@ def test_octopus_export_billed_per_slot(monkeypatch):
     monkeypatch.setattr(config, "OCTOPUS_API_KEY", "key", raising=False)
     monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE", "E-1R-AGILE-OUTGOING", raising=False)
     monkeypatch.setattr(config, "MANUAL_TARIFF_EXPORT_PENCE", 5.0, raising=False)
+    monkeypatch.setattr(config, "EXPORT_TARIFF_MODE", "outgoing_agile", raising=False)
 
     class _Slot:
         def __init__(self, interval_start, consumption_kwh):
@@ -203,6 +211,53 @@ def test_octopus_export_billed_per_slot(monkeypatch):
     assert cost is not None
     # 1×30 + 1×50 = 80p, NOT 2×5 = 10p flat.
     assert cost.export_earnings_pence == pytest.approx(80.0)
+
+
+def test_octopus_export_billed_flat_seg_by_default(monkeypatch):
+    """Default seg_flat mode values export at the flat SEG rate, ignoring Agile."""
+    from datetime import datetime, UTC
+
+    import src.db as db_mod
+    import src.energy.octopus_client as oc
+    import src.scheduler.agile as agile_mod
+
+    monkeypatch.setattr(config, "OCTOPUS_API_KEY", "key", raising=False)
+    monkeypatch.setattr(config, "OCTOPUS_EXPORT_TARIFF_CODE", "E-1R-AGILE-OUTGOING", raising=False)
+    monkeypatch.setattr(config, "EXPORT_TARIFF_MODE", "seg_flat", raising=False)
+    monkeypatch.setattr(config, "EXPORT_SEG_RATE_PENCE", 4.10, raising=False)
+
+    class _Slot:
+        def __init__(self, interval_start, consumption_kwh):
+            self.interval_start = interval_start
+            self.consumption_kwh = consumption_kwh
+
+    t0 = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    t1 = datetime(2026, 1, 1, 12, 30, tzinfo=UTC)
+
+    monkeypatch.setattr(oc, "get_mpan_roles", lambda *a, **k: oc.MpanRoles(
+        import_mpan="imp", import_serial="is", export_mpan="exp", export_serial="es",
+        gsp="_C", source="test"))
+
+    def _fake_consumption(mpan, serial, pf, pt):
+        if mpan == "imp":
+            return [_Slot(t0, 2.0), _Slot(t1, 2.0)]
+        return [_Slot(t0, 1.0), _Slot(t1, 1.0)]  # 1 kWh export each slot
+    monkeypatch.setattr(oc, "fetch_consumption", _fake_consumption)
+    monkeypatch.setattr(agile_mod, "fetch_agile_rates", lambda **k: [
+        {"valid_from": t0.isoformat(), "value_inc_vat": 10.0},
+        {"valid_from": t1.isoformat(), "value_inc_vat": 10.0},
+    ])
+    # High Agile rates must be IGNORED in seg_flat mode.
+    monkeypatch.setattr(db_mod, "get_agile_export_rates_in_range", lambda a, b: [
+        {"valid_from": t0.isoformat(), "value_inc_vat": 30.0},
+        {"valid_from": t1.isoformat(), "value_inc_vat": 50.0},
+    ])
+
+    e = _energy(2026, 1, import_kwh=4.0, export_kwh=2.0)
+    cost = monthly._compute_cost_octopus(e, n_days=1)
+    assert cost is not None
+    # 2 kWh × 4.10p flat SEG = 8.2p, NOT the 80p per-slot Agile.
+    assert cost.export_earnings_pence == pytest.approx(8.2)
 
 
 # ── tariff_engine usage-days proration ───────────────────────────────────────

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -159,6 +159,7 @@ export function EnergyChartWidget({ execution }: EnergyChartWidgetProps) {
         discharge: period.energy.discharge_kwh,
         importCost: period.cost?.import_cost_pounds ?? 0,
         exportRevenue: period.cost?.export_earnings_pounds ?? 0,
+        standing: (period.cost?.standing_charge_pence ?? 0) / 100,
         netCost: period.cost?.net_cost_pounds ?? 0,
       }
     : null;
@@ -238,7 +239,8 @@ export function EnergyChartWidget({ execution }: EnergyChartWidgetProps) {
           )}
           <span class="echart-foot-grp">
             <strong>Grid £</strong>&nbsp;
-            <span class="echart-tok echart-tok-cost">£{summary.importCost.toFixed(2)} paid</span> −
+            <span class="echart-tok echart-tok-cost">£{summary.importCost.toFixed(2)} paid</span> +
+            <span class="echart-tok echart-tok-cost">£{summary.standing.toFixed(2)} standing</span> −
             <span class="echart-tok echart-tok-rev">£{summary.exportRevenue.toFixed(2)} earned</span> =
             <strong class={summary.netCost >= 0 ? "echart-tok-cost" : "echart-tok-rev"}>
               £{summary.netCost.toFixed(2)} net

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -262,13 +262,19 @@ export function TodayPlanWidget({ pv, loading, execution, cheapThresholdP, peakT
   }, [pv, execution, theme, cheapThresholdP, peakThresholdP]);
 
   const acc = pv?.accuracy;
+  // Forecast for elapsed slots isn't persisted yet (#462), so by evening the
+  // "expected by now" baseline collapses toward 0 — which would make any real
+  // generation read as a huge bogus "above forecast". Detect that and show an
+  // honest "comparison unavailable" instead of a misleading number.
+  const forecastMissing = acc != null && acc.forecast_kwh < 0.1 && acc.actual_kwh >= 0.1;
   // Plain-language accuracy: did solar come in above or below the forecast so
   // far, and by how much. The per-slot detail (miss bar) is in the chart hover.
   const biasWord = acc == null ? "" :
-    Math.abs(acc.bias_kwh) < 0.1 ? "tracking forecast"
+    forecastMissing ? "forecast comparison unavailable"
+    : Math.abs(acc.bias_kwh) < 0.1 ? "tracking forecast"
     : acc.bias_kwh > 0 ? `${acc.bias_kwh.toFixed(1)} kWh above forecast`
     : `${Math.abs(acc.bias_kwh).toFixed(1)} kWh below forecast`;
-  const biasTone = acc == null ? "" : Math.abs(acc.bias_kwh) < 0.1 ? "" : acc.bias_kwh > 0 ? " today-plan-acc--pos" : " today-plan-acc--neg";
+  const biasTone = acc == null || forecastMissing ? "" : Math.abs(acc.bias_kwh) < 0.1 ? "" : acc.bias_kwh > 0 ? " today-plan-acc--pos" : " today-plan-acc--neg";
 
   // Headline day total = solar ALREADY generated (actual, locked) + forecast for
   // the slots still to come. Use actual ONLY for fully-elapsed slots; the current
@@ -296,9 +302,18 @@ export function TodayPlanWidget({ pv, loading, execution, cheapThresholdP, peakT
       )}
       {acc && (
         <div class="today-plan-acc">
-          <span>Solar so far today: <strong>{acc.actual_kwh.toFixed(1)}</strong> kWh vs <strong>{acc.forecast_kwh.toFixed(1)}</strong> expected by now</span>
+          {forecastMissing ? (
+            <span>Solar so far today: <strong>{acc.actual_kwh.toFixed(1)}</strong> kWh generated</span>
+          ) : (
+            <span>Solar so far today: <strong>{acc.actual_kwh.toFixed(1)}</strong> kWh vs <strong>{acc.forecast_kwh.toFixed(1)}</strong> expected by now</span>
+          )}
           <span class="today-plan-acc-sep">·</span>
-          <span class={biasTone.trim()} title="Actual vs the forecast for the slots elapsed so far (not the full-day total in the card header). Hover any slot for its miss.">
+          <span
+            class={biasTone.trim()}
+            title={forecastMissing
+              ? "The forecast for slots earlier today isn't persisted yet (#462), so there's no baseline to compare against this far into the day."
+              : "Actual vs the forecast for the slots elapsed so far (not the full-day total in the card header). Hover any slot for its miss."}
+          >
             {biasWord}
           </span>
         </div>


### PR DESCRIPTION
Closes #468

Three Home-page coherence fixes surfaced by the May-2026 cost audit (#465/#467). All are display/valuation alignment so Home matches the Insights tab and the real Octopus statement.

## 1. Energy Flow "Grid £" equation now balances
Was `£X paid − £Y earned = £Z net` — never balanced because `net` includes the standing charge. Now:
`£X paid + £S standing − £Y earned = £Z net`, pulling `standing_charge_pence` from the period cost.

## 2. monthly.py export → actual tariff (SEG by default)
`_compute_cost_octopus` always priced export at per-slot Outgoing Agile, so Home's export £ diverged 3-5× from the Insights tab. Now honours `EXPORT_TARIFF_MODE`:
- `seg_flat` (default) → `export_kwh × EXPORT_SEG_RATE_PENCE` (the real flat SEG)
- `outgoing_agile` → per-slot Agile (unchanged path)

Mirrors `pnl.export_revenues_for_day`, so Home and Insights agree.

## 3. Today's Plan robust when forecast baseline missing
By evening the elapsed-slot "expected by now" forecast collapses to ~0 (forecast-persistence gap, #462), making real generation read as a bogus "16.4 kWh above forecast". Now shows "forecast comparison unavailable" + an explanatory tooltip when `forecast_kwh ≈ 0` while `actual_kwh > 0`. The persistence fix stays tracked in #462 — this is interim UI mitigation only.

## Tests
- New `test_octopus_export_billed_flat_seg_by_default` (SEG default) + updated `test_octopus_export_billed_per_slot` to opt into `outgoing_agile`.
- `ui` build clean; full backend suite green except the 3 pre-existing #464 failures (confirmed failing on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)