### PR TITLE
fix(insights): period views reuse pnl engine so Home matches Hero + Insights

### DIFF
--- a/src/energy/monthly.py
+++ b/src/energy/monthly.py
@@ -367,6 +367,75 @@ def _period_cost(
     return _compute_cost(energy, n_days=n_days)
 
 
+def _pnl_cost_for_range(
+    start: date, end: date
+) -> tuple[MonthlyCostSummary, float, float] | None:
+    """Realised cost + import/export kWh from the authoritative pnl engine.
+
+    Reuses :func:`analytics.pnl.compute_period_pnl` so the Home period views
+    (Energy Flow foot + headline £) report the SAME realised cost as the Hero
+    and the Insights tab: real-money import (meter-preferring with the Fox
+    sanity guard), flat-SEG export per ``EXPORT_TARIFF_MODE``, negative-price
+    import credits, and the ``AGILE_TARIFF_START_DATE`` clamp. The returned kWh
+    quantities replace the raw Fox import/export so the displayed kWh and £ stay
+    internally consistent — ``paid + standing − earned = net`` balances exactly.
+
+    Returns ``None`` when pnl can't price the range (no Agile data / fully
+    pre-Agile) so the caller falls back to the Fox/Octopus engine. Imported
+    lazily to avoid a circular import (pnl → db → … → monthly is not a cycle,
+    but keep the dependency one-directional and lazy regardless).
+    """
+    try:
+        from ..analytics.pnl import compute_period_pnl
+        p = compute_period_pnl(start, end)
+    except Exception as exc:  # pragma: no cover - defensive
+        # WARNING (not info): a pnl failure silently reverts the endpoint to the
+        # Fox/Octopus engine — the very one that over-states export — so this
+        # must be visible in logs, not buried.
+        logger.warning("pnl period cost unavailable for %s..%s — falling back to Fox engine: %s", start, end, exc)
+        return None
+    if not p or int(p.get("n_days") or 0) == 0:
+        return None
+    import_pence = round(float(p.get("import_cost_gbp") or 0.0) * 100, 2)
+    export_pence = round(float(p.get("export_revenue_gbp") or 0.0) * 100, 2)
+    standing_pence = round(float(p.get("standing_charge_gbp") or 0.0) * 100, 2)
+    # Recompute net from the DISPLAYED parts so the Energy Flow equation
+    # (paid + standing − earned = net) balances exactly on screen. pnl's own
+    # realised_net_cost_gbp is rounded independently of its parts and can differ
+    # by ~1p; both reconcile to the same £ at statement precision.
+    net_pence = round(import_pence + standing_pence - export_pence, 2)
+    # fixed shadow maps to the FIXED_TARIFF_* (e.g. British Gas) counterfactual —
+    # same basis as the Fox _fixed_shadow fallback — present only when configured.
+    bg_shadow = p.get("fixed_tariff_shadow_real_gbp")
+    bg_delta = p.get("delta_vs_fixed_tariff_real_gbp")
+    cost = MonthlyCostSummary(
+        import_cost_pence=import_pence,
+        export_earnings_pence=export_pence,
+        standing_charge_pence=standing_pence,
+        net_cost_pence=net_pence,
+        fixed_shadow_pence=round(float(bg_shadow) * 100, 2) if bg_shadow is not None else None,
+        delta_vs_fixed_pence=round(float(bg_delta) * 100, 2) if bg_delta is not None else None,
+    )
+    return cost, float(p.get("import_kwh") or 0.0), float(p.get("export_kwh") or 0.0)
+
+
+def _apply_pnl_cost(
+    energy: MonthlyEnergySummary, start: date, end: date
+) -> MonthlyCostSummary | None:
+    """Override ``energy``'s import/export kWh from pnl and return the matching
+    realised cost, or ``None`` if pnl can't price the range (caller falls back).
+
+    Mutates ``energy`` only on success so the displayed kWh and the cost come
+    from the same source."""
+    res = _pnl_cost_for_range(start, end)
+    if res is None:
+        return None
+    cost, import_kwh, export_kwh = res
+    energy.import_kwh = round(import_kwh, 2)
+    energy.export_kwh = round(export_kwh, 2)
+    return cost
+
+
 def _get_daikin_heating_kwh(year: int, month: int) -> float | None:
     """Get heating electrical consumption (kWh) for the month from Daikin when available. Returns None if not configured or not exposed.
 
@@ -674,7 +743,11 @@ def get_period_insights(
             charge_kwh=round(charge_kwh, 2),
             discharge_kwh=round(discharge_kwh, 2),
         )
-        cost = MonthlyCostSummary(
+        # Prefer the authoritative pnl engine over the per-month Fox sum so the
+        # year headline matches Hero + Insights (overrides energy import/export
+        # kWh too). Per-month chart_data + heating analytics stay Fox-sourced.
+        year_end = min(date(year, 12, 31), today)
+        cost = _apply_pnl_cost(energy, date(year, 1, 1), year_end) or MonthlyCostSummary(
             import_cost_pence=round(import_cost_pence, 2),
             export_earnings_pence=round(export_earnings_pence, 2),
             standing_charge_pence=round(standing_charge_pence, 2),
@@ -718,7 +791,12 @@ def get_period_insights(
         if (y, m) == (today.year, today.month):
             daily = [r for r in daily if r.get("date", "") <= today.isoformat()]
         n_days = len(daily)
-        cost = _best_cost(energy, n_days=n_days)
+        # Prefer the authoritative pnl engine (matches Hero + Insights tab);
+        # fall back to the Fox/Octopus engine when pnl can't price the range.
+        month_end = date(y, m, monthrange(y, m)[1])
+        if (y, m) == (today.year, today.month):
+            month_end = today
+        cost = _apply_pnl_cost(energy, date(y, m, 1), month_end) or _best_cost(energy, n_days=n_days)
         daikin_heating = _get_daikin_heating_kwh(y, m)
         heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(
             energy, cost, daikin_heating_kwh=daikin_heating
@@ -761,7 +839,8 @@ def get_period_insights(
             )
             day_from = datetime(y, m, d, 0, 0, 0, tzinfo=UTC)
             day_to = datetime(y, m, d, 23, 59, 59, tzinfo=UTC)
-            cost = _period_cost(energy, day_from, day_to, n_days=1)
+            # pnl engine first (matches Hero + Insights); Fox/Octopus fallback.
+            cost = _apply_pnl_cost(energy, dte, dte) or _period_cost(energy, day_from, day_to, n_days=1)
             heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(energy, cost)
             insights = MonthlyInsights(
                 energy=energy,
@@ -811,7 +890,9 @@ def get_period_insights(
         days_count = max(1, len(daily_all))
         week_from = datetime(week_start.year, week_start.month, week_start.day, 0, 0, 0, tzinfo=UTC)
         week_to = datetime(week_end.year, week_end.month, week_end.day, 23, 59, 59, tzinfo=UTC)
-        cost = _period_cost(energy, week_from, week_to, n_days=days_count)
+        # pnl engine first (matches Hero + Insights); Fox/Octopus fallback. The
+        # per-day chart_data bars stay Fox-sourced; only the foot total + £ use pnl.
+        cost = _apply_pnl_cost(energy, week_start, week_end) or _period_cost(energy, week_from, week_to, n_days=days_count)
         heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(energy, cost)
         insights = MonthlyInsights(energy=energy, cost=cost, heating_estimate_kwh=heating_kwh, heating_estimate_cost_pence=heating_cost_pence, equivalent_gas_cost_pence=equiv_gas_pence, gas_comparison_ahead_pounds=ahead_pounds)
         label = f"{week_start.strftime('%d')}–{week_end.strftime('%d %b %Y')}" if week_start.month == week_end.month else f"{week_start.strftime('%d %b')} – {week_end.strftime('%d %b %Y')}"

--- a/tests/test_monthly_cost_proration.py
+++ b/tests/test_monthly_cost_proration.py
@@ -126,6 +126,10 @@ def _patch_client(monkeypatch, client):
     monkeypatch.setattr(monthly, "_client", lambda: client)
     monkeypatch.setattr(monthly, "_get_daikin_heating_kwh", lambda *a, **k: None)
     monkeypatch.setattr(monthly, "_build_heating_analytics", lambda *a, **k: None)
+    # These tests cover the Fox/Octopus engine proration + chart_data trimming,
+    # which is now the FALLBACK. Force it by making the pnl engine decline, so
+    # they stay deterministic and independent of the SQLite pnl path.
+    monkeypatch.setattr(monthly, "_pnl_cost_for_range", lambda *a, **k: None)
 
 
 def test_period_month_current_prorates_standing(monkeypatch):
@@ -162,6 +166,84 @@ def test_period_month_past_bills_full_month(monkeypatch):
     _patch_client(monkeypatch, _FakeClient(days_with_data=ndays))
     out = monthly.get_period_insights("month", month_str=f"{py:04d}-{pm:02d}")
     assert out.insights.cost.standing_charge_pence == pytest.approx(ndays * 50.0)
+
+
+def test_pnl_cost_for_range_maps_real_money_fields(monkeypatch):
+    """_pnl_cost_for_range maps compute_period_pnl's real-money axis correctly:
+    import_cost_gbp, export_revenue_gbp, standing_charge_gbp, realised_net_cost_gbp,
+    and the FIXED_TARIFF_* shadow → pence on MonthlyCostSummary."""
+    import src.analytics.pnl as pnl_mod
+    fake = {
+        "n_days": 31,
+        "import_cost_gbp": 50.91,
+        "export_revenue_gbp": 2.26,
+        "standing_charge_gbp": 18.37,
+        "realised_net_cost_gbp": 67.02,
+        "import_kwh": 314.1,
+        "export_kwh": 55.2,
+        "fixed_tariff_shadow_real_gbp": 75.0,
+        "delta_vs_fixed_tariff_real_gbp": 7.98,
+    }
+    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e: fake)
+    res = monthly._pnl_cost_for_range(date(2026, 5, 1), date(2026, 5, 31))
+    assert res is not None
+    cost, imp, exp = res
+    assert cost.import_cost_pence == pytest.approx(5091.0)
+    assert cost.export_earnings_pence == pytest.approx(226.0)
+    assert cost.standing_charge_pence == pytest.approx(1837.0)
+    assert cost.net_cost_pence == pytest.approx(6702.0)
+    assert cost.fixed_shadow_pence == pytest.approx(7500.0)
+    assert cost.delta_vs_fixed_pence == pytest.approx(798.0)
+    assert (imp, exp) == pytest.approx((314.1, 55.2))
+
+
+def test_pnl_cost_for_range_returns_none_when_unpriced(monkeypatch):
+    """Empty/pre-Agile range (n_days == 0) → None so the caller falls back."""
+    import src.analytics.pnl as pnl_mod
+    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e: {"n_days": 0})
+    assert monthly._pnl_cost_for_range(date(2026, 1, 1), date(2026, 1, 31)) is None
+
+
+def test_pnl_cost_for_range_no_fixed_shadow(monkeypatch):
+    """When FIXED_TARIFF_* isn't configured, pnl omits the bg keys → None shadow."""
+    import src.analytics.pnl as pnl_mod
+    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e: {
+        "n_days": 7, "import_cost_gbp": 10.0, "export_revenue_gbp": 1.0,
+        "standing_charge_gbp": 4.0, "realised_net_cost_gbp": 13.0,
+        "import_kwh": 60.0, "export_kwh": 24.0,
+    })
+    res = monthly._pnl_cost_for_range(date(2026, 5, 1), date(2026, 5, 7))
+    assert res is not None
+    cost, _, _ = res
+    assert cost.fixed_shadow_pence is None
+    assert cost.delta_vs_fixed_pence is None
+
+
+def test_period_month_prefers_pnl_and_overrides_kwh(monkeypatch):
+    """When the pnl engine prices the range, get_period_insights uses ITS cost
+    and import/export kWh (so Home matches Hero + Insights), not the Fox sum."""
+    today = date.today()
+    _patch_client(monkeypatch, _FakeClient(days_with_data=today.day))
+    # Fox would report import=3×days, export=1×days. pnl says otherwise.
+    pnl_cost = monthly.MonthlyCostSummary(
+        import_cost_pence=5000.0, export_earnings_pence=226.0,
+        standing_charge_pence=1837.0, net_cost_pence=6611.0,
+        fixed_shadow_pence=7000.0, delta_vs_fixed_pence=389.0,
+    )
+    monkeypatch.setattr(
+        monthly, "_pnl_cost_for_range",
+        lambda start, end: (pnl_cost, 314.1, 55.2),
+    )
+    out = monthly.get_period_insights("month", month_str=today.strftime("%Y-%m"))
+    # Cost comes from pnl…
+    assert out.insights.cost.net_cost_pence == pytest.approx(6611.0)
+    assert out.insights.cost.export_earnings_pence == pytest.approx(226.0)
+    # …and so do the displayed import/export kWh (overridden from Fox).
+    assert out.insights.energy.import_kwh == pytest.approx(314.1)
+    assert out.insights.energy.export_kwh == pytest.approx(55.2)
+    # Equation balances: paid + standing − earned == net.
+    c = out.insights.cost
+    assert c.import_cost_pence + c.standing_charge_pence - c.export_earnings_pence == pytest.approx(c.net_cost_pence)
 
 
 # ── _compute_cost_octopus: per-slot Outgoing export billing ──────────────────


