### PR TITLE
fix(lp): skip terminal DHW floor when K2 pinning is active (#422)

### DIFF
--- a/src/scheduler/lp_optimizer.py
+++ b/src/scheduler/lp_optimizer.py
@@ -1119,7 +1119,13 @@ def solve_lp(
     # Skip terminal tank/indoor floors in passive mode — same reason as shower
     # hard constraint above. Firmware controls comfort; the LP only optimises
     # battery/grid/PV around the predicted Daikin draw.
-    if not passive_daikin:
+    #
+    # #422 — also skip when the tank trajectory is PINNED to the dhw_policy
+    # forecast (K2): ``tank[i+1] == _pinned_tank[i+1]`` already fixes tank[n],
+    # so an additional ``tank[n] >= terminal_dhw_floor`` floor can directly
+    # contradict the pin (guests mode + last slot in a shower window → pinned
+    # 45 °C vs a 53 °C floor → Infeasible). The pin governs the tank entirely.
+    if not passive_daikin and not _dhw_pinned:
         # PR 4 of plan: when the last slot lands inside a shower window, keep
         # the tight terminal floor so the LP must finish with a hot tank for
         # in-progress showers. When it lands OUTSIDE shower windows (e.g. a

--- a/tests/test_lp_dhw_pinning.py
+++ b/tests/test_lp_dhw_pinning.py
@@ -359,3 +359,28 @@ def test_lp_pinning_passive_mode_unaffected(monkeypatch):
     # Passive mode + pinning could be infeasible — LP returns ok=False if so.
     # Either outcome is acceptable as long as it doesn't crash.
     assert plan is not None
+
+
+def test_lp_pinning_guests_with_last_slot_in_shower_window_is_feasible(monkeypatch):
+    """#422 regression: under K2 pinning the pinned trajectory clamps
+    ``tank[n]`` to the dhw_policy value (e.g. NORMAL 45 °C), but the terminal
+    DHW floor was still active and (guests mode, last slot in the evening shower
+    window) used ``TARGET_DHW_TEMP_MIN_GUESTS_C-2 = 53`` — directly contradicting
+    the pin → Infeasible. Fix: skip the terminal floor when ``_dhw_pinned``.
+    Without the guard this asserts ``plan.ok=False``.
+    """
+    monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "guests", raising=False)
+    monkeypatch.setattr(config, "TARGET_DHW_TEMP_MIN_GUESTS_C", 55.0, raising=False)
+    # Horizon ending inside the evening shower window (20:00-22:00 BST): 2 slots
+    # at 21:00 + 21:30 local, both in-window, so the LAST slot is in-window.
+    base = datetime(2026, 6, 1, 21, 0, tzinfo=TZ_LOCAL).astimezone(UTC)
+    n = 2
+    slots = [base + timedelta(minutes=30 * i) for i in range(n)]
+    plan = _solve(
+        slots=slots, prices=[15.0] * n, pv=[1.0] * n,
+        base_load=[0.3] * n, init_soc=5.8, init_tank=45.0,
+    )
+    assert plan.ok, (
+        "LP must be feasible under guests+pinning with the last slot in the "
+        f"shower window (terminal floor must defer to the pin); got {plan.status}"
+    )


### PR DESCRIPTION
Closes #422 (resurrects the never-merged fix; the bug is still live on `main`).

## Bug
Under K2 DHW pinning (`DHW_FIXED_SCHEDULE_ENABLED=true`, prod default), the pin
clamps `tank[n]` via `tank[i+1] == _pinned_tank[i+1]`. But the terminal DHW floor
(`lp_optimizer.py:1122`) was guarded only by `not passive_daikin`. In **guests**
mode with the horizon's last slot in the evening shower window, that floor =
`TARGET_DHW_TEMP_MIN_GUESTS_C − 2 = 53 °C` while the pin holds 45 °C → the two
constraints contradict → **Infeasible** → held-schedule fallback (prod run 1154,
2026-05-27).

## Fix
`if not passive_daikin and not _dhw_pinned:` — the pin already fully determines
the tank trajectory, so the terminal floor must defer to it (same `not
_dhw_pinned` guard the per-slot balance / shower floor / legionella already
carry; #406 missed this one).

Regression test in `test_lp_dhw_pinning.py` — **verified it fails (Infeasible)
without the guard and passes with it**. LP/DHW suites green (77 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)