### PR TITLE
perf(insights): reuse the pnl daily loop for period chart bars

### DIFF
--- a/src/analytics/pnl.py
+++ b/src/analytics/pnl.py
@@ -480,8 +480,16 @@ def _agile_start_date() -> date | None:
         return None
 
 
-def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> dict[str, Any]:
+def compute_period_pnl(
+    start_day: date, end_day: date, *, label: str = "", include_daily: bool = False
+) -> dict[str, Any]:
     """Aggregate daily PnL across a date range (both bounds inclusive).
+
+    ``include_daily=True`` attaches an ``out["daily"]`` list of
+    ``{date, import_kwh, export_kwh}`` (one per day in the clamped range) so a
+    caller that also needs per-day kWh (e.g. chart bars that must sum to the
+    foot, #470) gets them from this single daily loop instead of re-running
+    ``compute_daily_pnl`` itself.
 
     Sums every numeric component of ``compute_daily_pnl`` so callers get a full
     breakdown — not just the deltas. Standing charge is implicitly accounted for
@@ -583,12 +591,19 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
     bg_delta_real = 0.0
     bg_label: str | None = None
     bg_seen = False
+    daily_rows: list[dict[str, Any]] = []
 
     for i in range(n):
         d = start_day + timedelta(days=i)
         p = compute_daily_pnl(d)
         for k in totals:
             totals[k] += float(p.get(k) or 0.0)
+        if include_daily:
+            daily_rows.append({
+                "date": d.isoformat(),
+                "import_kwh": round(float(p.get("import_kwh") or 0.0), 3),
+                "export_kwh": round(float(p.get("export_kwh") or 0.0), 3),
+            })
         if "fixed_tariff_shadow_gbp" in p:
             bg_seen = True
             bg_shadow += float(p["fixed_tariff_shadow_gbp"])
@@ -612,6 +627,8 @@ def compute_period_pnl(start_day: date, end_day: date, *, label: str = "") -> di
         out["clamped"] = True
         out["clamp_reason"] = clamp_reason
     out.update({k: round(v, 4 if not k.endswith("_kwh") else 3) for k, v in totals.items()})
+    if include_daily:
+        out["daily"] = daily_rows
     if bg_seen:
         out["fixed_tariff_label"] = bg_label or "fixed tariff"
         out["fixed_tariff_shadow_real_gbp"] = round(bg_shadow_real, 4)

--- a/src/energy/monthly.py
+++ b/src/energy/monthly.py
@@ -369,8 +369,8 @@ def _period_cost(
 
 def _pnl_cost_for_range(
     start: date, end: date
-) -> tuple[MonthlyCostSummary, float, float] | None:
-    """Realised cost + import/export kWh from the authoritative pnl engine.
+) -> tuple[MonthlyCostSummary, float, float, dict[str, tuple[float, float]]] | None:
+    """Realised cost + import/export kWh + per-day kWh from the pnl engine.
 
     Reuses :func:`analytics.pnl.compute_period_pnl` so the Home period views
     (Energy Flow foot + headline £) report the SAME realised cost as the Hero
@@ -380,6 +380,10 @@ def _pnl_cost_for_range(
     quantities replace the raw Fox import/export so the displayed kWh and £ stay
     internally consistent — ``paid + standing − earned = net`` balances exactly.
 
+    The 4th element is a ``{date_iso: (import_kwh, export_kwh)}`` per-day map,
+    sourced from the SAME daily loop as the foot total (``include_daily=True``),
+    so the chart-bar overlay (#470) doesn't re-run ``compute_daily_pnl``.
+
     Returns ``None`` when pnl can't price the range (no Agile data / fully
     pre-Agile) so the caller falls back to the Fox/Octopus engine. Imported
     lazily to avoid a circular import (pnl → db → … → monthly is not a cycle,
@@ -387,7 +391,7 @@ def _pnl_cost_for_range(
     """
     try:
         from ..analytics.pnl import compute_period_pnl
-        p = compute_period_pnl(start, end)
+        p = compute_period_pnl(start, end, include_daily=True)
     except Exception as exc:  # pragma: no cover - defensive
         # WARNING (not info): a pnl failure silently reverts the endpoint to the
         # Fox/Octopus engine — the very one that over-states export — so this
@@ -416,44 +420,43 @@ def _pnl_cost_for_range(
         fixed_shadow_pence=round(float(bg_shadow) * 100, 2) if bg_shadow is not None else None,
         delta_vs_fixed_pence=round(float(bg_delta) * 100, 2) if bg_delta is not None else None,
     )
