### PR TITLE
feat(appliance): nudge the user to load the machine for an upcoming negative/cheap window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,21 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   across the 6 call sites; scenario variance from the spread. Kill-switch
   `LP_RESIDUAL_PROFILE_V2`; Insights "when you spend the most" heatmap.
 
+### Added — proactive appliance load nudge (2026-06-07)
+- **Nudge the user to LOAD the washer/dishwasher for an upcoming negative/cheap
+  window** (Tracked by #498). HEM can't load the machine (the physical
+  Smart-Control button is the consent gate), so when day-ahead rates land
+  (`octopus_fetch`) and a registered appliance is *idle*, it pushes ONE Telegram
+  nudge with the recommended run window, deadline, and est. cost (negative = paid
+  to run). Debounced once per appliance per window via `runtime_settings`
+  (restart-safe). Negative-only push by default; the morning/night brief carries
+  a softer cheap-window suggestion line (pull). Reuses the existing cheapest-
+  window picker + deadline roll — both already prefer negative slots; the only
+  gap was the heads-up. New `AlertType.APPLIANCE_WINDOW_NUDGE`; knobs
+  `APPLIANCE_WINDOW_NUDGE_{ENABLED,PRICE_THRESHOLD_P,HORIZON_HOURS,BRIEF_THRESHOLD_P}`.
+  Note: the deadline already rolls to tomorrow when passed, so a stale 07:00
+  deadline was never the blocker — the missing load + nudge was.
+
 ### Added — legionella tank stand-off (2026-06-07)
 - **HEM stands off the DHW tank during the firmware's weekly thermal-shock
   cycle** (Tracked by #498). The Onecta firmware owns the tank during legionella,

--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -67,6 +67,7 @@ def build_morning_payload() -> str:
         ("temperature", _temperature_range_today_line, (today, tz)),
         ("day_cost_forecast", _day_cost_forecast_line, (today, tz)),
         ("now_state", _now_state_line, ()),
+        ("appliance_window", _appliance_window_suggestion_line, (tz,)),
     ):
         result = _safe_call(label, fn, *args)
         if result:
@@ -89,6 +90,39 @@ def build_morning_payload() -> str:
         lines.extend(["", f"**Tomorrow ({today + timedelta(days=1)}):** {tomorrow_peaks}"])
 
     return "\n".join(lines)
+
+
+def _appliance_window_suggestion_line(tz: ZoneInfo) -> str | None:
+    """Brief (pull) suggestion: if a registered+idle appliance faces an upcoming
+    cheap window (≤ ``APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P``), suggest loading
+    it. Covers cheap-but-not-negative windows (the push path is negative-only).
+    Returns one line or ``None`` (no appliance / no fitting cheap window).
+    """
+    try:
+        from ..scheduler import appliance_dispatch
+        now = datetime.now(UTC)
+        thr = float(getattr(config, "APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P", 8.0))
+        horizon_h = float(getattr(config, "APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS", 24))
+        tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+        rates = (
+            db.get_rates_for_period(tariff, now, now + timedelta(hours=horizon_h))
+            if tariff else None
+        )
+        sugg = appliance_dispatch.compute_appliance_window_suggestions(
+            now, rates, max_price_p=thr, strict=False,
+        )
+    except Exception:  # pragma: no cover — diagnostic line must never break the brief
+        return None
+    if not sugg:
+        return None
+    s = sugg[0]
+    start = s["recommended_start_utc"].astimezone(tz).strftime("%H:%M")
+    end = s["recommended_end_utc"].astimezone(tz).strftime("%H:%M")
+    tag = "paga" if s["is_negative"] else "barata"
+    return (
+        f"🧺 Janela {tag} {start}–{end} (média {s['avg_price_pence']:.1f}p) — "
+        f"carregue a {s['appliance_name']} + Smart Control (prazo {s['deadline_local']})."
+    )
 
 
 def _pv_bias_line() -> str | None:
@@ -413,6 +447,11 @@ def build_night_payload() -> str:
     )
     if peaks:
         lines.extend(["", f"**Heads-up for tomorrow:** {peaks}"])
+
+    # ── Appliance load suggestion (cheap window ahead — load it tonight) ─
+    appliance_line = _safe_call("appliance_window", _appliance_window_suggestion_line, tz)
+    if appliance_line:
+        lines.extend(["", appliance_line])
 
     return "\n".join(lines)
 

--- a/src/config.py
+++ b/src/config.py
@@ -512,6 +512,31 @@ class Config:
     APPLIANCE_DEFAULT_BASE_LOAD_KW: float = float(
         os.getenv("APPLIANCE_DEFAULT_BASE_LOAD_KW", "0.4")
     )
