### PR TITLE
feat(pv): adaptive recent-bias corrector — close the forecast feedback loop (#486)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -598,6 +598,33 @@ class Config:
         in ("1", "true", "yes", "on")
     )
 
+    # --- Adaptive PV recent-bias corrector (#486) ----------------------------
+    # Closed feedback loop on the COMMITTED forecast's own error: per UTC hour,
+    # the recency-weighted mean of actual/forecast from ``pv_error_log`` nudges
+    # the day-ahead PV forecast. Because it's driven by REALISED error (not
+    # clear-sky potential), genuine morning shade stays low (actual low there →
+    # factor ≈ 1) while systematic under-forecast (e.g. clear mornings 2× low)
+    # gets corrected. Damped + clamped + recomputed daily after the error
+    # rebuild → stable, self-converging. Off by default (observe first).
+    PV_RECENT_BIAS_ENABLED: bool = (
+        os.getenv("PV_RECENT_BIAS_ENABLED", "false").strip().lower() in ("1", "true", "yes", "on")
+    )
+    PV_RECENT_BIAS_WINDOW_DAYS: int = int(os.getenv("PV_RECENT_BIAS_WINDOW_DAYS", "14"))
+    PV_RECENT_BIAS_HALFLIFE_DAYS: float = float(os.getenv("PV_RECENT_BIAS_HALFLIFE_DAYS", "5"))
+    # The corrector ACCUMULATES on its previous factor each refresh, nudged by
+    # the RESIDUAL error (ratio of actual to the already-corrected forecast):
+    # ``new = old × (1 + damping·(ratio−1))``. So it ramps to FULL correction
+    # over a few days (while the corrected forecast still under-shoots, ratio>1
+    # keeps pushing the factor up; once it matches, ratio≈1 and it settles) and
+    # self-stabilises if it over-shoots (ratio<1 pulls it back). Damping sets the
+    # ramp speed. Clamp is a hard safety rail, wide enough to fully correct the
+    # observed ~2× morning bias.
+    PV_RECENT_BIAS_DAMPING: float = float(os.getenv("PV_RECENT_BIAS_DAMPING", "0.5"))
+    PV_RECENT_BIAS_MIN: float = float(os.getenv("PV_RECENT_BIAS_MIN", "0.4"))
+    PV_RECENT_BIAS_MAX: float = float(os.getenv("PV_RECENT_BIAS_MAX", "2.5"))
+    # A slot needs at least this forecast+actual kWh to contribute (drop noise).
+    PV_RECENT_BIAS_MIN_KWH: float = float(os.getenv("PV_RECENT_BIAS_MIN_KWH", "0.05"))
+
     # Agile scheduler (Daikin ASHP by price)
     SCHEDULER_ENABLED: bool = os.getenv("SCHEDULER_ENABLED", "false").lower() in ("true", "1", "yes")
     OCTOPUS_TARIFF_CODE: str = (os.getenv("OCTOPUS_TARIFF_CODE") or "").strip()

--- a/src/db.py
+++ b/src/db.py
@@ -860,6 +860,20 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         )"""
     )
 
+    # #486: pv_recent_bias — adaptive closed-loop corrector. Per UTC hour, the
+    # damped recency-weighted mean of actual/forecast from ``pv_error_log``
+    # (the COMMITTED forecast's own realised error). Applied as a final nudge
+    # on the day-ahead PV forecast; self-converges as the error shrinks.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS pv_recent_bias (
+            hour_utc        INTEGER PRIMARY KEY CHECK(hour_utc >= 0 AND hour_utc < 24),
+            factor          REAL NOT NULL,
+            raw_ratio       REAL,
+            samples         INTEGER NOT NULL,
+            computed_at     TEXT NOT NULL
+        )"""
+    )
+
     # V14: presence_periods — manually-flagged periods of household presence
     # (home / travel / guests) so future load-pattern analyses + LP calibration
     # can de-bias the rolling load profile by occupancy. Read by analytics
