### PR TITLE
feat(home): forecast baseline (#462), chart bars from pnl (#470), Today's Plan legend

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -148,19 +148,20 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
     except Exception as e:
         logger.warning("pv/today: dispatch kinds failed (%s)", e)
 
-    # Committed-plan PV: the frozen per-slot PV-generation forecast the LP last
-    # solved against (lp_solution_snapshot.pv_forecast_kwh). Distinct from the
-    # live forecast above — it only moves when the LP re-solves. slot_time_utc
-    # is stored in +00:00 form, so normalise to the ...Z key via _norm_z.
+    # Committed-plan PV: the per-slot PV-generation forecast the LP committed to,
+    # STITCHED across every solve of the day (#462). A single snapshot only
+    # covers run_at→horizon, so by evening the morning slots would be missing —
+    # the stitch back-fills each elapsed slot with the forecast that was current
+    # when it began, and resolves future slots to the latest plan. This is what
+    # gives the accuracy block a real "expected by now" baseline (the live
+    # forecast above is forward-only → 0 for elapsed slots). slot_time_utc is
+    # stored in +00:00 form, so normalise to the ...Z key via _norm_z.
     planned_by: dict[str, float] = {}
     plan_committed_at: str | None = None
     try:
+        for stu, pf in db.committed_pv_forecast_by_slot(d).items():
+            planned_by[_norm_z(stu)] = float(pf)
         if rid is not None:
-            for row in db.get_lp_solution_slots(rid):
-                pf = row.get("pv_forecast_kwh")
-                stu = row.get("slot_time_utc")
-                if pf is not None and stu:
-                    planned_by[_norm_z(stu)] = float(pf)
             inp = db.get_lp_inputs(rid)
             if inp and inp.get("run_at_utc"):
                 plan_committed_at = _norm_z(inp["run_at_utc"])
@@ -192,10 +193,18 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
             "kind": kind_by.get(key),
         })
         if elapsed and a is not None:
+            # Compare against the COMMITTED plan (frozen at solve time, stitched
+            # so elapsed slots have a real value). The live forecast `f` is
+            # forward-only → 0 for elapsed slots, which is why "expected by now"
+            # used to collapse to 0 by evening (#462). Fall back to `f` only if a
+            # slot has no committed forecast at all.
+            base = planned_by.get(key)
+            if base is None:
+                base = f
             compared += 1
-            acc_f += f
+            acc_f += base
             acc_a += a
-            acc_abs += abs(a - f)
+            acc_abs += abs(a - base)
 
     accuracy: dict[str, Any] | None = None
     if compared > 0:

--- a/src/db.py
+++ b/src/db.py
@@ -1031,6 +1031,26 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_forecast_skill_log_date ON forecast_skill_log(date_utc)"
     )