-    return cost, float(p.get("import_kwh") or 0.0), float(p.get("export_kwh") or 0.0)
+    daily_map: dict[str, tuple[float, float]] = {
+        str(r.get("date")): (float(r.get("import_kwh") or 0.0), float(r.get("export_kwh") or 0.0))
+        for r in (p.get("daily") or [])
+    }
+    return cost, float(p.get("import_kwh") or 0.0), float(p.get("export_kwh") or 0.0), daily_map
 
 
-def _overlay_pnl_daily_kwh(chart_rows: list[dict]) -> None:
+def _overlay_pnl_daily_kwh(chart_rows: list[dict], daily_map: dict[str, tuple[float, float]]) -> None:
     """Replace each chart row's import/export kWh with the pnl per-day values so
     the stacked bars sum to the pnl FOOT total (#470). Without this the bars stay
     Fox telemetry (which over-counts export) and don't add up to the foot. Only
-    import/export are touched — solar/load/charge/discharge stay Fox. In-place,
-    best-effort per row; a row that can't be priced keeps its Fox value.
-
-    ``chart_rows`` must be per-DAY rows (``date`` = ``YYYY-MM-DD``) — never call
-    on the year view's per-month rows."""
-    from ..analytics.pnl import compute_daily_pnl
+    import/export are touched — solar/load/charge/discharge stay Fox. In-place;
+    a row with no pnl entry (e.g. a pre-Agile day the clamp dropped) keeps its
+    Fox value. ``daily_map`` comes from :func:`_pnl_cost_for_range` — the SAME
+    daily loop as the foot, so no extra ``compute_daily_pnl`` calls."""
     for row in chart_rows:
-        try:
-            d = date.fromisoformat(str(row.get("date"))[:10])
-            p = compute_daily_pnl(d)
-            row["import_kwh"] = round(float(p.get("import_kwh") or 0.0), 2)
-            row["export_kwh"] = round(float(p.get("export_kwh") or 0.0), 2)
-        except Exception:  # pragma: no cover - defensive; keep Fox value
+        kv = daily_map.get(str(row.get("date", ""))[:10]) or daily_map.get(str(row.get("date", "")))
+        if kv is None:
             continue
+        row["import_kwh"] = round(kv[0], 2)
+        row["export_kwh"] = round(kv[1], 2)
 
 
 def _apply_pnl_cost(
     energy: MonthlyEnergySummary, start: date, end: date
-) -> MonthlyCostSummary | None:
+) -> tuple[MonthlyCostSummary, dict[str, tuple[float, float]]] | None:
     """Override ``energy``'s import/export kWh from pnl and return the matching
-    realised cost, or ``None`` if pnl can't price the range (caller falls back).
-
-    Mutates ``energy`` only on success so the displayed kWh and the cost come
-    from the same source."""
+    realised cost + per-day kWh map, or ``None`` if pnl can't price the range
+    (caller falls back). Mutates ``energy`` only on success so the displayed kWh
+    and the cost come from the same source."""
     res = _pnl_cost_for_range(start, end)
     if res is None:
         return None
-    cost, import_kwh, export_kwh = res
+    cost, import_kwh, export_kwh, daily_map = res
     energy.import_kwh = round(import_kwh, 2)
     energy.export_kwh = round(export_kwh, 2)
-    return cost
+    return cost, daily_map
 
 
 def _get_daikin_heating_kwh(year: int, month: int) -> float | None:
