### PR TITLE
feat(daikin,ui): thermal-coherent LWT + curve-aware radiator plan + load composition

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1508,7 +1508,8 @@ async def daikin_heating_plan():
 
     from .. import db as _db
     from .. import dhw_policy as _dhw
-    from ..scheduler.lp_dispatch import _preheat_lwt_offset
+    from ..physics import get_lwt_base_c
+    from ..scheduler.lp_dispatch import _preheat_lwt_offset, smooth_lwt_offsets
 
     try:
         tz = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
@@ -1606,6 +1607,7 @@ async def daikin_heating_plan():
         return "standard"
 
     slots_out: list[dict] = []
+    raw_offsets: list[int | None] = []
     cur = win_start_utc
     while cur < win_end_utc:
         outdoor = temp_by_hour.get(cur.isoformat().replace("+00:00", "")[:13])
@@ -1614,18 +1616,36 @@ async def daikin_heating_plan():
         off = None
         if enabled and outdoor is not None and price is not None:
             off = _preheat_lwt_offset(price, outdoor, cheap_thr=cheap_thr, peak_thr=peak_thr)
+        raw_offsets.append(off)
         tank_temp, tank_kind = _tank_at(cur)
+        # Natural weather-curve LWT (radiator water temp the firmware targets at
+        # this outdoor temp, offset 0). The offset is only meaningful relative
+        # to this — the real setpoint is curve + offset.
+        lwt_base = round(get_lwt_base_c(outdoor), 1) if (heating_on and outdoor is not None) else None
         slots_out.append({
             "slot_utc": cur.isoformat().replace("+00:00", "Z"),
             "outdoor_c": round(outdoor, 1) if outdoor is not None else None,
             "price_p": round(price, 2) if price is not None else None,
             "tier": _tier(price),
             "lwt_offset": off,
+            "lwt_base_c": lwt_base,
+            "lwt_setpoint_c": None,   # filled after smoothing (depends on offset)
             "heating_on": heating_on,
             "tank_temp_c": tank_temp,
             "tank_kind": tank_kind,
         })
         cur = cur + _td(minutes=30)
