### PR TITLE
feat(dhw): stand off the tank during the firmware legionella cycle (tank-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,18 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   across the 6 call sites; scenario variance from the spread. Kill-switch
   `LP_RESIDUAL_PROFILE_V2`; Insights "when you spend the most" heatmap.
 
+### Added — legionella tank stand-off (2026-06-07)
+- **HEM stands off the DHW tank during the firmware's weekly thermal-shock
+  cycle** (Tracked by #498). The Onecta firmware owns the tank during legionella,
+  so any tank PATCH HEM sends is arbitrated/overridden (wasted quota + churn +
+  `READ_ONLY`). The reconciler now skips tank-device writes inside a configured
+  window and leaves those rows pending so they resume once it closes. **TANK ONLY
+  — LWT / space-heating still fire.** Window defaults to Sunday 11:00 UTC for
+  120 min (ramp + ~1 h hold); knobs `DHW_LEGIONELLA_STANDOFF_{ENABLED,DOW,
+  START_HOUR_UTC,START_MINUTE_UTC,DURATION_MINUTES}`. Telemetry:
+  `legionella_tank_standoff` in `action_log`. The LP already budgets the cycle's
+  heat-up energy, so only the actuation side needed the guard.
+
 ### Fixed — 2026-06-07 negative-price-window incident (live)
 - **LWT drift backstop reset a legitimate offset from a completed row** (#497).
   Pre-fire idempotency marks an applied `lwt_preheat` row `completed`; the drift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,19 @@ EOF
 
 ### Legionella thermal-shock cycle
 
-Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously (Sunday ~11:00 local). **The LP and dispatch layer do not schedule or override this cycle** — the `DHW_LEGIONELLA_*` env vars are gone from the code. Python ignores unrecognised keys in `.env` so lingering entries are harmless; delete them on your next `.env` touch. If a `shutdown` or `max_heat` action happens to overlap the cycle window, Onecta firmware arbitrates.
+Daikin Onecta firmware runs the weekly thermal-shock cycle autonomously (default Sunday 11:00 UTC; user-reconfigurable on the unit). **HEM does not schedule this cycle** — the old `DHW_LEGIONELLA_*` *scheduling* vars are gone. Python ignores unrecognised keys in `.env` so lingering entries are harmless; delete them on your next `.env` touch.
+
+**Tank stand-off (2026-06-07).** Because the firmware OWNS the DHW tank during the cycle, any tank PATCH HEM sends in that window is arbitrated/overridden (wasted Daikin quota + churn + `READ_ONLY`). So the reconciler now **skips tank-device writes inside a configured stand-off window and leaves those rows pending** so they resume the moment the window closes (the firmware leaves the tank hot; HEM's next warmup/setback then brings it back to plan). **TANK ONLY — LWT / space-heating rows still fire** (legionella is a DHW-tank cycle). The LP already BUDGETS the cycle's heat-up energy (`forecast_dhw_load_per_slot` ramp), so only the *actuation* side needed the guard. Telemetry: `legionella_tank_standoff` events in `action_log`. New `.env` knobs (defaults = Sunday 11:00 UTC, 120 min — covers the ramp from the overnight setback up to ~60 °C plus the firmware's ~1 h hold):
+
+```
+DHW_LEGIONELLA_STANDOFF_ENABLED=true            # master switch (the ONLY tank-write block during the cycle)
+DHW_LEGIONELLA_STANDOFF_DOW=6                    # weekday, Mon=0 .. Sun=6 (datetime.weekday())
+DHW_LEGIONELLA_STANDOFF_START_HOUR_UTC=11        # window start (UTC); must not cross midnight
+DHW_LEGIONELLA_STANDOFF_START_MINUTE_UTC=0
+DHW_LEGIONELLA_STANDOFF_DURATION_MINUTES=120     # ramp + ~1 h hold; tune from `legionella_tank_standoff` telemetry
+```
+
+Helper: `src/state_machine.py:in_legionella_standoff(now_utc)`. The guard sits in `_reconcile_daikin_actions` before the pending→active transition. If a `shutdown`/`max_heat` action overlaps the cycle window outside the guard, Onecta firmware still arbitrates.
 
 ### User-override propagation (Epic 14, #386 — 2026-05-21)
 

--- a/src/config.py
+++ b/src/config.py
@@ -866,6 +866,33 @@ class Config:
     DHW_NEGATIVE_PRICE_BOOST_C: float = float(
         os.getenv("DHW_NEGATIVE_PRICE_BOOST_C", "60")
     )
+    # --- Legionella thermal-shock STAND-OFF (2026-06-07) ---
+    # The Onecta firmware owns the DHW tank during its weekly thermal-shock
+    # cycle. Any tank PATCH HEM sends in that window is arbitrated/overridden by
+    # the firmware → wasted Daikin quota + churn + READ_ONLY. So the reconciler
+    # SKIPS tank-device writes during a configured window (LWT / space heating
+    # are NOT affected — legionella is a DHW-tank cycle only). This does NOT
+    # schedule the cycle (firmware does) and is unrelated to the removed
+    # DHW_LEGIONELLA_* scheduling vars — it only tells HEM when to stand off the
+    # tank. Window is defined in UTC on one weekday; must not cross midnight.
+    # Default: Sunday (weekday 6) 11:00 UTC for 120 min — covers the ramp from
+    # the overnight setback (~37 °C) up to ~60 °C plus the firmware's ~1 h hold.
+    DHW_LEGIONELLA_STANDOFF_ENABLED: bool = (
+        os.getenv("DHW_LEGIONELLA_STANDOFF_ENABLED", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
+    DHW_LEGIONELLA_STANDOFF_DOW: int = int(  # Mon=0 .. Sun=6 (datetime.weekday())
+        os.getenv("DHW_LEGIONELLA_STANDOFF_DOW", "6")
+    )
+    DHW_LEGIONELLA_STANDOFF_START_HOUR_UTC: int = int(
+        os.getenv("DHW_LEGIONELLA_STANDOFF_START_HOUR_UTC", "11")
+    )
+    DHW_LEGIONELLA_STANDOFF_START_MINUTE_UTC: int = int(
+        os.getenv("DHW_LEGIONELLA_STANDOFF_START_MINUTE_UTC", "0")
+    )
+    DHW_LEGIONELLA_STANDOFF_DURATION_MINUTES: int = int(
+        os.getenv("DHW_LEGIONELLA_STANDOFF_DURATION_MINUTES", "120")
+    )
     # NOTE: the leading-warmup defer (a boost SUPERSEDES the warmup that would
     # otherwise pre-heat at a positive price right before it) is driven by
     # LP_PRE_NEGATIVE_PRECOOL_HOURS below — the SAME window the LP's energy

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -54,6 +54,41 @@ _TANK_DRIFT_NOTIFIED: bool = False
 # semantics as the tank flag above). Cleared when the offset is back at 0.
 _LWT_DRIFT_NOTIFIED: bool = False
 
+# 2026-06-07 — dedup for the legionella tank stand-off skip log (one telemetry
+# row per suppressed action_schedule row per process, not per 5-min tick).
+_LEGIONELLA_STANDOFF_LOGGED: set[int] = set()
+
+
+def _is_tank_action(params: dict[str, Any]) -> bool:
+    """True when a row commands the DHW tank (vs. an LWT/space-heating row).
+
+    Legionella stand-off only suppresses tank writes; LWT rows still fire.
+    """
+    if not isinstance(params, dict):
+        return False
+    return any(k in params for k in ("tank_temp", "tank_power", "tank_powerful"))
+
+
+def in_legionella_standoff(now_utc: datetime) -> bool:
+    """True when ``now_utc`` is inside the configured weekly legionella
+    thermal-shock window, during which the Onecta firmware owns the DHW tank
+    and HEM must not write to it (see ``DHW_LEGIONELLA_STANDOFF_*``).
+
+    The window is defined in UTC on one weekday and must not cross midnight
+    (the default Sunday 11:00 + 120 min does not).
+    """
+    if not getattr(config, "DHW_LEGIONELLA_STANDOFF_ENABLED", False):
+        return False
+    if now_utc.weekday() != int(config.DHW_LEGIONELLA_STANDOFF_DOW):
+        return False
+    start = now_utc.replace(
+        hour=int(config.DHW_LEGIONELLA_STANDOFF_START_HOUR_UTC),
+        minute=int(config.DHW_LEGIONELLA_STANDOFF_START_MINUTE_UTC),
+        second=0, microsecond=0,
+    )
+    end = start + timedelta(minutes=int(config.DHW_LEGIONELLA_STANDOFF_DURATION_MINUTES))
+    return start <= now_utc < end
+
 
 def _parse_utc(s: str) -> datetime:
     x = str(s).replace("Z", "+00:00")
@@ -245,6 +280,32 @@ def _reconcile_daikin_actions(
                 )
             if status in ("pending", "active"):
                 db.mark_action(aid, "completed")
+            continue
+
+        # Legionella stand-off (2026-06-07): the Onecta firmware owns the DHW
+        # tank during its weekly thermal-shock cycle, so any tank PATCH we send
+        # is arbitrated/overridden by the firmware (TANK ONLY — LWT / space
+        # heating are unaffected). Skip firing tank rows inside the window and
+        # leave them PENDING so they resume the moment the window closes (the
+        # firmware leaves the tank hot; HEM's next warmup/setback then brings it
+        # back to plan). Do not mark completed — that would strand the row.
+        if (
+            getattr(config, "DHW_LEGIONELLA_STANDOFF_ENABLED", False)
+            and _is_tank_action(params)
+            and in_legionella_standoff(now_utc)
+        ):
+            if aid not in _LEGIONELLA_STANDOFF_LOGGED:
+                _LEGIONELLA_STANDOFF_LOGGED.add(aid)
+                try:
+                    db.log_action(
+                        device="daikin",
+                        action="legionella_tank_standoff",
+                        params={"row_id": aid, "kind": atype},
+                        result="skipped",
+                        trigger=trigger,
+                    )
+                except Exception as _exc:
+                    logger.debug("legionella stand-off log failed (non-fatal): %s", _exc)
             continue
 
         if status == "pending" and start <= now_utc < end:

--- a/tests/test_legionella_standoff.py
+++ b/tests/test_legionella_standoff.py
@@ -1,0 +1,166 @@
+"""Legionella thermal-shock STAND-OFF (2026-06-07).
+
+The Onecta firmware owns the DHW tank during its weekly thermal-shock cycle, so
+HEM must not write to the tank in that window (any PATCH is arbitrated away).
+The reconciler skips TANK rows inside the window and leaves them pending;
+LWT / space-heating rows are unaffected.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.config import config
+from src.daikin.models import DaikinDevice
+
+# 2026-06-07 is a Sunday (weekday()==6) — the default stand-off DOW.
+_SUN = datetime(2026, 6, 7, tzinfo=UTC)
+
+
+def _cfg(monkeypatch, *, enabled=True, dow=6, hour=11, minute=0, dur=120):
+    monkeypatch.setattr(config, "DHW_LEGIONELLA_STANDOFF_ENABLED", enabled, raising=False)
+    monkeypatch.setattr(config, "DHW_LEGIONELLA_STANDOFF_DOW", dow, raising=False)
+    monkeypatch.setattr(config, "DHW_LEGIONELLA_STANDOFF_START_HOUR_UTC", hour, raising=False)
+    monkeypatch.setattr(config, "DHW_LEGIONELLA_STANDOFF_START_MINUTE_UTC", minute, raising=False)
+    monkeypatch.setattr(config, "DHW_LEGIONELLA_STANDOFF_DURATION_MINUTES", dur, raising=False)
+
+
+# --- pure helpers -----------------------------------------------------------
+
+def test_in_window_true(monkeypatch):
+    from src.state_machine import in_legionella_standoff
+    _cfg(monkeypatch)
+    assert in_legionella_standoff(_SUN.replace(hour=11, minute=30)) is True
+    assert in_legionella_standoff(_SUN.replace(hour=11, minute=0)) is True   # inclusive start
+    assert in_legionella_standoff(_SUN.replace(hour=12, minute=59)) is True
+
+
+def test_out_of_window(monkeypatch):
+    from src.state_machine import in_legionella_standoff
+    _cfg(monkeypatch)
+    assert in_legionella_standoff(_SUN.replace(hour=10, minute=59)) is False  # before start
+    assert in_legionella_standoff(_SUN.replace(hour=13, minute=0)) is False   # exclusive end
+    assert in_legionella_standoff(_SUN.replace(hour=13, minute=1)) is False
+
+
+def test_wrong_weekday(monkeypatch):
+    from src.state_machine import in_legionella_standoff
+    _cfg(monkeypatch)
+    sat = _SUN - timedelta(days=1)  # Saturday, same time
+    assert in_legionella_standoff(sat.replace(hour=11, minute=30)) is False
+
+
+def test_disabled(monkeypatch):
+    from src.state_machine import in_legionella_standoff
+    _cfg(monkeypatch, enabled=False)
+    assert in_legionella_standoff(_SUN.replace(hour=11, minute=30)) is False
+
+
+def test_is_tank_action():
+    from src.state_machine import _is_tank_action
+    assert _is_tank_action({"tank_temp": 60, "tank_power": True}) is True
+    assert _is_tank_action({"tank_powerful": True}) is True
+    assert _is_tank_action({"lwt_offset": 10}) is False
+    assert _is_tank_action({"climate_on": True}) is False
+    assert _is_tank_action({}) is False
+
+
+# --- reconcile integration --------------------------------------------------
+
+def _seed(conn, *, action_type, params):
+    """Insert an active daikin row whose window covers the Sunday 11:30 tick."""
+    start = _SUN.replace(hour=4, minute=0).isoformat()
+    end = _SUN.replace(hour=12, minute=0).isoformat()
+    conn.execute(
+        """INSERT INTO action_schedule
+           (date, start_time, end_time, device, action_type, params, status, created_at)
+           VALUES (?, ?, ?, 'daikin', ?, ?, 'pending', ?)""",
+        (_SUN.date().isoformat(), start, end, action_type, json.dumps(params),
+         _SUN.isoformat()),
+    )
+    rid = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    conn.commit()
+    return rid
+
+
+def _reconcile_env(monkeypatch):
+    import src.state_machine as sm
+    _cfg(monkeypatch)
+    monkeypatch.setattr("src.config.config.DAIKIN_CONTROL_MODE", "active", raising=False)
+    monkeypatch.setattr("src.config.config.DAIKIN_LWT_PREHEAT_ENABLED", True, raising=False)
+    monkeypatch.setattr("src.config.config.PREFIRE_STATE_MATCH_ENABLED", False, raising=False)
+    monkeypatch.setattr("src.daikin_bulletproof.config.OPENCLAW_READ_ONLY", False, raising=False)
+    sm._LEGIONELLA_STANDOFF_LOGGED.clear()
+    sm._FIRST_APPLIED_SESSION.clear()
+    applied: list[dict] = []
+    monkeypatch.setattr(
+        "src.state_machine.apply_scheduled_daikin_params",
+        lambda dev, client, params, trigger: applied.append(params) or True,
+    )
+    return sm, applied
+
+
+def test_tank_row_skipped_in_window(monkeypatch):
+    sm, applied = _reconcile_env(monkeypatch)
+    with tempfile.TemporaryDirectory() as td:
+        from src import db
+        monkeypatch.setattr("src.config.config.DB_PATH", str(Path(td) / "t.db"))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            rid = _seed(conn, action_type="tank_negative_boost",
+                        params={"tank_temp": 60, "tank_power": True, "tank_powerful": True})
+        finally:
+            conn.close()
+        # Live device diverges (45 ≠ 60) so WITHOUT the guard it would fire.
+        dev = DaikinDevice(id="gw", name="x", tank_target=45.0, tank_on=True)
+        now = _SUN.replace(hour=11, minute=30)
+        rows = db.get_actions_for_plan_date(now.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, MagicMock(), dev, now, trigger="test")
+        assert applied == [], "tank write must be suppressed during legionella"
+        # Row stays pending (not completed) so it resumes after the window.
+        row = db.get_action_by_id(rid)
+        assert row["status"] == "pending"
+
+
+def test_tank_row_fires_outside_window(monkeypatch):
+    sm, applied = _reconcile_env(monkeypatch)
+    with tempfile.TemporaryDirectory() as td:
+        from src import db
+        monkeypatch.setattr("src.config.config.DB_PATH", str(Path(td) / "t.db"))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            _seed(conn, action_type="tank_negative_boost",
+                  params={"tank_temp": 60, "tank_power": True, "tank_powerful": True})
+        finally:
+            conn.close()
+        dev = DaikinDevice(id="gw", name="x", tank_target=45.0, tank_on=True)
+        now = _SUN.replace(hour=9, minute=30)  # before the 11:00 window
+        rows = db.get_actions_for_plan_date(now.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, MagicMock(), dev, now, trigger="test")
+        assert len(applied) == 1 and applied[0].get("tank_temp") == 60
+
+
+def test_lwt_row_still_fires_in_window(monkeypatch):
+    sm, applied = _reconcile_env(monkeypatch)
+    with tempfile.TemporaryDirectory() as td:
+        from src import db
+        monkeypatch.setattr("src.config.config.DB_PATH", str(Path(td) / "t.db"))
+        db.init_db()
+        conn = db.get_connection()
+        try:
+            _seed(conn, action_type="lwt_preheat", params={"lwt_offset": 10})
+        finally:
+            conn.close()
+        dev = DaikinDevice(id="gw", name="x", lwt_offset=0.0)  # diverged → would fire
+        now = _SUN.replace(hour=11, minute=30)
+        rows = db.get_actions_for_plan_date(now.date().isoformat(), device="daikin")
+        sm._reconcile_daikin_actions(rows, MagicMock(), dev, now, trigger="test")
+        assert len(applied) == 1 and applied[0].get("lwt_offset") == 10, \
+            "LWT/space-heating must NOT be suppressed by the tank stand-off"


### PR DESCRIPTION
Tracked by #498. Follows up the user moving their legionella thermal-shock cycle to 11:00 UTC (Sunday).

## Why
The Onecta firmware **owns the DHW tank** during its weekly thermal-shock cycle. Any tank PATCH HEM sends in that window is arbitrated/overridden by the firmware → wasted Daikin quota + churn + `READ_ONLY`. (The LP already budgets the cycle's heat-up energy via `forecast_dhw_load_per_slot`; only the *actuation* side was unguarded.)

## What
The reconciler now **skips tank-device writes inside a configured stand-off window** and leaves those rows **pending** so they resume the moment the window closes (the firmware leaves the tank hot; HEM's next warmup/setback then brings it back to plan). **TANK ONLY — LWT / space-heating rows still fire** (legionella is a DHW-tank cycle).

- Helper `in_legionella_standoff(now_utc)`; guard in `_reconcile_daikin_actions` before the pending→active transition; `_is_tank_action(params)` distinguishes tank vs LWT rows.
- Telemetry: `legionella_tank_standoff` events in `action_log`.
- Does **not** schedule the cycle (firmware does); unrelated to the removed `DHW_LEGIONELLA_*` scheduling vars.

## Config (`.env`) — defaults Sunday 11:00 UTC, 120 min
```
DHW_LEGIONELLA_STANDOFF_ENABLED=true
DHW_LEGIONELLA_STANDOFF_DOW=6            # Mon=0 .. Sun=6
DHW_LEGIONELLA_STANDOFF_START_HOUR_UTC=11
DHW_LEGIONELLA_STANDOFF_START_MINUTE_UTC=0
DHW_LEGIONELLA_STANDOFF_DURATION_MINUTES=120   # ramp (~37→60) + ~1h hold; tune from telemetry
```

## Tests
`tests/test_legionella_standoff.py` — window in/out/exclusive-end/weekday/disabled, `_is_tank_action`, and reconcile integration: tank row **skipped** in-window (stays pending), **fires** out-of-window, and **LWT still fires** in-window. Full suite: **1533 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)