### PR DESCRIPTION
Completes the export-£ coherence work from #468 (whose UI/rate half shipped in #469). Follow-up limitation tracked in #470.

## Problem
The Home **Energy Flow** / period-insights endpoint (`/api/v1/energy/period`) used a *separate* Fox/Octopus cost engine from the Hero + Insights tab. Verified live on prod for May 2026:

| | export kWh | export £ | net £ |
|---|---|---|---|
| Insights (pnl/fair-compare) | 55.2 | £2.26 | ~£69.8 |
| Home Energy Flow (old) | 84.0 | £3.44 | £86.96 |
| **Octopus statement** | 56.5 | £2.32 | £70.43 |

## Fix
`get_period_insights` (day/week/month/year) now prefers `analytics.pnl.compute_period_pnl` — the authoritative engine with meter-preferring import (Fox sanity guard), flat-SEG export per `EXPORT_TARIFF_MODE`, negative-price credits, and the `AGILE_TARIFF_START_DATE` clamp. Two helpers:
- `_pnl_cost_for_range(start, end)` → maps the real-money axis (`import_cost_gbp`, `export_revenue_gbp`, `standing_charge_gbp`, `fixed_tariff_shadow_real_gbp`) into `MonthlyCostSummary`.
- `_apply_pnl_cost(energy, start, end)` → also overrides the displayed import/export **kWh** so kWh and £ stay internally consistent.

Falls back to the Fox engine when pnl can't price the range (pre-Agile / no data).

## Review fixes (independent Plan-agent pass)
- **Net recomputed from displayed parts** so `paid + standing − earned = net` balances exactly on screen (pnl's `realised_net_cost_gbp` is independently rounded, ~1p drift).
- **pnl failure logs at WARNING** — a silent revert to the over-stating Fox engine must be visible.
- Confirmed the `fixed_shadow` basis matches across the fallback boundary (both use `FIXED_TARIFF_*`).

## Known limitation (#470)
Per-day chart **bars** stay Fox telemetry, so they can diverge from the pnl **foot total** in kWh; the AGILE clamp affects the April-2026 standing-per-bar invariant only. Headline audited numbers are correct.

## Tests
- New: `_pnl_cost_for_range` field-mapping, None-on-unpriced, no-fixed-shadow, and `get_period_insights` prefers-pnl + kWh-override + equation-balances.
- Existing Fox-engine proration tests pinned to the fallback (`_pnl_cost_for_range → None`).
- Full backend suite green except the 3 pre-existing #464 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)