### PR TITLE
feat(auth): viewer/admin role model — passive viewer open, admin gated

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -47,7 +47,7 @@ from ..scheduler.lp_replay import (
     sweep_cadences as lp_sweep_cadences,
 )
 from . import safeguards
-from .middleware import ApiV1BearerAuth, BearerAuthMiddleware
+from .middleware import ApiV1RoleAuth, BearerAuthMiddleware, token_matches_any
 from .models import (
     ActionResult,
     ActionStatus,
@@ -261,19 +261,29 @@ if _cors_origins:
         expose_headers=["WWW-Authenticate"],
     )
 
-# Bearer guard for /api/v1/* — accepts the SPA's HEM_UI_TOKEN OR the
-# OpenClaw token so existing flows keep working through one header. The
-# guard is gated by HEM_UI_AUTH_REQUIRED so this PR can ship + reach
-# prod without breaking the inline UI before B6's cutover. Flip the
-# env var to True once the SPA container is the only /api/v1 consumer.
+# Role guard for /api/v1/* — viewer-open, admin-gated. Safe reads pass for
+# everyone (the shareable passive surface); writes + Settings/Journal require
+# an admin token (HEM_ADMIN_TOKEN, typed in the UI "unlock", or the OpenClaw
+# token for server-to-server). HEM_UI_TOKEN is deliberately NOT admin — it is
+# baked into the UI's config.js and readable by any viewer. Gated by
+# HEM_UI_AUTH_REQUIRED (no-op when False, for dev).
+_ADMIN_TOKEN_GETTERS = [
+    lambda: config.HEM_ADMIN_TOKEN,
+    lambda: config.HEM_OPENCLAW_TOKEN,
+]
+
+
+def _request_is_admin(request: Request) -> bool:
+    """True when the request carries a valid admin bearer. Used by the few
+    handlers that must gate a *side effect* on a GET (which the method-based
+    middleware can't see) — e.g. ?refresh=true forcing a Daikin quota burn."""
+    presented = request.headers.get("authorization", "")
+    tok = presented[7:].strip() if presented.lower().startswith("bearer ") else ""
+    return token_matches_any(tok, _ADMIN_TOKEN_GETTERS)
 app.add_middleware(
-    ApiV1BearerAuth,
-    tokens=[
-        lambda: config.HEM_UI_TOKEN,
-        lambda: config.HEM_OPENCLAW_TOKEN,
-    ],
+    ApiV1RoleAuth,
+    admin_tokens=_ADMIN_TOKEN_GETTERS,
     enabled=lambda: bool(config.HEM_UI_AUTH_REQUIRED),
-    public_paths=("/api/v1/health",),
 )
 
 app.include_router(energy_providers_router.router)
@@ -472,6 +482,26 @@ async def health():
         "version": app.version,
         "revision": sha,
         "mcp_token_present": bool(config.HEM_OPENCLAW_TOKEN),
+    }
+
+
+@app.get("/api/v1/whoami")
+async def whoami(request: Request):
+    """Report the caller's role so the UI can show admin controls or not.
+
+    Public (no auth needed): a viewer with no token gets ``viewer``; presenting
+    a valid admin token gets ``admin``. ``admin_configured`` tells the UI
+    whether an admin secret exists at all (so it can hide the unlock prompt when
+    none is set), and ``auth_enforced`` mirrors HEM_UI_AUTH_REQUIRED.
+    """
+    presented = request.headers.get("authorization", "")
+    tok = presented[7:].strip() if presented.lower().startswith("bearer ") else ""
+    is_admin = token_matches_any(tok, _ADMIN_TOKEN_GETTERS)
+    admin_configured = any((g() or "").strip() for g in _ADMIN_TOKEN_GETTERS)
+    return {
+        "role": "admin" if is_admin else "viewer",
+        "admin_configured": admin_configured,
+        "auth_enforced": bool(config.HEM_UI_AUTH_REQUIRED),
     }
 
 
@@ -1661,12 +1691,18 @@ async def settings_delete(key: str):
 
 
 @app.get("/api/v1/daikin/status", response_model=list[DaikinStatusResponse])
-async def daikin_status(refresh: bool = False):
+async def daikin_status(request: Request, refresh: bool = False):
     """Get status of all Daikin devices.
 
     Set ?refresh=true to force a live fetch (subject to rate limiting and the daily
     quota). Without the flag the cached value is returned immediately.
+
+    ``refresh`` is a privileged side effect (it spends the daily Onecta quota),
+    so it is honoured only for admins when auth is enforced — a viewer always
+    gets the cached value, preventing a tokenless quota-drain DoS.
     """
+    if refresh and config.HEM_UI_AUTH_REQUIRED and not _request_is_admin(request):
+        refresh = False
     logger.debug("GET /api/v1/daikin/status refresh=%s", refresh)
     try:
         if refresh:

--- a/src/api/middleware.py
+++ b/src/api/middleware.py
@@ -26,9 +26,39 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 TokenLike = Union[str, Callable[[], str]]
 
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
 
 def _resolve(t: TokenLike) -> str:
     return (t() if callable(t) else t or "").strip()