+
+    # Apply the same thermal-coherence smoothing the dispatch layer applies, so
+    # the chart shows the sustained blocks we'll actually command (not the raw
+    # per-slot price chatter). The actual radiator setpoint = curve base + the
+    # (smoothed) offset, clamped to the device LWT range.
+    smoothed = smooth_lwt_offsets(raw_offsets, int(getattr(config, "DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS", 4)))
+    for s, off in zip(slots_out, smoothed):
+        s["lwt_offset"] = off
+        base = s.get("lwt_base_c")
+        if base is not None:
+            s["lwt_setpoint_c"] = round(max(18.0, min(50.0, base + (off or 0))), 1)
 
     days_out = [
         {"date": d.isoformat(),

--- a/src/config.py
+++ b/src/config.py
@@ -950,6 +950,15 @@ class Config:
     DAIKIN_LWT_PREHEAT_COMFORT_BAND_C: float = float(
         os.getenv("DAIKIN_LWT_PREHEAT_COMFORT_BAND_C", "0.5")
     )
+    # Thermal coherence: a building's thermal mass has a multi-hour time
+    # constant, so toggling the LWT offset for short price wiggles is both
+    # ineffective and wasteful of the Daikin quota. Smooth the per-slot offset
+    # sequence so it changes only in sustained blocks: short 0-gaps between two
+    # equal non-zero blocks are bridged, and any boost/setback block shorter
+    # than this many half-hour slots is dropped to neutral. Default 4 = 2 h.
+    DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS: int = int(
+        os.getenv("DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS", "4")
+    )
     OPTIMIZATION_DISABLE_WEATHER_REGULATION: bool = os.getenv(
         "OPTIMIZATION_DISABLE_WEATHER_REGULATION", "false"
     ).lower() in ("true", "1", "yes")

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -360,6 +360,62 @@ def _preheat_lwt_offset(
     return max(lo, min(hi, int(off)))
 
 
+def smooth_lwt_offsets(offsets: list[int | None], min_block: int) -> list[int | None]:
+    """Make a per-slot LWT-offset sequence thermally coherent (#481 follow-up).
+
+    A building's thermal mass has a multi-hour time constant, so a per-slot
+    price-tier offset chatters (e.g. ``+3, 0, +3, 0, +3`` when the price hovers
+    at the cheap threshold) — thermally pointless and a waste of Daikin writes.
+    Two passes, in order:
+
+    1. **Bridge** short ``0`` gaps (``< min_block`` slots) that sit between two
+       runs of the SAME non-zero offset — a brief price blip shouldn't fracture
+       a sustained boost/setback block.
+    2. **Drop** any non-zero run shorter than ``min_block`` to ``0`` — a boost
+       or setback too short to move the thermal mass isn't worth a write.
+
+    ``None`` slots (not heating / feature off) are inert: never bridged across,
+    never counted in a run. With ``min_block <= 1`` the input is returned as-is.
+    """
+    out = list(offsets)
+    n = len(out)
+    if min_block <= 1 or n == 0:
+        return out
+
+    # Pass 1 — bridge short same-value 0-gaps.
+    i = 0
+    while i < n:
+        if out[i] != 0:
+            i += 1
+            continue
+        j = i
+        while j < n and out[j] == 0:
+            j += 1
+        left = out[i - 1] if i > 0 else None
+        right = out[j] if j < n else None
+        if (j - i) < min_block and left is not None and left != 0 and left == right:
+            for k in range(i, j):
+                out[k] = left
+        i = j
+
+    # Pass 2 — drop sub-threshold non-zero blocks to neutral.
+    i = 0
+    while i < n:
+        v = out[i]
+        if not v:  # None or 0
+            i += 1
+            continue
+        j = i
+        while j < n and out[j] == v:
+            j += 1
+        if (j - i) < min_block:
+            for k in range(i, j):
+                out[k] = 0
+        i = j
+
+    return out
+
+
 def _lwt_preheat_pairs(
     plan: LpPlan,
     forecast: list[HourlyForecast],
@@ -398,6 +454,11 @@ def _lwt_preheat_pairs(
         offsets.append(_preheat_lwt_offset(
             price, outdoor, cheap_thr=cheap_thr, peak_thr=peak_thr, indoor_c=indoor_c,
         ))
+
+    # Thermal coherence: collapse per-slot price chatter into sustained blocks
+    # so we don't toggle the heat pump for wiggles the thermal mass can't follow
+    # (and don't burn Daikin writes doing it). See ``smooth_lwt_offsets``.
+    offsets = smooth_lwt_offsets(offsets, int(config.DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS))
 
     restore_window = max(2, int(getattr(config, "LP_RESTORE_WINDOW_MINUTES", 5)))
     out: list[tuple[dict[str, Any] | None, dict[str, Any]]] = []

--- a/tests/test_heating_plan_endpoint.py
+++ b/tests/test_heating_plan_endpoint.py
@@ -43,6 +43,9 @@ def test_heating_plan_cold_cheap_slot_boosts(monkeypatch):
     monkeypatch.setattr(config, "OPTIMIZATION_CHEAP_THRESHOLD_PENCE", 12.0, raising=False)
     monkeypatch.setattr(config, "OPTIMIZATION_PEAK_THRESHOLD_PENCE", 25.0, raising=False)
     monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE", raising=False)
+    # Disable smoothing so a single seeded slot's offset survives (smoothing has
+    # its own tests); this checks the per-slot offset + curve-setpoint math.
+    monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS", 1, raising=False)
 
     # A cold (5 °C) + cheap (5p) slot at 10:00 UTC today → boost +3.
     today = datetime.now(_tz()).date()
@@ -77,6 +80,9 @@ def test_heating_plan_cold_cheap_slot_boosts(monkeypatch):
     assert target["tier"] == "cheap"
     assert target["heating_on"] is True
     assert target["lwt_offset"] == 3  # cold + cheap → +BOOST
+    # Radiator setpoint = weather-curve base (at 5 °C) + offset; base in [18,50].
+    assert target["lwt_base_c"] is not None and 18.0 <= target["lwt_base_c"] <= 50.0
+    assert target["lwt_setpoint_c"] == round(min(50.0, target["lwt_base_c"] + 3), 1)
     # A tank target/kind is resolved for the slot (dhw_policy, allow_past).
     assert target["tank_kind"] in ("warmup", "setback", "boost")
 

--- a/tests/test_lwt_preheat.py
+++ b/tests/test_lwt_preheat.py
@@ -19,8 +19,40 @@ import pytest
 
 from src.config import config
 from src.daikin.models import DaikinDevice
-from src.scheduler.lp_dispatch import _lwt_preheat_pairs, _preheat_lwt_offset
+from src.scheduler.lp_dispatch import _lwt_preheat_pairs, _preheat_lwt_offset, smooth_lwt_offsets
 from src.scheduler.lp_optimizer import LpPlan
+
+
+# --------------------------------------------------------------------------- #
+# smooth_lwt_offsets — thermal coherence (no per-slot chatter)
+# --------------------------------------------------------------------------- #
+def test_smooth_drops_short_isolated_blocks():
+    # A lone 1-slot boost is thermally negligible → dropped to neutral.
+    assert smooth_lwt_offsets([0, 0, 3, 0, 0], 4) == [0, 0, 0, 0, 0]
+
+
+def test_smooth_keeps_sustained_blocks():
+    # A 4-slot boost meets the threshold → kept.
+    assert smooth_lwt_offsets([3, 3, 3, 3, 0], 4) == [3, 3, 3, 3, 0]
+
+
+def test_smooth_bridges_short_gap_between_same_blocks():
+    # The real chatter case: +3,0,+3,0,+3 around the cheap threshold → one block.
+    assert smooth_lwt_offsets([3, 0, 3, 0, 3, 3, 3, 3], 4) == [3, 3, 3, 3, 3, 3, 3, 3]
+
+
+def test_smooth_does_not_bridge_different_neighbours():
+    # boost→0→setback is a genuine transition; the 0 buffer stays.
+    out = smooth_lwt_offsets([3, 3, 3, 3, 0, -2, -2, -2, -2], 4)
+    assert out == [3, 3, 3, 3, 0, -2, -2, -2, -2]
+
+
+def test_smooth_passthrough_when_min_block_one():
+    assert smooth_lwt_offsets([3, 0, -2, 0, 3], 1) == [3, 0, -2, 0, 3]
+
+
+def test_smooth_preserves_none():
+    assert smooth_lwt_offsets([None, None, 3, 3, 3, 3, None], 4) == [None, None, 3, 3, 3, 3, None]
 
 # Tiers used throughout: cheap ≤ 12, peak ≥ 25 (the prod defaults).
 CHEAP = 12.0
@@ -39,6 +71,9 @@ def enabled(monkeypatch):
     monkeypatch.setattr(config, "OPTIMIZATION_LWT_OFFSET_MAX", 5.0)
     monkeypatch.setattr(config, "DAIKIN_WEATHER_CURVE_HIGH_C", 18.0)
     monkeypatch.setattr(config, "INDOOR_SETPOINT_C", 21.0)
+    # Disable thermal-coherence smoothing for the per-slot windowing tests so a
+    # short test sequence isn't collapsed; smoothing is exercised separately.
+    monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS", 1)
 
 
 def _off(price, outdoor, **kw):

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -168,11 +168,12 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
         </div>
       )}
       {granularity === "day" && dayHasSlots && (
-        <div class="echart-flag">
-          <span class="echart-flag-icon"><Icon name="schedule" size={14} /></span>
-          Household load: <strong>forecast</strong> (dashed) vs <strong>actual</strong>
-          {" "}(solid) — residual demand, i.e. consumption minus the heat pump.
-          Daikin shown as a context line; tariff tier shades the background.
+        <div class="echart-legend2">
+          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--house)" /> Base</span>
+          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--accent)" /> Appliances</span>
+          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--warn)" /> Heat pump</span>
+          <span class="echart-l2"><span class="echart-l2-line" /> Forecast</span>
+          <span class="echart-l2-hint">stacked = where your energy goes · ◉ now</span>
         </div>
       )}
 
