### PR TITLE
fix(dhw,override): recover live-cycle paid boost on re-plan; respect manual gesture until window end

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1671,6 +1671,18 @@ class Config:
     USER_OVERRIDE_RESPECT_HOURS: float = float(
         os.getenv("USER_OVERRIDE_RESPECT_HOURS", "4.0")
     )
+    # 2026-06-07: extend respect of a manual LWT/tank gesture to the END of the
+    # planned window it was made in (the overridden row's end_time), not just
+    # the fixed USER_OVERRIDE_RESPECT_HOURS grace. Matters for windows longer
+    # than that grace — e.g. a multi-hour negative-price tank boost: nudge the
+    # tank by hand and HEM leaves it alone until the boost window closes. The
+    # live ``user_gesture_still_in_effect`` check is still the safety gate
+    # (revert the manual change → HEM resumes at once), so a long window can
+    # never wedge the schedule. Set false to revert to the fixed-hours grace.
+    USER_OVERRIDE_RESPECT_UNTIL_WINDOW_END: bool = (
+        os.getenv("USER_OVERRIDE_RESPECT_UNTIL_WINDOW_END", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
     # Feature flag for the pre-fire state-match dedupe. When True (default),
     # the heartbeat compares the live device state against a pending row's
     # params before firing — already-matching rows are marked completed with

--- a/src/db.py
+++ b/src/db.py
@@ -1451,28 +1451,50 @@ def find_recent_user_override(
     *,
     within_hours: float,
     now_utc: datetime | None = None,
+    respect_until_window_end: bool = False,
 ) -> dict[str, Any] | None:
     """Epic 14 (#386): the most-recent ``user_overridden`` action_schedule row
-    for ``device`` whose ``overridden_by_user_at`` falls inside the trailing
-    ``within_hours`` window. Returns ``None`` when no such row exists.
+    for ``device`` whose override is still in effect. Returns ``None`` when no
+    such row exists.
+
+    An override qualifies when EITHER:
+      * its ``overridden_by_user_at`` timestamp is inside the trailing
+        ``within_hours`` window (the original fixed grace), OR
+      * ``respect_until_window_end`` is set AND the overridden row's own
+        planned window still covers now (``end_time > now``). This honours
+        "if I change the tank/LWT by hand, don't touch it until the end of the
+        planned window" for windows longer than ``within_hours`` (e.g. a
+        multi-hour negative-price boost) — the 2026-06-07 requirement. The
+        caller's live ``user_gesture_still_in_effect`` check remains the real
+        safety gate: revert the manual change and HEM resumes control at once,
+        so a far-future ``end_time`` can never wedge the schedule.
 
     Used by the heartbeat reconciler to propagate a user's manual gesture
     (e.g. tank power-off via Onecta) onto fresh rows the LP inserts after
     a replan, so the user doesn't have to keep undoing the same action.
     """
-    if within_hours <= 0:
-        return None
     now = now_utc or datetime.now(UTC)
-    cutoff = (now - timedelta(hours=within_hours)).isoformat()
+    now_iso = now.isoformat()
+    clauses: list[str] = ["device = ?", "overridden_by_user_at IS NOT NULL"]
+    params: list[Any] = [device]
+    time_terms: list[str] = []
+    if within_hours > 0:
+        time_terms.append("overridden_by_user_at >= ?")
+        params.append((now - timedelta(hours=within_hours)).isoformat())
+    if respect_until_window_end:
+        time_terms.append("end_time > ?")
+        params.append(now_iso)
+    if not time_terms:
+        return None
+    clauses.append("(" + " OR ".join(time_terms) + ")")
     with _lock:
         conn = get_connection()
         try:
             cur = conn.execute(
                 "SELECT * FROM action_schedule "
-                "WHERE device = ? AND overridden_by_user_at IS NOT NULL "
-                "AND overridden_by_user_at >= ? "
+                "WHERE " + " AND ".join(clauses) + " "
                 "ORDER BY overridden_by_user_at DESC LIMIT 1",
-                (device, cutoff),
+                tuple(params),
             )
             r = cur.fetchone()
             return _row_action(r) if r else None

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -157,6 +157,7 @@ def generate_daily_tank_schedule(
     agile_rates: list[dict[str, Any]] | None = None,
     mode: str | None = None,
     allow_past: bool = False,
+    boosts_only_from: datetime | None = None,
 ) -> list[dict[str, Any]]:
     """Generate tank action rows for the local calendar day starting at
     ``DHW_WARMUP_START_HOUR_LOCAL`` (default 13:00) on ``target_date_local``
@@ -171,6 +172,16 @@ def generate_daily_tank_schedule(
         agile_rates: optional list of {valid_from, value_inc_vat}; used
             to detect negative-price windows for boost overrides
         mode: optimization preset; defaults to ``config.OPTIMIZATION_PRESET``
+        boosts_only_from: when set, return ONLY this cycle's
+            ``tank_negative_boost`` rows, each clipped to start at
+            ``max(window_start, boosts_only_from)`` (drop any already ended).
+            Used by the writer to recover the early-morning paid boost of the
+            *currently-live* cycle (anchored at yesterday's warmup) that the
+            cycle-split otherwise drops on an overnight re-plan — the
+            2026-06-07 paid-window incident. Structural warmup/setback rows are
+            deliberately NOT re-emitted: they already fired when the cycle
+            began, and a fresh setback sharing the boost's start would thrash
+            against it (neither row ever reaches a state-matched "completed").
 
     Returns:
         List of action dicts; empty when ``mode='vacation'``.
@@ -186,9 +197,11 @@ def generate_daily_tank_schedule(
     # immediately and they'd be wasted churn. Tomorrow is fine (advance
     # scheduling). ``allow_past=True`` lets read-only callers (e.g. the
     # heating-plan timeline endpoint) regenerate a past day's deterministic
-    # schedule for display without writing anything.
+    # schedule for display without writing anything. ``boosts_only_from``
+    # deliberately reaches back into the live (yesterday-anchored) cycle, so it
+    # also bypasses this guard — it clips to ``boosts_only_from`` instead.
     today_local = datetime.now(_tz_local()).date()
-    if not allow_past and target_date_local < today_local:
+    if boosts_only_from is None and not allow_past and target_date_local < today_local:
         logger.info(
             "dhw_policy: skipping %s (in the past; today=%s)",
             target_date_local, today_local,
@@ -234,6 +247,25 @@ def generate_daily_tank_schedule(
     setback_start_utc = setback_start.astimezone(UTC)
     next_warmup_utc = next_warmup.astimezone(UTC)
     neg_windows = _detect_negative_windows(agile_rates, warmup_start_utc, next_warmup_utc)
+
+    # Boosts-only recovery path: emit just the negative-boost rows of this
+    # (already-running) cycle, clipped to ``boosts_only_from``. No structural
+    # rows — see the param docstring. Keeps the writer idempotent: the next
+    # re-plan's range-clear removes these and rewrites with a fresh clip.
+    if boosts_only_from is not None:
+        boost_rows: list[dict[str, Any]] = []
+        for nw_start, nw_end in neg_windows:
+            start = max(nw_start, boosts_only_from)
+            if start >= nw_end:
+                continue  # window already fully elapsed
+            boost_rows.append(_make_action(
+                action_type="tank_negative_boost",
+                start_utc=start,
+                end_utc=nw_end,
+                tank_temp_c=boost_c,
+                tank_powerful=True,
+            ))
+        return boost_rows
 
     # If a boost window opens at/near the warmup start, defer the warmup past it
     # (chaining consecutive boosts that each fall within the lead window of the
@@ -563,6 +595,7 @@ def write_daily_tank_schedule(
     agile_rates: list[dict[str, Any]] | None = None,
     mode: str | None = None,
     clear_existing: bool = True,
+    boosts_only_from: datetime | None = None,
 ) -> int:
     """Write a day's tank schedule into ``action_schedule``.
 
@@ -588,6 +621,7 @@ def write_daily_tank_schedule(
         target_date_local,
         agile_rates=agile_rates,
         mode=mode,
+        boosts_only_from=boosts_only_from,
     )
     if not rows:
         logger.info("dhw_policy: no rows for %s (mode=%s)", target_date_local, mode)

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -1167,6 +1167,48 @@ def write_daikin_from_lp_plan(
                 rows_total += n
             except Exception as e:
                 logger.warning("dhw_policy: write for %s failed: %s", day, e)
+
+        # 2026-06-07 paid-window incident — cycle-split boost recovery.
+        # The dhw "day" anchors at warmup_hour (13:00 local), so before that
+        # hour we are still inside YESTERDAY's cycle. The (0,1) loop above only
+        # covers today's + tomorrow's cycles, and the past-date guard drops
+        # yesterday's — so a negative-price boost that lands in the live cycle's
+        # still-future tail (e.g. an 04:00→12:00 UTC paid window) is silently
+        # lost on every overnight re-plan. Re-emit just that cycle's boost rows,
+        # clipped to the LP horizon start (= the range-clear floor, so the next
+        # re-plan idempotently replaces them). No-op when no live negative window.
+        now_local_t = datetime.now(tz_local_local)
+        if now_local_t.hour < warmup_hour:
+            live_anchor = now_local_t.date() - timedelta(days=1)
+            live_start_local = datetime(
+                live_anchor.year, live_anchor.month, live_anchor.day,
+                warmup_hour, 0, tzinfo=tz_local_local,
+            )
+            live_end_local = live_start_local + timedelta(days=1)
+            import_tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+            try:
+                agile_live = db.get_rates_for_period(
+                    import_tariff,
+                    live_start_local.astimezone(_UTC_T),
+                    live_end_local.astimezone(_UTC_T),
+                ) if import_tariff else None
+            except Exception as _e:
+                logger.debug("dhw_policy: live-cycle import rates unavailable: %s", _e)
+                agile_live = None
+            clip_from = (
+                plan.slot_starts_utc[0] if plan.slot_starts_utc
+                else datetime.now(_UTC_T)
+            )
+            try:
+                rows_total += dhw_policy.write_daily_tank_schedule(
+                    target_date_local=live_anchor,
+                    agile_rates=agile_live,
+                    clear_existing=False,  # cleared widely above
+                    boosts_only_from=clip_from,
+                )
+            except Exception as e:
+                logger.warning("dhw_policy: live-cycle boost recovery failed: %s", e)
+
         # K1.1 bug #6 — log says "0 rows" not "2 days" when vacation
         # silenced both calls. Counting is row-count only now.
         logger.info(

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -323,6 +323,9 @@ def _reconcile_daikin_actions(
                         device="daikin",
                         within_hours=float(config.USER_OVERRIDE_RESPECT_HOURS),
                         now_utc=now_utc,
+                        respect_until_window_end=bool(
+                            config.USER_OVERRIDE_RESPECT_UNTIL_WINDOW_END
+                        ),
                     )
                     if src is not None and src.get("id") != aid:
                         src_params = src.get("params") or {}
@@ -557,6 +560,9 @@ def _check_tank_power_drift(
             device="daikin",
             within_hours=float(config.USER_OVERRIDE_RESPECT_HOURS),
             now_utc=now_utc,
+            respect_until_window_end=bool(
+                config.USER_OVERRIDE_RESPECT_UNTIL_WINDOW_END
+            ),
         )
         if src is not None:
             src_params = src.get("params") or {}
@@ -679,6 +685,9 @@ def _check_lwt_offset_drift(
             device="daikin",
             within_hours=float(config.USER_OVERRIDE_RESPECT_HOURS),
             now_utc=now_utc,
+            respect_until_window_end=bool(
+                config.USER_OVERRIDE_RESPECT_UNTIL_WINDOW_END
+            ),
         )
         if src is not None:
             src_params = src.get("params") or {}

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -204,6 +204,90 @@ def test_negative_slot_outside_horizon_ignored():
     assert boost == []
 
 
+# ---------------------------------------------------------------------------
+# Boosts-only recovery (2026-06-07 cycle-split paid-window incident)
+# ---------------------------------------------------------------------------
+
+
+def test_boosts_only_emits_only_clipped_boost():
+    """``boosts_only_from`` returns ONLY the negative-boost rows of the live
+    (yesterday-anchored) cycle, clipped to start at the clip point — never the
+    structural warmup/setback rows."""
+    # Live cycle anchored 2026-05-31 (warmup 31st 13:00 BST → 1st 13:00 BST).
+    # Paid window 04:00→07:00 UTC on the 1st sits in that cycle's tail.
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
+        {"valid_from": "2026-06-01T04:30:00Z", "value_inc_vat": -4.5},
+        {"valid_from": "2026-06-01T05:00:00Z", "value_inc_vat": -3.0},
+        {"valid_from": "2026-06-01T05:30:00Z", "value_inc_vat": -2.0},
+    ]
+    clip = datetime(2026, 6, 1, 5, 0, tzinfo=UTC)  # "now" mid-window
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 5, 31), agile_rates=outgoing, mode="normal",
+        boosts_only_from=clip,
+    )
+    assert len(rows) == 1
+    assert rows[0]["action_type"] == "tank_negative_boost"
+    assert rows[0]["params"]["tank_temp"] == 60
+    assert rows[0]["params"]["tank_powerful"] is True
+    start = datetime.fromisoformat(rows[0]["start_time"].replace("Z", "+00:00"))
+    end = datetime.fromisoformat(rows[0]["end_time"].replace("Z", "+00:00"))
+    assert start == clip                       # clipped to now, not 04:00
+    assert end == datetime(2026, 6, 1, 6, 0, tzinfo=UTC)  # window end (05:30+30)
+
+
+def test_boosts_only_drops_fully_elapsed_window():
+    """A negative window that has entirely passed the clip point yields no row."""
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
+    ]
+    clip = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)  # well after the 04:00-04:30 window
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 5, 31), agile_rates=outgoing, mode="normal",
+        boosts_only_from=clip,
+    )
+    assert rows == []
+
+
+def test_boosts_only_bypasses_past_date_guard():
+    """The live cycle is yesterday-anchored; boosts_only_from must bypass the
+    past-date guard that would otherwise return [] for the writer."""
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
+    ]
+    # date(2026,5,31) < frozen-today(2026,6,1) → guard would normally skip.
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 5, 31), agile_rates=outgoing, mode="normal",
+        boosts_only_from=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+    )
+    assert len(rows) == 1
+    assert rows[0]["action_type"] == "tank_negative_boost"
+
+
+def test_boosts_only_no_negative_window_is_noop():
+    """No live negative window → no rows (and no structural rows leak in)."""
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": 8.0},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 5, 31), agile_rates=outgoing, mode="normal",
+        boosts_only_from=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+    )
+    assert rows == []
+
+
+def test_boosts_only_vacation_still_empty():
+    """Vacation mode emits nothing even on the boosts-only path."""
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
+    ]
+    rows = dhw_policy.generate_daily_tank_schedule(
+        date(2026, 5, 31), agile_rates=outgoing, mode="vacation",
+        boosts_only_from=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+    )
+    assert rows == []
+
+
 def test_outgoing_rates_none_no_crash():
     """agile_rates=None just yields warmup+setback, no boost; doesn't crash."""
     rows = dhw_policy.generate_daily_tank_schedule(

--- a/tests/test_user_override.py
+++ b/tests/test_user_override.py
@@ -472,6 +472,81 @@ def test_find_recent_user_override_filters_by_device(monkeypatch):
         assert result["id"] == rid
 
 
+# ── 2026-06-07: respect_until_window_end ──────────────────────────────────────
+
+def _seed_row_window(conn, *, start_offset_seconds: int, end_offset_seconds: int,
+                     params: dict) -> int:
+    """Insert a daikin row with explicit start/end offsets (seconds, signed)."""
+    now = datetime.now(UTC)
+    start = (now + timedelta(seconds=start_offset_seconds)).isoformat()
+    end = (now + timedelta(seconds=end_offset_seconds)).isoformat()
+    conn.execute(
+        """INSERT INTO action_schedule
+           (date, start_time, end_time, device, action_type, params, status, created_at)
+           VALUES (?, ?, ?, 'daikin', 'tank_negative_boost', ?, 'active', ?)""",
+        (now.date().isoformat(), start, end, json.dumps(params), now.isoformat()),
+    )
+    rid = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    conn.commit()
+    return rid
+
+
+def test_respect_until_window_end_keeps_override_past_fixed_grace(monkeypatch):
+    """Gesture older than within_hours, but the overridden row's window still
+    covers now → respected when respect_until_window_end=True."""
+    from src import db
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        now = datetime.now(UTC)
+        conn = db.get_connection()
+        try:
+            # 11h boost window: started 8h ago, ends in 3h.
+            rid = _seed_row_window(
+                conn, start_offset_seconds=-3600 * 8, end_offset_seconds=3600 * 3,
+                params={"tank_temp": 60, "tank_power": True},
+            )
+        finally:
+            conn.close()
+        # Gesture 8h ago — well outside the 4h fixed grace.
+        db.mark_action_user_overridden(rid, overridden_at=(now - timedelta(hours=8)).isoformat())
+
+        # Fixed grace only → expired.
+        assert db.find_recent_user_override(
+            "daikin", within_hours=4.0, now_utc=now,
+        ) is None
+        # Window-end extension → still respected (window not over).
+        res = db.find_recent_user_override(
+            "daikin", within_hours=4.0, now_utc=now, respect_until_window_end=True,
+        )
+        assert res is not None and res["id"] == rid
+
+
+def test_respect_until_window_end_releases_after_window_closes(monkeypatch):
+    """Once the overridden row's window has fully passed, even the window-end
+    extension stops respecting it (falls back to the fixed grace)."""
+    from src import db
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "t.db"
+        monkeypatch.setattr("src.config.config.DB_PATH", str(path))
+        db.init_db()
+        now = datetime.now(UTC)
+        conn = db.get_connection()
+        try:
+            # Window ended 1h ago.
+            rid = _seed_row_window(
+                conn, start_offset_seconds=-3600 * 9, end_offset_seconds=-3600,
+                params={"tank_temp": 60},
+            )
+        finally:
+            conn.close()
+        db.mark_action_user_overridden(rid, overridden_at=(now - timedelta(hours=8)).isoformat())
+        assert db.find_recent_user_override(
+            "daikin", within_hours=4.0, now_utc=now, respect_until_window_end=True,
+        ) is None
+
+
 # ── Epic 14 (#386): user_gesture_still_in_effect ──────────────────────────────
 
 def test_user_gesture_still_in_effect_tank_power_diverged():


### PR DESCRIPTION
Closes #498.

Two defects surfaced live during the **2026-06-07 11h negative-price window** (04:00→15:00 UTC, paid to import).

## 1. Cycle-split drops the live-cycle paid boost
`dhw_policy` anchors the tank "day" at `DHW_WARMUP_START_HOUR_LOCAL` (13:00 local). Before that hour *now* is still inside **yesterday's** cycle. The writer only generates today+tomorrow (`offset in (0,1)`) and the past-date guard drops earlier cycles, so a negative-price boost in the live cycle's still-future tail (04:00→12:00 UTC) was **silently lost on every overnight re-plan** — the tank held the 30 °C setback through ~6.5 h of a paid window instead of banking ~2 kWh at 60 °C.

**Fix:** `generate_daily_tank_schedule(..., boosts_only_from=<clip>)` re-emits ONLY the live cycle's `tank_negative_boost` rows, clipped to the LP horizon start (= the range-clear floor, so the next re-plan idempotently replaces them). Structural warmup/setback rows are deliberately NOT re-emitted — they already fired, and a fresh setback sharing the boost's start would **thrash** against it (neither row ever reaching a state-matched `completed`). Wired in the writer for `now_local.hour < warmup_hour`.

## 2. Respect a manual gesture until the planned window ends
A manual LWT/tank change in the Onecta app was only respected for the fixed `USER_OVERRIDE_RESPECT_HOURS` (4 h). On a multi-hour planned window HEM would resume control mid-window and revert the user.

**Fix:** new flag `USER_OVERRIDE_RESPECT_UNTIL_WINDOW_END` (default **true**) extends `find_recent_user_override` so an override also stays in effect while the overridden row's own `end_time > now`. The live `user_gesture_still_in_effect` check remains the safety gate — revert the manual change and HEM resumes at once, so a long window can never wedge the schedule. **No new Daikin polling**: detection rides the existing pre-fire reconcile (the `dev` state already fetched).

## Tests
- `tests/test_dhw_policy.py`: 5 boosts-only cases (clip, fully-elapsed drop, past-date-guard bypass, no-window no-op, vacation).
- `tests/test_user_override.py`: 2 window-end cases (respected past fixed grace; released after window closes).
- Full suite: **1522 passed, 3 skipped, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)