### PR TITLE
fix(dispatch): don't freeze battery — only merge same-floor SelfUse windows

### DIFF
--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -660,7 +660,16 @@ def _max_optional(a: int | None, b: int | None) -> int | None:
 def _coarse_merge_fox(
     merged: list[tuple[datetime, datetime, tuple]],
 ) -> list[tuple[datetime, datetime, tuple]]:
-    """Collapse SelfUse variants; preserve highest minSocOnGrid + maxSoc when merging solar_charge windows."""
+    """Collapse adjacent SelfUse windows — but ONLY when they share the same
+    ``minSocOnGrid``. A ``solar_charge`` hold (min 100, "let PV stockpile, no
+    discharge") must NEVER merge-absorb a normal SelfUse/peak window (min 10,
+    "discharge to cover load / the evening peak"): taking the higher min froze
+    the battery for the whole merged span — e.g. 11:00–23:59 at 100 % after the
+    morning grid-charge, leaving it unusable through the peak it was charged for
+    (prod 2026-06-06). Keeping differing-min windows separate preserves the
+    standalone hold AND lets the discharge windows discharge; the group-cap /
+    overflow logic handles any extra windows. ``maxSoc`` keeps the higher cap
+    (harmless — it caps charging, not discharge)."""
     out: list[tuple[datetime, datetime, tuple]] = []
     for a, b, k in merged:
         # Normalise SelfUse-shape entries; preserve the original max_soc (5th element).
@@ -668,11 +677,13 @@ def _coarse_merge_fox(
             nk = ("SelfUse", None, None, k[3], k[4] if len(k) > 4 else None)
         else:
             nk = k
-        if out and out[-1][2][0] == "SelfUse" and nk[0] == "SelfUse" and out[-1][1] == a:
+        if (
+            out and out[-1][2][0] == "SelfUse" and nk[0] == "SelfUse"
+            and out[-1][1] == a and out[-1][2][3] == nk[3]  # same floor only
+        ):
             prev = out[-1][2]
-            merged_msg = max(prev[3], nk[3])
             merged_max = _max_optional(prev[4] if len(prev) > 4 else None, nk[4])
-            out[-1] = (out[-1][0], b, ("SelfUse", None, None, merged_msg, merged_max))
+            out[-1] = (out[-1][0], b, ("SelfUse", None, None, nk[3], merged_max))
         elif out and out[-1][2] == nk and out[-1][1] == a:
             out[-1] = (out[-1][0], b, nk)
         else:

--- a/tests/test_fox_merge_selfuse_minsoc.py
+++ b/tests/test_fox_merge_selfuse_minsoc.py
@@ -1,0 +1,43 @@
+"""_coarse_merge_fox must not freeze the battery when it collapses a
+solar_charge SelfUse window (minSocOnGrid=100, "hold for PV") with a normal
+SelfUse window (minSocOnGrid=10, "discharge"). Taking the MAX froze the whole
+merged window at 100% → the battery couldn't discharge during the evening peak
+it was charged for (prod 2026-06-06). The merge must take the MIN so discharge
+stays allowed wherever any constituent window allowed it.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from src.scheduler.optimizer import _coarse_merge_fox
+
+_T0 = datetime(2026, 6, 6, 9, 0, tzinfo=UTC)
+
+
+def _w(h0: int, h1: int, msg: int, max_soc=None):
+    return (_T0 + timedelta(hours=h0), _T0 + timedelta(hours=h1),
+            ("SelfUse", None, None, msg, max_soc))
+
+
+def test_solar_charge_does_not_freeze_adjacent_discharge():
+    # solar_charge (hold, min 100) immediately followed by a self-use window
+    # that must DISCHARGE (min 10). They must NOT collapse into one window
+    # frozen at 100% — the discharge window keeps its reserve floor (the prod
+    # bug: a 100% min spanned the whole evening so the battery never discharged).
+    merged = _coarse_merge_fox([_w(0, 3, 100, 100), _w(3, 8, 10, None)])
+    assert len(merged) == 2, "differing minSoc must stay separate (not freeze)"
+    # the hold stays a hold; the discharge window keeps min 10 (not frozen to 100)
+    assert merged[0][2][3] == 100
+    assert merged[1][2][3] == 10, f"discharge window frozen: min={merged[1][2][3]}"
+
+
+def test_two_solar_charge_holds_stay_held():
+    merged = _coarse_merge_fox([_w(0, 3, 100, 100), _w(3, 6, 100, 100)])
+    assert len(merged) == 1
+    assert merged[0][2][3] == 100  # both hold → stays a hold
+
+
+def test_two_normal_selfuse_stay_at_reserve():
+    merged = _coarse_merge_fox([_w(0, 3, 10), _w(3, 6, 10)])
+    assert len(merged) == 1
+    assert merged[0][2][3] == 10


### PR DESCRIPTION
Closes #479

**Live prod bug today (08:31 BST).** The committed Fox V3 schedule:
| window | mode | status |
|---|---|---|
| 07:00–07:30 | ForceCharge→60% | PAST (cheap morning — correct) |
| 10:00–10:59 | ForceCharge→89% | FUTURE |
| **11:00–23:59** | SelfUse **minSoc 100** | **FUTURE — FROZEN** (no discharge all evening) |
| 00:00–06:59 | SelfUse minSoc 100 | PAST — already froze overnight |

The battery is force-charged from grid in the morning and then **frozen at 100% (can't discharge)** through the 35p evening peak it was charged for → imports at peak instead. The LP plan itself wants to discharge in the evening — only the V3 translation froze it.

**Root cause:** `optimizer._coarse_merge_fox` merged adjacent SelfUse windows with `max(minSocOnGrid)`. A midday `solar_charge` hold (min 100) merged with the evening `standard`/`peak` SelfUse windows (min 10) → merged span inherited 100 → no discharge.

**Fix:** only merge SelfUse windows that share the same `minSocOnGrid`. Holds merge with holds, normals with normals; a hold next to a discharge window stays **separate** so the discharge window keeps min 10. maxSoc keeps the higher cap (harmless).

Pre-existing LP→Fox V3 translation bug, surfaced after #478 changed the plan shape — **not** the load forecast (that's working correctly; the buy *amount* is fine, the bug is that the bought energy was frozen).

## Tests
- New `tests/test_fox_merge_selfuse_minsoc.py` reproduces the freeze (failed before, passes after) + two-holds-merge + two-normals-merge.
- 317 fox/dispatch/optimizer/merge/schedule tests pass; no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)