@@ -767,7 +770,8 @@ def get_period_insights(
         # year headline matches Hero + Insights (overrides energy import/export
         # kWh too). Per-month chart_data + heating analytics stay Fox-sourced.
         year_end = min(date(year, 12, 31), today)
-        cost = _apply_pnl_cost(energy, date(year, 1, 1), year_end) or MonthlyCostSummary(
+        _pnl_res = _apply_pnl_cost(energy, date(year, 1, 1), year_end)
+        cost = _pnl_res[0] if _pnl_res is not None else MonthlyCostSummary(
             import_cost_pence=round(import_cost_pence, 2),
             export_earnings_pence=round(export_earnings_pence, 2),
             standing_charge_pence=round(standing_charge_pence, 2),
@@ -816,10 +820,12 @@ def get_period_insights(
         month_end = date(y, m, monthrange(y, m)[1])
         if (y, m) == (today.year, today.month):
             month_end = today
-        pnl_cost = _apply_pnl_cost(energy, date(y, m, 1), month_end)
-        cost = pnl_cost or _best_cost(energy, n_days=n_days)
-        if pnl_cost is not None:
-            _overlay_pnl_daily_kwh(daily)  # bars sum to the pnl foot (#470)
+        pnl_res = _apply_pnl_cost(energy, date(y, m, 1), month_end)
+        if pnl_res is not None:
+            cost, _daily_map = pnl_res
+            _overlay_pnl_daily_kwh(daily, _daily_map)  # bars sum to the pnl foot (#470)
+        else:
+            cost = _best_cost(energy, n_days=n_days)
         daikin_heating = _get_daikin_heating_kwh(y, m)
         heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(
             energy, cost, daikin_heating_kwh=daikin_heating
@@ -863,7 +869,10 @@ def get_period_insights(
             day_from = datetime(y, m, d, 0, 0, 0, tzinfo=UTC)
             day_to = datetime(y, m, d, 23, 59, 59, tzinfo=UTC)
             # pnl engine first (matches Hero + Insights); Fox/Octopus fallback.
-            cost = _apply_pnl_cost(energy, dte, dte) or _period_cost(energy, day_from, day_to, n_days=1)
+            # chart_data below is built from the (pnl-overridden) energy, so the
+            # single day bar already matches — no separate overlay needed.
+            _pnl_res = _apply_pnl_cost(energy, dte, dte)
+            cost = _pnl_res[0] if _pnl_res is not None else _period_cost(energy, day_from, day_to, n_days=1)
             heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(energy, cost)
             insights = MonthlyInsights(
                 energy=energy,
@@ -914,10 +923,12 @@ def get_period_insights(
         week_from = datetime(week_start.year, week_start.month, week_start.day, 0, 0, 0, tzinfo=UTC)
         week_to = datetime(week_end.year, week_end.month, week_end.day, 23, 59, 59, tzinfo=UTC)
         # pnl engine first (matches Hero + Insights); Fox/Octopus fallback.
-        pnl_cost = _apply_pnl_cost(energy, week_start, week_end)
-        cost = pnl_cost or _period_cost(energy, week_from, week_to, n_days=days_count)
-        if pnl_cost is not None:
-            _overlay_pnl_daily_kwh(daily_all)  # bars sum to the pnl foot (#470)
+        pnl_res = _apply_pnl_cost(energy, week_start, week_end)
+        if pnl_res is not None:
+            cost, _daily_map = pnl_res
+            _overlay_pnl_daily_kwh(daily_all, _daily_map)  # bars sum to the pnl foot (#470)
+        else:
+            cost = _period_cost(energy, week_from, week_to, n_days=days_count)
         heating_kwh, heating_cost_pence, equiv_gas_pence, ahead_pounds = _compute_heating_and_gas(energy, cost)
         insights = MonthlyInsights(energy=energy, cost=cost, heating_estimate_kwh=heating_kwh, heating_estimate_cost_pence=heating_cost_pence, equivalent_gas_cost_pence=equiv_gas_pence, gas_comparison_ahead_pounds=ahead_pounds)
         label = f"{week_start.strftime('%d')}–{week_end.strftime('%d %b %Y')}" if week_start.month == week_end.month else f"{week_start.strftime('%d %b')} – {week_end.strftime('%d %b %Y')}"

--- a/tests/test_monthly_cost_proration.py
+++ b/tests/test_monthly_cost_proration.py
@@ -183,11 +183,20 @@ def test_pnl_cost_for_range_maps_real_money_fields(monkeypatch):
         "export_kwh": 55.2,
         "fixed_tariff_shadow_real_gbp": 75.0,
         "delta_vs_fixed_tariff_real_gbp": 7.98,
+        "daily": [
+            {"date": "2026-05-01", "import_kwh": 10.0, "export_kwh": 2.0},
+            {"date": "2026-05-02", "import_kwh": 9.0, "export_kwh": 1.5},
+        ],
     }
-    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e: fake)
+    captured = {}
+    def _fake(s, e, *, include_daily=False, label=""):
+        captured["include_daily"] = include_daily
+        return fake
+    monkeypatch.setattr(pnl_mod, "compute_period_pnl", _fake)
     res = monthly._pnl_cost_for_range(date(2026, 5, 1), date(2026, 5, 31))
     assert res is not None
-    cost, imp, exp = res
+    cost, imp, exp, daily_map = res
+    assert captured["include_daily"] is True  # asks for the per-day rows
     assert cost.import_cost_pence == pytest.approx(5091.0)
     assert cost.export_earnings_pence == pytest.approx(226.0)
     assert cost.standing_charge_pence == pytest.approx(1837.0)
@@ -195,28 +204,31 @@ def test_pnl_cost_for_range_maps_real_money_fields(monkeypatch):
     assert cost.fixed_shadow_pence == pytest.approx(7500.0)
     assert cost.delta_vs_fixed_pence == pytest.approx(798.0)
     assert (imp, exp) == pytest.approx((314.1, 55.2))
+    assert daily_map["2026-05-01"] == pytest.approx((10.0, 2.0))
+    assert daily_map["2026-05-02"] == pytest.approx((9.0, 1.5))
 
 
 def test_pnl_cost_for_range_returns_none_when_unpriced(monkeypatch):
     """Empty/pre-Agile range (n_days == 0) → None so the caller falls back."""
     import src.analytics.pnl as pnl_mod
-    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e: {"n_days": 0})
+    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e, **k: {"n_days": 0})
     assert monthly._pnl_cost_for_range(date(2026, 1, 1), date(2026, 1, 31)) is None
 
 
 def test_pnl_cost_for_range_no_fixed_shadow(monkeypatch):
     """When FIXED_TARIFF_* isn't configured, pnl omits the bg keys → None shadow."""
     import src.analytics.pnl as pnl_mod
-    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e: {
+    monkeypatch.setattr(pnl_mod, "compute_period_pnl", lambda s, e, **k: {
         "n_days": 7, "import_cost_gbp": 10.0, "export_revenue_gbp": 1.0,
         "standing_charge_gbp": 4.0, "realised_net_cost_gbp": 13.0,
         "import_kwh": 60.0, "export_kwh": 24.0,
     })
     res = monthly._pnl_cost_for_range(date(2026, 5, 1), date(2026, 5, 7))
     assert res is not None
-    cost, _, _ = res
+    cost, _imp, _exp, _daily = res
     assert cost.fixed_shadow_pence is None
     assert cost.delta_vs_fixed_pence is None
+    assert _daily == {}  # no "daily" key in the fake → empty map
 
 
 def test_period_month_overlays_chart_bars_from_pnl(monkeypatch):
@@ -228,10 +240,14 @@ def test_period_month_overlays_chart_bars_from_pnl(monkeypatch):
         import_cost_pence=100.0, export_earnings_pence=10.0,
         standing_charge_pence=50.0, net_cost_pence=140.0,
     )
-    # Re-enable pnl (overriding _patch_client's None) + stub per-day pnl.
-    monkeypatch.setattr(monthly, "_pnl_cost_for_range", lambda s, e: (pnl_cost, 7.0, 3.0))
-    import src.analytics.pnl as pnl_mod
-    monkeypatch.setattr(pnl_mod, "compute_daily_pnl", lambda d: {"import_kwh": 9.9, "export_kwh": 4.4})
+    # Per-day map (from the single pnl daily loop) covering this month's days.
+    daily_map = {
+        f"{today.year:04d}-{today.month:02d}-{d:02d}": (9.9, 4.4)
+        for d in range(1, today.day + 1)
+    }
+    # Re-enable pnl (overriding _patch_client's None); the overlay reads the
+    # daily_map — no separate compute_daily_pnl calls.
+    monkeypatch.setattr(monthly, "_pnl_cost_for_range", lambda s, e: (pnl_cost, 7.0, 3.0, daily_map))
     out = monthly.get_period_insights("month", month_str=today.strftime("%Y-%m"))
     assert out.chart_data, "expected chart rows"
     assert all(r["import_kwh"] == pytest.approx(9.9) for r in out.chart_data)
@@ -253,7 +269,7 @@ def test_period_month_prefers_pnl_and_overrides_kwh(monkeypatch):
     )
     monkeypatch.setattr(
         monthly, "_pnl_cost_for_range",
-        lambda start, end: (pnl_cost, 314.1, 55.2),
+        lambda start, end: (pnl_cost, 314.1, 55.2, {}),  # empty daily_map: bars not asserted here
     )
     out = monthly.get_period_insights("month", month_str=today.strftime("%Y-%m"))
     # Cost comes from pnl…


### PR DESCRIPTION
Follow-up optimization for the #470 chart-bar overlay (the N+1 the review flagged).

## Before
`get_period_insights` (month/week) computed per-day pnl **twice**:
- `compute_period_pnl` looped `compute_daily_pnl` over every day for the foot total, then
- `_overlay_pnl_daily_kwh` looped `compute_daily_pnl` again, per chart row, for the bars.

~62 daily solves for a month view.

## After
`compute_period_pnl(include_daily=True)` attaches a per-day `{date, import_kwh, export_kwh}` list from its **existing** loop. `_pnl_cost_for_range` threads that map out (4th tuple element), `_apply_pnl_cost` returns it, and `_overlay_pnl_daily_kwh` reads it instead of re-running `compute_daily_pnl`. ~31 daily solves — halved. No behaviour change: bars still sum to the foot.

`include_daily` defaults False, so every other `compute_period_pnl` caller (briefs, MTD/YTD, MCP) is unaffected.

## Tests
- `_pnl_cost_for_range` mapping test asserts `include_daily=True` is requested and the daily map is built; the #470 overlay test now feeds the map directly (no `compute_daily_pnl` stub).
- Full backend suite green except the pre-existing #464 trio.

Tracked by #470