+
+
+def token_matches_any(presented: str, tokens: Iterable[TokenLike]) -> bool:
+    """Constant-time check: does ``presented`` equal any non-empty token?
+
+    Shared by :class:`ApiV1RoleAuth` and the ``/whoami`` handler so the
+    definition of "is this an admin token" lives in exactly one place.
+    """
+    offered = (presented or "").strip().encode("utf-8")
+    if not offered:
+        return False
+    matched = False
+    for t in tokens:
+        exp = _resolve(t)
+        if exp and hmac.compare_digest(offered, exp.encode("utf-8")):
+            matched = True  # keep looping — constant-ish, don't early-return
+    return matched
+
+
+def bearer_from_scope(scope: Scope) -> str:
+    """Extract the bearer token value from an ASGI scope's headers (or "")."""
+    for name, value in scope.get("headers") or []:
+        if name == b"authorization":
+            presented = value.decode("latin-1", errors="replace")
+            if presented.lower().startswith("bearer "):
+                return presented[7:].strip()
+            return ""
+    return ""
 
 
 class BearerAuthMiddleware:
@@ -131,6 +161,91 @@ class ApiV1BearerAuth:
             for exp in expected_tokens
         ):
             await _reject(send, 401, "invalid token", realm="hem-api")
+            return
+
+        await self.app(scope, receive, send)
+
+
+class ApiV1RoleAuth:
+    """Role-based guard for ``/api/v1/*`` — viewer-open, admin-gated.
+
+    The system is shareable as a passive **viewer** (read-only) without any
+    token, while **admin** actions (anything that mutates state, plus the
+    Settings and Journal admin reads) require an admin token.
+
+    Per request (when ``enabled()``):
+
+    * **Public paths** (``/health``, ``/whoami``) — always pass.
+    * **Safe reads** — ``GET``/``HEAD``/``OPTIONS`` on a non-admin path pass for
+      everyone, with or without a token (the viewer surface).
+    * **Admin-required** — any non-safe method (POST/PUT/PATCH/DELETE) OR a
+      path under ``admin_read_prefixes`` (Settings, Journal/action-log,
+      integration credentials) — pass only with a valid admin token, else 401.
+
+    When ``enabled()`` is False the middleware is a no-op (dev: all open).
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        admin_tokens: Iterable[TokenLike],
+        enabled: Callable[[], bool],
+        prefix: str = "/api/v1/",
+        public_paths: Iterable[str] = ("/api/v1/health", "/api/v1/whoami"),
+        admin_read_prefixes: Iterable[str] = (
+            "/api/v1/settings",
+            # Journal/action-log is served under several paths — gate the DATA,
+            # not just one route (a security review caught /schedule/history and
+            # /recent-triggers leaking the same action_log a viewer must not see).
+            "/api/v1/action-log",
+            "/api/v1/schedule/history",
+            "/api/v1/recent-triggers",
+            "/api/v1/integrations",   # SmartThings credentials / OAuth
+            "/api/v1/workbench",      # LP override sandbox (admin tool, in Settings)
+        ),
+    ) -> None:
+        self.app = app
+        self._admin_tokens = list(admin_tokens)
+        self._enabled = enabled
+        self._prefix = prefix
+        self._public_paths = frozenset(public_paths)
+        self._admin_read_prefixes = tuple(admin_read_prefixes)
+
+    def _needs_admin(self, method: str, path: str) -> bool:
+        if method.upper() not in SAFE_METHODS:
+            return True
+        return any(path.startswith(p) for p in self._admin_read_prefixes)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if not path.startswith(self._prefix):
+            await self.app(scope, receive, send)
+            return
+
+        if not self._enabled():
+            await self.app(scope, receive, send)
+            return
+
+        if path in self._public_paths:
+            await self.app(scope, receive, send)
+            return
+
+        if not self._needs_admin(scope.get("method", "GET"), path):
+            await self.app(scope, receive, send)  # viewer-permissible read
+            return
+
+        # Admin required from here on.
+        presented = bearer_from_scope(scope)
+        if not presented:
+            await _reject(send, 401, "admin token required", realm="hem-api")
+            return
+        if not token_matches_any(presented, self._admin_tokens):
+            await _reject(send, 401, "invalid admin token", realm="hem-api")
             return
 
         await self.app(scope, receive, send)

--- a/src/config.py
+++ b/src/config.py
@@ -236,9 +236,20 @@ class Config:
         "HEM_UI_TOKEN_FILE", "data/.hem-ui-token"
     )
     HEM_UI_TOKEN: str = os.getenv("HEM_UI_TOKEN", "").strip()
-    # Default False — keeps the inline UI working without bearer headers
-    # during the B1 → B6 transition. Flip to True once the SPA container
-    # is the only /api/v1 consumer (after B6 cutover).
+    # ── Viewer/Admin role model ─────────────────────────────────────────────
+    # The UI defaults to a passive VIEWER (read-only, no token) so it can be
+    # shared (even outside Tailscale) without exposing controls. Mutating the
+    # system (writes) and the Settings/Journal admin reads require the ADMIN
+    # secret below — the user types it once in the UI ("unlock"), it's stored
+    # in the browser and sent as the bearer. HEM_OPENCLAW_TOKEN is also
+    # admin-level so server-to-server flows keep working.
+    # IMPORTANT: HEM_UI_TOKEN is NOT admin — it is baked into the UI's
+    # config.js (readable by any viewer), so granting it write power would
+    # defeat the model. Only HEM_ADMIN_TOKEN + HEM_OPENCLAW_TOKEN are admin.
+    HEM_ADMIN_TOKEN: str = os.getenv("HEM_ADMIN_TOKEN", "").strip()
+    # Default False — middleware is a no-op (dev: everything open). When True,
+    # the role model is enforced: safe reads open to viewers, writes +
+    # Settings/Journal gated on an admin token. Set True in prod.
     HEM_UI_AUTH_REQUIRED: bool = os.getenv(
         "HEM_UI_AUTH_REQUIRED", "false"
     ).lower() in ("true", "1", "yes")

--- a/tests/api/test_bearer_auth_v1.py
+++ b/tests/api/test_bearer_auth_v1.py
@@ -1,12 +1,16 @@
-"""Tests for ApiV1BearerAuth (Story B1, Epic 13b).
+"""Tests for ApiV1RoleAuth — the viewer-open / admin-gated /api/v1 guard.
 
-Covers the auth contract for the new /api/v1/* middleware:
+The model (replacing the old all-or-nothing bearer guard):
 
-* gate flag off → no header required (preserves pre-B1 behaviour)
-* gate flag on  → 401 without header / 401 with wrong token /
-                  200 with HEM_UI_TOKEN / 200 with HEM_OPENCLAW_TOKEN
-* /api/v1/health stays public regardless of gate
-* /mcp keeps using HEM_OPENCLAW_TOKEN (its own middleware path unaffected)
+* gate flag off → middleware is a no-op (dev: everything open)
+* gate flag on:
+    - safe reads (GET) on non-admin paths → open to VIEWERS (no token)
+    - writes (POST/PUT/PATCH/DELETE) → require an ADMIN token
+    - Settings + Journal (action-log) reads → require an ADMIN token
+    - HEM_UI_TOKEN is NOT admin (it's baked into the UI's config.js)
+    - HEM_ADMIN_TOKEN + HEM_OPENCLAW_TOKEN ARE admin
+* /api/v1/health and /api/v1/whoami stay public
+* /mcp keeps its own HEM_OPENCLAW_TOKEN guard
 """
 from __future__ import annotations
 