+    # Per-slot PV forecast error log (issue #462). Persists, for each half-hour
+    # slot, the COMMITTED PV-generation forecast (stitched across LP solves — the
+    # forecast as known when the slot began) vs the realised actual, so model
+    # improvement has a slot-level history and the /pv/today accuracy block has a
+    # real baseline for already-elapsed slots. Distinct from forecast_skill_log
+    # (which is hourly and sourced from raw meteo snapshots, not the committed LP
+    # plan). One row per slot; rebuilt nightly, idempotent on slot_time_utc.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS pv_error_log (
+            slot_time_utc   TEXT PRIMARY KEY,
+            run_id          INTEGER,
+            forecast_kwh    REAL,
+            actual_kwh      REAL,
+            error_kwh       REAL,
+            built_at_utc    TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_pv_error_log_slot ON pv_error_log(slot_time_utc)"
+    )
     # Older DBs predate the Daikin LWT calibration table — idempotent CREATE.
     conn.execute(
         """CREATE TABLE IF NOT EXISTS daikin_lwt_kw_calibration (
@@ -4139,6 +4159,144 @@ def get_lp_solution_slots(run_id: int) -> list[dict[str, Any]]:
             conn.close()
 
 
+def _parse_iso_utc(s: str | None) -> datetime | None:
+    """Parse an ISO timestamp (``...Z`` or ``+00:00``) to an aware UTC datetime."""
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def committed_pv_forecast_by_slot(day: date) -> dict[str, float]:
+    """Per-slot committed PV-generation forecast for ``day`` (issue #462).
+
+    The latest LP solve only covers ``run_at → horizon``, so a single snapshot
+    leaves a hole over the morning by evening (why /pv/today showed "0 expected
+    by now"). This STITCHES across every solve of the day: for each slot it
+    returns the ``pv_forecast_kwh`` from the most recent solve whose ``run_at <=
+    slot_start`` (the forecast as known when the slot began); if none qualifies
+    (e.g. the day's first solve fired after that slot), it falls back to the
+    EARLIEST solve that forecast the slot. Future slots naturally resolve to the
+    latest committed plan (their start is after every run_at).
+
+    Returns ``{slot_time_utc (stored form): pv_forecast_kwh}``. Empty on error.
+    """
+    day_start = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    day_end = day_start + timedelta(days=1)
+    with _lock:
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                """SELECT s.slot_time_utc, s.pv_forecast_kwh, o.run_at
+                   FROM lp_solution_snapshot s
+                   JOIN optimizer_log o ON s.run_id = o.id
+                   WHERE s.slot_time_utc >= ? AND s.slot_time_utc < ?
+                     AND s.pv_forecast_kwh IS NOT NULL""",
+                (day_start.isoformat(), day_end.isoformat()),
+            ).fetchall()
+        except sqlite3.Error as e:
+            logger.warning("committed_pv_forecast_by_slot query failed: %s", e)
+            return {}
+        finally:
+            conn.close()
+
+    # Per slot, pick: latest eligible run (run_at <= slot_start); else earliest.
+    best: dict[str, tuple[datetime, float, bool]] = {}
+    for slot_iso, kwh, run_at in rows:
+        slot_dt = _parse_iso_utc(slot_iso)
+        run_dt = _parse_iso_utc(run_at)
+        if slot_dt is None or run_dt is None:
+            continue
+        eligible = run_dt <= slot_dt
+        cur = best.get(slot_iso)
+        if cur is None:
+            best[slot_iso] = (run_dt, float(kwh), eligible)
+            continue
+        c_run, _c_kwh, c_elig = cur
+        if eligible and not c_elig:
+            best[slot_iso] = (run_dt, float(kwh), True)  # eligible beats not
+        elif eligible and c_elig:
+            if run_dt > c_run:  # most recent forecast known at slot start
+                best[slot_iso] = (run_dt, float(kwh), True)
+        elif (not eligible) and (not c_elig):
+            if run_dt < c_run:  # earliest forecast ever made for the slot
+                best[slot_iso] = (run_dt, float(kwh), False)
+        # else: keep the existing eligible row over a non-eligible newcomer
+    return {k: v[1] for k, v in best.items()}
+
+
+def rebuild_pv_error_log_for_date(day: date) -> int:
+    """Persist per-slot committed-forecast-vs-actual rows for ``day`` (#462).
+
+    Joins the stitched committed forecast (:func:`committed_pv_forecast_by_slot`)
+    with the realised half-hour solar roll-up. One row per slot that has a
+    forecast and/or an actual; idempotent on ``slot_time_utc``. Returns rows
+    written. Best-effort: callers (the nightly cron) swallow exceptions.
+    """
+    forecast = committed_pv_forecast_by_slot(day)
+    try:
+        actual = half_hourly_solar_kwh_for_day(day)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("rebuild_pv_error_log: actual roll-up failed for %s: %s", day, e)
+        actual = {}
+    # actual_map keys are Z-form; forecast keys are stored (+00:00) form. Index
+    # both by a canonical Z key so they line up.
+    def _z(s: str) -> str:
+        dt = _parse_iso_utc(s)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ") if dt else s
+    f_by_z = {_z(k): v for k, v in forecast.items()}
+    a_by_z = {_z(k): v for k, v in actual.items()}
+    built_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    written = 0
+    with _lock:
+        conn = get_connection()
+        try:
+            for slot_z in sorted(set(f_by_z) | set(a_by_z)):
+                f = f_by_z.get(slot_z)
+                a = a_by_z.get(slot_z)
+                err = (a - f) if (a is not None and f is not None) else None
+                conn.execute(
+                    """INSERT INTO pv_error_log
+                         (slot_time_utc, run_id, forecast_kwh, actual_kwh, error_kwh, built_at_utc)
+                       VALUES (?, NULL, ?, ?, ?, ?)
+                       ON CONFLICT(slot_time_utc) DO UPDATE SET
+                         forecast_kwh=excluded.forecast_kwh,
+                         actual_kwh=excluded.actual_kwh,
+                         error_kwh=excluded.error_kwh,
+                         built_at_utc=excluded.built_at_utc""",
+                    (slot_z, f, a, err, built_at),
+                )
+                written += 1
+            conn.commit()
+        except sqlite3.Error as e:
+            logger.warning("rebuild_pv_error_log write failed for %s: %s", day, e)
+        finally:
+            conn.close()
+    return written
+
+
+def get_pv_error_log_for_date(day: date) -> list[dict[str, Any]]:
+    """Return persisted per-slot forecast/actual/error rows for ``day`` (#462)."""
+    day_start = datetime(day.year, day.month, day.day, tzinfo=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    day_end = (datetime(day.year, day.month, day.day, tzinfo=UTC) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT slot_time_utc, forecast_kwh, actual_kwh, error_kwh, built_at_utc
+                   FROM pv_error_log
+                   WHERE slot_time_utc >= ? AND slot_time_utc < ?
+                   ORDER BY slot_time_utc""",
+                (day_start, day_end),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
 def get_lp_inputs(run_id: int) -> dict[str, Any] | None:
     """Return the inputs row for a run_id, or None if absent."""
     with _lock:
@@ -4875,6 +5033,7 @@ def prune_history_tables() -> dict[str, int]:
         ("daikin_telemetry", "fetched_at", _config.DAIKIN_TELEMETRY_RETENTION_DAYS, True),
         ("meteo_forecast_history", "forecast_fetch_at_utc", _config.METEO_FORECAST_HISTORY_RETENTION_DAYS, False),
         ("forecast_skill_log", "built_at_utc", _config.METEO_FORECAST_HISTORY_RETENTION_DAYS, False),
+        ("pv_error_log", "slot_time_utc", _config.METEO_FORECAST_HISTORY_RETENTION_DAYS, False),
         ("lp_solution_snapshot", "slot_time_utc", _config.LP_SNAPSHOT_RETENTION_DAYS, False),
         ("lp_inputs_snapshot", "run_at_utc", _config.LP_SNAPSHOT_RETENTION_DAYS, False),
         ("config_audit", "changed_at_utc", _config.CONFIG_AUDIT_RETENTION_DAYS, False),

--- a/src/energy/monthly.py
+++ b/src/energy/monthly.py
@@ -419,6 +419,26 @@ def _pnl_cost_for_range(
     return cost, float(p.get("import_kwh") or 0.0), float(p.get("export_kwh") or 0.0)
 
 
+def _overlay_pnl_daily_kwh(chart_rows: list[dict]) -> None:
+    """Replace each chart row's import/export kWh with the pnl per-day values so
+    the stacked bars sum to the pnl FOOT total (#470). Without this the bars stay
+    Fox telemetry (which over-counts export) and don't add up to the foot. Only
+    import/export are touched — solar/load/charge/discharge stay Fox. In-place,
+    best-effort per row; a row that can't be priced keeps its Fox value.
+
+    ``chart_rows`` must be per-DAY rows (``date`` = ``YYYY-MM-DD``) — never call
+    on the year view's per-month rows."""
+    from ..analytics.pnl import compute_daily_pnl
+    for row in chart_rows:
+        try:
+            d = date.fromisoformat(str(row.get("date"))[:10])
+            p = compute_daily_pnl(d)
+            row["import_kwh"] = round(float(p.get("import_kwh") or 0.0), 2)
+            row["export_kwh"] = round(float(p.get("export_kwh") or 0.0), 2)
+        except Exception:  # pragma: no cover - defensive; keep Fox value
+            continue
+
+
 def _apply_pnl_cost(
     energy: MonthlyEnergySummary, start: date, end: date
 ) -> MonthlyCostSummary | None:
@@ -796,7 +816,10 @@ def get_period_insights(
         month_end = date(y, m, monthrange(y, m)[1])
         if (y, m) == (today.year, today.month):
             month_end = today
-        cost = _apply_pnl_cost(energy, date(y, m, 1), month_end) or _best_cost(energy, n_days=n_days)
+        pnl_cost = _apply_pnl_cost(energy, date(y, m, 1), month_end)
+        cost = pnl_cost or _best_cost(energy, n_days=n_days)
+        if pnl_cost is not None:
+            _overlay_pnl_daily_kwh(daily)  # bars sum to the pnl foot (#470)
         daikin_heating = _get_daikin_heating_kwh(y, m)
         heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(
             energy, cost, daikin_heating_kwh=daikin_heating
@@ -890,9 +913,11 @@ def get_period_insights(
         days_count = max(1, len(daily_all))
         week_from = datetime(week_start.year, week_start.month, week_start.day, 0, 0, 0, tzinfo=UTC)
         week_to = datetime(week_end.year, week_end.month, week_end.day, 23, 59, 59, tzinfo=UTC)
-        # pnl engine first (matches Hero + Insights); Fox/Octopus fallback. The
-        # per-day chart_data bars stay Fox-sourced; only the foot total + £ use pnl.
-        cost = _apply_pnl_cost(energy, week_start, week_end) or _period_cost(energy, week_from, week_to, n_days=days_count)
+        # pnl engine first (matches Hero + Insights); Fox/Octopus fallback.
+        pnl_cost = _apply_pnl_cost(energy, week_start, week_end)
+        cost = pnl_cost or _period_cost(energy, week_from, week_to, n_days=days_count)
+        if pnl_cost is not None:
+            _overlay_pnl_daily_kwh(daily_all)  # bars sum to the pnl foot (#470)
         heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(energy, cost)
         insights = MonthlyInsights(energy=energy, cost=cost, heating_estimate_kwh=heating_kwh, heating_estimate_cost_pence=heating_cost_pence, equivalent_gas_cost_pence=equiv_gas_pence, gas_comparison_ahead_pounds=ahead_pounds)
         label = f"{week_start.strftime('%d')}–{week_end.strftime('%d %b %Y')}" if week_start.month == week_end.month else f"{week_start.strftime('%d %b')} – {week_end.strftime('%d %b %Y')}"

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -710,6 +710,20 @@ def bulletproof_forecast_skill_log_job() -> None:
         logger.warning("forecast_skill_log rebuild failed (non-fatal): %s", e)
 
 
+def bulletproof_pv_error_log_job() -> None:
+    """Persist yesterday's per-slot committed-forecast-vs-actual PV rows (#462).
+
+    Runs nightly after the Fox/PV roll-ups so the prior UTC day has its fullest
+    actuals. Best-effort only — a failure must not disturb the scheduler.
+    """
+    target_day = datetime.now(UTC).date() - timedelta(days=1)
+    try:
+        rows = db.rebuild_pv_error_log_for_date(target_day)
+        logger.info("pv_error_log rebuild: date_utc=%s rows=%d", target_day.isoformat(), rows)
+    except Exception as e:
+        logger.warning("pv_error_log rebuild failed (non-fatal): %s", e)
+
+
 def bulletproof_pv_calibration_refresh_job() -> None:
     """Recompute the per-hour and per-(hour, cloud-bucket) PV calibration
     tables from fresh ``pv_realtime_history`` and ``meteo_forecast_value``
@@ -1838,6 +1852,15 @@ def start_background_scheduler() -> None:
                 id="bulletproof_forecast_skill_log",
             )
             logger.info("Forecast skill rebuild cron scheduled (04:15 UTC daily)")
+            # Per-slot PV forecast-error log (#462). 04:20 UTC — after the skill
+            # rebuild (04:15) and the Fox/PV roll-ups (02:30), before PV
+            # calibration refresh (04:30) so it has the prior day's full actuals.
+            _background_scheduler.add_job(
+                bulletproof_pv_error_log_job,
+                CronTrigger(hour=4, minute=20, timezone=ZoneInfo("UTC")),
+                id="bulletproof_pv_error_log",
+            )
+            logger.info("PV error-log rebuild cron scheduled (04:20 UTC daily)")
             # PV calibration refresh — keeps pv_calibration_hourly +
             # pv_calibration_hourly_cloud current. Runs at 04:30 UTC, after
             # skill-log rebuild (04:15) and Fox/Daikin rollups (02:30 / 02:35)

--- a/tests/test_db_retention.py
+++ b/tests/test_db_retention.py
@@ -141,6 +141,8 @@ def test_prune_history_tables_returns_per_table_counts():
         "meteo_forecast_value",
         "meteo_forecast_history",
         "forecast_skill_log",
+        # Per-slot PV forecast-error log (#462) rides on the meteo retention.
+        "pv_error_log",
         "lp_solution_snapshot",
         "lp_inputs_snapshot",
         "config_audit",

--- a/tests/test_monthly_cost_proration.py
+++ b/tests/test_monthly_cost_proration.py
@@ -219,6 +219,27 @@ def test_pnl_cost_for_range_no_fixed_shadow(monkeypatch):
     assert cost.delta_vs_fixed_pence is None
 
 
+def test_period_month_overlays_chart_bars_from_pnl(monkeypatch):
+    """#470: when pnl prices the month, the per-day chart bars' import/export are
+    overlaid from pnl per-day so they sum to the foot; solar/load stay Fox."""
+    today = date.today()
+    _patch_client(monkeypatch, _FakeClient(days_with_data=today.day))  # sets _pnl→None
+    pnl_cost = monthly.MonthlyCostSummary(
+        import_cost_pence=100.0, export_earnings_pence=10.0,
+        standing_charge_pence=50.0, net_cost_pence=140.0,
+    )
+    # Re-enable pnl (overriding _patch_client's None) + stub per-day pnl.
+    monkeypatch.setattr(monthly, "_pnl_cost_for_range", lambda s, e: (pnl_cost, 7.0, 3.0))
+    import src.analytics.pnl as pnl_mod
+    monkeypatch.setattr(pnl_mod, "compute_daily_pnl", lambda d: {"import_kwh": 9.9, "export_kwh": 4.4})
+    out = monthly.get_period_insights("month", month_str=today.strftime("%Y-%m"))
+    assert out.chart_data, "expected chart rows"
+    assert all(r["import_kwh"] == pytest.approx(9.9) for r in out.chart_data)
+    assert all(r["export_kwh"] == pytest.approx(4.4) for r in out.chart_data)
+    # Fox-only series untouched.
+    assert all(r["solar_kwh"] == pytest.approx(0.0) for r in out.chart_data)
+
+
 def test_period_month_prefers_pnl_and_overrides_kwh(monkeypatch):
     """When the pnl engine prices the range, get_period_insights uses ITS cost
     and import/export kWh (so Home matches Hero + Insights), not the Fox sum."""

--- a/tests/test_pv_error_log.py
+++ b/tests/test_pv_error_log.py
@@ -1,0 +1,139 @@
+"""Per-slot committed PV forecast stitch + pv_error_log persistence (#462)."""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src import db
+from src.api.routers import pv as pv_router
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db.config, "DB_PATH", str(db_path))
+    db.init_db()
+    import src.weather as weather
+    monkeypatch.setattr(weather, "fetch_forecast", lambda hours=48: [])
+    yield db_path
+
+
+def _seed_run(run_at: datetime, slots: list[tuple[datetime, float]]) -> int:
+    """Insert an optimizer_log run + its lp_solution_snapshot PV forecasts.
+
+    slot_time_utc is stored in the +00:00 form the optimizer uses
+    (``slot_start.isoformat()``)."""
+    with db._lock:
+        conn = db.get_connection()
+        try:
+            cur = conn.execute(
+                "INSERT INTO optimizer_log (run_at) VALUES (?)",
+                (run_at.isoformat().replace("+00:00", "Z"),),
+            )
+            run_id = int(cur.lastrowid)
+            for i, (slot_dt, kwh) in enumerate(slots):
+                conn.execute(
+                    """INSERT INTO lp_solution_snapshot
+                         (run_id, slot_index, slot_time_utc, pv_forecast_kwh)
+                       VALUES (?, ?, ?, ?)""",
+                    (run_id, i, slot_dt.isoformat(), kwh),
+                )
+            conn.commit()
+            return run_id
+        finally:
+            conn.close()
+
+
+def _day_slots(day, kwh: float, start_hour=0, end_hour=24):
+    out = []
+    base = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    for i in range(start_hour * 2, end_hour * 2):
+        out.append((base + timedelta(minutes=30 * i), kwh))
+    return out
+
+
+def test_stitch_picks_latest_eligible_run_per_slot():
+    day = (datetime.now(UTC) - timedelta(days=2)).date()
+    base = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    # Early run at 00:05 forecasts the WHOLE day at 1.0.
+    _seed_run(base + timedelta(minutes=5), _day_slots(day, 1.0))
+    # Midday re-solve at 12:00 forecasts 12:00→ at 2.0.
+    _seed_run(base + timedelta(hours=12), _day_slots(day, 2.0, start_hour=12))
+
+    got = db.committed_pv_forecast_by_slot(day)
+    # A 06:00 slot: only the early run is eligible (12:00 run_at > 06:00) → 1.0.
+    k0600 = (base + timedelta(hours=6)).isoformat()
+    assert got[k0600] == pytest.approx(1.0)
+    # A 13:00 slot: both runs eligible; most recent (12:00) wins → 2.0.
+    k1300 = (base + timedelta(hours=13)).isoformat()
+    assert got[k1300] == pytest.approx(2.0)
+
+
+def test_stitch_falls_back_to_earliest_when_none_eligible():
+    day = (datetime.now(UTC) - timedelta(days=2)).date()
+    base = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    # Only run fired at 06:00, but it (re)forecast the 00:00 slot too. No run has
+    # run_at <= 00:00, so the earliest (only) run is the fallback for that slot.
+    _seed_run(base + timedelta(hours=6), _day_slots(day, 1.5))
+    got = db.committed_pv_forecast_by_slot(day)
+    k0000 = base.isoformat()
+    assert got[k0000] == pytest.approx(1.5)
+
+
+def test_rebuild_pv_error_log_joins_forecast_and_actual():
+    day = (datetime.now(UTC) - timedelta(days=2)).date()
+    base = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    _seed_run(base + timedelta(minutes=5), _day_slots(day, 1.0))
+    # Seed ~2 kWh actual across the 10:00 hour (two 30-min slots).
+    for m in (0, 15, 30, 45, 60):
+        ts = base + timedelta(hours=10, minutes=m)
+        db.save_pv_realtime_sample(ts.isoformat().replace("+00:00", "Z"), solar_power_kw=2.0, source="test")
+
+    written = db.rebuild_pv_error_log_for_date(day)
+    assert written > 0
+    rows = {r["slot_time_utc"]: r for r in db.get_pv_error_log_for_date(day)}
+    k1000 = (base + timedelta(hours=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert k1000 in rows
+    r = rows[k1000]
+    assert r["forecast_kwh"] == pytest.approx(1.0)
+    assert r["actual_kwh"] is not None and r["actual_kwh"] > 0
+    # error = actual − forecast
+    assert r["error_kwh"] == pytest.approx(r["actual_kwh"] - 1.0)
+
+
+def test_rebuild_is_idempotent():
+    day = (datetime.now(UTC) - timedelta(days=2)).date()
+    base = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    _seed_run(base + timedelta(minutes=5), _day_slots(day, 1.0))
+    n1 = db.rebuild_pv_error_log_for_date(day)
+    n2 = db.rebuild_pv_error_log_for_date(day)
+    assert n1 == n2
+    # No duplicate rows (PRIMARY KEY on slot_time_utc).
+    rows = db.get_pv_error_log_for_date(day)
+    keys = [r["slot_time_utc"] for r in rows]
+    assert len(keys) == len(set(keys))
+
+
+def test_pv_today_accuracy_uses_committed_plan_for_elapsed_slots():
+    """The accuracy baseline must come from the committed plan, not the
+    forward-only live forecast (which is 0 for elapsed slots)."""
+    day = (datetime.now(UTC) - timedelta(days=1)).date()  # fully elapsed
+    base = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    # Committed plan forecasts every slot at 0.5 kWh.
+    _seed_run(base + timedelta(minutes=5), _day_slots(day, 0.5))
+    # Realised ~3 kWh across the 10:00 hour.
+    for m in (0, 15, 30, 45, 60):
+        ts = base + timedelta(hours=10, minutes=m)
+        db.save_pv_realtime_sample(ts.isoformat().replace("+00:00", "Z"), solar_power_kw=3.0, source="test")
+
+    resp = asyncio.run(pv_router.get_pv_today(date=day.isoformat()))
+    acc = resp["accuracy"]
+    assert acc is not None
+    # Forecast baseline is NON-zero now (committed plan), unlike the old behaviour.
+    assert acc["forecast_kwh"] > 0
+    # Two elapsed 10:00 slots compared at 0.5 each → ~1.0 forecast baseline.
+    assert acc["forecast_kwh"] == pytest.approx(1.0, abs=1e-6)
+    # And the committed-plan line is populated per slot.
+    assert any(s["pv_planned_kwh"] == pytest.approx(0.5) for s in resp["slots"])

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -320,11 +320,20 @@ export function TodayPlanWidget({ pv, loading, execution, cheapThresholdP, peakT
       )}
       <div ref={ref} style={{ width: "100%", height: "320px" }} />
       {pv?.slots?.length ? (
-        <p class="today-plan-note muted">
-          Bold line = actual solar; dotted = the plan (committed behind ◉ now,
-          live forecast ahead). Background shades the tariff tier — blue = paid
-          (negative), green = cheap, amber = peak. Hover a slot for its detail.
-        </p>
+        <div class="today-plan-legend" role="note" aria-label="Chart legend">
+          <span class="tpl-grp">
+            <strong>Solar</strong>
+            <span class="tpl-tok"><span class="tpl-line tpl-line--actual" aria-hidden="true" /> actual</span>
+            <span class="tpl-tok"><span class="tpl-line tpl-line--plan" aria-hidden="true" /> plan</span>
+          </span>
+          <span class="tpl-grp">
+            <strong>Tariff</strong>
+            <span class="tpl-tok"><span class="tpl-sw tpl-sw--neg" aria-hidden="true" /> paid</span>
+            <span class="tpl-tok"><span class="tpl-sw tpl-sw--cheap" aria-hidden="true" /> cheap</span>
+            <span class="tpl-tok"><span class="tpl-sw tpl-sw--peak" aria-hidden="true" /> peak</span>
+          </span>
+          <span class="tpl-hint">◉ now · hover a slot for detail</span>
+        </div>
       ) : null}
       {!pv?.slots?.length && !loading && <p class="muted">No plan data for today yet.</p>}
     </div>

--- a/ui/src/components/home/today-plan.css
+++ b/ui/src/components/home/today-plan.css
@@ -50,3 +50,45 @@
 }
 .today-plan-acc--pos { color: var(--ok); font-weight: 600; }
 .today-plan-acc--neg { color: var(--warn); font-weight: 600; }
+
+/* Chart legend — mirrors the Energy Flow foot legend (.echart-foot): a row of
+   labelled groups with colour swatches, replacing the old prose caption. */
+.today-plan-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-4);
+  font-size: var(--font-2xs);
+  color: var(--text-dim);
+  padding-top: var(--space-2);
+  border-top: 1px dashed color-mix(in srgb, var(--border) 55%, transparent);
+}
+.tpl-grp { display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.tpl-grp strong {
+  color: var(--text-mute);
+  font-weight: 700;
+  font-size: var(--font-2xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.tpl-tok { display: inline-flex; align-items: center; gap: 4px; font-weight: 600; }
+/* Line glyphs: solid bold = realised actual, dotted = the plan/forecast. */
+.tpl-line { display: inline-block; width: 16px; height: 0; }
+.tpl-line--actual { border-top: 2.5px solid var(--pv); }
+.tpl-line--plan { border-bottom: 1.5px dotted var(--pv); }
+/* Tier swatches: match the chart's markArea fills (neg has a visible border;
+   cheap/peak are soft washes). */
+.tpl-sw { display: inline-block; width: 11px; height: 11px; border-radius: 2px; }
+.tpl-sw--neg {
+  background: color-mix(in srgb, var(--neg-price) 26%, transparent);
+  border: 1px solid var(--neg-price);
+}
+.tpl-sw--cheap {
+  background: color-mix(in srgb, var(--cheap) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cheap) 55%, transparent);
+}
+.tpl-sw--peak {
+  background: color-mix(in srgb, var(--peak) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--peak) 55%, transparent);
+}
+.tpl-hint { color: var(--text-mute); font-weight: 500; margin-left: auto; }


### PR DESCRIPTION
The two remaining Home follow-ups + the Today's Plan legend, in one change (touches UI + backend, so a single deploy rebuilds both images).

## #462 — "expected by now" gets a real baseline
The Today's Plan accuracy block compared actuals against the **forward-only live forecast** (0 for elapsed slots), so by evening it collapsed to "0.0 expected by now" and real generation read as a bogus surplus. PR #469 was an interim "unavailable" mitigation; this is the real fix.

- **`db.committed_pv_forecast_by_slot(day)`** stitches the committed PV forecast across every solve of the day — each slot gets the forecast from the most recent solve whose `run_at <= slot_start` (what we knew when it began), earliest-solve fallback otherwise; future slots resolve to the latest plan. Replaces the single-run `planned_by` (which left a morning hole) for both the committed-plan line and the `/pv/today` accuracy baseline.
- **`pv_error_log`** table + nightly `bulletproof_pv_error_log_job` (04:20 UTC) persist per-slot committed-forecast-vs-actual rows for model improvement (the literal issue ask), with retention on the meteo horizon.

## #470 — period chart bars sum to the pnl foot
`get_period_insights` (month/week) overlays each bar's import/export kWh from `compute_daily_pnl` (`_overlay_pnl_daily_kwh`) so the stacked bars add up to the pnl foot total instead of over-counting Fox telemetry. Solar/load/charge/discharge stay Fox. (N daily-pnl calls per request — acceptable for a navigation-loaded endpoint; a future optimization could thread per-day rows out of `compute_period_pnl`.)

## Today's Plan legend
Replaced the prose caption with a visual chip legend mirroring the Energy Flow foot: **Solar** (actual/plan line glyphs), **Tariff** (paid/cheap/peak swatches), and a "◉ now · hover a slot" hint.

## Review (independent Plan-agent pass)
No crash/correctness bugs. `_lock` is an RLock (no deadlock in the nightly rebuild), `_norm_z`/`_iso_z` keys align, the stitch reducer is order-independent, the overlay only runs on per-day rows and is per-row best-effort. Low-severity notes (retention over-retains by a boundary fraction — err-safe; N+1 overlay) accepted as documented.

## Tests
- New `tests/test_pv_error_log.py`: stitch latest-eligible + earliest-fallback, error-log join + idempotency, and `/pv/today` accuracy now uses the committed plan for elapsed slots.
- `#470` overlay test + `test_db_retention` updated for the new table.
- Full backend suite green except the pre-existing #464 trio.

Closes #462
Closes #470