### PR TITLE
fix(pv): warm-start the recent-bias corrector from history (#486)

### DIFF
--- a/src/weather.py
+++ b/src/weather.py
@@ -1405,8 +1405,16 @@ def compute_pv_recent_bias_by_hour() -> tuple[dict[int, float], dict[int, float]
         if w <= 0 or n < 2:
             continue
         ratio = sw / w
-        old = float(prev.get(h, 1.0))
-        applied = max(lo, min(hi, old * (1.0 + damping * (ratio - 1.0))))
+        if h in prev:
+            # Have a prior factor → damped accumulation (stable ongoing tracking,
+            # avoids overshoot on a noisy new day).
+            applied = float(prev[h]) * (1.0 + damping * (ratio - 1.0))
+        else:
+            # WARM START (#486 Q2): we already have the historical error — jump
+            # straight to the measured correction instead of crawling from 1.0
+            # over days. The window mean is itself a smoothed estimate.
+            applied = ratio
+        applied = max(lo, min(hi, applied))
         raw[h] = round(ratio, 4)
         factors[h] = round(applied, 4)
         samples[h] = int(n)

--- a/tests/test_pv_recent_bias.py
+++ b/tests/test_pv_recent_bias.py
@@ -23,7 +23,7 @@ def _seed(conn, *, hour: int, days_ago: float, forecast: float, actual: float):
 
 
 def _cfg(monkeypatch, **kw):
-    defaults = dict(WINDOW_DAYS=14, HALFLIFE_DAYS=5.0, DAMPING=0.5, MIN=0.6, MAX=1.6, MIN_KWH=0.05)
+    defaults = dict(WINDOW_DAYS=14, HALFLIFE_DAYS=5.0, DAMPING=0.5, MIN=0.4, MAX=2.5, MIN_KWH=0.05)
     defaults.update(kw)
     monkeypatch.setattr(config, "PV_RECENT_BIAS_WINDOW_DAYS", defaults["WINDOW_DAYS"], raising=False)
     monkeypatch.setattr(config, "PV_RECENT_BIAS_HALFLIFE_DAYS", defaults["HALFLIFE_DAYS"], raising=False)
@@ -33,7 +33,9 @@ def _cfg(monkeypatch, **kw):
     monkeypatch.setattr(config, "PV_RECENT_BIAS_MIN_KWH", defaults["MIN_KWH"], raising=False)
 
 
-def test_damped_clamped_correction(monkeypatch):
+def test_warm_start_full_correction_first_pass(monkeypatch):
+    # No prior factor → jump straight to the measured ratio (we already have the
+    # history; don't crawl from 1.0). Damping only kicks in once a factor exists.
     import src.db as db
     from src import weather
 
@@ -55,10 +57,9 @@ def test_damped_clamped_correction(monkeypatch):
         factors, raw, samples, diag = weather.compute_pv_recent_bias_by_hour()
 
     assert round(raw[9], 2) == 2.0
-    # Damped 0.5 toward 1.0: 1 + 0.5*(2-1) = 1.5 (within clamp).
-    assert factors[9] == 1.5
+    assert factors[9] == 2.0  # warm start = full measured correction
     assert round(raw[14], 2) == 0.5
-    assert factors[14] == 0.75
+    assert factors[14] == 0.5
     assert samples[9] == 4
 
 
@@ -200,4 +201,4 @@ def test_refresh_persists_and_get(monkeypatch):
         n = weather.refresh_pv_recent_bias()
         got = db.get_pv_recent_bias()
     assert n >= 1
-    assert got.get(9) == 1.5
+    assert got.get(9) == 2.0  # warm start (no prior) = full measured ratio


### PR DESCRIPTION
Follow-up to #488, addressing two questions from the user.

**Q: "the LP re-plans every ~30 min — why correct only nightly?"** It doesn't —
the corrector is **read on every re-plan**; only its *learned value* updates
nightly, because its input (`pv_error_log`) only gains data nightly. Recomputing
it more often yields the same number. Intraday correction of **today's** slots is
already done by `compute_today_pv_correction_factor_by_hour` on every solve (from
5-min telemetry). The recent-bias covers the **tomorrow/overnight** slots that
the today-corrector deliberately skips.

**Q: "we already have past data — why wait for new data?"** Fixed. The corrector
started at 1.0 and accumulated over nightly refreshes (slow ramp). Now it
**warm-starts**: an hour with no prior factor seeds straight to the measured
(recency-weighted, smoothed) ratio — full correction from day one. Damped
accumulation still governs subsequent refreshes (stable tracking, no overshoot).
This fixes the overnight plan immediately instead of over days.

Tests updated (first pass = full ratio; accumulation path keeps damped). On
deploy the prod table is cleared + refreshed so the warm-start takes effect now.

Closes #486 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)