### PR TITLE
test(#464): make calibration/load-profile tests date-robust

### DIFF
--- a/tests/test_pv_calibration_3d.py
+++ b/tests/test_pv_calibration_3d.py
@@ -124,13 +124,14 @@ def test_compute_3d_separates_low_vs_high_elevation():
     from src.weather import compute_pv_calibration_3d_table
 
     conn = sqlite3.connect(config.DB_PATH)
-    today = datetime.now(UTC).date()
-    # Seed 5 days of hour 12 UTC. May has elevation ~58° at noon in
-    # London → bucket 4 (>55°). All samples should populate (12, 0, 4).
+    # Seed 5 days of hour 12 UTC on FIXED, distinct May-2026 dates. May noon in
+    # London has elevation ~58° → bucket 4 (>55°). Fixed dates (not today-d) so
+    # captured_at never collides regardless of the wall-clock date the suite runs
+    # on (#464 — the old `day.day if <=28 else 15` clamp mapped two days onto
+    # May 15 → UNIQUE constraint crash). When these dates age out of the lookback
+    # window the table is simply "skipped" — the assertion tolerates that.
     for d in range(1, 6):
-        day = today - timedelta(days=d)
-        # Use May date to control elevation ~58°
-        base = datetime(2026, 5, day.day if day.day <= 28 else 15, 12, 0, tzinfo=UTC)
+        base = datetime(2026, 5, 10 + d, 12, 0, tzinfo=UTC)  # May 11..15, distinct
         _seed_meteo(conn, base, direct_pv_kw=4.0, cloud_pct=10.0)
         _seed_meteo(conn, base + timedelta(minutes=30), direct_pv_kw=4.0, cloud_pct=10.0)
         for m in (10, 30, 50):

--- a/tests/test_tariff_aware_load_profile.py
+++ b/tests/test_tariff_aware_load_profile.py
@@ -86,7 +86,12 @@ def test_tariff_aware_profile_separates_cheap_vs_peak_for_same_clock_time(
         _save_pv_load(ts, load_kw=0.8)  # 0.8 kW × 0.5 h = 0.4 kWh
         _save_exec_with_kind(ts, kind="peak", agile_p=30.0)
 
-    profile = db.tariff_aware_residual_load_profile_kwh(min_samples_per_kind=5)
+    # Wide window so the FIXED May-2026 seed dates always fall inside the rolling
+    # lookback regardless of the wall-clock date the suite runs on (#464 — the
+    # default 30-day window made these fail once "today" drifted past June 2026).
+    # The fixed May dates are deliberate: May is BST, so 12:00 UTC → 13:00 local
+    # deterministically, with no DST-boundary ambiguity across the 13-day span.
+    profile = db.tariff_aware_residual_load_profile_kwh(min_samples_per_kind=5, window_days=100_000)
 
     # Expect both kind-aware buckets present (6 samples each ≥ 5)
     cheap_key = (13, 0, "cheap")
@@ -121,7 +126,9 @@ def test_tariff_aware_profile_drops_buckets_below_threshold(
         _save_pv_load(ts, load_kw=2.4)
         _save_exec_with_kind(ts, kind="cheap", agile_p=4.0)
 
-    profile = db.tariff_aware_residual_load_profile_kwh(min_samples_per_kind=5)
+    # Wide window — see the note in the sibling test (#464: fixed dates vs the
+    # default 30-day rolling lookback).
+    profile = db.tariff_aware_residual_load_profile_kwh(min_samples_per_kind=5, window_days=100_000)
 
     assert (13, 0, "cheap") not in profile
     assert (13, 0) in profile  # plain fallback always available


### PR DESCRIPTION
Closes #464

The 3 tests that turned CI red on `main` were **not** state-leakage/isolation bugs — the conftest DB isolation and `src/db.py` are correct. They were **wall-clock date bugs** (root-caused with a reproduction):

- `test_tariff_aware_load_profile` (×2): seeded fixed **May-2026** dates, but `tariff_aware_residual_load_profile_kwh` filters on a **30-day rolling window** from `now`. Once "today" drifted past June 2026 the seed fell outside the window → empty buckets → `missing (13,0,'cheap')` / `(13,0) in {}`. Fix: pass `window_days=100_000` so the **fixed** dates (deliberately May = BST → deterministic 13:00 local, no DST ambiguity) always qualify.
- `test_pv_calibration_3d`: the `day.day if day.day <= 28 else 15` clamp mapped two loop days onto **May 15** on certain calendar dates → duplicate `captured_at` → `UNIQUE constraint failed`. Fix: fixed distinct **May 11..15** dates, independent of `today`.

The `pytest-randomly` "order-dependence" was a red herring: random ordering only changed which date-bug surfaced first; they fail on the affected dates regardless of order.

Verified: full suite `1436 passed, 3 skipped, 1 xfailed` (no failures), and the two tariff tests pass standalone again.