### PR TITLE
feat(daikin): LWT +10 (no cutoff) + tank pre-cool into negative windows

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1625,9 +1625,10 @@ async def daikin_heating_plan():
         raw_offsets.append(off)
         tank_temp, tank_kind = _tank_at(cur)
         # Natural weather-curve LWT (radiator water temp the firmware targets at
-        # this outdoor temp, offset 0). The offset is only meaningful relative
-        # to this — the real setpoint is curve + offset.
-        lwt_base = round(get_lwt_base_c(outdoor), 1) if (heating_on and outdoor is not None) else None
+        # this outdoor temp, offset 0). Computed whenever outdoor is known so the
+        # commanded setpoint (curve + offset) shows across the whole window — the
+        # firmware owns the actual on/off, not our old cutoff.
+        lwt_base = round(get_lwt_base_c(outdoor), 1) if outdoor is not None else None
         slots_out.append({
             "slot_utc": cur.isoformat().replace("+00:00", "Z"),
             "outdoor_c": round(outdoor, 1) if outdoor is not None else None,

--- a/src/config.py
+++ b/src/config.py
@@ -843,6 +843,17 @@ class Config:
     DHW_TEMP_SETBACK_C: float = float(
         os.getenv("DHW_TEMP_SETBACK_C", "37")
     )
+    # Pre-cool the tank toward the device minimum during the setback that runs
+    # INTO a negative-price window, so the paid boost (cold → 60 °C) absorbs the
+    # most kWh while we're paid — and zero positive-price reheat happens just
+    # before. Only applied when no shower window falls between setback start and
+    # the boost (the boost reheats to 60 before showers). NOTE: the gain is
+    # bounded by standing loss (~0.5 °C/h) — the tank can't be force-cooled, only
+    # left to coast — so expect ~0.5–1 kWh, not a step change.
+    DHW_TANK_PRECOOL_ENABLED: bool = (
+        os.getenv("DHW_TANK_PRECOOL_ENABLED", "true").strip().lower() in ("1", "true", "yes", "on")
+    )
+    DHW_TANK_PRECOOL_TARGET_C: int = int(os.getenv("DHW_TANK_PRECOOL_TARGET_C", "30"))
     # Commandable SETPOINT during negative-price slots (import price < 0 p/kWh):
     # the tank target we WRITE to the heat pump. Grid is paying us to consume, so
     # we drive the setpoint to its max. MUST stay ≤ the device's heat-pump
@@ -968,7 +979,11 @@ class Config:
         os.getenv("OPTIMIZATION_PREHEAT_LWT_BOOST", os.getenv("SCHEDULER_PREHEAT_LWT_BOOST", "2"))
     )
     OPTIMIZATION_LWT_OFFSET_MIN: float = float(os.getenv("OPTIMIZATION_LWT_OFFSET_MIN", "-10"))
-    OPTIMIZATION_LWT_OFFSET_MAX: float = float(os.getenv("OPTIMIZATION_LWT_OFFSET_MAX", "5"))
+    # Device range is ±10. Raised 5→10 (2026-06-06): the Daikin firmware applies
+    # the offset relative to its OWN weather curve and decides whether to heat,
+    # so a high offset doesn't force pointless heating — it lets paid windows
+    # push the radiator water to the top of the operating range.
+    OPTIMIZATION_LWT_OFFSET_MAX: float = float(os.getenv("OPTIMIZATION_LWT_OFFSET_MAX", "10"))
     # --- Heuristic LWT pre-heat (#481) — active space-heating control ---------
     # When enabled, HEM drives the Daikin leaving-water-temperature OFFSET by a
     # simple price-tier rule: boost in cheap slots (pre-heat the house) and set
@@ -990,7 +1005,7 @@ class Config:
     # OPTIMIZATION_LWT_OFFSET_MAX clamp; the comfort guard suppresses it once a
     # room sensor exists. Default = the current offset ceiling (+5). Raise
     # OPTIMIZATION_LWT_OFFSET_MAX (and this) for an even wider paid-window range.
-    DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C: int = int(os.getenv("DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", "5"))
+    DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C: int = int(os.getenv("DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", "10"))
     # Comfort dead-band (°C) used by the sensor-ready guard: once a real room
     # temperature is available, suppress boost above SETPOINT+band and suppress
     # setback below SETPOINT-band. No-op while indoor_temp telemetry is absent.

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -68,6 +68,42 @@ def _make_action(
     }
 
 
+def _shower_in_span(start_utc: datetime, end_utc: datetime, tz: ZoneInfo) -> bool:
+    """True if any configured DHW shower window overlaps ``[start, end)`` in
+    local time (#tank-precool guard). Parses ``DHW_SHOWER_SCHEDULE``
+    (``"HH:MM-HH:MM,…"``). Conservative: any parse trouble → True (don't
+    pre-cool when unsure). Empty schedule → False.
+    """
+    sched = (getattr(config, "DHW_SHOWER_SCHEDULE", "") or "").strip()
+    if not sched or end_utc <= start_utc:
+        return False
+    windows: list[tuple[int, int]] = []
+    for part in sched.split(","):
+        part = part.strip()
+        if "-" not in part:
+            continue
+        try:
+            a, b = part.split("-", 1)
+            sh, sm = a.split(":")
+            eh, em = b.split(":")
+            windows.append((int(sh) * 60 + int(sm), int(eh) * 60 + int(em)))
+        except ValueError:
+            return True  # unparseable → assume a shower could be there
+    if not windows:
+        return False
+    day = start_utc.astimezone(tz).date()
+    last = end_utc.astimezone(tz).date()
+    while day <= last:
+        midnight = datetime(day.year, day.month, day.day, tzinfo=tz)
+        for ws, we in windows:
+            sw = (midnight + timedelta(minutes=ws)).astimezone(UTC)
+            ew = (midnight + timedelta(minutes=we)).astimezone(UTC)
+            if sw < end_utc and ew > start_utc:
+                return True
+        day = day + timedelta(days=1)
+    return False
+
+
 def _detect_negative_windows(
     agile_rates: list[dict[str, Any]] | None,
     horizon_start_utc: datetime,
@@ -226,6 +262,28 @@ def generate_daily_tank_schedule(
             else:
                 break
 
+    # Tank pre-cool into a negative window: drop the setback target toward the
+    # device minimum so the paid boost (cold → boost_c) absorbs the most kWh and
+    # no positive-price reheat fires just before it. Guarded by no shower in the
+    # setback→first-boost span (the boost reheats to boost_c before any later
+    # shower). PHYSICS CAVEAT: standing loss (~0.5 °C/h) caps real cooling — for
+    # a window soon after the warmup the tank is still coasting well above the
+    # target, so the gain is small; the value is mostly far-from-warmup windows
+    # + the guaranteed no-reheat-before-paid.
+    effective_setback_c = setback_c
+    if (
+        getattr(config, "DHW_TANK_PRECOOL_ENABLED", False)
+        and mode != "guests"
+        and neg_windows
+    ):
+        first_neg_start = min(nw[0] for nw in neg_windows)
+        if setback_start_utc <= first_neg_start and not _shower_in_span(
+            setback_start_utc, first_neg_start, tz
+        ):
+            effective_setback_c = min(
+                setback_c, int(getattr(config, "DHW_TANK_PRECOOL_TARGET_C", 30))
+            )
+
     rows: list[dict[str, Any]] = []
 
     if mode == "guests":
@@ -253,7 +311,7 @@ def generate_daily_tank_schedule(
             action_type="tank_setback",
             start_utc=setback_start_utc,
             end_utc=next_warmup_utc,
-            tank_temp_c=setback_c,
+            tank_temp_c=effective_setback_c,
         ))
 
     for nw_start, nw_end in neg_windows:

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -333,9 +333,12 @@ def _preheat_lwt_offset(
     """
     if not config.DAIKIN_LWT_PREHEAT_ENABLED:
         return None
-    # Firmware only heats below the curve's high anchor; nothing to nudge above it.
-    if outdoor_c >= float(config.DAIKIN_WEATHER_CURVE_HIGH_C):
-        return None
+    # No outdoor cutoff: the Daikin firmware applies the offset relative to its
+    # OWN weather curve and decides whether to run the compressor, so emitting
+    # the offset when it's mild doesn't force pointless heating — the firmware
+    # ignores it above its own heating ambient threshold. We just set the offset;
+    # the unit owns the on/off. (Was previously gated at DAIKIN_WEATHER_CURVE_
+    # HIGH_C, which cut the offset mid-paid-window — the user's call to remove.)
 
     boost = int(config.DAIKIN_LWT_PREHEAT_BOOST_C)
     neg_boost = int(getattr(config, "DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", boost))

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -534,3 +534,34 @@ def test_negative_boost_uses_powerful():
     )
     boost = next(r for r in rows if r["action_type"] == "tank_negative_boost")
     assert boost["params"]["tank_powerful"] is True
+
+
+def test_precool_lowers_setback_into_negative_window(monkeypatch):
+    # A negative window in the setback period + evening showers (no conflict) →
+    # the setback target drops toward the device minimum (pre-cool).
+    monkeypatch.setattr(config, "DHW_TANK_PRECOOL_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "DHW_TANK_PRECOOL_TARGET_C", 30, raising=False)
+    monkeypatch.setattr(config, "DHW_SHOWER_SCHEDULE", "19:00-22:00", raising=False)
+    neg = datetime(2026, 6, 2, 4, 0, tzinfo=UTC)  # inside setback (22:00 d1→13:00 d2)
+    rates = [{"valid_from": neg.isoformat().replace("+00:00", "Z"), "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal", agile_rates=rates)
+    setback = [r for r in rows if r["action_type"] == "tank_setback"][0]
+    assert setback["params"]["tank_temp"] == 30
+
+
+def test_no_precool_without_negative_window(monkeypatch):
+    monkeypatch.setattr(config, "DHW_TANK_PRECOOL_ENABLED", True, raising=False)
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal")
+    setback = [r for r in rows if r["action_type"] == "tank_setback"][0]
+    assert setback["params"]["tank_temp"] == int(round(float(config.DHW_TEMP_SETBACK_C)))
+
+
+def test_no_precool_when_shower_in_span(monkeypatch):
+    # A morning shower between setback start and the boost → guard blocks precool.
+    monkeypatch.setattr(config, "DHW_TANK_PRECOOL_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "DHW_SHOWER_SCHEDULE", "07:00-08:00", raising=False)
+    neg = datetime(2026, 6, 2, 9, 0, tzinfo=UTC)  # boost after the 07:00 BST shower
+    rates = [{"valid_from": neg.isoformat().replace("+00:00", "Z"), "value_inc_vat": -5.0}]
+    rows = dhw_policy.generate_daily_tank_schedule(date(2026, 6, 1), mode="normal", agile_rates=rates)
+    setback = [r for r in rows if r["action_type"] == "tank_setback"][0]
+    assert setback["params"]["tank_temp"] == int(round(float(config.DHW_TEMP_SETBACK_C)))

--- a/tests/test_lwt_preheat.py
+++ b/tests/test_lwt_preheat.py
@@ -89,10 +89,11 @@ def test_disabled_returns_none(monkeypatch):
     assert _off(5.0, COLD) is None
 
 
-def test_warm_day_returns_none(enabled):
-    # Firmware won't run the compressor → emit nothing (climate hands-off, no quota).
-    assert _off(5.0, WARM) is None
-    assert _off(30.0, WARM) is None
+def test_warm_day_still_emits_offset(enabled):
+    # No outdoor cutoff: the offset is emitted regardless of outdoor temp; the
+    # Daikin firmware (its own weather curve) decides whether to actually heat.
+    assert _off(5.0, WARM) == 3       # cheap → +3 (firmware ignores if too warm)
+    assert _off(30.0, WARM) == -2     # peak → setback
 
 
 def test_cheap_slot_boosts(enabled):
@@ -112,9 +113,10 @@ def test_negative_boost_clamped_to_offset_max(enabled, monkeypatch):
     assert _off(-3.0, COLD) == 5  # clamp at MAX=5
 
 
-def test_negative_warm_day_still_none(enabled):
-    # Even when paid, no boost if the firmware isn't heating (mild outdoor).
-    assert _off(-3.0, WARM) is None
+def test_negative_warm_day_still_boosts(enabled):
+    # Paid window: push the offset to max regardless of outdoor temp — the
+    # firmware decides whether to heat (cutoff removed).
+    assert _off(-3.0, WARM) == 5  # fixture clamp MAX=5
 
 
 def test_peak_slot_sets_back(enabled):
@@ -202,10 +204,13 @@ def test_neutral_slots_emit_nothing(enabled):
     assert _lwt_preheat_pairs(plan, []) == []
 
 
-def test_warm_slots_emit_nothing(enabled):
-    # Cheap price but warm outdoor → firmware idle → no offset write.
+def test_warm_slots_still_emit(enabled):
+    # Cutoff removed: cheap+warm slots still emit the offset (the firmware
+    # decides whether to heat). One +3 boost window over the three slots.
     plan = _plan([5, 5, 5], [WARM] * 3)
-    assert _lwt_preheat_pairs(plan, []) == []
+    pairs = _lwt_preheat_pairs(plan, [])
+    assert len(pairs) == 1
+    assert pairs[0][1]["params"]["lwt_offset"] == 3
 
 
 def test_restore_returns_offset_to_zero(enabled):


### PR DESCRIPTION
Two user-requested maximisations for **paid** (negative-price) windows.

## 1. LWT to the top of the ±10 range, no outdoor cutoff
Per the user: the Daikin firmware applies the offset relative to its **own**
weather curve and decides whether to heat, so a high offset doesn't force
pointless heating — the unit owns on/off. So:
- Removed the 18 °C cutoff from `_preheat_lwt_offset` (it cut the boost
  mid-paid-window — now the offset spans the whole window; the firmware ignores
  it when it's too mild).
- `OPTIMIZATION_LWT_OFFSET_MAX` 5 → **10**; `DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C`
  5 → **10** (paid slots push the radiator water to the top of the range).
- Heating-plan endpoint shows the commanded setpoint across the whole window.

Open-loop until the room sensor — the knobs are the aggressiveness control.

## 2. Tank pre-cool into a negative window
When the setback runs into a negative window **and no shower falls in the
setback→boost span**, the setback target drops toward the device minimum
(`DHW_TANK_PRECOOL_TARGET_C`, 30) so the paid boost (cold → 60) absorbs the most
kWh and zero positive-price reheat fires first. `DHW_TANK_PRECOOL_ENABLED`
(default on).

**⚠️ Physics caveat (documented):** standing loss (~0.5 °C/h) caps real
cooling — the tank can only coast, not be force-cooled — so a window **soon
after the warmup** (like tomorrow's 04:00) sees the tank still coasting ~40 °C,
well above the target → little change. The value is mostly far-from-warmup
windows + the guaranteed no-reheat-before-paid. Honest framing: this won't move
tomorrow much; the LWT change is the real win.

Tests: LWT warm-day now emits (cutoff gone), negative→max+clamp; tank pre-cool
lowers / no-neg-skips / shower-guard. Affected suites green (289 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)