@@ -4597,6 +4611,23 @@ def rebuild_pv_error_log_for_date(day: date) -> int:
     return written
 
 
+def get_pv_error_log_range(start_utc_iso: str, end_utc_iso: str) -> list[dict[str, Any]]:
+    """Return per-slot forecast/actual rows in [start, end) (#486 bias loop)."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT slot_time_utc, forecast_kwh, actual_kwh
+                   FROM pv_error_log
+                   WHERE slot_time_utc >= ? AND slot_time_utc < ?
+                   ORDER BY slot_time_utc""",
+                (start_utc_iso, end_utc_iso),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
 def get_pv_error_log_for_date(day: date) -> list[dict[str, Any]]:
     """Return persisted per-slot forecast/actual/error rows for ``day`` (#462)."""
     day_start = datetime(day.year, day.month, day.day, tzinfo=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -4788,6 +4819,43 @@ def get_pv_calibration_hourly() -> dict[int, float]:
             cur = conn.execute(
                 "SELECT hour_utc, factor FROM pv_calibration_hourly"
             )
+            return {int(r[0]): float(r[1]) for r in cur.fetchall()}
+        finally:
+            conn.close()
+
+
+def upsert_pv_recent_bias(
+    factors: dict[int, float],
+    raw_ratios: dict[int, float],
+    samples: dict[int, int],
+    computed_at: str,
+) -> int:
+    """Replace the ``pv_recent_bias`` table with freshly-computed factors (#486)."""
+    n = 0
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM pv_recent_bias")
+            for h, f in factors.items():
+                conn.execute(
+                    """INSERT OR REPLACE INTO pv_recent_bias
+                       (hour_utc, factor, raw_ratio, samples, computed_at)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (int(h), float(f), float(raw_ratios.get(h, f)), int(samples.get(h, 0)), computed_at),
+                )
+                n += 1
+            conn.commit()
+        finally:
+            conn.close()
+    return n
+
+
+def get_pv_recent_bias() -> dict[int, float]:
+    """Return cached per-hour adaptive PV bias factors, or ``{}`` when empty."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute("SELECT hour_utc, factor FROM pv_recent_bias")
             return {int(r[0]): float(r[1]) for r in cur.fetchall()}
         finally:
             conn.close()

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -722,6 +722,13 @@ def bulletproof_pv_error_log_job() -> None:
         logger.info("pv_error_log rebuild: date_utc=%s rows=%d", target_day.isoformat(), rows)
     except Exception as e:
         logger.warning("pv_error_log rebuild failed (non-fatal): %s", e)
+    # #486 — refresh the adaptive recent-bias corrector from the just-rebuilt
+    # error log (no-op effect on the LP unless PV_RECENT_BIAS_ENABLED).
+    try:
+        from ..weather import refresh_pv_recent_bias
+        refresh_pv_recent_bias()
+    except Exception as e:
+        logger.warning("pv_recent_bias refresh failed (non-fatal): %s", e)
 
 
 def bulletproof_pv_calibration_refresh_job() -> None:

--- a/src/weather.py
+++ b/src/weather.py
@@ -1343,6 +1343,94 @@ def compute_today_pv_correction_factor_by_hour(
     }
 
 
+def compute_pv_recent_bias_by_hour() -> tuple[dict[int, float], dict[int, float], dict[int, int], dict[str, Any]]:
+    """Adaptive closed-loop PV bias corrector (#486).
+
+    Per UTC hour, the **recency-weighted mean** of ``actual/forecast`` from
+    ``pv_error_log`` — i.e. how wrong the COMMITTED forecast was, weighted so
+    recent days dominate (half-life decay). Returns
+    ``(applied_factors, raw_ratios, samples, diag)``:
+
+    * ``raw_ratios[h]`` — the measured weighted actual/forecast (the RESIDUAL
+      error of the already-corrected forecast).
+    * ``applied_factors[h]`` — the PREVIOUS factor accumulated by the residual:
+      ``old × (1 + damping·(ratio−1))``, clamped to ``[MIN, MAX]``. Ramps to
+      full correction over a few refreshes and self-stabilises on over-shoot;
+      the loop's fixed point is ratio ≈ 1 (zero residual error).
+
+    Because it's keyed on realised error, genuine morning shade (actual low →
+    ratio ≈ 1) is left alone while systematic under-forecast (ratio > 1) is
+    corrected. Slots below ``PV_RECENT_BIAS_MIN_KWH`` on either side are dropped.
+    """
+    from . import db as _db
+    window = int(getattr(config, "PV_RECENT_BIAS_WINDOW_DAYS", 14))
+    half_life = float(getattr(config, "PV_RECENT_BIAS_HALFLIFE_DAYS", 5))
+    damping = float(getattr(config, "PV_RECENT_BIAS_DAMPING", 0.5))
+    lo = float(getattr(config, "PV_RECENT_BIAS_MIN", 0.4))
+    hi = float(getattr(config, "PV_RECENT_BIAS_MAX", 2.5))
+    min_kwh = float(getattr(config, "PV_RECENT_BIAS_MIN_KWH", 0.05))
+    # Accumulate on the previous factor → the loop ramps to FULL correction
+    # (measuring residual error against the already-corrected forecast).
+    try:
+        prev = _db.get_pv_recent_bias()
+    except Exception:  # pragma: no cover — cold start / missing table
+        prev = {}
+
+    now = datetime.now(UTC)
+    start = now - timedelta(days=window)
+    rows = _db.get_pv_error_log_range(
+        start.strftime("%Y-%m-%dT%H:%M:%SZ"), now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    acc: dict[int, list[float]] = {}  # hour -> [sum_w_ratio, sum_w, n]
+    for r in rows:
+        f = r.get("forecast_kwh") or 0.0
+        a = r.get("actual_kwh")
+        if a is None or f < min_kwh or a < min_kwh:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(r["slot_time_utc"]).replace("Z", "+00:00"))
+        except (ValueError, TypeError, KeyError):
+            continue
+        age_days = max(0.0, (now - ts).total_seconds() / 86400.0)
+        w = 0.5 ** (age_days / half_life) if half_life > 0 else 1.0
+        d = acc.setdefault(ts.hour, [0.0, 0.0, 0.0])
+        d[0] += w * (a / f)
+        d[1] += w
+        d[2] += 1
+
+    factors: dict[int, float] = {}
+    raw: dict[int, float] = {}
+    samples: dict[int, int] = {}
+    for h, (sw, w, n) in acc.items():
+        if w <= 0 or n < 2:
+            continue
+        ratio = sw / w
+        old = float(prev.get(h, 1.0))
+        applied = max(lo, min(hi, old * (1.0 + damping * (ratio - 1.0))))
+        raw[h] = round(ratio, 4)
+        factors[h] = round(applied, 4)
+        samples[h] = int(n)
+    diag = {"window_days": window, "half_life_days": half_life, "damping": damping,
+            "min_kwh": min_kwh, "clamp": [lo, hi], "n_hours": len(factors)}
+    return factors, raw, samples, diag
+
+
+def refresh_pv_recent_bias() -> int:
+    """Recompute + persist the adaptive PV bias table (cron after error rebuild)."""
+    from . import db as _db
+    factors, raw, samples, diag = compute_pv_recent_bias_by_hour()
+    if not factors:
+        logger.info("pv_recent_bias: nothing to compute (%s)", diag)
+        return 0
+    ca = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    n = _db.upsert_pv_recent_bias(factors, raw, samples, ca)
+    logger.info(
+        "pv_recent_bias refreshed: %d hours; applied=%s raw=%s",
+        n, {h: factors[h] for h in sorted(factors)}, {h: raw[h] for h in sorted(raw)},
+    )
+    return n
+
+
 def compute_solar_elevation_deg(
     slot_utc: datetime,
     lat: float | None = None,
@@ -2062,6 +2150,16 @@ def forecast_to_lp_inputs(
         flat_cal = compute_pv_calibration_factor() if not cal_cloud and not cal_hourly else 1.0
     except sqlite3.OperationalError:
         flat_cal = 1.0
+    # #486 — adaptive recent-bias corrector: a per-hour final nudge from the
+    # committed forecast's own realised error (pv_error_log). Separate from the
+    # calibration tables (which train on raw data), so applying it here closes a
+    # convergent loop without contaminating training. Off → empty dict → no-op.
+    recent_bias: dict[int, float] = {}
+    if getattr(config, "PV_RECENT_BIAS_ENABLED", False):
+        try:
+            recent_bias = _db.get_pv_recent_bias()
+        except sqlite3.OperationalError:
+            recent_bias = {}
 
     # PV scale: explicit arg > config override > 1.0. Accept float OR per-hour dict.
     if pv_scale is None:
@@ -2139,6 +2237,9 @@ def forecast_to_lp_inputs(
             table_3d=cal_3d,
             slot_utc=st,
         )
+        # #486 — adaptive recent-bias nudge (no-op when disabled / no data).
+        if recent_bias:
+            kw_ac *= recent_bias.get(st.hour, 1.0)
         # Apply calibration scale and enforce per-hour physical ceiling
         slot_ceil = hourly_ceil.get(st.hour, cap * eff * 0.5)
         pv_kwh = min(slot_ceil, max(0.0, kw_ac * 0.5))

--- a/tests/test_pv_recent_bias.py
+++ b/tests/test_pv_recent_bias.py
@@ -1,0 +1,203 @@
+"""Adaptive PV recent-bias corrector (#486) — closed loop on the committed
+forecast's own error (pv_error_log), damped + clamped + recency-weighted."""
+from __future__ import annotations
+
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from src.config import config
+
+
+def _seed(conn, *, hour: int, days_ago: float, forecast: float, actual: float):
+    ts = (datetime.now(UTC) - timedelta(days=days_ago)).replace(
+        hour=hour, minute=0, second=0, microsecond=0
+    )
+    conn.execute(
+        """INSERT OR REPLACE INTO pv_error_log
+           (slot_time_utc, run_id, forecast_kwh, actual_kwh, error_kwh, built_at_utc)
+           VALUES (?, 1, ?, ?, ?, ?)""",
+        (ts.strftime("%Y-%m-%dT%H:%M:%SZ"), forecast, actual, actual - forecast,
+         datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")),
+    )
+
+
+def _cfg(monkeypatch, **kw):
+    defaults = dict(WINDOW_DAYS=14, HALFLIFE_DAYS=5.0, DAMPING=0.5, MIN=0.6, MAX=1.6, MIN_KWH=0.05)
+    defaults.update(kw)
+    monkeypatch.setattr(config, "PV_RECENT_BIAS_WINDOW_DAYS", defaults["WINDOW_DAYS"], raising=False)
+    monkeypatch.setattr(config, "PV_RECENT_BIAS_HALFLIFE_DAYS", defaults["HALFLIFE_DAYS"], raising=False)
+    monkeypatch.setattr(config, "PV_RECENT_BIAS_DAMPING", defaults["DAMPING"], raising=False)
+    monkeypatch.setattr(config, "PV_RECENT_BIAS_MIN", defaults["MIN"], raising=False)
+    monkeypatch.setattr(config, "PV_RECENT_BIAS_MAX", defaults["MAX"], raising=False)
+    monkeypatch.setattr(config, "PV_RECENT_BIAS_MIN_KWH", defaults["MIN_KWH"], raising=False)
+
+
+def test_damped_clamped_correction(monkeypatch):
+    import src.db as db
+    from src import weather
+
+    _cfg(monkeypatch)
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            # Hour 9: forecast 2× too low (ratio 2.0) over several recent days.
+            for d in range(1, 5):
+                _seed(conn, hour=9, days_ago=d, forecast=1.0, actual=2.0)
+            # Hour 14: forecast 2× too high (ratio 0.5).
+            for d in range(1, 5):
+                _seed(conn, hour=14, days_ago=d, forecast=2.0, actual=1.0)
+            conn.commit()
+        finally:
+            conn.close()
+        factors, raw, samples, diag = weather.compute_pv_recent_bias_by_hour()
+
+    assert round(raw[9], 2) == 2.0
+    # Damped 0.5 toward 1.0: 1 + 0.5*(2-1) = 1.5 (within clamp).
+    assert factors[9] == 1.5
+    assert round(raw[14], 2) == 0.5
+    assert factors[14] == 0.75
+    assert samples[9] == 4
+
+
+def test_clamp_caps_extreme(monkeypatch):
+    import src.db as db
+    from src import weather
+
+    _cfg(monkeypatch, DAMPING=1.0, MAX=1.6)  # full correction, but clamp bites
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            for d in range(1, 5):
+                _seed(conn, hour=9, days_ago=d, forecast=0.5, actual=3.0)  # ratio 6
+            conn.commit()
+        finally:
+            conn.close()
+        factors, raw, _s, _d = weather.compute_pv_recent_bias_by_hour()
+    assert raw[9] == 6.0
+    assert factors[9] == 1.6  # clamped to MAX
+
+
+def test_recency_weighting_favours_recent(monkeypatch):
+    import src.db as db
+    from src import weather
+
+    _cfg(monkeypatch, HALFLIFE_DAYS=2.0, DAMPING=1.0)
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            # Recent days say ratio ~1.0; one very old day says ratio 3.0.
+            for d in (1, 2, 3):
+                _seed(conn, hour=10, days_ago=d, forecast=1.0, actual=1.0)
+            _seed(conn, hour=10, days_ago=13, forecast=1.0, actual=3.0)
+            conn.commit()
+        finally:
+            conn.close()
+        _f, raw, _s, _d = weather.compute_pv_recent_bias_by_hour()
+    # The stale 3.0 is heavily down-weighted → weighted ratio stays near 1.
+    assert raw[10] < 1.3
+
+
+def test_min_samples_excluded(monkeypatch):
+    import src.db as db
+    from src import weather
+
+    _cfg(monkeypatch)
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            _seed(conn, hour=11, days_ago=1, forecast=1.0, actual=2.0)  # only 1 sample
+            conn.commit()
+        finally:
+            conn.close()
+        factors, _r, _s, _d = weather.compute_pv_recent_bias_by_hour()
+    assert 11 not in factors
+
+
+def test_accumulates_toward_full_correction(monkeypatch):
+    # With a previous factor of 1.5 and the corrected forecast still 1.33× low,
+    # the factor ACCUMULATES upward (toward full correction), not back to ~1.5.
+    import src.db as db
+    from src import weather
+
+    _cfg(monkeypatch, DAMPING=0.5, MAX=2.5)
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        # seed previous factor
+        db.upsert_pv_recent_bias({9: 1.5}, {9: 2.0}, {9: 4},
+                                 datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"))
+        conn = db.get_connection()
+        try:
+            for d in range(1, 5):
+                _seed(conn, hour=9, days_ago=d, forecast=1.5, actual=2.0)  # residual ratio 1.33
+            conn.commit()
+        finally:
+            conn.close()
+        factors, raw, _s, _d = weather.compute_pv_recent_bias_by_hour()
+    assert round(raw[9], 2) == 1.33
+    # old 1.5 × (1 + 0.5*(1.333-1)) = 1.5 × 1.1665 ≈ 1.75 — grew past 1.5.
+    assert 1.7 < factors[9] < 1.8
+
+
+def test_apply_path_scales_pv_when_enabled(monkeypatch):
+    import src.db as db
+    from src import weather
+    from src.weather import HourlyForecast, forecast_to_lp_inputs
+
+    # Pin the flat calibration to 1.0 so base PV is positive (empty test DB
+    # would otherwise make compute_pv_calibration_factor return ~0).
+    monkeypatch.setattr(weather, "compute_pv_calibration_factor", lambda *a, **k: 1.0)
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        # Bias factor 2.0 at UTC hour 9.
+        db.upsert_pv_recent_bias({9: 2.0}, {9: 2.0}, {9: 4},
+                                 datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+        base = datetime(2026, 6, 10, 8, 0, tzinfo=UTC)
+        fc = [
+            HourlyForecast(time_utc=base + timedelta(hours=k), temperature_c=12.0,
+                           cloud_cover_pct=10.0, shortwave_radiation_wm2=300.0,
+                           estimated_pv_kw=0.0, heating_demand_factor=0.0)
+            for k in range(4)
+        ]
+        slots = [datetime(2026, 6, 10, 9, 0, tzinfo=UTC)]  # UTC hour 9
+
+        monkeypatch.setattr(config, "PV_RECENT_BIAS_ENABLED", False, raising=False)
+        off = forecast_to_lp_inputs(fc, slots, pv_scale=1.0).pv_kwh_per_slot[0]
+        monkeypatch.setattr(config, "PV_RECENT_BIAS_ENABLED", True, raising=False)
+        on = forecast_to_lp_inputs(fc, slots, pv_scale=1.0).pv_kwh_per_slot[0]
+
+    assert off > 0.0, "need positive base PV to test scaling"
+    # Enabled ≈ 2× disabled (modulo the physical ceiling, which is well above).
+    assert abs(on - 2.0 * off) < 1e-6
+
+
+def test_refresh_persists_and_get(monkeypatch):
+    import src.db as db
+    from src import weather
+
+    _cfg(monkeypatch)
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            for d in range(1, 5):
+                _seed(conn, hour=9, days_ago=d, forecast=1.0, actual=2.0)
+            conn.commit()
+        finally:
+            conn.close()
+        n = weather.refresh_pv_recent_bias()
+        got = db.get_pv_recent_bias()
+    assert n >= 1
+    assert got.get(9) == 1.5


### PR DESCRIPTION
Closes #486 (first iteration).

## The problem (audited)

The LP systematically **under-forecasts PV**, worst in the morning. From
`pv_error_log` (the committed forecast vs actual, 21 days):

| UTC hour | actual/forecast |
|---|---|
| 06 | 2.20 |
| 07 | 2.22 |
| 08 | 2.13 |
| 09 | 2.68 |
| whole day | 1.26 |

So it over-imports overnight to cover a morning it thinks will be dark, then the
real solar floods in and the surplus is **exported** (import **and** export same
day). Direct £ is modest (~£13/yr) but the pessimism is systemic. The user has
**real morning shade**, so the fix must separate shade from bias, and wanted an
adaptive self-correcting loop (à la HA SolarForecast ML).

## The fix — a convergent closed loop

`compute_pv_recent_bias_by_hour`: per UTC hour, the recency-weighted (half-life)
mean of `actual/forecast` from `pv_error_log` — the committed forecast's own
**residual** error. It **accumulates** on the previous factor:

```
new = clamp(old × (1 + damping·(ratio − 1)),  MIN, MAX)
```

so it **ramps to full correction** over a few refreshes and self-stabilises if it
over-shoots (ratio<1 pulls it back); the fixed point is ratio≈1 (zero residual).
Because it's driven by **realised error** (not clear-sky potential), genuine
morning shade (actual low → ratio≈1) is left alone, while systematic
under-forecast is corrected — separating shade from bias.

- Applied as a final per-hour nudge on `kw_ac` in `forecast_to_lp_inputs`,
  **separate** from the calibration tables (which train on raw data), so the loop
  is convergent and doesn't contaminate training.
- Recomputed daily right after the `pv_error_log` rebuild cron.
- New `pv_recent_bias` table + helpers; `PV_RECENT_BIAS_*` config knobs.

## Safety / tests

**Off by default** (`PV_RECENT_BIAS_ENABLED=false`) — ship, enable on prod,
observe. 7 unit tests incl. multiplicative **accumulation/convergence** and the
**apply path** (2× scale enabled, no-op disabled). Independent review caught the
original damp-toward-1 design (left ~56% of a 2× bias) → switched to
multiplicative accumulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)