### PR TITLE
feat(daikin): reset stray LWT offset to 0 when nothing justifies it (#461 ask 1)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1671,6 +1671,19 @@ class Config:
         os.getenv("TANK_DRIFT_CHECK_ENABLED", "true").strip().lower()
         in ("1", "true", "yes", "on")
     )
+    # #461 — LWT-offset drift backstop. When HEM owns the offset (pre-heat
+    # enabled) and the live offset is non-zero but no active lwt_preheat slot
+    # justifies it, reset it to 0 — after the user's grace window
+    # (USER_OVERRIDE_RESPECT_HOURS) so a manual override gets respected then
+    # cleared. Catches a manual offset that has no paired restore.
+    LWT_OFFSET_DRIFT_CHECK_ENABLED: bool = (
+        os.getenv("LWT_OFFSET_DRIFT_CHECK_ENABLED", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
+    LWT_OFFSET_DRIFT_AUTO_RECOVER: bool = (
+        os.getenv("LWT_OFFSET_DRIFT_AUTO_RECOVER", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
     # Fox ESS: soft daily budget (real limit ≈1440; we stop at 1200 for 15% headroom)
     FOX_DAILY_BUDGET: int = int(os.getenv("FOX_DAILY_BUDGET", "1200"))
     # Default realtime data TTL — raised from 30 s to 300 s (5 min) to match heartbeat

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -50,6 +50,9 @@ _USER_OVERRIDE_INHERITED_NOTIFIED: set[int] = set()
 # page Telegram every 2 min for the same condition. Cleared when the heartbeat
 # observes tank_on == True again — a fresh drift episode then re-pings.
 _TANK_DRIFT_NOTIFIED: bool = False
+# #461 — dedup for the LWT-offset drift backstop (same one-page-per-episode
+# semantics as the tank flag above). Cleared when the offset is back at 0.
+_LWT_DRIFT_NOTIFIED: bool = False
 
 
 def _parse_utc(s: str) -> datetime:
@@ -466,6 +469,11 @@ def _reconcile_daikin_actions(
     # belt-and-braces backstop for any drift mechanism we haven't yet
     # imagined.
     _check_tank_power_drift(actions, client, dev, now_utc, trigger=trigger)
+    # #461 — LWT-offset drift: when HEM owns the offset (pre-heat enabled) but
+    # the live device holds a non-zero offset no plan slot justifies, reset it
+    # to 0 once the user's grace window has passed. Catches a manual offset with
+    # no paired restore.
+    _check_lwt_offset_drift(actions, client, dev, now_utc, trigger=trigger)
     # PR J diverter removed 2026-05-23 (K2-cleanup) — superseded by K1's
     # dhw_policy fixed schedule. The diverter's "lift tank during PV
     # abundance" goal is now redundant: tank lives at NORMAL=45 °C via
@@ -596,6 +604,126 @@ def _check_tank_power_drift(
             notify_critical(msg) if not recovered else notify_risk(msg)
         except Exception as _exc:
             logger.debug("tank-drift notify failed (non-fatal): %s", _exc)
+
+
+def _check_lwt_offset_drift(
+    actions: list[dict[str, Any]],
+    client: DaikinClient,
+    dev: Any,
+    now_utc: datetime,
+    *,
+    trigger: str,
+) -> None:
+    """#461 — reset a stray non-zero LWT offset to 0 when nothing justifies it.
+
+    Only acts when HEM is actually managing the offset
+    (``DAIKIN_LWT_PREHEAT_ENABLED``); otherwise climate is hands-off and a
+    non-zero offset is the user's/firmware's to keep. Bails (fail-safe) on:
+
+    * feature/check flag disabled, or vacation preset;
+    * live offset unknown (cache miss) or already ≈0 (no drift);
+    * an active/pending ``lwt_preheat`` slot covering now carries a non-zero
+      offset (the pre-heat plan justifies it);
+    * a recent user override is still in effect — respect the gesture for
+      ``USER_OVERRIDE_RESPECT_HOURS`` (this is what lets a *manual* offset stand
+      for the grace window, then get reset once it ages out — the #461 ask).
+
+    Dedupes via ``_LWT_DRIFT_NOTIFIED`` (one page per episode; cleared at 0).
+    """
+    global _LWT_DRIFT_NOTIFIED
+
+    if not config.DAIKIN_LWT_PREHEAT_ENABLED or not config.LWT_OFFSET_DRIFT_CHECK_ENABLED:
+        return
+    if (config.OPTIMIZATION_PRESET or "normal").strip().lower() == "vacation":
+        return
+    off = getattr(dev, "lwt_offset", None)
+    if off is None:
+        return  # unknown live state — fail-safe
+    if abs(float(off)) < 0.5:
+        if _LWT_DRIFT_NOTIFIED:
+            _LWT_DRIFT_NOTIFIED = False
+        return
+
+    # Does any current slot's lwt_preheat action justify a non-zero offset?
+    for act in actions:
+        try:
+            start = _parse_utc(act["start_time"])
+            end = _parse_utc(act["end_time"])
+        except (ValueError, KeyError, TypeError):
+            continue
+        if not (start <= now_utc < end):
+            continue
+        if (act.get("status") or "") not in ("pending", "active"):
+            continue
+        if act.get("overridden_by_user_at"):
+            continue
+        if act.get("action_type") != "lwt_preheat":
+            continue
+        params = act.get("params") or {}
+        if isinstance(params, str):
+            try:
+                params = json.loads(params)
+            except (json.JSONDecodeError, TypeError):
+                params = {}
+        po = params.get("lwt_offset")
+        if po is not None and abs(float(po)) >= 0.5:
+            return  # a pre-heat window justifies the non-zero offset
+
+    # Respect a still-in-effect user gesture (grace window before reset).
+    try:
+        src = db.find_recent_user_override(
+            device="daikin",
+            within_hours=float(config.USER_OVERRIDE_RESPECT_HOURS),
+            now_utc=now_utc,
+        )
+        if src is not None:
+            src_params = src.get("params") or {}
+            if isinstance(src_params, str):
+                try:
+                    src_params = json.loads(src_params)
+                except (json.JSONDecodeError, TypeError):
+                    src_params = {}
+            if user_gesture_still_in_effect(dev, src_params):
+                return
+    except Exception as _exc:
+        logger.debug("lwt-drift override lookup failed (non-fatal): %s", _exc)
+
+    # Drift confirmed — reset the offset to 0 (full settable/zone/read-only
+    # guard is inside apply_scheduled_daikin_params).
+    db.log_action(
+        device="daikin",
+        action="lwt_offset_drift_detected",
+        params={"lwt_offset": float(off), "auto_recover": bool(config.LWT_OFFSET_DRIFT_AUTO_RECOVER)},
+        result="alert",
+        trigger=trigger,
+    )
+    recovered = False
+    if (
+        config.LWT_OFFSET_DRIFT_AUTO_RECOVER
+        and not config.OPENCLAW_READ_ONLY
+        and config.DAIKIN_CONTROL_MODE == "active"
+    ):
+        try:
+            apply_scheduled_daikin_params(
+                dev, client, {"lwt_offset": 0, "lp_optimizer": True},
+                trigger=f"lwt_drift_recover:{trigger}",
+            )
+            recovered = True
+        except (DaikinError, ValueError) as exc:
+            logger.warning("lwt-offset-drift auto-recover failed: %s", exc)
+
+    if not _LWT_DRIFT_NOTIFIED:
+        _LWT_DRIFT_NOTIFIED = True
+        try:
+            msg = (
+                f"LWT offset = {off:+.0f}°C with no plan slot justifying it — "
+                f"{'reset to 0' if recovered else 'manual reset may be needed'} "
+                f"(trigger={trigger})"
+            )
+            notify_risk(msg)
+        except Exception as _exc:
+            logger.debug("lwt-drift notify failed (non-fatal): %s", _exc)
+
 
 def reconcile_daikin_schedule_for_date(
     plan_date: str,

--- a/tests/test_lwt_offset_drift.py
+++ b/tests/test_lwt_offset_drift.py
@@ -1,0 +1,94 @@
+"""#461 — LWT-offset drift backstop: reset a stray non-zero offset to 0 when no
+plan slot justifies it, after the user's grace window. Mirrors the tank-power
+drift backstop."""
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.config import config
+from src.daikin.models import DaikinDevice
+
+
+def _common(monkeypatch, *, enabled=True):
+    import src.state_machine as sm
+    monkeypatch.setattr("src.config.config.DAIKIN_LWT_PREHEAT_ENABLED", enabled)
+    monkeypatch.setattr("src.config.config.LWT_OFFSET_DRIFT_CHECK_ENABLED", True)
+    monkeypatch.setattr("src.config.config.LWT_OFFSET_DRIFT_AUTO_RECOVER", True)
+    monkeypatch.setattr("src.config.config.DAIKIN_CONTROL_MODE", "active")
+    monkeypatch.setattr("src.config.config.OPTIMIZATION_PRESET", "normal")
+    monkeypatch.setattr("src.config.config.USER_OVERRIDE_RESPECT_HOURS", 4.0)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False)
+    monkeypatch.setattr("src.state_machine.notify_risk", lambda *a, **k: None)
+    sm._LWT_DRIFT_NOTIFIED = False
+    applied: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: applied.append(params) or True,
+    )
+    return sm, applied
+
+
+def _slot(action_type, offset, *, status="active"):
+    now = datetime.now(UTC)
+    return {
+        "action_type": action_type,
+        "start_time": (now - timedelta(minutes=10)).isoformat(),
+        "end_time": (now + timedelta(minutes=20)).isoformat(),
+        "status": status,
+        "params": json.dumps({"lwt_offset": offset, "lp_optimizer": True}),
+    }
+
+
+def _run(monkeypatch, sm, actions, dev):
+    with tempfile.TemporaryDirectory() as td:
+        from src import db
+        monkeypatch.setattr("src.config.config.DB_PATH", str(Path(td) / "t.db"))
+        db.init_db()
+        sm._check_lwt_offset_drift(actions, MagicMock(), dev, datetime.now(UTC), trigger="test")
+
+
+def test_resets_stray_offset(monkeypatch):
+    sm, applied = _common(monkeypatch)
+    dev = DaikinDevice(id="gw", name="x", lwt_offset=3.0)
+    _run(monkeypatch, sm, [], dev)  # no slot justifies the +3
+    assert len(applied) == 1
+    assert applied[0].get("lwt_offset") == 0
+
+
+def test_justified_by_preheat_slot(monkeypatch):
+    sm, applied = _common(monkeypatch)
+    dev = DaikinDevice(id="gw", name="x", lwt_offset=3.0)
+    _run(monkeypatch, sm, [_slot("lwt_preheat", 3)], dev)  # window wants +3
+    assert applied == []
+
+
+def test_zero_offset_is_noop(monkeypatch):
+    sm, applied = _common(monkeypatch)
+    dev = DaikinDevice(id="gw", name="x", lwt_offset=0.0)
+    _run(monkeypatch, sm, [], dev)
+    assert applied == []
+
+
+def test_disabled_feature_hands_off(monkeypatch):
+    # Pre-heat off → climate hands-off → never touch a non-zero offset.
+    sm, applied = _common(monkeypatch, enabled=False)
+    dev = DaikinDevice(id="gw", name="x", lwt_offset=4.0)
+    _run(monkeypatch, sm, [], dev)
+    assert applied == []
+
+
+def test_respects_recent_user_override(monkeypatch):
+    sm, applied = _common(monkeypatch)
+    dev = DaikinDevice(id="gw", name="x", lwt_offset=3.0)
+    # Override ROW holds what HEM scheduled (offset 0); the device still shows
+    # the user's manual 3 → the gesture contradicts the schedule → in effect.
+    monkeypatch.setattr(
+        "src.state_machine.db.find_recent_user_override",
+        lambda **kw: {"id": 7, "params": {"lwt_offset": 0}},
+    )
+    _run(monkeypatch, sm, [], dev)
+    assert applied == []  # respect the grace window


### PR DESCRIPTION
Addresses **ask 1** of #461. Now that HEM actively drives the LWT offset (#481,
lab-enabled), a **manual** offset (Onecta / physical) set when no LP window is
active has no paired restore and persists indefinitely.

New `_check_lwt_offset_drift` heartbeat backstop, mirroring the proven
`_check_tank_power_drift`:
- **Only acts when HEM owns the offset** (`DAIKIN_LWT_PREHEAT_ENABLED`) —
  otherwise climate is hands-off and a non-zero offset is the user's/firmware's
  to keep.
- Resets to 0 when the device holds a non-zero offset no active `lwt_preheat`
  slot justifies, **after** respecting a still-in-effect user gesture
  (`USER_OVERRIDE_RESPECT_HOURS`) — so a manual override stands for its grace
  window then clears (exactly the ask).
- Reset rides `apply_scheduled_daikin_params` (settable/zone/read-only guard);
  one page per episode; gated by `LWT_OFFSET_DRIFT_{CHECK_ENABLED,AUTO_RECOVER}`
  (default true); vacation-exempt; fail-safe on unknown live state.

Activates automatically on prod (gated on the already-true pre-heat flag). 5
tests; state-machine/daikin suites green.

**Ask 2** (verify space LWT ramps during negative windows) stays open — the
heuristic treats negative as cheap → `+BOOST`, worth a telemetry trace to confirm
the firmware ramps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)