+    # --- Proactive appliance load nudge (2026-06-07) ---
+    # HEM can't load the machine (the physical Smart-Control button is the consent
+    # gate), so when a notably-cheap / NEGATIVE Agile window is upcoming and a
+    # registered appliance is idle, it pushes ONE high-signal Telegram nudge to
+    # load it + Smart-Control, with a recommended run window. Fires when day-ahead
+    # rates land (octopus_fetch); debounced once per appliance per window.
+    APPLIANCE_WINDOW_NUDGE_ENABLED: bool = (
+        os.getenv("APPLIANCE_WINDOW_NUDGE_ENABLED", "true").strip().lower()
+        in ("true", "1", "yes", "on")
+    )
+    # Push threshold: empty → push on NEGATIVE windows only (high signal, aligns
+    # with the "negative always pings" rule). Set a number (pence) to also push
+    # on windows whose mean ≤ that — more nudges, more push load.
+    APPLIANCE_WINDOW_NUDGE_PRICE_THRESHOLD_P: str = (
+        os.getenv("APPLIANCE_WINDOW_NUDGE_PRICE_THRESHOLD_P") or ""
+    )
+    # How far ahead (hours) to scan for a candidate window.
+    APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS: float = float(
+        os.getenv("APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS", "24")
+    )
+    # Cheap-window threshold (pence) for the PULL morning/night brief suggestion
+    # line — independent of the push threshold; covers cheap-but-not-negative.
+    APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P: float = float(
+        os.getenv("APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P", "8.0")
+    )
 
     # Max tank temperature (°C) — the physical ceiling for EVERYTHING: the LP
     # tank-variable bound, the soft per-slot ceiling, every setpoint we command,

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -55,6 +55,10 @@ class AlertType(str, Enum):
     APPLIANCE_FINISHED = "appliance_finished"
     APPLIANCE_ARMED = "appliance_armed"
     APPLIANCE_CANCELLED = "appliance_cancelled"
+    # 2026-06-07 — proactive "load the machine for an upcoming cheap/negative
+    # window" nudge (the user must physically load + Smart-Control; HEM can only
+    # prompt). Negative-only by default; debounced once per appliance per window.
+    APPLIANCE_WINDOW_NUDGE = "appliance_window_nudge"
     # 2026-05-21 — LP solver failure (Infeasible / CBC crash). Default route:
     # ``severity=critical`` so it bypasses the morning-brief mute; rate-limited
     # by hash so a recurring failure across MPC re-solves only pages once.
@@ -76,6 +80,7 @@ _HOOK_PAYLOAD_NAMES: dict[str, str] = {
     "appliance_finished": "EnergyApplianceFinish",
     "appliance_armed": "EnergyApplianceArmed",
     "appliance_cancelled": "EnergyApplianceCancelled",
+    "appliance_window_nudge": "EnergyApplianceNudge",
     "lp_failure": "EnergyLPFailure",
 }
 
@@ -100,6 +105,7 @@ _TELEGRAM_HEADERS: dict[str, str] = {
     "appliance_finished": "✅ Appliance finished",
     "appliance_armed": "🧺 Appliance armed",
     "appliance_cancelled": "🚫 Appliance cancelled",
+    "appliance_window_nudge": "🧺⚡ Carregue a máquina",
     "lp_failure": "🚨 LP solver failure",
 }
 
@@ -117,6 +123,7 @@ _APPLIANCE_FANOUT_ALERT_KEYS: frozenset[str] = frozenset({
     AlertType.APPLIANCE_STARTING.value,
     AlertType.APPLIANCE_FINISHED.value,
     AlertType.APPLIANCE_CANCELLED.value,
+    AlertType.APPLIANCE_WINDOW_NUDGE.value,
 })
 
 
