### PR TITLE
feat(appliance): learn typical_kw from measured actual_kwh history (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   sustained blocks (`DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS`, default 4 = 2 h):
   short 0-gaps between equal blocks are bridged, sub-2 h blocks dropped. Kills
   the `+3/0/+3/0` chatter at the cheap threshold and the wasted Daikin writes.
+- **LWT-offset drift backstop** (#461 ask 1, PR #492). When HEM owns the offset
+  (pre-heat enabled) and the live device holds a non-zero offset no plan slot
+  justifies, the heartbeat resets it to 0 — after respecting a still-in-effect
+  user gesture for `USER_OVERRIDE_RESPECT_HOURS`. Catches a manual offset
+  (Onecta / physical) that has no paired restore. Mirrors the tank-power drift
+  backstop; gated by `LWT_OFFSET_DRIFT_{CHECK_ENABLED,AUTO_RECOVER}`.
+
+### Added — appliance scheduling
+- **Learned `typical_kw` from measured history** (#222). The cycle-energy
+  estimate the LP and dispatch use now prefers the rolling mean of recent
+  completed runs' measured `actual_kwh` (`kW = actual_kwh / duration`) over the
+  static registration default, once `APPLIANCE_LEARNED_KW_MIN_SAMPLES` (3) runs
+  exist — `db.appliance_learned_typical_kw` over the last
+  `APPLIANCE_LEARNED_KW_LOOKBACK` (10). Fixes the ~3× over-estimate (registration
+  0.5 kW vs measured ~0.2–0.4 kW eco cycles) that made the LP route around the
+  wash more than necessary. Applied at `_arm_or_replan` (window picker) and both
+  LP residual-load overlays; the σ-based safety margin (#235) is unchanged.
+  `GET /api/v1/appliances` now returns `learned_typical_kw` + `learned_samples`
+  + `effective_typical_kw` so the learning is visible.
 
 ### Added — adaptive solar forecast
 - **PV recent-bias corrector** (#486, PRs #488 + #489). A convergent feedback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,15 @@ appliance IS the consent gate — no MCP confirm.
 `setMachineState run` command for all three. Register multiple devices
 via the discover/register MCP tools or REST endpoints.
 
+**Learned `typical_kw` (#222).** The cycle-energy estimate prefers the rolling
+mean of recent completed runs' measured `actual_kwh` (SmartThings energy
+counter, #235) over the static registration `typical_kw`, once
+`APPLIANCE_LEARNED_KW_MIN_SAMPLES` (3) runs exist — `db.appliance_learned_typical_kw`
+over the last `APPLIANCE_LEARNED_KW_LOOKBACK` (10). Registration default 0.5 kW
+over-estimated eco cycles ~3× (real ~0.2–0.4 kW), so the LP used to route around
+the wash more than necessary. `GET /api/v1/appliances` surfaces
+`learned_typical_kw` / `learned_samples` / `effective_typical_kw`.
+
 ---
 
 ## Key `.env` settings to know

--- a/src/api/routers/appliances.py
+++ b/src/api/routers/appliances.py
@@ -66,6 +66,16 @@ class UpdateApplianceRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 def _public_appliance(row: dict[str, Any]) -> dict[str, Any]:
+    # #222 — surface the learned power so the operator can see the system
+    # learning ("0.42 kW, mean of 8 runs") vs the static registration default.
+    learned_kw: float | None = None
+    learned_n = 0
+    try:
+        learned = db.appliance_learned_typical_kw(int(row["id"]))
+        if learned is not None:
+            learned_kw, learned_n = learned
+    except Exception:  # pragma: no cover — display enrichment must never 500
+        pass
     return {
         "id": row["id"],
         "vendor": row["vendor"],
@@ -75,6 +85,9 @@ def _public_appliance(row: dict[str, Any]) -> dict[str, Any]:
         "default_duration_minutes": row["default_duration_minutes"],
         "deadline_local_time": row["deadline_local_time"],
         "typical_kw": row["typical_kw"],
+        "learned_typical_kw": learned_kw,   # null until >= min_samples runs
+        "learned_samples": learned_n,
+        "effective_typical_kw": learned_kw if learned_kw is not None else row["typical_kw"],
         "enabled": bool(row["enabled"]),
         "created_at": row["created_at"],
     }

--- a/src/config.py
+++ b/src/config.py
@@ -470,6 +470,17 @@ class Config:
     APPLIANCE_FALLBACK_SAFETY_MARGIN_KWH: float = float(
         os.getenv("APPLIANCE_FALLBACK_SAFETY_MARGIN_KWH", "0.3")
     )
+    # #222 — learn an appliance's typical power from measured `actual_kwh`
+    # history (SmartThings energy counter) instead of the static registration
+    # default. The central cycle-energy estimate uses the rolling mean of the
+    # last N completed runs once ≥ MIN_SAMPLES exist; otherwise it falls back to
+    # `appliances.typical_kw`. (The σ-based safety margin is separate, #235.)
+    APPLIANCE_LEARNED_KW_LOOKBACK: int = int(
+        os.getenv("APPLIANCE_LEARNED_KW_LOOKBACK", "10")
+    )
+    APPLIANCE_LEARNED_KW_MIN_SAMPLES: int = int(
+        os.getenv("APPLIANCE_LEARNED_KW_MIN_SAMPLES", "3")
+    )
     # Inverter grid-charge rate (kWh per 30-min slot) used to size the
     # refill-window search in the battery-aware picker. Fox EP11 ≈ 1.5;
     # smaller inverters under-fill / larger over-fill if hardcoded.

--- a/src/db.py
+++ b/src/db.py
@@ -6014,6 +6014,44 @@ def get_appliance(appliance_id: int) -> dict[str, Any] | None:
             conn.close()
 
 
+def appliance_learned_typical_kw(
+    appliance_id: int, *, lookback_n: int = 10, min_samples: int = 3
+) -> tuple[float, int] | None:
+    """Rolling-mean power (kW) learned from measured cycle energy (#222).
+
+    From the most recent ``lookback_n`` completed jobs with a real
+    ``actual_kwh`` (SmartThings energy counter, #235), per-job
+    ``kW = actual_kwh / (duration_minutes/60)``. Returns ``(mean_kw,
+    n_samples)`` once ``n >= min_samples``, else ``None`` so the caller falls
+    back to the static registration ``typical_kw``.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                """SELECT actual_kwh, duration_minutes FROM appliance_jobs
+                   WHERE appliance_id = ? AND status = 'completed'
+                     AND actual_kwh IS NOT NULL AND actual_kwh > 0
+                     AND duration_minutes IS NOT NULL AND duration_minutes > 0
+                   ORDER BY id DESC LIMIT ?""",
+                (int(appliance_id), max(1, int(lookback_n))),
+            ).fetchall()
+        finally:
+            conn.close()
+    kws: list[float] = []
+    for r in rows:
+        try:
+            a = float(r["actual_kwh"])
+            d = float(r["duration_minutes"])
+            if a > 0 and d > 0:
+                kws.append(a / (d / 60.0))
+        except (TypeError, ValueError, KeyError):
+            continue
+    if len(kws) < int(min_samples):
+        return None
+    return (round(sum(kws) / len(kws), 4), len(kws))
+
+
 def update_appliance(appliance_id: int, **fields: Any) -> bool:
     """Update one or more fields on an appliance. Returns True if a row was
     updated. Silently ignores keys not in :data:`_APPLIANCE_UPDATABLE_FIELDS`."""

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -445,6 +445,24 @@ def _historical_kwh_variance(
         return 0.0
 
 
+def _effective_typical_kw(appliance_id: int, static_kw: float) -> tuple[float, int]:
+    """#222 — the LEARNED rolling-mean power (kW) when enough measured runs
+    exist, else the static registration ``typical_kw``. Returns
+    ``(kw, n_learned)``; ``n_learned == 0`` means the static fallback was used.
+    """
+    try:
+        learned = db.appliance_learned_typical_kw(
+            int(appliance_id),
+            lookback_n=int(getattr(config, "APPLIANCE_LEARNED_KW_LOOKBACK", 10)),
+            min_samples=int(getattr(config, "APPLIANCE_LEARNED_KW_MIN_SAMPLES", 3)),
+        )
+    except Exception:  # pragma: no cover — never let learning break dispatch
+        learned = None
+    if learned is not None and learned[0] > 0:
+        return (float(learned[0]), int(learned[1]))
+    return (float(static_kw), 0)
+
+
 def find_battery_aware_window(
     earliest_start_utc: datetime,
     deadline_utc: datetime,
@@ -706,9 +724,11 @@ def _committed_load_profile_excluding(
         logger.debug("committed_load_profile: query failed", exc_info=True)
         return {}
     profile: dict[datetime, float] = {}
+    _kw_memo: dict[int, float] = {}
     for row in rows:
         try:
-            if int(row.get("appliance_id") or 0) == int(exclude_appliance_id):
+            aid = int(row.get("appliance_id") or 0)
+            if aid == int(exclude_appliance_id):
                 continue
             ps = _parse_iso(row["planned_start_utc"])
             pe = _parse_iso(row["planned_end_utc"])
@@ -717,6 +737,11 @@ def _committed_load_profile_excluding(
         kw = float(row.get("appliance_typical_kw") or 0.0)
         if kw <= 0:
             continue
+        # #222 — overlay the learned power when available.
+        if aid:
+            if aid not in _kw_memo:
+                _kw_memo[aid] = _effective_typical_kw(aid, kw)[0]
+            kw = _kw_memo[aid]
         slot = ps.replace(second=0, microsecond=0)
         if slot.minute < 30:
             slot = slot.replace(minute=0)
@@ -1194,7 +1219,16 @@ def _arm_or_replan(
             )
         return
 
-    appliance_kw = float(appliance.get("typical_kw") or 0.5)
+    # #222 — prefer the learned rolling-mean power over the static registration
+    # default once enough measured runs exist, so the LP stops over-estimating
+    # the cycle energy (and routing around the wash more than necessary).
+    static_kw = float(appliance.get("typical_kw") or 0.5)
+    appliance_kw, _learned_n = _effective_typical_kw(appliance_id, static_kw)
+    if _learned_n:
+        logger.info(
+            "appliance #%d: using LEARNED %.3f kW (mean of %d runs) vs registered %.3f kW",
+            appliance_id, appliance_kw, _learned_n, static_kw,
+        )
     marginal = build_marginal_cost_per_slot(now, deadline_utc, appliance_kw)
     if marginal:
         logger.info(
@@ -1547,6 +1581,7 @@ def appliance_load_profile_kw(
         return {}
 
     profile: dict[datetime, float] = {}
+    _kw_memo: dict[int, float] = {}
     for row in rows:
         try:
             ps = _parse_iso(row["planned_start_utc"])
@@ -1556,6 +1591,13 @@ def appliance_load_profile_kw(
         kw = float(row.get("appliance_typical_kw") or 0.0)
         if kw <= 0:
             continue
+        # #222 — overlay the LEARNED power when available (same value the picker
+        # committed with), so the LP residual profile matches the real cycle.
+        aid = int(row.get("appliance_id") or 0)
+        if aid:
+            if aid not in _kw_memo:
+                _kw_memo[aid] = _effective_typical_kw(aid, kw)[0]
+            kw = _kw_memo[aid]
         # Snap to half-hour grid and walk slots.
         slot = ps.replace(second=0, microsecond=0)
         if slot.minute < 30:

--- a/tests/test_appliance_learned_kw.py
+++ b/tests/test_appliance_learned_kw.py
@@ -1,0 +1,102 @@
+"""#222 — learn appliance typical_kw from measured actual_kwh history.
+
+The rolling mean of recent completed runs' cycle energy replaces the static
+registration default once enough samples exist; below the threshold, callers
+fall back to the registered typical_kw.
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from src.config import config
+
+
+def _seed_job(conn, *, appliance_id: int, actual_kwh, duration_min: int, status="completed"):
+    conn.execute(
+        """INSERT INTO appliance_jobs
+           (appliance_id, status, armed_at_utc, deadline_utc, duration_minutes,
+            planned_start_utc, planned_end_utc, actual_kwh, created_at, updated_at)
+           VALUES (?, ?, '2026-06-06T00:00:00Z', '2026-06-06T06:00:00Z', ?,
+                   '2026-06-06T01:00:00Z', '2026-06-06T03:00:00Z', ?,
+                   '2026-06-06T00:00:00Z', '2026-06-06T00:00:00Z')""",
+        (appliance_id, status, duration_min, actual_kwh),
+    )
+
+
+def test_rolling_mean_kw(monkeypatch):
+    import src.db as db
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            # 4 completed runs: 0.4 kWh over 120 min → 0.2 kW each.
+            for _ in range(4):
+                _seed_job(conn, appliance_id=1, actual_kwh=0.4, duration_min=120)
+            conn.commit()
+        finally:
+            conn.close()
+        out = db.appliance_learned_typical_kw(1, min_samples=3)
+    assert out is not None
+    mean_kw, n = out
+    assert n == 4
+    assert abs(mean_kw - 0.2) < 1e-6
+
+
+def test_below_min_samples_returns_none(monkeypatch):
+    import src.db as db
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            _seed_job(conn, appliance_id=1, actual_kwh=0.4, duration_min=120)
+            _seed_job(conn, appliance_id=1, actual_kwh=0.5, duration_min=120)
+            conn.commit()
+        finally:
+            conn.close()
+        assert db.appliance_learned_typical_kw(1, min_samples=3) is None
+
+
+def test_ignores_incomplete_and_zero(monkeypatch):
+    import src.db as db
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            for _ in range(3):
+                _seed_job(conn, appliance_id=1, actual_kwh=0.6, duration_min=120)  # 0.3 kW
+            # noise that must be excluded:
+            _seed_job(conn, appliance_id=1, actual_kwh=None, duration_min=120)       # no measurement
+            _seed_job(conn, appliance_id=1, actual_kwh=0.0, duration_min=120)        # zero
+            _seed_job(conn, appliance_id=1, actual_kwh=0.6, duration_min=120, status="scheduled")
+            conn.commit()
+        finally:
+            conn.close()
+        out = db.appliance_learned_typical_kw(1, min_samples=3)
+    assert out is not None
+    assert abs(out[0] - 0.3) < 1e-6 and out[1] == 3
+
+
+def test_effective_kw_prefers_learned_else_static(monkeypatch):
+    import src.db as db
+    from src.scheduler.appliance_dispatch import _effective_typical_kw
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setattr(config, "DB_PATH", str(Path(td) / "t.db"), raising=False)
+        monkeypatch.setattr(config, "APPLIANCE_LEARNED_KW_MIN_SAMPLES", 3, raising=False)
+        db.init_db()
+        # No history → static fallback.
+        kw, n = _effective_typical_kw(1, static_kw=0.5)
+        assert kw == 0.5 and n == 0
+        # With history → learned.
+        conn = db.get_connection()
+        try:
+            for _ in range(3):
+                _seed_job(conn, appliance_id=1, actual_kwh=0.4, duration_min=120)  # 0.2 kW
+            conn.commit()
+        finally:
+            conn.close()
+        kw, n = _effective_typical_kw(1, static_kw=0.5)
+    assert abs(kw - 0.2) < 1e-6 and n == 3


### PR DESCRIPTION
Closes #222.

## Problem
`appliances.typical_kw` is a registration guess (default 0.5 kW) that never
updates. Audit: registration `0.5 kW × 163 min = 1.36 kWh` vs Samsung eco40
`≈ 0.4–0.6 kWh` — a ~3× over-estimate → the LP routes around the wash more than
necessary.

## What was already there
The measured cycle energy is captured (`appliance_jobs.actual_kwh`, #235) and
used for the σ safety margin — but the **central energy estimate stayed static**.

## This PR
- `db.appliance_learned_typical_kw(appliance_id, lookback_n, min_samples)` —
  rolling-mean power (`actual_kwh / duration`) of the last
  `APPLIANCE_LEARNED_KW_LOOKBACK` (10) completed runs; returns `(mean_kw, n)`
  once `APPLIANCE_LEARNED_KW_MIN_SAMPLES` (3) exist, else `None`.
- `_effective_typical_kw` (learned-or-static) wired into **`_arm_or_replan`**
  (the window picker — the AC's named target) and **both LP residual-load
  overlays**, so the LP + dispatch agree on the real cycle energy. The σ-based
  safety margin (#235) is unchanged.
- `GET /api/v1/appliances` now returns `learned_typical_kw` / `learned_samples`
  / `effective_typical_kw` so the learning is visible (the "0.42 kW, 8 runs" AC).

## Acceptance criteria
- [x] `actual_kwh` populated for completed runs (already, #235)
- [x] After ≥3 historical runs, `_arm_or_replan` uses the learned value
- [x] Learning state surfaced (`/api/v1/appliances`, + an arm-time log line)
- [x] Test: synthetic history → rolling mean (4 tests)

Docs updated: CHANGELOG `[Unreleased]` + CLAUDE.md appliance section (also added
the post-#490 LWT-drift-backstop #492 entry). Appliance suite green (97 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)