### PR TITLE
feat(daikin): aggressive LWT boost on negative (paid) slots — maximise the range (#481)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -982,6 +982,15 @@ class Config:
     ).lower() in ("true", "1", "yes")
     DAIKIN_LWT_PREHEAT_BOOST_C: int = int(os.getenv("DAIKIN_LWT_PREHEAT_BOOST_C", "3"))
     DAIKIN_LWT_PREHEAT_PEAK_SETBACK_C: int = int(os.getenv("DAIKIN_LWT_PREHEAT_PEAK_SETBACK_C", "-2"))
+    # NEGATIVE (paid-to-import) slots: push the space-heating offset to the TOP
+    # of the operating range instead of the modest cheap-slot boost — bank the
+    # most thermal mass into the building while the grid pays us, alongside the
+    # already-maxed tank. Bounded above by the firmware heating cutoff
+    # (DAIKIN_WEATHER_CURVE_HIGH_C — no heat when it's mild out) and below by the
+    # OPTIMIZATION_LWT_OFFSET_MAX clamp; the comfort guard suppresses it once a
+    # room sensor exists. Default = the current offset ceiling (+5). Raise
+    # OPTIMIZATION_LWT_OFFSET_MAX (and this) for an even wider paid-window range.
+    DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C: int = int(os.getenv("DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", "5"))
     # Comfort dead-band (°C) used by the sensor-ready guard: once a real room
     # temperature is available, suppress boost above SETPOINT+band and suppress
     # setback below SETPOINT-band. No-op while indoor_temp telemetry is absent.

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -338,11 +338,21 @@ def _preheat_lwt_offset(
         return None
 
     boost = int(config.DAIKIN_LWT_PREHEAT_BOOST_C)
+    neg_boost = int(getattr(config, "DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", boost))
     setback = int(config.DAIKIN_LWT_PREHEAT_PEAK_SETBACK_C)
     band = float(config.DAIKIN_LWT_PREHEAT_COMFORT_BAND_C)
     setpoint = float(config.INDOOR_SETPOINT_C)
 
-    if price_p <= cheap_thr:
+    if price_p < 0:
+        # PAID to import — push space heating to the TOP of the operating range
+        # (clamped below) to bank the most thermal mass while we're paid for it,
+        # not the modest cheap-slot nudge. Heating-cutoff gate above already
+        # ensures this only fires when the firmware is actually heating.
+        off = neg_boost
+        # Comfort guard (sensor-ready): don't over-heat an already-warm room.
+        if indoor_c is not None and indoor_c >= setpoint + band:
+            off = 0
+    elif price_p <= cheap_thr:
         off = boost
         # Comfort guard (sensor-ready): don't pre-heat an already-warm room.
         if indoor_c is not None and indoor_c >= setpoint + band:

--- a/tests/test_lwt_preheat.py
+++ b/tests/test_lwt_preheat.py
@@ -65,6 +65,7 @@ WARM = 20.0  # outdoor ≥ 18 → firmware idle
 def enabled(monkeypatch):
     monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_ENABLED", True)
     monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_BOOST_C", 3)
+    monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", 5)
     monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_PEAK_SETBACK_C", -2)
     monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_COMFORT_BAND_C", 0.5)
     monkeypatch.setattr(config, "OPTIMIZATION_LWT_OFFSET_MIN", -10.0)
@@ -97,6 +98,23 @@ def test_warm_day_returns_none(enabled):
 def test_cheap_slot_boosts(enabled):
     assert _off(5.0, COLD) == 3
     assert _off(CHEAP, COLD) == 3  # boundary inclusive
+
+
+def test_negative_slot_pushes_to_max(enabled):
+    # Paid to import → aggressive boost to the top of the range (5), not +3.
+    assert _off(-3.0, COLD) == 5
+    assert _off(-0.01, COLD) == 5
+
+
+def test_negative_boost_clamped_to_offset_max(enabled, monkeypatch):
+    # The aggressive negative boost is still bounded by OPTIMIZATION_LWT_OFFSET_MAX.
+    monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", 9)
+    assert _off(-3.0, COLD) == 5  # clamp at MAX=5
+
+
+def test_negative_warm_day_still_none(enabled):
+    # Even when paid, no boost if the firmware isn't heating (mild outdoor).
+    assert _off(-3.0, WARM) is None
 
 
 def test_peak_slot_sets_back(enabled):


### PR DESCRIPTION
Per the user: during a **paid** (negative-price) window we want to dump the most
energy we can, and the LWT offset has an operating range (up to
`OPTIMIZATION_LWT_OFFSET_MAX`) that the fixed `+3` trigger wasn't using.

On **negative** slots, the heuristic now pushes the space-heating offset to
`DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C` (default **+5** = the current ceiling)
instead of the modest cheap-slot `+3` — banking the most thermal mass into the
building while the grid pays us, alongside the already-maxed 60 °C tank.

Bounds preserved:
- **Heating cutoff** — no boost when `outdoor ≥ DAIKIN_WEATHER_CURVE_HIGH_C`
  (can't usefully heat a mild day; this is the outdoor-temp gate).
- **Clamp** — bounded by `OPTIMIZATION_LWT_OFFSET_MAX`.
- **Comfort guard** — sensor-ready; suppresses when the room is already warm
  (no-op until a room sensor lands; open-loop for now → tunable knob is the
  user's control over aggressiveness).

Timely for tomorrow's 11 h negative window: the cold-morning hours
(04:00–10:30 UTC, outdoor < 18 °C) bank **+5** LWT instead of +3. 4 tests
(negative→max, clamp, warm-day none, cheap still +3); LWT suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)