@@ -21,7 +25,6 @@ def _isolated_db(monkeypatch, tmp_path):
     monkeypatch.setenv("DB_PATH", db_path)
     from src import config as _config
     monkeypatch.setattr(_config.config, "DB_PATH", db_path, raising=False)
-    # Point the token files at tmp_path so we don't clobber the dev tokens.
     monkeypatch.setattr(
         _config.config, "HEM_UI_TOKEN_FILE",
         str(tmp_path / ".hem-ui-token"), raising=False,
@@ -35,13 +38,12 @@ def _isolated_db(monkeypatch, tmp_path):
     yield
 
 
-def _set_tokens(monkeypatch, *, ui: str, openclaw: str, required: bool) -> None:
+def _set_tokens(monkeypatch, *, ui="ui-tok", admin="admin-tok", openclaw="oc-tok", required=True) -> None:
     from src import config as _config
     monkeypatch.setattr(_config.config, "HEM_UI_TOKEN", ui, raising=False)
+    monkeypatch.setattr(_config.config, "HEM_ADMIN_TOKEN", admin, raising=False)
     monkeypatch.setattr(_config.config, "HEM_OPENCLAW_TOKEN", openclaw, raising=False)
-    monkeypatch.setattr(
-        _config.config, "HEM_UI_AUTH_REQUIRED", required, raising=False,
-    )
+    monkeypatch.setattr(_config.config, "HEM_UI_AUTH_REQUIRED", required, raising=False)
 
 
 def _client() -> TestClient:
@@ -49,110 +51,163 @@ def _client() -> TestClient:
     return TestClient(app)
 
 
-# ---------------------------------------------------------------------------
-# Gate OFF — preserves pre-B1 behaviour
-# ---------------------------------------------------------------------------
-
-def test_api_v1_open_when_gate_disabled(monkeypatch) -> None:
-    """Default config (HEM_UI_AUTH_REQUIRED=false) → bearer not required.
-    Critical to keep the inline UI working during the B1 → B6 transition."""
-    _set_tokens(monkeypatch, ui="ui-tok", openclaw="oc-tok", required=False)
-    resp = _client().get("/api/v1/health")
-    assert resp.status_code == 200
+def _auth(tok: str) -> dict:
+    return {"Authorization": f"Bearer {tok}"}
 
 
-# ---------------------------------------------------------------------------
-# Gate ON — rejects unauthenticated and bad-token calls
-# ---------------------------------------------------------------------------
+# ── Gate OFF — everything open (dev) ────────────────────────────────────────
 
-def test_api_v1_rejects_missing_bearer_when_required(monkeypatch) -> None:
-    _set_tokens(monkeypatch, ui="ui-tok", openclaw="oc-tok", required=True)
+def test_all_open_when_gate_disabled(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=False)
+    c = _client()
+    assert c.get("/api/v1/health").status_code == 200
+    # Even a write passes with no token when the gate is off.
+    assert c.post("/api/v1/optimization/propose", json={}).status_code != 401
+
+
+# ── Viewer reads are OPEN when the gate is on ───────────────────────────────
+
+def test_safe_read_open_to_viewer_without_token(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
     resp = _client().get("/api/v1/scheduler/timeline")
+    # The whole point: a viewer with NO token can read. Endpoint may 200 or
+    # 5xx on its own, but the auth layer must not 401.
+    assert resp.status_code != 401
+
+
+def test_ui_token_is_viewer_level_for_reads(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    resp = _client().get("/api/v1/scheduler/timeline", headers=_auth("ui-tok"))
+    assert resp.status_code != 401
+
+
+# ── Writes require an ADMIN token ───────────────────────────────────────────
+
+def test_write_rejected_without_token(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    resp = _client().post("/api/v1/optimization/propose", json={})
     assert resp.status_code == 401
     assert resp.headers.get("www-authenticate", "").startswith("Bearer")
-    assert "bearer" in resp.json()["error"].lower()
 
 
-def test_api_v1_rejects_wrong_bearer_when_required(monkeypatch) -> None:
-    _set_tokens(monkeypatch, ui="ui-tok", openclaw="oc-tok", required=True)
-    resp = _client().get(
-        "/api/v1/scheduler/timeline",
-        headers={"Authorization": "Bearer wrong-token"},
-    )
+def test_write_rejected_with_ui_token(monkeypatch) -> None:
+    """HEM_UI_TOKEN is baked into config.js → must NOT grant writes."""
+    _set_tokens(monkeypatch, required=True)
+    resp = _client().post("/api/v1/optimization/propose", json={}, headers=_auth("ui-tok"))
     assert resp.status_code == 401
-    assert "invalid" in resp.json()["error"].lower()
+    assert "admin" in resp.json()["error"].lower()
 
 
-def test_api_v1_accepts_ui_token_when_required(monkeypatch) -> None:
-    _set_tokens(monkeypatch, ui="ui-tok-A", openclaw="oc-tok", required=True)
-    resp = _client().get(
-        "/api/v1/health",
-        headers={"Authorization": "Bearer ui-tok-A"},
-    )
-    # health stays public, but accepting the header here proves the middleware
-    # tolerates a correct token even on public paths
-    assert resp.status_code == 200
+def test_write_passes_auth_with_admin_token(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    resp = _client().post("/api/v1/optimization/propose", json={}, headers=_auth("admin-tok"))
+    assert resp.status_code != 401  # past the auth layer (handler may still 4xx/5xx)
 
 
-def test_api_v1_accepts_openclaw_token_when_required(monkeypatch) -> None:
-    """OpenClaw's token also passes the /api/v1 guard so server-to-server
-    flows that already use it keep working without a second token mint."""
-    _set_tokens(monkeypatch, ui="ui-tok", openclaw="oc-tok-B", required=True)
-    resp = _client().get(
-        "/api/v1/scheduler/timeline",
-        headers={"Authorization": "Bearer oc-tok-B"},
-    )
-    # 200 if endpoint returns data, 4xx/5xx is fine — we're testing
-    # middleware passthrough, NOT the endpoint's own logic. The key
-    # invariant: NOT 401 from the auth layer.
+def test_write_passes_auth_with_openclaw_token(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    resp = _client().post("/api/v1/optimization/propose", json={}, headers=_auth("oc-tok"))
     assert resp.status_code != 401
 
 
-# ---------------------------------------------------------------------------
-# Public path exception — /api/v1/health stays open even when gate is on
-# ---------------------------------------------------------------------------
+# ── Settings + Journal reads require ADMIN ──────────────────────────────────
 
-def test_api_v1_health_stays_public_when_gate_required(monkeypatch) -> None:
-    """compose's healthcheck: needs /api/v1/health reachable without a header."""
-    _set_tokens(monkeypatch, ui="ui-tok", openclaw="oc-tok", required=True)
-    resp = _client().get("/api/v1/health")
-    assert resp.status_code == 200
-    assert resp.json()["status"] == "ok"
+def test_settings_read_requires_admin(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    c = _client()
+    assert c.get("/api/v1/settings").status_code == 401
+    assert c.get("/api/v1/settings", headers=_auth("ui-tok")).status_code == 401
+    assert c.get("/api/v1/settings", headers=_auth("admin-tok")).status_code != 401
 
 
-# ---------------------------------------------------------------------------
-# /mcp untouched — separate BearerAuthMiddleware path
-# ---------------------------------------------------------------------------
+def test_action_log_read_requires_admin(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    c = _client()
+    assert c.get("/api/v1/action-log").status_code == 401
+    assert c.get("/api/v1/action-log", headers=_auth("admin-tok")).status_code != 401
+
+
+@pytest.mark.parametrize("path", [
+    "/api/v1/schedule/history",   # same action_log journal, different route
+    "/api/v1/recent-triggers",    # action_log triggers
+    "/api/v1/workbench/profiles", # LP override sandbox (admin tool)
+    "/api/v1/integrations/smartthings/status",
+])
+def test_other_journal_and_admin_reads_require_admin(monkeypatch, path) -> None:
+    """The Journal data leaks via more than one path — gate the DATA, not one
+    route. A viewer must not read any of these."""
+    _set_tokens(monkeypatch, required=True)
+    c = _client()
+    assert c.get(path).status_code == 401, f"{path} leaked to viewer"
+    assert c.get(path, headers=_auth("ui-tok")).status_code == 401, f"{path} leaked to ui-token"
+    assert c.get(path, headers=_auth("admin-tok")).status_code != 401, f"{path} blocked admin"
+
+
+def test_viewer_can_read_plan_schedule_not_history(monkeypatch) -> None:
+    """The PLAN (/api/v1/schedule) is viewer-readable; only its /history
+    (the journal) is admin-gated. Guards against over-gating the prefix."""
+    _set_tokens(monkeypatch, required=True)
+    assert _client().get("/api/v1/schedule").status_code != 401
+
+
+def test_viewer_refresh_does_not_burn_daikin_quota(monkeypatch) -> None:
+    """GET /daikin/status?refresh=true is a privileged side effect (spends the
+    Onecta quota). A viewer's refresh must be downgraded to the cached read;
+    only an admin forces a live refresh."""
+    _set_tokens(monkeypatch, required=True)
+    from src.api import main as _main
+
+    class _Cached:
+        devices: list = []
+        source = "test"
+        stale = False
+
+    calls = {"force": 0, "cached": 0}
+    monkeypatch.setattr(_main.daikin_service, "force_refresh_devices",
+                        lambda actor=None: (calls.__setitem__("force", calls["force"] + 1), _Cached())[1])
+    monkeypatch.setattr(_main.daikin_service, "get_cached_devices",
+                        lambda allow_refresh=False, actor=None: (calls.__setitem__("cached", calls["cached"] + 1), _Cached())[1])
+    monkeypatch.setattr(_main, "get_daikin_client", lambda: None)
+
+    c = _client()
+    # Viewer asks to refresh → downgraded to cached (no quota burn).
+    c.get("/api/v1/daikin/status?refresh=true")
+    assert calls["force"] == 0 and calls["cached"] == 1
+    # Admin refresh → live force.
+    c.get("/api/v1/daikin/status?refresh=true", headers=_auth("admin-tok"))
+    assert calls["force"] == 1
+
+
+# ── Public paths ────────────────────────────────────────────────────────────
+
+def test_health_and_whoami_public(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    c = _client()
+    assert c.get("/api/v1/health").status_code == 200
+    assert c.get("/api/v1/whoami").status_code == 200
+
+
+def test_whoami_reports_role(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    c = _client()
+    assert c.get("/api/v1/whoami").json()["role"] == "viewer"
+    assert c.get("/api/v1/whoami", headers=_auth("ui-tok")).json()["role"] == "viewer"
+    body = c.get("/api/v1/whoami", headers=_auth("admin-tok")).json()
+    assert body["role"] == "admin"
+    assert body["admin_configured"] is True
+    assert body["auth_enforced"] is True
+
+
+# ── /mcp untouched ──────────────────────────────────────────────────────────
 
 def test_mcp_still_uses_openclaw_token(monkeypatch) -> None:
-    """The /mcp mount must continue to require HEM_OPENCLAW_TOKEN
-    regardless of HEM_UI_AUTH_REQUIRED — that's its own middleware."""
-    _set_tokens(monkeypatch, ui="ui-tok", openclaw="oc-tok-mcp", required=False)
-    # No header → 401 from BearerAuthMiddleware on /mcp
-    resp = _client().get("/mcp/")
-    assert resp.status_code == 401
-    # Wrong token → 401
-    resp = _client().get(
-        "/mcp/", headers={"Authorization": "Bearer wrong"},
-    )
-    assert resp.status_code == 401
-    # UI token alone does NOT open /mcp (that mount only knows the OpenClaw token)
-    resp = _client().get(
-        "/mcp/", headers={"Authorization": "Bearer ui-tok"},
-    )
-    assert resp.status_code == 401
+    _set_tokens(monkeypatch, openclaw="oc-tok-mcp", required=False)
+    c = _client()
+    assert c.get("/mcp/").status_code == 401
+    assert c.get("/mcp/", headers=_auth("wrong")).status_code == 401
+    assert c.get("/mcp/", headers=_auth("ui-tok")).status_code == 401
 
 
-# ---------------------------------------------------------------------------
-# Non-/api/v1 routes (root, /static, etc) — untouched by the new middleware
-# ---------------------------------------------------------------------------
-
-def test_non_api_v1_routes_unaffected_when_gate_required(monkeypatch) -> None:
-    """The cockpit / static templates served from the FastAPI app's root
-    must not be gated by the /api/v1 middleware. (B5 removes them
-    entirely; until then they stay open even with HEM_UI_AUTH_REQUIRED=True.)"""
-    _set_tokens(monkeypatch, ui="ui-tok", openclaw="oc-tok", required=True)
-    # Health is FastAPI-served (not /api/v1 prefix), confirm passthrough
-    resp = _client().get("/healthz")
-    # 200 or 404 are both fine — what matters is NOT 401 from the new guard
-    assert resp.status_code != 401
+def test_non_api_v1_routes_unaffected(monkeypatch) -> None:
+    _set_tokens(monkeypatch, required=True)
+    assert _client().get("/healthz").status_code != 401

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,17 +1,36 @@
 import { Route, Switch } from "wouter-preact";
 import { lazy, Suspense } from "preact/compat";
+import { useEffect } from "preact/hooks";
+import type { ComponentType } from "preact";
 import { TopNav } from "./components/shell/TopNav";
 import { Footer } from "./components/shell/Footer";
 import { ToastHost } from "./components/common/Toast";
 import { Spinner } from "./components/common/Spinner";
 import Landing from "./routes/landing";
+import { role, refreshRole } from "./lib/auth";
 
 // Settings + Report + Insights are lazy — off the critical path (home is default).
 const Settings = lazy(() => import("./routes/settings"));
 const Report = lazy(() => import("./routes/report"));
 const Insights = lazy(() => import("./routes/insights"));
 
+/** Render an admin-only route; viewers get a locked panel instead of the page
+ *  (defense for a direct URL — the API also rejects the underlying calls). */
+function AdminOnlyRoute({ component: C }: { component: ComponentType }) {
+  if (role.value === "admin") return <C />;
+  return (
+    <div class="page-padded admin-locked">
+      <h1>🔒 Admin required</h1>
+      <p>This page is only available to admins. Use the <strong>Admin</strong> button
+        in the top bar to unlock with your secret.</p>
+    </div>
+  );
+}
+
 export function App() {
+  // Confirm our role with the server on boot (a stored admin token may have
+  // been rotated → silently drops to viewer).
+  useEffect(() => { refreshRole(); }, []);
   return (
     <div class="shell">
       <TopNav />
@@ -20,8 +39,8 @@ export function App() {
           <Switch>
             <Route path="/" component={Landing} />
             <Route path="/insights" component={Insights} />
-            <Route path="/report" component={Report} />
-            <Route path="/settings" component={Settings} />
+            <Route path="/report">{() => <AdminOnlyRoute component={Report} />}</Route>
+            <Route path="/settings">{() => <AdminOnlyRoute component={Settings} />}</Route>
             <Route>
               <div class="page-padded">
                 <h1>Not found</h1>

--- a/ui/src/components/home/HeatingControls.tsx
+++ b/ui/src/components/home/HeatingControls.tsx
@@ -5,6 +5,7 @@ import { Toggle } from "../common/Inputs";
 import { Modal } from "../common/Modal";
 import { Icon } from "../common/Icon";
 import { toast } from "../../lib/toast";
+import { role } from "../../lib/auth";
 
 interface HeatingControlsProps {
   dev: DaikinDevice | null;
@@ -27,6 +28,26 @@ function clamp(v: number, lo: number, hi: number): number {
 // needs a confirmation modal — that consent is the gate, so the controls then
 // apply directly (no per-action confirm).
 export function HeatingControls({ dev, controlMode, onChanged }: HeatingControlsProps) {
+  // Viewer is passive — no heat-pump controls. (The API also rejects the
+  // underlying writes; this hides the surface so viewers aren't misled.)
+  if (role.value !== "admin") {
+    return (
+      <div class="heating-controls heating-controls--locked">
+        <div class="heating-controls-head">
+          <span class="heating-controls-title">Controls</span>
+          <span
+            class="heating-controls-passive"
+            title="Heat-pump controls are admin-only. Use the Admin button in the top bar to unlock."
+          >
+            🔒 admin
+          </span>
+        </div>
+        <p class="muted heating-controls-hint">
+          Heat-pump controls are available to admins. Unlock <strong>Admin</strong> in the top bar to change settings.
+        </p>
+      </div>
+    );
+  }
   const active = (dev?.control_mode ?? controlMode) === "active";
   const [unlocked, setUnlocked] = useState(false);
   const [confirmingUnlock, setConfirmingUnlock] = useState(false);

--- a/ui/src/components/shell/AdminButton.tsx
+++ b/ui/src/components/shell/AdminButton.tsx
@@ -1,0 +1,91 @@
+import { useState } from "preact/hooks";
+import { role, adminConfigured, unlock, lock } from "../../lib/auth";
+
+/** Lock/unlock control in the top nav.
+ *  Viewer → a 🔒 button that reveals an inline password field to enter the
+ *  admin secret. Admin → an "Admin" badge + Unlock(lock) button. */
+export function AdminButton() {
+  const [open, setOpen] = useState(false);
+  const [secret, setSecret] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(false);
+
+  if (role.value === "admin") {
+    return (
+      <button
+        type="button"
+        class="admin-badge admin-badge--on"
+        title="You have admin access — click to lock (return to viewer)"
+        onClick={() => lock()}
+      >
+        <span class="admin-dot" aria-hidden="true" />
+        Admin · Lock
+      </button>
+    );
+  }
+
+  // Admin not configured server-side → no way to unlock; show a hint, no field.
+  if (!adminConfigured.value) {
+    return (
+      <span class="admin-badge admin-badge--none" title="No admin secret configured on the server">
+        Viewer
+      </span>
+    );
+  }
+
+  async function submit(e: Event) {
+    e.preventDefault();
+    if (!secret.trim() || busy) return;
+    setBusy(true);
+    setErr(false);
+    const ok = await unlock(secret);
+    setBusy(false);
+    if (ok) {
+      setOpen(false);
+      setSecret("");
+    } else {
+      setErr(true);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        class="admin-badge"
+        title="Unlock admin to change settings"
+        onClick={() => setOpen(true)}
+      >
+        <span class="admin-lock" aria-hidden="true">🔒</span> Admin
+      </button>
+    );
+  }
+
+  return (
+    <form class={`admin-unlock${err ? " admin-unlock--err" : ""}`} onSubmit={submit}>
+      <input
+        type="password"
+        class="admin-unlock-input"
+        placeholder="Admin secret"
+        autoFocus
+        value={secret}
+        disabled={busy}
+        onInput={(e) => {
+          setSecret((e.target as HTMLInputElement).value);
+          setErr(false);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            setOpen(false);
+            setSecret("");
+            setErr(false);
+          }
+        }}
+      />
+      <button type="submit" class="admin-unlock-go" disabled={busy || !secret.trim()}>
+        {busy ? "…" : "Unlock"}
+      </button>
+      {err && <span class="admin-unlock-msg" role="alert">Wrong secret</span>}
+    </form>
+  );
+}

--- a/ui/src/components/shell/Footer.tsx
+++ b/ui/src/components/shell/Footer.tsx
@@ -1,9 +1,11 @@
-import { buildSha, hasBearer } from "../../lib/api";
+import { buildSha } from "../../lib/api";
 import { QuotaChips } from "./QuotaChips";
+import { role } from "../../lib/auth";
 
 export function Footer() {
   const sha = buildSha();
   const shortSha = sha.length > 7 ? sha.slice(0, 7) : sha;
+  const isAdmin = role.value === "admin";
   return (
     <footer class="footer">
       <div class="footer-inner">
@@ -11,8 +13,8 @@ export function Footer() {
           HEM build <code>{shortSha}</code>
         </span>
         <span>•</span>
-        <span title={hasBearer() ? "Authorization header attached to /api requests" : "No bearer configured"}>
-          {hasBearer() ? "Authenticated" : "Unauthenticated"}
+        <span title={isAdmin ? "Admin: write access enabled" : "Viewer: read-only"}>
+          {isAdmin ? "Admin" : "Viewer"}
         </span>
         <span>•</span>
         <QuotaChips />

--- a/ui/src/components/shell/TopNav.tsx
+++ b/ui/src/components/shell/TopNav.tsx
@@ -1,15 +1,20 @@
 import { Link, useLocation } from "wouter-preact";
 import { ThemeToggle } from "./ThemeToggle";
+import { AdminButton } from "./AdminButton";
+import { role } from "../../lib/auth";
 
 const tabs = [
   { href: "/", label: "Home" },
   { href: "/insights", label: "Insights" },
-  { href: "/report", label: "Journal" },
-  { href: "/settings", label: "Settings" },
+  // Journal + Settings are admin-only (they expose action-log + config).
+  { href: "/report", label: "Journal", adminOnly: true },
+  { href: "/settings", label: "Settings", adminOnly: true },
 ];
 
 export function TopNav() {
   const [path] = useLocation();
+  const isAdmin = role.value === "admin";
+  const visible = tabs.filter((t) => !t.adminOnly || isAdmin);
   return (
     <header class="topnav">
       <div class="topnav-inner">
@@ -18,7 +23,7 @@ export function TopNav() {
           <span>Home Energy Manager</span>
         </Link>
         <nav class="topnav-tabs" aria-label="Primary">
-          {tabs.map((t) => (
+          {visible.map((t) => (
             <Link
               key={t.href}
               href={t.href}
@@ -28,6 +33,7 @@ export function TopNav() {
             </Link>
           ))}
         </nav>
+        <AdminButton />
         <ThemeToggle />
       </div>
     </header>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -24,6 +24,27 @@ function runtimeConfig(): RuntimeConfig {
   return window.__HEM_CONFIG__ || DEFAULT_CONFIG;
 }
 
+// ── Admin token (viewer/admin role model) ──────────────────────────────────
+// The UI is a passive VIEWER by default: no Authorization header → the API
+// serves read-only data. An admin "unlocks" by entering the admin secret,
+// which we store here (+ localStorage) and send as the bearer on every request
+// so the API grants write + Settings/Journal access. The baked config.js token
+// is intentionally NOT used — viewer means no token. See lib/auth.ts.
+const ADMIN_TOKEN_KEY = "hem.adminToken";
+let _adminToken: string | null =
+  typeof localStorage !== "undefined" ? localStorage.getItem(ADMIN_TOKEN_KEY) : null;
+
+export function getAdminToken(): string | null {
+  return _adminToken;
+}
+
+export function setAdminToken(token: string | null): void {
+  _adminToken = token && token.trim() ? token.trim() : null;
+  if (typeof localStorage === "undefined") return;
+  if (_adminToken) localStorage.setItem(ADMIN_TOKEN_KEY, _adminToken);
+  else localStorage.removeItem(ADMIN_TOKEN_KEY);
+}
+
 function joinUrl(base: string, path: string): string {
   const cleanPath = path.startsWith("/") ? path : "/" + path;
   const cleanBase = base.replace(/\/$/, "");
@@ -43,10 +64,12 @@ export class HemApiError extends Error {
 type FetchInit = RequestInit & { headers?: HeadersInit };
 
 function withAuth(init: FetchInit | undefined): FetchInit {
-  const cfg = runtimeConfig();
   const headers = new Headers(init?.headers);
-  if (cfg.bearer && !headers.has("Authorization")) {
-    headers.set("Authorization", `Bearer ${cfg.bearer}`);
+  // Admin token only — viewer sends no Authorization header. (The baked
+  // config.js bearer is no longer used: it would be a token readable by any
+  // viewer, so it must not carry privilege.)
+  if (_adminToken && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${_adminToken}`);
   }
   return { ...(init || {}), headers };
 }
@@ -115,5 +138,5 @@ export function buildSha(): string {
 }
 
 export function hasBearer(): boolean {
-  return !!runtimeConfig().bearer;
+  return !!_adminToken;
 }

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,0 +1,60 @@
+// Viewer/Admin role store.
+//
+// The UI is a passive VIEWER by default (read-only, no token) so it can be
+// shared safely. An admin "unlocks" by entering the admin secret; we verify it
+// against GET /whoami, persist it (lib/api.setAdminToken → localStorage) and
+// flip `role` to "admin", which reveals the Settings + Journal tabs and the
+// write controls. Server-side enforcement is the real boundary (ApiV1RoleAuth);
+// this just drives the UI.
+import { signal } from "@preact/signals";
+import { getJson, getAdminToken, setAdminToken } from "./api";
+
+export type Role = "viewer" | "admin";
+
+export const role = signal<Role>(getAdminToken() ? "admin" : "viewer");
+export const adminConfigured = signal<boolean>(true);
+export const authEnforced = signal<boolean>(false);
+
+type WhoAmI = { role: string; admin_configured?: boolean; auth_enforced?: boolean };
+
+/** Re-check the role against the server. Called on boot: a stored admin token
+ *  may have been rotated/revoked, in which case we silently drop to viewer. */
+export async function refreshRole(): Promise<void> {
+  try {
+    const r = await getJson<WhoAmI>("/whoami");
+    adminConfigured.value = r.admin_configured !== false;
+    authEnforced.value = !!r.auth_enforced;
+    const isAdmin = r.role === "admin";
+    role.value = isAdmin ? "admin" : "viewer";
+    if (!isAdmin && getAdminToken()) setAdminToken(null); // stale token → clear
+  } catch {
+    // /whoami unreachable — keep whatever we have (optimistic).
+  }
+}
+
+/** Try to elevate to admin with `secret`. Returns true on success. */
+export async function unlock(secret: string): Promise<boolean> {
+  const prev = getAdminToken();
+  setAdminToken(secret);
+  try {
+    const r = await getJson<WhoAmI>("/whoami");
+    if (r.role === "admin") {
+      role.value = "admin";
+      return true;
+    }
+  } catch {
+    // fall through to revert
+  }
+  setAdminToken(prev); // wrong secret / error → revert to prior state
+  return false;
+}
+
+/** Drop back to viewer. */
+export function lock(): void {
+  setAdminToken(null);
+  role.value = "viewer";
+}
+
+export function isAdmin(): boolean {
+  return role.value === "admin";
+}

--- a/ui/src/styles/shell.css
+++ b/ui/src/styles/shell.css
@@ -74,6 +74,65 @@
   background: var(--bg-card);
   border-color: var(--border);
 }
+/* Admin unlock / lock control (top nav) */
+.admin-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: color 100ms, background 100ms, border-color 100ms;
+}
+.admin-badge:hover { color: var(--text); background: var(--bg-card); }
+.admin-badge--none { cursor: default; opacity: 0.7; }
+.admin-badge--on {
+  color: var(--ok, #10b981);
+  border-color: color-mix(in srgb, var(--ok, #10b981) 45%, transparent);
+}
+.admin-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--ok, #10b981);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ok, #10b981) 22%, transparent);
+}
+.admin-lock { font-size: 0.85em; }
+.admin-unlock {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.admin-unlock-input {
+  width: 130px;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: var(--font-xs);
+}
+.admin-unlock--err .admin-unlock-input { border-color: var(--warn, #f59e0b); }
+.admin-unlock-go {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: var(--font-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.admin-unlock-go:disabled { opacity: 0.5; cursor: default; }
+.admin-unlock-msg { font-size: var(--font-2xs); color: var(--warn, #f59e0b); }
+
+/* Admin-locked route + control placeholders */
+.admin-locked h1 { font-size: var(--font-xl); }
+.heating-controls--locked { opacity: 0.85; }
+
 /* Footer */
 .footer {
   border-top: 1px solid var(--border);


### PR DESCRIPTION
Closes #475

Two access modes so the dashboard is shareable (even outside Tailscale) without exposing controls.

- **Viewer** (default): no token, read-only. Home + Insights. Sends **no** Authorization header.
- **Admin**: types a secret once ("unlock") → stored in the browser, sent as the bearer → Settings/Journal tabs + write controls appear.

## API — the security boundary (`ApiV1RoleAuth`)
- Safe reads (GET/HEAD/OPTIONS) on non-admin paths → open to viewers.
- Writes (POST/PUT/PATCH/DELETE) → admin token required.
- Admin-only reads → Settings, **all** Journal routes (`/action-log`, `/schedule/history`, `/recent-triggers`), integration credentials, workbench sandbox.
- Admin tokens = `HEM_ADMIN_TOKEN` + `HEM_OPENCLAW_TOKEN`. **`HEM_UI_TOKEN` is NOT admin** — it's baked into the UI's `config.js` (any viewer can read it), so it must carry no privilege.
- `GET /api/v1/whoami` (public) reports the caller's role so the UI adapts.
- `?refresh=true` on `/daikin/status` is a privileged side effect (spends the Onecta quota) → honoured only for admins when auth is enforced (no tokenless quota-drain DoS).
- Gated by `HEM_UI_AUTH_REQUIRED` (no-op when False, dev). **Prod must set it True** + set `HEM_ADMIN_TOKEN`.

## UI
`lib/api.ts` (admin-token-only bearer), `lib/auth.ts` (role store + unlock/lock via `/whoami`), `AdminButton` (unlock with secret / lock), `TopNav` (hide Journal/Settings for viewer), `app.tsx` (route guards), `HeatingControls` (hidden for viewer), `Footer` (Viewer/Admin).

## Independent security review → fixes applied
Caught that the Journal leaked via `/schedule/history` + `/recent-triggers` (gate the **data**, not one route) and the refresh-quota DoS. Confirmed `token_matches_any` fails closed when no admin token is configured, `/whoami` echoes no secret, no path-prefix/case bypass (no `root_path`), and the UI no longer transmits the baked token.

## Tests
`tests/api/test_bearer_auth_v1.py` rewritten to the new contract: viewer reads open, writes/Settings/Journal require admin, `HEM_UI_TOKEN` is viewer-level, the other journal routes are gated, the refresh side-effect is admin-only, `/whoami` reports role. Full suite green except the (now-fixed-on-main) nothing — `1441 passed`.

## Deploy note
Needs prod `.env`: `HEM_ADMIN_TOKEN=<secret>` + `HEM_UI_AUTH_REQUIRED=true`. Both images rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)