@@ -714,6 +721,56 @@ def notify_appliance_armed(
     _dispatch(
         AlertType.APPLIANCE_ARMED, body, urgent=False, extra=extra,
         telegram_header_override=f"🧺 {appliance_name} {verb}",
+    )
+
+
+def notify_appliance_window_nudge(
+    *,
+    appliance_name: str,
+    recommended_start_local: str,
+    recommended_end_local: str,
+    deadline_local: str,
+    duration_minutes: int,
+    avg_price_pence: float,
+    est_kwh: float,
+    est_cost_pence: float,
+    is_negative: bool,
+) -> None:
+    """🧺⚡ A cheap/negative window is coming — prompt the user to LOAD the
+    machine + enable Smart Control so the dispatcher can run it at the best slot.
+
+    HEM can't load the machine (the physical Smart-Control button is the consent
+    gate), so this is the only lever. pt-BR body; debounced once per window by
+    the caller (``appliance_dispatch.nudge_appliance_windows``).
+    """
+    if is_negative or est_cost_pence < 0:
+        headline = "Janela paga (negativa) chegando!"
+        # est_cost_pence is signed; negative = you're paid to run.
+        money = f"você RECEBE ~{abs(est_cost_pence):.0f}p"
+    else:
+        headline = "Janela barata chegando!"
+        money = f"custo ~{est_cost_pence:.0f}p"
+    body = "\n".join([
+        headline,
+        f"Carregue a {appliance_name} e ative o Smart Control até {deadline_local}.",
+        f"Recomendado: {recommended_start_local}–{recommended_end_local} "
+        f"({duration_minutes} min) · média {avg_price_pence:.1f}p/kWh",
+        f"Estimado: {est_kwh:.1f} kWh → {money}",
+    ])
+    extra = {
+        "appliance": appliance_name,
+        "recommended_start_local": recommended_start_local,
+        "recommended_end_local": recommended_end_local,
+        "deadline_local": deadline_local,
+        "duration_minutes": int(duration_minutes),
+        "avg_price_pence": round(float(avg_price_pence), 2),
+        "est_kwh": round(float(est_kwh), 2),
+        "est_cost_pence": round(float(est_cost_pence), 1),
+        "is_negative": bool(is_negative),
+    }
+    _dispatch(
+        AlertType.APPLIANCE_WINDOW_NUDGE, body, urgent=False, extra=extra,
+        telegram_header_override=f"🧺⚡ Carregue a {appliance_name}",
     )
 
 

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -1035,7 +1035,6 @@ def compute_appliance_window_suggestions(
     )
     if not windows:
         return []
-    first_window_start, _ = windows[0]
     out: list[dict[str, Any]] = []
     for app in db.list_appliances(enabled_only=True):
         try:
@@ -1047,15 +1046,26 @@ def compute_appliance_window_suggestions(
                 or config.APPLIANCE_DEFAULT_DEADLINE_LOCAL
             )
             deadline_utc = _next_deadline_utc(deadline_local, now=now)
+            # Clamp the recommendation search to the SAME detection horizon so the
+            # recommended window can't sit beyond it (review HIGH/MEDIUM: detection
+            # 24h vs deadline up to ~31h diverged, and the message then pointed at
+            # a window the trigger never saw).
+            eff_deadline = min(deadline_utc, horizon_end)
             duration = int(app.get("default_duration_minutes") or 120)
-            # Cheapest fitting run window in [now, deadline] — naturally anchors
+            # Cheapest fitting run window in [now, eff_deadline] — naturally anchors
             # on the negative/cheap slots (lowest mean). Raises if it can't fit.
             try:
                 start_utc, end_utc, avg_p = find_cheapest_window(
-                    now, deadline_utc, duration,
+                    now, eff_deadline, duration,
                 )
             except ValueError:
                 continue  # no fit before the deadline
+            # Coherence guard: the recommended window MUST overlap a detected
+            # qualifying window, else the nudge would advertise a slot that isn't
+            # actually cheap/negative (kills the synthetic _fallback_window=0.0p
+            # case and the deadline-before-the-window case).
+            if not any(ws < end_utc and we > start_utc for ws, we in windows):
+                continue
             kw, _n = _effective_typical_kw(
                 appliance_id, float(app.get("typical_kw") or 0.5),
             )
@@ -1064,7 +1074,6 @@ def compute_appliance_window_suggestions(
             out.append({
                 "appliance_id": appliance_id,
                 "appliance_name": app.get("name") or f"appliance #{appliance_id}",
-                "candidate_window_start_utc": first_window_start,
                 "recommended_start_utc": start_utc,
                 "recommended_end_utc": end_utc,
                 "deadline_utc": deadline_utc,
@@ -1118,7 +1127,10 @@ def nudge_appliance_windows(
     fired: list[dict[str, Any]] = []
     for s in suggestions:
         key = f"appliance_nudge_last_{s['appliance_id']}"
-        window_id = _iso(s["candidate_window_start_utc"])
+        # Debounce on the RECOMMENDED window the user actually sees — one push per
+        # recommended window. A genuinely new (cheaper) window shifts the start →
+        # re-fires; re-plans of the same window keep the same start → suppressed.
+        window_id = _iso(s["recommended_start_utc"])
         try:
             if db.get_runtime_setting(key) == window_id:
                 continue  # already nudged for this window

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -952,6 +952,214 @@ def _fallback_window(
 
 
 # ---------------------------------------------------------------------------
+# Proactive load nudge (2026-06-07)
+#
+# HEM can't load the machine (the physical Smart-Control button is the consent
+# gate), so when a notably-cheap / NEGATIVE Agile window is upcoming and a
+# registered appliance is idle, push ONE nudge to load it + Smart-Control, with
+# a recommended run window. The scheduler then arms it the moment the user
+# enables remote control. SmartThings is deliberately NOT consulted here — the
+# whole premise is the machine isn't enabled yet, so a ST outage can't block it.
+# ---------------------------------------------------------------------------
+
+def _detect_price_windows(
+    rates: list[dict[str, Any]] | None,
+    start_utc: datetime,
+    end_utc: datetime,
+    *,
+    max_price_p: float,
+    strict: bool = False,
+) -> list[tuple[datetime, datetime]]:
+    """Group consecutive 30-min slots whose price is at/below ``max_price_p``
+    (``strict`` → strictly below) into contiguous windows within
+    ``[start, end)``. Sibling of ``dhw_policy._detect_negative_windows`` (which
+    is negative-only and must stay that way — DHW depends on it). Returns
+    ``[(start, end), ...]``; empty when no qualifying slots.
+    """
+    if not rates:
+        return []
+    qual: list[datetime] = []
+    for r in rates:
+        try:
+            ts_raw = r.get("valid_from") or r.get("slot_time_utc")
+            rate = float(r.get("value_inc_vat", r.get("rate_p", 999)))
+        except (TypeError, ValueError):
+            continue
+        if not ts_raw:
+            continue
+        qualifies = (rate < max_price_p) if strict else (rate <= max_price_p)
+        if not qualifies:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+        if not (start_utc <= ts < end_utc):
+            continue
+        qual.append(ts)
+    if not qual:
+        return []
+    qual.sort()
+    windows: list[tuple[datetime, datetime]] = []
+    cur_start = qual[0]
+    cur_end = cur_start + timedelta(minutes=30)
+    for ts in qual[1:]:
+        if ts == cur_end:
+            cur_end = ts + timedelta(minutes=30)
+        else:
+            windows.append((cur_start, cur_end))
+            cur_start = ts
+            cur_end = ts + timedelta(minutes=30)
+    windows.append((cur_start, cur_end))
+    return windows
+
+
+def compute_appliance_window_suggestions(
+    now: datetime,
+    rates: list[dict[str, Any]] | None,
+    *,
+    max_price_p: float,
+    strict: bool,
+) -> list[dict[str, Any]]:
+    """Pure compute (no notify, no debounce). When a qualifying (≤/< ``max_price_p``)
+    window exists in the next ``APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS``, return one
+    suggestion per enabled + idle appliance for its cheapest run window before the
+    deadline. Used by both the push path (negative-only) and the brief line
+    (cheap). Returns ``[]`` when nothing qualifies. Never raises on a single
+    appliance — bad rows are skipped.
+    """
+    horizon_h = float(getattr(config, "APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS", 24))
+    horizon_end = now + timedelta(hours=max(1.0, horizon_h))
+    windows = _detect_price_windows(
+        rates, now, horizon_end, max_price_p=max_price_p, strict=strict,
+    )
+    if not windows:
+        return []
+    first_window_start, _ = windows[0]
+    out: list[dict[str, Any]] = []
+    for app in db.list_appliances(enabled_only=True):
+        try:
+            appliance_id = int(app["id"])
+            if db.get_active_appliance_job(appliance_id) is not None:
+                continue  # already loaded / scheduled — no nudge
+            deadline_local = (
+                app.get("deadline_local_time")
+                or config.APPLIANCE_DEFAULT_DEADLINE_LOCAL
+            )
+            deadline_utc = _next_deadline_utc(deadline_local, now=now)
+            duration = int(app.get("default_duration_minutes") or 120)
+            # Cheapest fitting run window in [now, deadline] — naturally anchors
+            # on the negative/cheap slots (lowest mean). Raises if it can't fit.
+            try:
+                start_utc, end_utc, avg_p = find_cheapest_window(
+                    now, deadline_utc, duration,
+                )
+            except ValueError:
+                continue  # no fit before the deadline
+            kw, _n = _effective_typical_kw(
+                appliance_id, float(app.get("typical_kw") or 0.5),
+            )
+            est_kwh = kw * duration / 60.0
+            est_cost_p = est_kwh * avg_p  # signed: negative = paid to run
+            out.append({
+                "appliance_id": appliance_id,
+                "appliance_name": app.get("name") or f"appliance #{appliance_id}",
+                "candidate_window_start_utc": first_window_start,
+                "recommended_start_utc": start_utc,
+                "recommended_end_utc": end_utc,
+                "deadline_utc": deadline_utc,
+                "deadline_local": deadline_local,
+                "duration_minutes": duration,
+                "avg_price_pence": avg_p,
+                "est_kwh": est_kwh,
+                "est_cost_pence": est_cost_p,
+                "is_negative": avg_p < 0,
+            })
+        except Exception as e:  # pragma: no cover — never break the scan
+            logger.debug("appliance nudge compute skip #%s: %s", app.get("id"), e)
+            continue
+    return out
+
+
+def nudge_appliance_windows(
+    *,
+    now: datetime | None = None,
+    rates: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Push at most one load nudge per enabled+idle appliance for an upcoming
+    negative (or ≤ threshold) window. Debounced per appliance per window via
+    ``runtime_settings`` (restart-safe). Returns the suggestions that fired.
+    Never raises — all DB / notify failures are swallowed.
+    """
+    if not getattr(config, "APPLIANCE_WINDOW_NUDGE_ENABLED", False):
+        return []
+    now = now or _now_utc()
+    # Push threshold: empty → negative-only (strict < 0); else ≤ X p.
+    thr_raw = (getattr(config, "APPLIANCE_WINDOW_NUDGE_PRICE_THRESHOLD_P", "") or "").strip()
+    if thr_raw:
+        try:
+            max_price_p, strict = float(thr_raw), False
+        except ValueError:
+            max_price_p, strict = 0.0, True
+    else:
+        max_price_p, strict = 0.0, True  # negative-only
+    if rates is None:
+        tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+        horizon_h = float(getattr(config, "APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS", 24))
+        try:
+            rates = db.get_rates_for_period(
+                tariff, now, now + timedelta(hours=max(1.0, horizon_h)),
+            ) if tariff else None
+        except Exception:
+            rates = None
+    suggestions = compute_appliance_window_suggestions(
+        now, rates, max_price_p=max_price_p, strict=strict,
+    )
+    fired: list[dict[str, Any]] = []
+    for s in suggestions:
+        key = f"appliance_nudge_last_{s['appliance_id']}"
+        window_id = _iso(s["candidate_window_start_utc"])
+        try:
+            if db.get_runtime_setting(key) == window_id:
+                continue  # already nudged for this window
+        except Exception:
+            pass
+        if _push_appliance_nudge(s):
+            try:
+                db.set_runtime_setting(key, window_id)
+            except Exception as e:  # pragma: no cover
+                logger.debug("appliance nudge debounce persist failed: %s", e)
+            fired.append(s)
+    return fired
+
+
+def _push_appliance_nudge(s: dict[str, Any]) -> bool:
+    """Deliver one nudge via the notifier. Returns True on a successful send."""
+    from ..notifier import notify_appliance_window_nudge
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+
+    def _loc(dt: datetime) -> str:
+        return dt.astimezone(tz).strftime("%H:%M")
+
+    try:
+        notify_appliance_window_nudge(
+            appliance_name=s["appliance_name"],
+            recommended_start_local=_loc(s["recommended_start_utc"]),
+            recommended_end_local=_loc(s["recommended_end_utc"]),
+            deadline_local=s["deadline_local"],
+            duration_minutes=int(s["duration_minutes"]),
+            avg_price_pence=float(s["avg_price_pence"]),
+            est_kwh=float(s["est_kwh"]),
+            est_cost_pence=float(s["est_cost_pence"]),
+            is_negative=bool(s["is_negative"]),
+        )
+        return True
+    except Exception as e:  # pragma: no cover — notify must never break the scan
+        logger.warning("appliance nudge push failed (non-fatal): %s", e)
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Reconcile (called from the LP solve)
 # ---------------------------------------------------------------------------
 

--- a/src/scheduler/octopus_fetch.py
+++ b/src/scheduler/octopus_fetch.py
@@ -52,6 +52,17 @@ def fetch_and_store_rates(fox: FoxESSClient | None = None) -> dict[str, Any]:
         clear_failure_streak=True,
     )
 
+    # Proactive appliance load nudge — fresh day-ahead rates just landed (~16:00),
+    # the natural moment to discover tomorrow's negative/cheap windows and prompt
+    # the user to LOAD the washer/dishwasher (the physical Smart-Control is the
+    # consent gate; HEM can only nudge). Debounced once per appliance per window.
+    # Non-fatal: a nudge failure must never block the rate store / LP solve.
+    try:
+        from .appliance_dispatch import nudge_appliance_windows
+        nudge_appliance_windows(now=now, rates=rates)
+    except Exception as e:
+        logger.warning("appliance window nudge (non-fatal): %s", e)
+
     # Fetch + persist Octopus Outgoing (export) rates when configured. Stored separately
     # in agile_export_rates so the LP can use a per-slot export price (Outgoing Agile
     # varies ±20p/kWh half-hourly, just like the import side). Failure here is non-fatal —

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,3 +61,16 @@ def _default_daikin_active_for_tests(monkeypatch):
     monkeypatch.setenv("DAIKIN_CONTROL_MODE", "active")
     from src.runtime_settings import clear_cache
     clear_cache()
+
+
+@pytest.fixture(autouse=True)
+def _default_legionella_standoff_off_for_tests(monkeypatch):
+    """2026-06-07: the legionella tank stand-off (prod default ON) skips tank
+    writes during a Sunday 11:00–13:00 UTC window. Legacy tank-reconcile tests
+    use ``datetime.now(UTC)`` as ``now`` and would intermittently fail when the
+    suite happens to run inside that window. Default it OFF for tests; the
+    dedicated ``test_legionella_standoff`` suite re-enables it explicitly.
+    """
+    monkeypatch.setattr(
+        "src.config.config.DHW_LEGIONELLA_STANDOFF_ENABLED", False, raising=False,
+    )

--- a/tests/test_appliance_window_nudge.py
+++ b/tests/test_appliance_window_nudge.py
@@ -1,0 +1,234 @@
+"""Proactive appliance load-nudge (2026-06-07).
+
+When a negative / notably-cheap Agile window is upcoming and a registered
+appliance is idle, HEM pushes one nudge to LOAD + Smart-Control the machine
+(the physical button is the consent gate — HEM can only prompt). Debounced once
+per appliance per window.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db
+from src.config import config
+from src.scheduler import appliance_dispatch
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    db.init_db()
+
+
+def _setup_cfg(monkeypatch):
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "TEST-TARIFF", raising=False)
+    monkeypatch.setattr(config, "APPLIANCE_WINDOW_NUDGE_ENABLED", True, raising=False)
+    monkeypatch.setattr(config, "APPLIANCE_WINDOW_NUDGE_PRICE_THRESHOLD_P", "", raising=False)
+    monkeypatch.setattr(config, "APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS", 24.0, raising=False)
+    monkeypatch.setattr(config, "BULLETPROOF_TIMEZONE", "Europe/London", raising=False)
+
+
+def _capture_notify(monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        "src.notifier.notify_appliance_window_nudge",
+        lambda **kw: calls.append(kw),
+    )
+    return calls
+
+
+def _add_washer(deadline_hours_ahead: float = 12.0):
+    tz = ZoneInfo("Europe/London")
+    deadline = (datetime.now(tz) + timedelta(hours=deadline_hours_ahead)).strftime("%H:%M")
+    return db.add_appliance(
+        vendor="smartthings", vendor_device_id="dev-test", name="Washer",
+        device_type="washer", default_duration_minutes=120,
+        deadline_local_time=deadline, typical_kw=0.5,
+    )
+
+
+def _seed_rates(start_utc: datetime, prices: list[float]) -> None:
+    rates, t = [], start_utc
+    for p in prices:
+        rates.append({
+            "valid_from": t.isoformat().replace("+00:00", "Z"),
+            "valid_to": (t + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+            "value_inc_vat": p,
+        })
+        t += timedelta(minutes=30)
+    db.save_agile_rates(rates, "TEST-TARIFF")
+
+
+def _now_top_of_hour() -> datetime:
+    return datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+
+
+# --- pure detector --------------------------------------------------------
+
+def test_detect_price_windows_groups_contiguous():
+    start = datetime(2026, 6, 7, 11, 0, tzinfo=UTC)
+    rates = [
+        {"valid_from": "2026-06-07T11:00:00Z", "value_inc_vat": -4.0},
+        {"valid_from": "2026-06-07T11:30:00Z", "value_inc_vat": -3.0},
+        {"valid_from": "2026-06-07T12:00:00Z", "value_inc_vat": 5.0},   # gap
+        {"valid_from": "2026-06-07T12:30:00Z", "value_inc_vat": -2.0},
+    ]
+    w = appliance_dispatch._detect_price_windows(
+        rates, start, start + timedelta(hours=4), max_price_p=0.0, strict=True,
+    )
+    assert len(w) == 2
+    assert w[0] == (datetime(2026, 6, 7, 11, 0, tzinfo=UTC),
+                    datetime(2026, 6, 7, 12, 0, tzinfo=UTC))
+
+
+def test_detect_price_windows_strict_vs_threshold():
+    start = datetime(2026, 6, 7, 11, 0, tzinfo=UTC)
+    rates = [{"valid_from": "2026-06-07T11:00:00Z", "value_inc_vat": 0.0}]
+    # strict < 0 excludes a 0.00 slot...
+    assert appliance_dispatch._detect_price_windows(
+        rates, start, start + timedelta(hours=1), max_price_p=0.0, strict=True,
+    ) == []
+    # ...but a ≤ 8p threshold includes it.
+    assert len(appliance_dispatch._detect_price_windows(
+        rates, start, start + timedelta(hours=1), max_price_p=8.0, strict=False,
+    )) == 1
+
+
+# --- nudge integration ----------------------------------------------------
+
+def test_nudge_fires_for_negative_window_idle(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0, 8.0, 8.0])
+
+    fired = appliance_dispatch.nudge_appliance_windows(now=now)
+    assert len(fired) == 1
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["appliance_name"] == "Washer"
+    assert c["is_negative"] is True
+    assert c["est_cost_pence"] < 0  # paid to run
+    assert "deadline_local" in c
+
+
+def test_nudge_skips_when_job_active(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    aid = _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+    db.create_appliance_job(
+        appliance_id=aid, armed_at_utc=now.isoformat(),
+        deadline_utc=(now + timedelta(hours=12)).isoformat(),
+        duration_minutes=120,
+        planned_start_utc=(now + timedelta(hours=1)).isoformat(),
+        planned_end_utc=(now + timedelta(hours=3)).isoformat(),
+        status="scheduled",
+    )
+    appliance_dispatch.nudge_appliance_windows(now=now)
+    assert calls == []
+
+
+def test_nudge_skips_when_flag_off(monkeypatch):
+    _setup_cfg(monkeypatch)
+    monkeypatch.setattr(config, "APPLIANCE_WINDOW_NUDGE_ENABLED", False, raising=False)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+    assert appliance_dispatch.nudge_appliance_windows(now=now) == []
+    assert calls == []
+
+
+def test_nudge_skips_when_no_negative_window(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [10.0, 12.0, 15.0, 20.0])  # all positive
+    assert appliance_dispatch.nudge_appliance_windows(now=now) == []
+    assert calls == []
+
+
+def test_nudge_debounced_within_window(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    aid = _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+
+    appliance_dispatch.nudge_appliance_windows(now=now)
+    appliance_dispatch.nudge_appliance_windows(now=now + timedelta(minutes=5))
+    assert len(calls) == 1  # second call debounced
+    assert db.get_runtime_setting(f"appliance_nudge_last_{aid}") is not None
+
+
+def test_nudge_refires_for_new_window(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer(deadline_hours_ahead=40)
+    # First window tomorrow-ish; nudge once.
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0])
+    appliance_dispatch.nudge_appliance_windows(now=now)
+    assert len(calls) == 1
+    # A DIFFERENT (later) negative window → new candidate start → re-fires.
+    _seed_rates(now + timedelta(hours=20), [-5.0, -5.0, -4.0])
+    appliance_dispatch.nudge_appliance_windows(now=now + timedelta(hours=10))
+    assert len(calls) == 2
+
+
+def test_nudge_no_fit_before_deadline_skips(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer(deadline_hours_ahead=1.0)  # deadline only 1h away, wash needs 2h
+    _seed_rates(now + timedelta(minutes=30), [-4.0, -4.5, -3.0])
+    appliance_dispatch.nudge_appliance_windows(now=now)
+    assert calls == []
+
+
+def test_nudge_multiple_appliances_one_each(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer()
+    db.add_appliance(
+        vendor="smartthings", vendor_device_id="dev-2", name="Dishwasher",
+        device_type="dishwasher", default_duration_minutes=120,
+        deadline_local_time=(datetime.now(ZoneInfo("Europe/London")) + timedelta(hours=12)).strftime("%H:%M"),
+        typical_kw=0.6,
+    )
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+    fired = appliance_dispatch.nudge_appliance_windows(now=now)
+    assert len(fired) == 2
+    names = {c["appliance_name"] for c in calls}
+    assert names == {"Washer", "Dishwasher"}
+
+
+# --- brief line -----------------------------------------------------------
+
+def test_brief_suggestion_line_for_cheap_window(monkeypatch):
+    _setup_cfg(monkeypatch)
+    monkeypatch.setattr(config, "APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P", 8.0, raising=False)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [3.0, 4.0, 3.5, 5.0])  # cheap, not negative
+    from src.analytics import daily_brief
+    line = daily_brief._appliance_window_suggestion_line(ZoneInfo("Europe/London"))
+    assert line is not None
+    assert "Washer" in line and "Smart Control" in line
+
+
+def test_brief_suggestion_line_none_when_no_window(monkeypatch):
+    _setup_cfg(monkeypatch)
+    monkeypatch.setattr(config, "APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P", 8.0, raising=False)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [20.0, 22.0, 25.0])  # expensive
+    from src.analytics import daily_brief
+    assert daily_brief._appliance_window_suggestion_line(ZoneInfo("Europe/London")) is None

--- a/tests/test_appliance_window_nudge.py
+++ b/tests/test_appliance_window_nudge.py
@@ -171,14 +171,15 @@ def test_nudge_refires_for_new_window(monkeypatch):
     _setup_cfg(monkeypatch)
     calls = _capture_notify(monkeypatch)
     now = _now_top_of_hour()
-    _add_washer(deadline_hours_ahead=40)
-    # First window tomorrow-ish; nudge once.
-    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0])
+    _add_washer(deadline_hours_ahead=12)
+    # First: a window at now+3h → recommended start = now+3h, nudge once.
+    _seed_rates(now + timedelta(hours=3), [-3.0, -3.0, -3.0, -3.0])
     appliance_dispatch.nudge_appliance_windows(now=now)
     assert len(calls) == 1
-    # A DIFFERENT (later) negative window → new candidate start → re-fires.
-    _seed_rates(now + timedelta(hours=20), [-5.0, -5.0, -4.0])
-    appliance_dispatch.nudge_appliance_windows(now=now + timedelta(hours=10))
+    # A cheaper, EARLIER window appears (now+1h) → new cheapest → recommended start
+    # shifts to now+1h ≠ now+3h → re-fires (same now, no deadline wrap).
+    _seed_rates(now + timedelta(hours=1), [-5.0, -5.0, -5.0, -5.0])
+    appliance_dispatch.nudge_appliance_windows(now=now)
     assert len(calls) == 2
 
 
@@ -189,6 +190,20 @@ def test_nudge_no_fit_before_deadline_skips(monkeypatch):
     _add_washer(deadline_hours_ahead=1.0)  # deadline only 1h away, wash needs 2h
     _seed_rates(now + timedelta(minutes=30), [-4.0, -4.5, -3.0])
     appliance_dispatch.nudge_appliance_windows(now=now)
+    assert calls == []
+
+
+def test_nudge_skips_when_negative_window_unreachable_before_deadline(monkeypatch):
+    """Review MEDIUM: a negative window exists in the horizon but the deadline is
+    BEFORE it → the recommended (pre-deadline) window can't overlap it → no nudge
+    (and no fabricated _fallback_window=0.0p push)."""
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer(deadline_hours_ahead=2.0)  # deadline ~2h away
+    # Negative window is 5h out — after the deadline → unreachable.
+    _seed_rates(now + timedelta(hours=5), [-4.0, -4.5, -3.0, -2.0])
+    assert appliance_dispatch.nudge_appliance_windows(now=now) == []
     assert calls == []
 
 


### PR DESCRIPTION
Tracked by #498. Workstream A of the 2026-06-07 negative-window follow-up.

## Why
Today's −4.79p window passed with the washer never loaded — and HEM never nudged the user. The scheduler already handles everything *once the machine is loaded* (`_next_deadline_utc` rolls a passed deadline to tomorrow; `find_cheapest_window` already prefers negative slots), but the **physical load + Smart-Control is the consent gate** and there was no heads-up. (So the stale 07:00 deadline was *not* the blocker, contrary to the morning-check note.)

## What
When day-ahead rates land (`octopus_fetch`) and a registered appliance is **idle**, push ONE Telegram nudge to load it + Smart-Control, with the recommended run window, deadline, and signed est. cost (negative = paid to run). Debounced once per appliance per window (`runtime_settings`, restart-safe). Negative-only push by default; the morning/night brief carries a softer cheap-window line (pull).

- `appliance_dispatch`: `nudge_appliance_windows` / `compute_appliance_window_suggestions` / `_detect_price_windows` (sibling of `dhw_policy._detect_negative_windows` — the negative-only detector is untouched). Reuses `_next_deadline_utc`, `find_cheapest_window`, `_effective_typical_kw`. Skips when a job is active / flag off / no fit before deadline. SmartThings **not** consulted (machine isn't enabled yet → a ST outage can't block the nudge).
- `notifier`: `AlertType.APPLIANCE_WINDOW_NUDGE` + `notify_appliance_window_nudge` (pt-BR, household fanout, `notification_routes` mute).
- `octopus_fetch`: non-fatal hook after `save_agile_rates`.
- `daily_brief`: cheap-window suggestion line in both briefs.
- Config: `APPLIANCE_WINDOW_NUDGE_{ENABLED,PRICE_THRESHOLD_P,HORIZON_HOURS,BRIEF_THRESHOLD_P}`.

## Also (test-isolation fix)
The legionella tank stand-off (#503, prod default **on**) skips tank writes Sunday 11:00–13:00 UTC; legacy tank-reconcile tests using `datetime.now(UTC)` failed when the suite ran in that window. `conftest` now defaults `DHW_LEGIONELLA_STANDOFF_ENABLED` off in tests; the dedicated `test_legionella_standoff` suite re-enables it.

## Tests
`tests/test_appliance_window_nudge.py` (12): detector grouping/strict, fires for negative+idle, skips (job active / flag off / no negative / no fit), debounce + re-fire for new window, multi-appliance one-each, brief line present/absent. Full suite: **1545 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)