### PR TITLE
fix(dhw): file live-cycle recovery boost under today's plan_date so it fires

### DIFF
--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -601,6 +601,7 @@ def write_daily_tank_schedule(
     mode: str | None = None,
     clear_existing: bool = True,
     boosts_only_as_of: datetime | None = None,
+    plan_date_override: str | None = None,
 ) -> int:
     """Write a day's tank schedule into ``action_schedule``.
 
@@ -615,6 +616,13 @@ def write_daily_tank_schedule(
         mode: optional override; defaults to ``config.OPTIMIZATION_PRESET``
         clear_existing: when True, calls ``db.clear_actions_in_range`` over
             the warmup window before upserting
+        plan_date_override: stamp rows with this ``plan_date`` instead of
+            ``target_date_local``. CRITICAL for the boosts-only live-cycle
+            recovery: the heartbeat reconciler selects rows by
+            ``get_actions_for_plan_date(today_local)``, so a live-cycle boost
+            anchored at *yesterday* must be filed under TODAY's plan_date or it
+            is never fired (2026-06-07: the recovered boost sat pending all
+            window because it inherited yesterday's plan_date).
 
     Returns:
         Number of rows written.
@@ -641,6 +649,7 @@ def write_daily_tank_schedule(
         end_iso = max(r["end_time"] for r in rows)
         db.clear_actions_in_range(start_iso, end_iso, device="daikin")
 
+    plan_date_str = plan_date_override or str(target_date_local)
     n_written = 0
     for r in rows:
         try:
@@ -650,7 +659,7 @@ def write_daily_tank_schedule(
                 start_time=r["start_time"],
                 end_time=r["end_time"],
                 params=r["params"],
-                plan_date=str(target_date_local),
+                plan_date=plan_date_str,
                 status="pending",
             )
             n_written += 1

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -1203,6 +1203,10 @@ def write_daikin_from_lp_plan(
                     agile_rates=agile_live,
                     clear_existing=False,  # cleared widely above
                     boosts_only_as_of=datetime.now(_UTC_T),
+                    # File under TODAY's plan_date — the heartbeat reconciler
+                    # selects rows by today_local; a yesterday-anchored boost
+                    # stamped with yesterday's date would never fire.
+                    plan_date_override=now_local_t.date().isoformat(),
                 )
             except Exception as e:
                 logger.warning("dhw_policy: live-cycle boost recovery failed: %s", e)

--- a/tests/test_dhw_policy.py
+++ b/tests/test_dhw_policy.py
@@ -520,6 +520,32 @@ def test_boosts_only_writer_is_idempotent_across_replans():
     assert n == 1, f"expected a single boost row across re-plans, got {n}"
 
 
+def test_boosts_only_files_under_override_plan_date():
+    """Finding 3 (2026-06-07): a live-cycle boost is anchored at yesterday, but
+    MUST be filed under TODAY's plan_date or the heartbeat reconciler
+    (get_actions_for_plan_date(today)) never selects it → never fires."""
+    import sqlite3
+    outgoing = [
+        {"valid_from": "2026-06-01T04:00:00Z", "value_inc_vat": -4.0},
+        {"valid_from": "2026-06-01T04:30:00Z", "value_inc_vat": -4.5},
+    ]
+    dhw_policy.write_daily_tank_schedule(
+        target_date_local=date(2026, 5, 31),          # live cycle anchored yesterday
+        agile_rates=outgoing,
+        mode="normal",
+        clear_existing=False,
+        boosts_only_as_of=datetime(2026, 6, 1, 4, 5, tzinfo=UTC),
+        plan_date_override="2026-06-01",               # file under TODAY
+    )
+    # The reconciler keys on the `date` column == today.
+    rows = _db.get_actions_for_plan_date("2026-06-01", device="daikin")
+    boosts = [r for r in rows if r["action_type"] == "tank_negative_boost"]
+    assert len(boosts) == 1, "boost must be selectable under today's plan_date"
+    # And NOT under yesterday's date.
+    y = _db.get_actions_for_plan_date("2026-05-31", device="daikin")
+    assert [r for r in y if r["action_type"] == "tank_negative_boost"] == []
+
+
 def test_write_vacation_writes_zero_rows():
     """write_daily_tank_schedule in vacation mode is a no-op."""
     n = dhw_policy.write_daily_tank_schedule(


### PR DESCRIPTION
Tracked by #498. Critical follow-up to #499/#500 — caught by verifying the live fire.

## The bug
The heartbeat reconciler selects rows via `get_actions_for_plan_date(today_local)` (the `date` column). The live-cycle boost recovery (#499) wrote the boost through `write_daily_tank_schedule(target_date_local=live_anchor)`, which stamped it with **yesterday's** date. So today's reconcile never selected the recovered `tank_negative_boost` → **it never fired**. It sat `pending` the entire paid window; the tank only reached 60 °C because the user set it manually.

(The 12:00→15:00 boost, written under today's date by the `offset in (0,1)` loop, fired fine — only the recovered *morning* boost was stranded.)

## Fix
New `plan_date_override` on `write_daily_tank_schedule`; the live-cycle caller stamps the boost with `today_local`. The row's start/end times are unchanged (those drive firing) — only the reconcile-selection key is corrected.

## Test
`test_boosts_only_files_under_override_plan_date`: the boosts-only write under an override plan_date is selectable by `get_actions_for_plan_date(today)` and absent under yesterday's date.

Full dhw_policy suite: 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)