### PR TITLE
fix(daikin): LWT drift backstop must not reset a completed-row offset (live incident)

### DIFF
--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -645,6 +645,12 @@ def _check_lwt_offset_drift(
         return
 
     # Does any current slot's lwt_preheat action justify a non-zero offset?
+    # NOTE: status is NOT filtered — a lwt_preheat row whose window covers now
+    # justifies the offset even when it's ``completed`` (it fired, or the
+    # pre-fire idempotency marked it noop because the device already held the
+    # value). Filtering to pending/active was a bug (#496-incident): it reset a
+    # legitimate live offset to 0 the moment its row completed. The time-window
+    # check below is what makes the row "current".
     for act in actions:
         try:
             start = _parse_utc(act["start_time"])
@@ -652,8 +658,6 @@ def _check_lwt_offset_drift(
         except (ValueError, KeyError, TypeError):
             continue
         if not (start <= now_utc < end):
-            continue
-        if (act.get("status") or "") not in ("pending", "active"):
             continue
         if act.get("overridden_by_user_at"):
             continue

--- a/tests/scheduler/test_appliance_dispatch.py
+++ b/tests/scheduler/test_appliance_dispatch.py
@@ -74,14 +74,22 @@ def patch_st(fake_client):
 
 @pytest.fixture
 def appliance_id():
-    """Insert a single appliance and return its id."""
+    """Insert a single appliance and return its id.
+
+    The deadline is ~12 h ahead of *now* (not a fixed "07:00") so the reconcile
+    always has room to place the 120-min window regardless of the wall-clock
+    time the suite runs at — a fixed early-morning deadline failed when CI ran
+    near it (no room before it).
+    """
+    from zoneinfo import ZoneInfo
+    deadline = (datetime.now(ZoneInfo("Europe/London")) + timedelta(hours=12)).strftime("%H:%M")
     return db.add_appliance(
         vendor="smartthings",
         vendor_device_id="dev-test",
         name="Test Washer",
         device_type="washer",
         default_duration_minutes=120,
-        deadline_local_time="07:00",
+        deadline_local_time=deadline,
         typical_kw=0.5,
     )
 

--- a/tests/test_lwt_offset_drift.py
+++ b/tests/test_lwt_offset_drift.py
@@ -66,6 +66,16 @@ def test_justified_by_preheat_slot(monkeypatch):
     assert applied == []
 
 
+def test_completed_preheat_slot_still_justifies(monkeypatch):
+    # #496-incident regression: a lwt_preheat row whose window covers now but is
+    # already `completed` (fired / noop'd by pre-fire idempotency) must STILL
+    # justify the live offset — the backstop must not reset it to 0.
+    sm, applied = _common(monkeypatch)
+    dev = DaikinDevice(id="gw", name="x", lwt_offset=10.0)
+    _run(monkeypatch, sm, [_slot("lwt_preheat", 10, status="completed")], dev)
+    assert applied == [], "completed in-window row must justify the offset"
+
+
 def test_zero_offset_is_noop(monkeypatch):
     sm, applied = _common(monkeypatch)
     dev = DaikinDevice(id="gw", name="x", lwt_offset=0.0)


### PR DESCRIPTION
**Live incident** during today's 11 h negative window. `_check_lwt_offset_drift`
(#492) reset the legitimate **+10** LWT offset to **0** ~10 min after it was
applied, then kept doing it every heartbeat → the paid-window space heating was
lost.

**Root cause:** the justification scan required `status in (pending, active)`,
but the in-window `lwt_preheat` row had been marked **completed** by the pre-fire
idempotency (the device already held +10 → the write was a noop). No
pending/active justifying row was found → the backstop treated the live offset as
stray drift → reset to 0.

**Fix:** drop the status filter. A `lwt_preheat` row whose `[start, end]` window
covers `now` justifies the offset regardless of status (`completed` = it
fired/noop'd; the window is still active). The time-window check is what makes a
row "current".

Mitigated live (disabled `LWT_OFFSET_DRIFT_CHECK_ENABLED` + re-plan → +10
restored, verified `lwt_offset=10`); this fix lets it be re-enabled correctly.
Regression test: a completed in-window row must justify the offset (no reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)