@@ -351,25 +352,38 @@ function optionForDay(
     priceBy.set(s.slot_utc, s.import_price_p ?? null);
   }
 
-  // Forecast residual household load (LP's load forecast, excludes heat pump).
-  const loadForecast = axis.map((iso) => {
-    const v = fcastBy.get(iso);
-    return v == null ? null : round2(v);
-  });
-  // Measured residual load = consumption − Daikin. Prefer residual_kwh; else
-  // base+appliance estimate; else consumption − daikin estimate.
-  const loadActual = axis.map((iso) => {
+  // Actual consumption split into a stacked composition — where the energy
+  // actually went, slot by slot: base (lights/fridge/always-on) + appliances
+  // (armed washer/dryer/dishwasher) + the Daikin heat pump.
+  const baseActual = axis.map((iso) => {
     const e = execBy.get(iso);
     if (!e) return null;
-    if (e.residual_kwh != null) return round2(e.residual_kwh);
-    if (e.base_load_kwh_est != null) return round2((e.base_load_kwh_est ?? 0) + (e.appliance_kwh_est ?? 0));
-    if (e.consumption_kwh != null) return round2(Math.max(0, e.consumption_kwh - (e.daikin_kwh_est ?? 0)));
+    if (e.base_load_kwh_est != null) return round2(e.base_load_kwh_est);
+    if (e.consumption_kwh != null) return round2(Math.max(0, e.consumption_kwh - (e.daikin_kwh_est ?? 0) - (e.appliance_kwh_est ?? 0)));
     return null;
   });
-  // Daikin (heat-pump) actual — context only, not part of the forecast pair.
+  const applianceActual = axis.map((iso) => {
+    const e = execBy.get(iso);
+    return e?.appliance_kwh_est == null ? null : round2(e.appliance_kwh_est);
+  });
   const daikinActual = axis.map((iso) => {
     const e = execBy.get(iso);
     return e?.daikin_kwh_est == null ? null : round2(e.daikin_kwh_est);
+  });
+  const hasAppliance = applianceActual.some((v) => (v ?? 0) > 0);
+  const totalActual = axis.map((iso, k) => {
+    const e = execBy.get(iso);
+    if (!e) return null;
+    if (e.consumption_kwh != null) return round2(e.consumption_kwh);
+    const b = baseActual[k] ?? 0, a = applianceActual[k] ?? 0, d = daikinActual[k] ?? 0;
+    return (baseActual[k] == null && applianceActual[k] == null && daikinActual[k] == null)
+      ? null : round2(b + a + d);
+  });
+  // Forecast household demand (LP's residual load forecast, excludes heat pump)
+  // — overlaid as a dashed line to compare against the base+appliance stack.
+  const loadForecast = axis.map((iso) => {
+    const v = fcastBy.get(iso);
+    return v == null ? null : round2(v);
   });
   const price = axis.map((iso) => priceBy.get(iso) ?? null);
 
@@ -423,53 +437,42 @@ function optionForDay(
     }
   }
 
+  const stackArea = (color: string, top: number) => ({
+    opacity: 1, color: areaGradient(color, top, top * 0.55),
+  });
   return {
     ...base,
-    legend: { ...(base.legend as object), data: ["Load forecast", "Load actual", "Daikin"] },
+    legend: { show: false },
     tooltip: {
       ...(base.tooltip as object),
       formatter: (params: Array<{ dataIndex: number }>) => {
         const i = params[0]?.dataIndex ?? 0;
         const tier = tierOf(price[i]);
-        const scale = Math.max(0.01, loadForecast[i] ?? 0, loadActual[i] ?? 0, daikinActual[i] ?? 0);
+        const scale = Math.max(0.01, totalActual[i] ?? 0, loadForecast[i] ?? 0);
         const bar = (label: string, val: number | null, col: string) => {
-          if (val == null || !Number.isFinite(val)) return "";
-          const w = Math.round(Math.max(0, Math.min(1, val / scale)) * 78);
+          if (val == null || !Number.isFinite(val) || val <= 0) return "";
+          const w = Math.round(Math.max(0, Math.min(1, val / scale)) * 70);
           return `<div style="display:flex;align-items:center;gap:6px;margin-top:3px;">` +
-            `<span style="width:74px;color:${t.textMute};font-size:11px;">${label}</span>` +
+            `<span style="width:70px;color:${t.textMute};font-size:11px;">${label}</span>` +
             `<span style="display:inline-block;width:${w}px;height:7px;border-radius:3px;background:${col};"></span>` +
             `<span style="font-size:11px;color:${t.text};">${val.toFixed(2)}</span></div>`;
         };
-        let missRow = "";
-        if (loadActual[i] != null && loadForecast[i] != null) {
-          const miss = loadActual[i]! - loadForecast[i]!;
-          const col = miss <= 0 ? t.cheap : t.importColor;
-          missRow = `<div style="margin-top:4px;font-size:11px;color:${col};">` +
-            `load ${miss <= 0 ? "under forecast −" : "over forecast +"}${Math.abs(miss).toFixed(2)} kWh</div>`;
-        }
         const head = `<strong>${labels[i]}</strong>${tier ? ` · ${tier}` : ""}` +
           (price[i] != null ? ` · ${price[i]!.toFixed(1)}p/kWh` : "");
-        return head +
-          bar("Load forecast", loadForecast[i], withAlpha(t.textMute, 0.5)) +
-          bar("Load actual", loadActual[i], withAlpha(t.textMute, 0.95)) +
-          missRow +
-          (daikinActual[i] != null
-            ? `<div style="margin-top:5px;border-top:1px solid ${withAlpha(t.textMute, 0.25)};padding-top:2px;"></div>` +
-              bar("Daikin (heat)", daikinActual[i], t.warn)
+        const totalRow = totalActual[i] != null
+          ? `<div style="margin-top:2px;font-size:11px;color:${t.text};">Total <strong>${totalActual[i]!.toFixed(2)} kWh</strong></div>` : "";
+        return head + totalRow +
+          bar("Base", baseActual[i], t.house) +
+          (hasAppliance ? bar("Appliances", applianceActual[i], t.accent) : "") +
+          bar("Heat pump", daikinActual[i], t.warn) +
+          (loadForecast[i] != null
+            ? `<div style="margin-top:4px;border-top:1px solid ${withAlpha(t.textMute, 0.25)};padding-top:2px;"></div>` +
+              bar("Forecast", loadForecast[i], withAlpha(t.textMute, 0.7))
             : "");
       },
     },
     xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
-    yAxis: [
-      { ...(base.yAxis as object), name: "kWh", position: "left" },
-      {
-        ...(base.yAxis as object),
-        name: "p",
-        position: "right",
-        splitLine: { show: false },
-        axisLabel: { color: t.textMute, fontSize: 11, formatter: "{value}p" },
-      },
-    ],
+    yAxis: [{ ...(base.yAxis as object), name: "kWh", position: "left" }],
     series: [
       // Tariff bands + now marker on a silent baseline series.
       {
@@ -482,30 +485,26 @@ function optionForDay(
         } : undefined,
         z: 0,
       },
-      // Load forecast — dim dashed line (the LP's prediction).
+      // Stacked composition — base (bottom) + appliances + heat pump. Smooth
+      // areas so the total reads as one filled shape; this is "where the energy
+      // went" through the day.
       {
-        name: "Load forecast", type: "line", smooth: true, showSymbol: false,
+        name: "Base", type: "line", stack: "load", smooth: true, showSymbol: false,
+        data: baseActual, lineStyle: { width: 0 }, areaStyle: stackArea(t.house, 0.7), z: 2,
+      },
+      ...(hasAppliance ? [{
+        name: "Appliances", type: "line", stack: "load", smooth: true, showSymbol: false,
+        data: applianceActual, lineStyle: { width: 0 }, areaStyle: stackArea(t.accent, 0.7), z: 2,
+      }] : []),
+      {
+        name: "Heat pump", type: "line", stack: "load", smooth: true, showSymbol: false,
+        data: daikinActual, lineStyle: { width: 0 }, areaStyle: stackArea(t.warn, 0.75), z: 2,
+      },
+      // Forecast household demand — a clean dashed line over the stack.
+      {
+        name: "Forecast", type: "line", smooth: true, showSymbol: false, connectNulls: false,
         data: loadForecast,
-        lineStyle: { color: withAlpha(t.textMute, 0.5), width: 1.5, type: "dashed", cap: "round" }, z: 2,
-      },
-      // Load actual — the ONE bold line: solid grey + gradient fill.
-      {
-        name: "Load actual", type: "line", smooth: true, showSymbol: false, connectNulls: false,
-        data: loadActual,
-        lineStyle: { color: withAlpha(t.house, 0.95), width: 2.75, cap: "round" },
-        areaStyle: { color: areaGradient(t.house, 0.28, 0.02) }, z: 4,
-      },
-      // Daikin (heat-pump) actual — quiet amber context line.
-      {
-        name: "Daikin", type: "line", smooth: true, showSymbol: false, connectNulls: false,
-        data: daikinActual,
-        lineStyle: { color: withAlpha(t.warn, 0.85), width: 1.25, type: [4, 4], cap: "round" }, z: 3,
-      },
-      // Import price → dashed step on the right axis (reference, not a hard line).
-      {
-        name: "Import price", type: "line", step: "middle", showSymbol: false,
-        yAxisIndex: 1, data: price,
-        lineStyle: { color: t.importColor, width: 1.25, opacity: 0.7, type: "dashed" }, z: 1,
+        lineStyle: { color: withAlpha(t.textMute, 0.85), width: 1.5, type: "dashed", cap: "round" }, z: 5,
       },
       // Pulsing "now".
       ...(nowIdx >= 0 ? [{

--- a/ui/src/components/home/HeatingPlanWidget.tsx
+++ b/ui/src/components/home/HeatingPlanWidget.tsx
@@ -14,11 +14,12 @@ function localHM(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
-// Heating-plan timeline (yesterday · today · tomorrow), one continuous chart in
-// the Today's-plan idiom: outdoor-temperature forecast + the LP/dispatch heating
-// decisions per slot — does it heat (warm background wash), how much LWT offset
-// (purple step, right axis), and the tank target (orange step). Tariff context
-// + price live in the tooltip; negative-price windows get a blue band.
+// Heating-plan timeline (yesterday · today · tomorrow). The story it tells, in
+// one temperature axis: the OUTDOOR forecast drives the weather-curve LWT (the
+// natural radiator water temp), and HEM nudges that into the actual RADIATOR
+// setpoint = curve + offset — boosting ahead of expensive periods, setting back
+// through them. The gap between the faint curve line and the bold radiator line
+// IS the offset. Tank target rides alongside; warm wash = heating, blue = paid.
 export function HeatingPlanWidget({ plan, loading }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
@@ -46,12 +47,13 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
     const labels = slots.map((s) => localHM(s.slot_utc));
 
     const outdoor = slots.map((s) => (s.outdoor_c == null ? null : s.outdoor_c));
+    const lwtBase = slots.map((s) => (s.lwt_base_c == null ? null : s.lwt_base_c));
+    const lwtSet = slots.map((s) => (s.lwt_setpoint_c == null ? null : s.lwt_setpoint_c));
     const tank = slots.map((s) => (s.tank_temp_c == null ? null : s.tank_temp_c));
-    const offset = slots.map((s) => (s.lwt_offset == null ? null : s.lwt_offset));
     const animate = !reducedMotion();
 
-    // --- Background bands: contiguous runs of heating-on (warm wash) + a
-    // stronger blue band over negative-price slots (the money event).
+    // Background bands: heating-on warm wash + a stronger blue band on
+    // negative-price ("paid to import") slots.
     type BandItem = [{ xAxis: number; itemStyle: object }, { xAxis: number }];
     const bands: BandItem[] = [];
     const runs = (pred: (i: number) => boolean, fill: object) => {
@@ -59,16 +61,12 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
       for (let i = 0; i <= n; i++) {
         const on = i < n && pred(i);
         if (on && start < 0) start = i;
-        if (!on && start >= 0) {
-          bands.push([{ xAxis: start - 0.5, itemStyle: fill }, { xAxis: i - 1 + 0.5 }]);
-          start = -1;
-        }
+        if (!on && start >= 0) { bands.push([{ xAxis: start - 0.5, itemStyle: fill }, { xAxis: i - 1 + 0.5 }]); start = -1; }
       }
     };
-    runs((i) => !!slots[i].heating_on, { color: withAlpha(t.warn, 0.07) });
-    runs((i) => slots[i].tier === "negative", { color: withAlpha(t.neg, 0.22), borderColor: withAlpha(t.neg, 0.8), borderWidth: 1 });
+    runs((i) => !!slots[i].heating_on, { color: withAlpha(t.warn, 0.06) });
+    runs((i) => slots[i].tier === "negative", { color: withAlpha(t.neg, 0.2), borderColor: withAlpha(t.neg, 0.75), borderWidth: 1 });
 
-    // --- Day separators + "now" marker (index-based, DST-safe).
     const dayStartIdx = (plan.days || []).map((d) => slots.findIndex((s) => s.slot_utc >= d.start_utc)).filter((i) => i > 0);
     const nowMs = plan.now_utc ? new Date(plan.now_utc).getTime() : Date.now();
     const firstMs = new Date(slots[0].slot_utc).getTime();
@@ -79,75 +77,61 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
       nowIdx = idx <= 0 ? n - 1 : idx - 1;
     }
     const dayLines = dayStartIdx.map((i) => ({
-      xAxis: i, lineStyle: { color: withAlpha(t.textMute, 0.4), width: 1, type: "solid" as const }, label: { show: false },
+      xAxis: i, lineStyle: { color: withAlpha(t.textMute, 0.35), width: 1, type: "solid" as const }, label: { show: false },
     }));
     const nowLine = nowIdx >= 0
-      ? [{ xAxis: nowIdx, lineStyle: { color: t.text, width: 1.5, opacity: 0.55 }, label: { show: false } }]
+      ? [{ xAxis: nowIdx, lineStyle: { color: t.text, width: 1.5, opacity: 0.5 }, label: { show: false } }]
       : [];
 
     chartRef.current.setOption({
       ...base,
       legend: { show: false },
-      grid: { left: 16, right: 40, top: 14, bottom: 22, containLabel: true },
+      grid: { left: 14, right: 16, top: 14, bottom: 22, containLabel: true },
       tooltip: {
         ...(base.tooltip as object),
         formatter: (params: Array<{ dataIndex: number }>) => {
           const i = params[0]?.dataIndex ?? 0;
           const s = slots[i];
           if (!s) return "";
-          const rows: string[] = [];
-          rows.push(`<strong>${labels[i]}</strong>${s.heating_on ? " · heating" : " · idle"}`);
-          if (s.outdoor_c != null) rows.push(`Outdoor: <strong>${s.outdoor_c.toFixed(1)}°C</strong>`);
-          if (s.lwt_offset != null) rows.push(`LWT offset: <strong>${s.lwt_offset > 0 ? "+" : ""}${s.lwt_offset}°C</strong>`);
-          if (s.tank_temp_c != null) rows.push(`Tank: <strong>${s.tank_temp_c}°C</strong>${s.tank_kind ? ` (${s.tank_kind})` : ""}`);
-          if (s.price_p != null) rows.push(`Price: ${s.price_p.toFixed(1)}p${s.tier ? ` · ${s.tier}` : ""}`);
+          const rows: string[] = [`<strong>${labels[i]}</strong>${s.heating_on ? " · heating" : " · idle"}`];
+          if (s.outdoor_c != null) rows.push(`Outdoor <strong>${s.outdoor_c.toFixed(1)}°C</strong>`);
+          if (s.lwt_setpoint_c != null) {
+            const off = s.lwt_offset || 0;
+            const offTxt = off ? ` (curve ${s.lwt_base_c?.toFixed(0)} ${off > 0 ? "+" : "−"}${Math.abs(off)})` : "";
+            rows.push(`Radiator LWT <strong>${s.lwt_setpoint_c.toFixed(0)}°C</strong>${offTxt}`);
+          }
+          if (s.tank_temp_c != null) rows.push(`Tank <strong>${s.tank_temp_c}°C</strong>${s.tank_kind ? ` · ${s.tank_kind}` : ""}`);
+          if (s.price_p != null) rows.push(`<span style="color:${t.textMute}">${s.price_p.toFixed(1)}p${s.tier ? ` · ${s.tier}` : ""}</span>`);
           return rows.join("<br/>");
         },
       },
       xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 11 } },
-      yAxis: [
-        { ...(base.yAxis as object), name: "°C", nameTextStyle: { color: t.textMute, fontSize: 10 },
-          axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}" } },
-        { ...(base.yAxis as object), name: "LWT", position: "right", splitLine: { show: false },
-          nameTextStyle: { color: t.textMute, fontSize: 10 },
-          axisLabel: { color: t.textMute, fontSize: 10, formatter: (v: number) => `${v > 0 ? "+" : ""}${v}` } },
-      ],
+      yAxis: [{ ...(base.yAxis as object), name: "°C", nameTextStyle: { color: t.textMute, fontSize: 10 },
+        axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}" } }],
       series: [
-        // Background bands + day separators + now line on a silent baseline.
-        {
-          name: "_bg", type: "line", data: slots.map(() => null), silent: true, z: 0,
+        { name: "_bg", type: "line", data: slots.map(() => null), silent: true, z: 0,
           markArea: bands.length ? { silent: true, data: bands } : undefined,
-          markLine: (dayLines.length || nowLine.length)
-            ? { silent: true, symbol: "none", data: [...dayLines, ...nowLine] }
-            : undefined,
-        },
-        // Outdoor temperature — the hero line (cool blue) with a soft fill.
-        {
-          name: "Outdoor", type: "line", smooth: true, showSymbol: false, connectNulls: true,
-          data: outdoor, yAxisIndex: 0,
-          lineStyle: { color: t.grid, width: 2.5, cap: "round" },
-          areaStyle: { color: areaGradient(t.grid, 0.18, 0.01) }, z: 4,
-        },
-        // Tank target — orange step (thermal).
-        {
-          name: "Tank", type: "line", step: "middle", smooth: false, showSymbol: false, connectNulls: false,
-          data: tank, yAxisIndex: 0,
-          lineStyle: { color: t.thermal, width: 1.75, type: "dashed", cap: "round" }, z: 3,
-        },
-        // LWT offset — purple step on the right axis.
-        {
-          name: "LWT offset", type: "line", step: "middle", showSymbol: false, connectNulls: false,
-          data: offset, yAxisIndex: 1,
-          lineStyle: { color: t.house, width: 2, cap: "round" },
-          areaStyle: { color: areaGradient(t.house, 0.14, 0.0), origin: "start" }, z: 2,
-        },
-        // Pulsing "now".
+          markLine: (dayLines.length || nowLine.length) ? { silent: true, symbol: "none", data: [...dayLines, ...nowLine] } : undefined },
+        // Outdoor — the cause (cool blue, soft fill, sits low).
+        { name: "Outdoor", type: "line", smooth: true, showSymbol: false, connectNulls: true,
+          data: outdoor, lineStyle: { color: t.grid, width: 2, cap: "round" },
+          areaStyle: { color: areaGradient(t.grid, 0.14, 0.0) }, z: 2 },
+        // Weather-curve LWT (offset 0) — faint dotted reference.
+        { name: "Curve LWT", type: "line", smooth: true, showSymbol: false, connectNulls: false,
+          data: lwtBase, lineStyle: { color: withAlpha(t.house, 0.45), width: 1, type: "dotted" }, z: 3 },
+        // Radiator LWT (curve + offset) — the hero: what HEM actually commands.
+        { name: "Radiator LWT", type: "line", smooth: true, showSymbol: false, connectNulls: false,
+          data: lwtSet, lineStyle: { color: t.house, width: 2.75, cap: "round" },
+          areaStyle: { color: areaGradient(t.house, 0.12, 0.0) }, z: 5 },
+        // Tank target — orange step.
+        { name: "Tank", type: "line", step: "middle", showSymbol: false, connectNulls: false,
+          data: tank, lineStyle: { color: t.thermal, width: 1.5, type: "dashed", cap: "round" }, z: 4 },
         ...(nowIdx >= 0 ? [{
           name: "_now", type: "effectScatter", silent: true, coordinateSystem: "cartesian2d",
-          symbolSize: 9, z: 6, showEffectOn: "render",
+          symbolSize: 8, z: 6, showEffectOn: "render",
           rippleEffect: { period: animate ? 2.4 : 0, scale: animate ? 3.0 : 1, brushType: "stroke" },
           itemStyle: { color: t.accent, shadowBlur: 8, shadowColor: t.accent },
-          data: [[nowIdx, outdoor[nowIdx] ?? 12]],
+          data: [[nowIdx, lwtSet[nowIdx] ?? outdoor[nowIdx] ?? 20]],
         }] : []),
       ],
     }, { notMerge: true });
@@ -164,11 +148,12 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
       {plan?.slots?.length ? (
         <div class="hpl-legend" role="note" aria-label="Chart legend">
           <span class="hpl-tok"><span class="hpl-line hpl-line--outdoor" /> outdoor</span>
-          <span class="hpl-tok"><span class="hpl-line hpl-line--tank" /> tank target</span>
-          <span class="hpl-tok"><span class="hpl-line hpl-line--lwt" /> LWT offset</span>
-          <span class="hpl-tok"><span class="hpl-sw hpl-sw--heat" /> heating on</span>
+          <span class="hpl-tok"><span class="hpl-line hpl-line--lwt" /> radiator LWT</span>
+          <span class="hpl-tok"><span class="hpl-line hpl-line--curve" /> curve (no offset)</span>
+          <span class="hpl-tok"><span class="hpl-line hpl-line--tank" /> tank</span>
+          <span class="hpl-tok"><span class="hpl-sw hpl-sw--heat" /> heating</span>
           <span class="hpl-tok"><span class="hpl-sw hpl-sw--neg" /> paid to import</span>
-          <span class="hpl-hint">◉ now · hover a slot for detail</span>
+          <span class="hpl-hint">◉ now · hover for detail</span>
         </div>
       ) : null}
       {!plan?.slots?.length && !loading && <p class="muted">No heating plan available yet.</p>}

--- a/ui/src/components/home/energy-chart.css
+++ b/ui/src/components/home/energy-chart.css
@@ -121,3 +121,21 @@
 .echart-tok-daikin { color: var(--warn); }
 .echart-tok-resid  { color: var(--house); }
 .echart-tok-mute   { color: var(--text-mute); font-weight: 500; }
+
+/* Day-view stacked-composition legend (Load details). */
+.echart-legend2 {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: var(--font-2xs);
+  color: var(--text-dim);
+  padding: 4px 4px 0;
+}
+.echart-l2 { display: inline-flex; align-items: center; gap: 5px; }
+.echart-l2-sw { display: inline-block; width: 11px; height: 11px; border-radius: 3px; }
+.echart-l2-line {
+  display: inline-block; width: 16px; height: 0;
+  border-top: 1.5px dashed var(--text-mute);
+}
+.echart-l2-hint { margin-left: auto; color: var(--text-mute); }

--- a/ui/src/components/home/heating-plan.css
+++ b/ui/src/components/home/heating-plan.css
@@ -48,7 +48,8 @@
 }
 .hpl-line--outdoor { border-top-color: var(--grid, #60a5fa); }
 .hpl-line--tank    { border-top-style: dashed; border-top-color: var(--thermal, #fb923c); }
-.hpl-line--lwt     { border-top-color: var(--house, #c084fc); }
+.hpl-line--lwt     { border-top-width: 3px; border-top-color: var(--house, #c084fc); }
+.hpl-line--curve   { border-top-style: dotted; border-top-color: color-mix(in srgb, var(--house, #c084fc) 55%, transparent); }
 .hpl-sw {
   display: inline-block;
   width: 11px;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -476,6 +476,8 @@ export interface HeatingPlanSlot {
   price_p?: number | null;
   tier?: "negative" | "cheap" | "standard" | "peak" | null;
   lwt_offset?: number | null;     // integer °C, e.g. +3 / -2; null = no offset
+  lwt_base_c?: number | null;     // weather-curve LWT at this outdoor temp (offset 0)
+  lwt_setpoint_c?: number | null; // actual radiator target = base + offset
   heating_on?: boolean;
   tank_temp_c?: number | null;
   tank_kind?: "warmup" | "setback" | "boost" | null;


### PR DESCRIPTION
Three issues raised by the user on the heating/load widgets.

## 1. LWT chatter wasn't thermally coherent (and burned Daikin writes)

The per-slot price-tier offset toggled `+3 / 0 / +3 / 0 / +3` when the price
hovered at the cheap threshold (real prod data, 05:00–07:00). A building's
thermal mass has a multi-hour time constant, so those flips do nothing thermally
and cost Daikin writes. New `smooth_lwt_offsets(offsets, min_block)`:
- **bridges** short `0`-gaps (`< min_block`) between two equal non-zero blocks;
- **drops** any non-zero block shorter than `min_block` to neutral.

`DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS` (default **4 = 2 h**). Applied in both the
dispatch actuation (`_lwt_preheat_pairs`) and the heating-plan endpoint, so the
chart shows the sustained blocks we actually command.

## 2. The offset is meaningless without the radiator (weather) curve

Per the user's WD curve (LWT vs outdoor). The heating-plan endpoint now returns
`lwt_base_c` (= `get_lwt_base_c(outdoor)`, the curve at that temp) and
`lwt_setpoint_c` (= base + offset, clamped). The chart was rebuilt around the
**actual radiator LWT**: outdoor (cause) → curve LWT (faint dotted) → radiator
setpoint (bold) — the gap between them *is* the offset — plus tank target.

## 3. "Load details" passed no information

The day view was two faint residual lines. Rebuilt into a clean **stacked-area
composition** — Base + Appliances + Heat pump = where the energy actually goes —
with a dashed household-demand forecast overlay, tariff bands and a now-marker.
Period view unchanged.

## Tests / review

`smooth_lwt_offsets` unit tests (bridge / drop / passthrough / None) + curve-
setpoint assertions on the endpoint. Independent review found no bugs (property-
tested the smoother over 400k inputs). `tsc` + `vite build` clean; full backend
suite green (1491 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)