### PR TITLE
fix(dhw,override): idempotent live-cycle boost recovery + Z-normalised override window-end compare

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1474,16 +1474,19 @@ def find_recent_user_override(
     a replan, so the user doesn't have to keep undoing the same action.
     """
     now = now_utc or datetime.now(UTC)
-    now_iso = now.isoformat()
     clauses: list[str] = ["device = ?", "overridden_by_user_at IS NOT NULL"]
     params: list[Any] = [device]
     time_terms: list[str] = []
     if within_hours > 0:
+        # overridden_by_user_at is stored in +00:00 form (datetime.isoformat).
         time_terms.append("overridden_by_user_at >= ?")
         params.append((now - timedelta(hours=within_hours)).isoformat())
     if respect_until_window_end:
+        # end_time is stored in Z form (dhw_policy._iso_z / lp_dispatch). Compare
+        # against a Z-form "now" so the lexicographic boundary is exact — a
+        # +00:00 "now" sorts after the same instant in Z form ('Z' > '+').
         time_terms.append("end_time > ?")
-        params.append(now_iso)
+        params.append(now.isoformat().replace("+00:00", "Z"))
     if not time_terms:
         return None
     clauses.append("(" + " OR ".join(time_terms) + ")")

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -157,7 +157,7 @@ def generate_daily_tank_schedule(
     agile_rates: list[dict[str, Any]] | None = None,
     mode: str | None = None,
     allow_past: bool = False,
-    boosts_only_from: datetime | None = None,
+    boosts_only_as_of: datetime | None = None,
 ) -> list[dict[str, Any]]:
     """Generate tank action rows for the local calendar day starting at
     ``DHW_WARMUP_START_HOUR_LOCAL`` (default 13:00) on ``target_date_local``
@@ -172,9 +172,13 @@ def generate_daily_tank_schedule(
         agile_rates: optional list of {valid_from, value_inc_vat}; used
             to detect negative-price windows for boost overrides
         mode: optimization preset; defaults to ``config.OPTIMIZATION_PRESET``
-        boosts_only_from: when set, return ONLY this cycle's
-            ``tank_negative_boost`` rows, each clipped to start at
-            ``max(window_start, boosts_only_from)`` (drop any already ended).
+        boosts_only_as_of: when set, return ONLY this cycle's
+            ``tank_negative_boost`` rows, dropping any window that has fully
+            ended (``end <= boosts_only_as_of``) and keeping each remaining
+            window at its NATURAL start (NOT clipped to the as-of time). The
+            stable start keeps the writer idempotent: ``upsert_action`` keys on
+            ``(device, action_type, start_time)``, so re-plans refresh the one
+            row instead of accumulating a fresh row per advancing clip point.
             Used by the writer to recover the early-morning paid boost of the
             *currently-live* cycle (anchored at yesterday's warmup) that the
             cycle-split otherwise drops on an overnight re-plan — the
@@ -197,11 +201,11 @@ def generate_daily_tank_schedule(
     # immediately and they'd be wasted churn. Tomorrow is fine (advance
     # scheduling). ``allow_past=True`` lets read-only callers (e.g. the
     # heating-plan timeline endpoint) regenerate a past day's deterministic
-    # schedule for display without writing anything. ``boosts_only_from``
+    # schedule for display without writing anything. ``boosts_only_as_of``
     # deliberately reaches back into the live (yesterday-anchored) cycle, so it
-    # also bypasses this guard — it clips to ``boosts_only_from`` instead.
+    # also bypasses this guard — it drops only windows that have fully ended.
     today_local = datetime.now(_tz_local()).date()
-    if boosts_only_from is None and not allow_past and target_date_local < today_local:
+    if boosts_only_as_of is None and not allow_past and target_date_local < today_local:
         logger.info(
             "dhw_policy: skipping %s (in the past; today=%s)",
             target_date_local, today_local,
@@ -249,18 +253,19 @@ def generate_daily_tank_schedule(
     neg_windows = _detect_negative_windows(agile_rates, warmup_start_utc, next_warmup_utc)
 
     # Boosts-only recovery path: emit just the negative-boost rows of this
-    # (already-running) cycle, clipped to ``boosts_only_from``. No structural
-    # rows — see the param docstring. Keeps the writer idempotent: the next
-    # re-plan's range-clear removes these and rewrites with a fresh clip.
-    if boosts_only_from is not None:
+    # (already-running) cycle. Drop windows that have fully ended; keep the rest
+    # at their NATURAL start (a stable upsert key → no per-re-plan accumulation,
+    # see the param docstring). A still-running window keeps its past start; the
+    # reconciler fires it on the next tick (start <= now < end) and state-match
+    # de-dupes thereafter. No structural rows.
+    if boosts_only_as_of is not None:
         boost_rows: list[dict[str, Any]] = []
         for nw_start, nw_end in neg_windows:
-            start = max(nw_start, boosts_only_from)
-            if start >= nw_end:
+            if nw_end <= boosts_only_as_of:
                 continue  # window already fully elapsed
             boost_rows.append(_make_action(
                 action_type="tank_negative_boost",
-                start_utc=start,
+                start_utc=nw_start,
                 end_utc=nw_end,
                 tank_temp_c=boost_c,
                 tank_powerful=True,
@@ -595,7 +600,7 @@ def write_daily_tank_schedule(
     agile_rates: list[dict[str, Any]] | None = None,
     mode: str | None = None,
     clear_existing: bool = True,
-    boosts_only_from: datetime | None = None,
+    boosts_only_as_of: datetime | None = None,
 ) -> int:
     """Write a day's tank schedule into ``action_schedule``.
 
@@ -621,7 +626,7 @@ def write_daily_tank_schedule(
         target_date_local,
         agile_rates=agile_rates,
         mode=mode,
-        boosts_only_from=boosts_only_from,
+        boosts_only_as_of=boosts_only_as_of,
     )
     if not rows:
         logger.info("dhw_policy: no rows for %s (mode=%s)", target_date_local, mode)

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -1174,9 +1174,11 @@ def write_daikin_from_lp_plan(
         # covers today's + tomorrow's cycles, and the past-date guard drops
         # yesterday's — so a negative-price boost that lands in the live cycle's
         # still-future tail (e.g. an 04:00→12:00 UTC paid window) is silently
-        # lost on every overnight re-plan. Re-emit just that cycle's boost rows,
-        # clipped to the LP horizon start (= the range-clear floor, so the next
-        # re-plan idempotently replaces them). No-op when no live negative window.
+        # lost on every overnight re-plan. Re-emit just that cycle's boost rows
+        # at their natural window start (a stable upsert key, so re-plans refresh
+        # the one row rather than accumulate a fresh one per advancing clip).
+        # ``as_of`` only drops windows that have fully ended. No-op when no live
+        # negative window.
         now_local_t = datetime.now(tz_local_local)
         if now_local_t.hour < warmup_hour:
             live_anchor = now_local_t.date() - timedelta(days=1)
@@ -1195,16 +1197,12 @@ def write_daikin_from_lp_plan(
             except Exception as _e:
                 logger.debug("dhw_policy: live-cycle import rates unavailable: %s", _e)
                 agile_live = None
-            clip_from = (
-                plan.slot_starts_utc[0] if plan.slot_starts_utc
-                else datetime.now(_UTC_T)
-            )
             try:
                 rows_total += dhw_policy.write_daily_tank_schedule(
                     target_date_local=live_anchor,
                     agile_rates=agile_live,
                     clear_existing=False,  # cleared widely above
-                    boosts_only_from=clip_from,
+                    boosts_only_as_of=datetime.now(_UTC_T),
                 )
             except Exception as e:
                 logger.warning("dhw_policy: live-cycle boost recovery failed: %s", e)

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -209,22 +209,22 @@ def test_negative_slot_outside_horizon_ignored():
 # ---------------------------------------------------------------------------
 
 
-def test_boosts_only_emits_only_clipped_boost():
-    """``boosts_only_from`` returns ONLY the negative-boost rows of the live
-    (yesterday-anchored) cycle, clipped to start at the clip point — never the
-    structural warmup/setback rows."""
+def test_boosts_only_emits_boost_at_natural_start():
+    """``boosts_only_as_of`` returns ONLY the negative-boost rows of the live
+    (yesterday-anchored) cycle — never the structural warmup/setback rows — and
+    keeps each window at its NATURAL start (NOT clipped to the as-of time), so
+    the upsert key is stable across re-plans."""
     # Live cycle anchored 2026-05-31 (warmup 31st 13:00 BST → 1st 13:00 BST).
-    # Paid window 04:00→07:00 UTC on the 1st sits in that cycle's tail.
     outgoing = [
         {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
         {"valid_from": "2026-06-01T04:30:00Z", "value_inc_vat": -4.5},
         {"valid_from": "2026-06-01T05:00:00Z", "value_inc_vat": -3.0},
         {"valid_from": "2026-06-01T05:30:00Z", "value_inc_vat": -2.0},
     ]
-    clip = datetime(2026, 6, 1, 5, 0, tzinfo=UTC)  # "now" mid-window
+    as_of = datetime(2026, 6, 1, 5, 0, tzinfo=UTC)  # "now" mid-window
     rows = dhw_policy.generate_daily_tank_schedule(
         date(2026, 5, 31), agile_rates=outgoing, mode="normal",
-        boosts_only_from=clip,
+        boosts_only_as_of=as_of,
     )
     assert len(rows) == 1
     assert rows[0]["action_type"] == "tank_negative_boost"
@@ -232,25 +232,44 @@ def test_boosts_only_emits_only_clipped_boost():
     assert rows[0]["params"]["tank_powerful"] is True
     start = datetime.fromisoformat(rows[0]["start_time"].replace("Z", "+00:00"))
     end = datetime.fromisoformat(rows[0]["end_time"].replace("Z", "+00:00"))
-    assert start == clip                       # clipped to now, not 04:00
-    assert end == datetime(2026, 6, 1, 6, 0, tzinfo=UTC)  # window end (05:30+30)
+    assert start == datetime(2026, 6, 1, 4, 0, tzinfo=UTC)  # NATURAL start, not as_of
+    assert end == datetime(2026, 6, 1, 6, 0, tzinfo=UTC)    # window end (05:30+30)
+
+
+def test_boosts_only_start_is_stable_across_advancing_as_of():
+    """Idempotency anchor: the emitted start does NOT move as ``as_of`` advances
+    through a still-running window — so re-plans refresh one row, not many."""
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
+        {"valid_from": "2026-06-01T04:30:00Z", "value_inc_vat": -4.5},
+        {"valid_from": "2026-06-01T05:00:00Z", "value_inc_vat": -3.0},
+    ]
+    starts = set()
+    for as_of_h, as_of_m in [(4, 10), (4, 45), (5, 0)]:
+        rows = dhw_policy.generate_daily_tank_schedule(
+            date(2026, 5, 31), agile_rates=outgoing, mode="normal",
+            boosts_only_as_of=datetime(2026, 6, 1, as_of_h, as_of_m, tzinfo=UTC),
+        )
+        assert len(rows) == 1
+        starts.add(rows[0]["start_time"])
+    assert len(starts) == 1  # one stable start regardless of as_of
 
 
 def test_boosts_only_drops_fully_elapsed_window():
-    """A negative window that has entirely passed the clip point yields no row."""
+    """A negative window that has entirely passed the as-of point yields no row."""
     outgoing = [
         {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
     ]
-    clip = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)  # well after the 04:00-04:30 window
+    as_of = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)  # well after the 04:00-04:30 window
     rows = dhw_policy.generate_daily_tank_schedule(
         date(2026, 5, 31), agile_rates=outgoing, mode="normal",
-        boosts_only_from=clip,
+        boosts_only_as_of=as_of,
     )
     assert rows == []
 
 
 def test_boosts_only_bypasses_past_date_guard():
-    """The live cycle is yesterday-anchored; boosts_only_from must bypass the
+    """The live cycle is yesterday-anchored; boosts_only_as_of must bypass the
     past-date guard that would otherwise return [] for the writer."""
     outgoing = [
         {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
@@ -258,7 +277,7 @@ def test_boosts_only_bypasses_past_date_guard():
     # date(2026,5,31) < frozen-today(2026,6,1) → guard would normally skip.
     rows = dhw_policy.generate_daily_tank_schedule(
         date(2026, 5, 31), agile_rates=outgoing, mode="normal",
-        boosts_only_from=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+        boosts_only_as_of=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
     )
     assert len(rows) == 1
     assert rows[0]["action_type"] == "tank_negative_boost"
@@ -271,7 +290,7 @@ def test_boosts_only_no_negative_window_is_noop():
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
         date(2026, 5, 31), agile_rates=outgoing, mode="normal",
-        boosts_only_from=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+        boosts_only_as_of=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
     )
     assert rows == []
 
@@ -283,7 +302,7 @@ def test_boosts_only_vacation_still_empty():
     ]
     rows = dhw_policy.generate_daily_tank_schedule(
         date(2026, 5, 31), agile_rates=outgoing, mode="vacation",
-        boosts_only_from=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
+        boosts_only_as_of=datetime(2026, 6, 1, 0, 0, tzinfo=UTC),
     )
     assert rows == []
 
@@ -474,6 +493,31 @@ def test_write_daily_tank_schedule_persists_rows():
     for r in rows:
         params = json.loads(r[1])
         assert params["dhw_policy"] is True  # marker present
+
+
+def test_boosts_only_writer_is_idempotent_across_replans():
+    """Finding 1 regression: re-running the boosts-only writer with an advancing
+    as-of (simulating overnight re-plans) must NOT accumulate duplicate
+    tank_negative_boost rows — the stable natural start keeps upsert at one row."""
+    import sqlite3
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
+        {"valid_from": "2026-06-01T04:30:00Z", "value_inc_vat": -4.5},
+        {"valid_from": "2026-06-01T05:00:00Z", "value_inc_vat": -3.0},
+    ]
+    for as_of_h, as_of_m in [(4, 5), (4, 35), (5, 5)]:
+        dhw_policy.write_daily_tank_schedule(
+            target_date_local=date(2026, 5, 31),
+            agile_rates=outgoing,
+            mode="normal",
+            clear_existing=False,
+            boosts_only_as_of=datetime(2026, 6, 1, as_of_h, as_of_m, tzinfo=UTC),
+        )
+    conn = sqlite3.connect(config.DB_PATH)
+    n = list(conn.execute(
+        "SELECT COUNT(*) FROM action_schedule WHERE action_type='tank_negative_boost'"
+    ))[0][0]
+    assert n == 1, f"expected a single boost row across re-plans, got {n}"
 
 
 def test_write_vacation_writes_zero_rows():


### PR DESCRIPTION
Tracked by #498. Follow-up hardening from an adversarial review of #499.

## 1. Boost recovery was not idempotent (medium)
#499's live-cycle boost recovery clipped each `tank_negative_boost` to the **advancing** LP-horizon start. But `upsert_action` keys on `(device, action_type, start_time)`, so a moving start inserted a **fresh** pending boost row every re-plan (~16/day over an 8 h window) instead of refreshing one. They were functionally harmless — all noop'd by pre-fire state-match (identical 60 °C/powerful target) — but they bloated the schedule/timeline, and the `"= range-clear floor … idempotently replaces"` comment was just wrong (these rows sit *below* the clear floor and are preserved as in-flight).

**Fix:** emit the boost at its **natural window start** (a stable upsert key). `boosts_only_as_of` now only **drops fully-elapsed windows** — it never clips. A still-running window keeps its past start and fires on the next reconcile tick (`start <= now < end`). Renamed `boosts_only_from` → `boosts_only_as_of` to match the new meaning.

## 2. Override window-end compare format mismatch (low)
`find_recent_user_override` compared `end_time` (stored **Z** form) against a `+00:00` "now". At the exact instant `'Z' > '+'` lexicographically, so a window ending *at* now still counted as covering now (sub-second permissive). Now compares against a Z-form now.

## Tests
- boost emitted at natural start (not as-of); start stable across an advancing as-of; **writer idempotent across 3 simulated re-plans → 1 row, not 3** (the regression guard for #1).
- Full dhw_policy + user_override suites: **67 passed**; broad affected suite **325 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)