### PR TITLE
feat(fox): pin maxSoc on negative_hold so solar can't waste paid-import headroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,20 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   across the 6 call sites; scenario variance from the spread. Kill-switch
   `LP_RESIDUAL_PROFILE_V2`; Insights "when you spend the most" heatmap.
 
+### Added — pin maxSoc on negative-hold so solar can't waste paid-import headroom (2026-06-07)
+- **`negative_hold` (Backup) slots now emit `maxSoc = reserve floor`** so PV can't
+  trickle-charge the battery during the hold phase of a negative-price window
+  (Tracked by #498). Live data showed Backup with `maxSoc=None` let free solar
+  creep the battery 10→21% mid-window — banking free PV at the exact time you'd
+  rather be *paid* to import. With the pin, surplus PV exports at SEG and the
+  battery refills from the paid force-charge instead. Pure post-solve Fox dispatch
+  mapping (`_slot_fox_tuple`) — the LP objective is unchanged. **The Fox wiki says
+  Backup normally lets PV charge and the maxSoc-pin is undocumented → it must be
+  empirically confirmed to clip PV on the H1.** Gated + kill-switch
+  `LP_NEGATIVE_HOLD_PIN_MAXSOC` (default true). No simultaneous import/export and
+  no PV curtailment exist on this inverter (researched) — this is the one real
+  lever.
+
 ### Added — proactive appliance load nudge (2026-06-07)
 - **Nudge the user to LOAD the washer/dishwasher for an upcoming negative/cheap
   window** (Tracked by #498). HEM can't load the machine (the physical

--- a/src/config.py
+++ b/src/config.py
@@ -576,6 +576,18 @@ class Config:
     FOX_FORCE_CHARGE_MAX_PWR: int = int(os.getenv("FOX_FORCE_CHARGE_MAX_PWR", "5000"))
     FOX_FORCE_CHARGE_NORMAL_PWR: int = int(os.getenv("FOX_FORCE_CHARGE_NORMAL_PWR", "3000"))
     FOX_EXPORT_MAX_PWR: int = int(os.getenv("FOX_EXPORT_MAX_PWR", "3680"))
+    # 2026-06-07: pin maxSoc to the reserve floor on `negative_hold` (Backup)
+    # slots so SOLAR can't trickle-charge the battery during the hold — preserving
+    # headroom for the PAID force-charge later in a negative window (surplus PV
+    # exports @ SEG instead of being banked for free, which forgoes the paid
+    # import). Live data 2026-06-07 showed Backup with maxSoc=None let PV creep
+    # the battery 10→21% mid-negative-window. The Fox wiki says Backup normally
+    # lets PV charge, and the maxSoc-pin is UNDOCUMENTED → verify on the H1 that
+    # it actually clips PV in Backup before trusting it. Kill-switch = false.
+    LP_NEGATIVE_HOLD_PIN_MAXSOC: bool = (
+        os.getenv("LP_NEGATIVE_HOLD_PIN_MAXSOC", "true").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
 
     LWT_OFFSET_MAX: float = float(os.getenv("LWT_OFFSET_MAX", "5"))
     LWT_OFFSET_MIN: float = float(os.getenv("LWT_OFFSET_MIN", "-5"))

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -368,7 +368,19 @@ def _slot_fox_tuple(
         # Fox "Backup" work mode = native "hold battery": no discharge, no grid
         # charge. Directly enforces the LP's dis = 0 constraint during negative
         # slots when chg is also zero (battery saturated or PV alone suffices).
-        return ("Backup", None, None, min_r, None)
+        #
+        # 2026-06-07: pin maxSoc to the reserve floor so SOLAR can't trickle-charge
+        # the battery during the hold (Backup otherwise lets PV charge — confirmed
+        # live: the battery crept 10→21% on free solar mid-negative-window). That
+        # surplus PV should EXPORT @ SEG and the battery refill from the PAID
+        # force-charge instead. Gated + kill-switch; the maxSoc-clips-PV-in-Backup
+        # behaviour is unverified on the H1 → confirm before fully trusting.
+        hold_max = (
+            int(min_r)
+            if getattr(config, "LP_NEGATIVE_HOLD_PIN_MAXSOC", False)
+            else None
+        )
+        return ("Backup", None, None, min_r, hold_max)
     return ("SelfUse", None, None, min_r, None)
 
 

--- a/tests/test_fox_lp_dispatch_soc.py
+++ b/tests/test_fox_lp_dispatch_soc.py
@@ -58,6 +58,34 @@ def test_slot_fox_tuple_force_charge_uses_target_and_reserve() -> None:
     assert msg == _min_r()
 
 
+def test_slot_fox_tuple_negative_hold_pins_maxsoc_to_floor(monkeypatch) -> None:
+    """2026-06-07: negative_hold (Backup) pins maxSoc = reserve floor so solar
+    can't trickle-charge the battery during the hold (when enabled)."""
+    monkeypatch.setattr(config, "LP_NEGATIVE_HOLD_PIN_MAXSOC", True, raising=False)
+    t0 = datetime(2026, 6, 1, 11, 0, tzinfo=UTC)
+    s = HalfHourSlot(
+        start_utc=t0, end_utc=t0 + timedelta(minutes=30),
+        price_pence=-4.0, kind="negative_hold",
+    )
+    wm, fds, pwr, msg, max_soc = _slot_fox_tuple(s)
+    assert wm == "Backup"
+    assert msg == _min_r()
+    assert max_soc == _min_r()  # pinned at the floor → no solar charge above it
+
+
+def test_slot_fox_tuple_negative_hold_maxsoc_none_when_disabled(monkeypatch) -> None:
+    """Kill-switch: maxSoc stays None (legacy Backup) when the pin is off."""
+    monkeypatch.setattr(config, "LP_NEGATIVE_HOLD_PIN_MAXSOC", False, raising=False)
+    t0 = datetime(2026, 6, 1, 11, 0, tzinfo=UTC)
+    s = HalfHourSlot(
+        start_utc=t0, end_utc=t0 + timedelta(minutes=30),
+        price_pence=-4.0, kind="negative_hold",
+    )
+    wm, fds, pwr, msg, max_soc = _slot_fox_tuple(s)
+    assert wm == "Backup"
+    assert max_soc is None
+
+
 def test_slot_fox_tuple_cheap_fallback_when_no_target() -> None:
     t0 = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
     s = HalfHourSlot(
@@ -190,10 +218,11 @@ def test_solar_charge_emits_solar_sponge_max_soc_100() -> None:
 
 
 def test_non_solar_charge_kinds_have_no_max_soc() -> None:
-    """ForceCharge / ForceDischarge / Backup / standard SelfUse must NOT emit maxSoc —
-    only solar_charge does. Defensive against accidentally capping other modes."""
+    """ForceCharge / ForceDischarge / standard SelfUse must NOT emit maxSoc.
+    Only solar_charge (cap=100) and negative_hold (cap=floor, 2026-06-07 pin,
+    tested separately) do. Defensive against accidentally capping other modes."""
     t0 = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
-    for kind in ("cheap", "negative", "standard", "negative_hold", "peak_export"):
+    for kind in ("cheap", "negative", "standard", "peak_export"):
         s = HalfHourSlot(
             start_utc=t0,
             end_utc=t0 + timedelta(minutes=30),


### PR DESCRIPTION
Tracked by #498. Workstream B realized — the live-validated lever from the user's `maxSoc` idea.

## Why (live data, 2026-06-07)
During a negative-price window the LP holds the battery low (Backup / `negative_hold`) and force-charges it from the **paid** grid in the most-negative slots. But the committed Backup groups had `maxSoc=None`, and live telemetry showed Backup **lets PV trickle-charge the battery** — it crept 10%→21% mid-window (`chg=2.28 kW` at 10:57 UTC from solar surplus). That banks **free** solar exactly when you'd rather be *paid* to import, shrinking the force-charge's paid headroom.

## What
`negative_hold` (Backup) now emits `maxSoc = MIN_SOC_RESERVE_PERCENT` (the floor), so PV can't charge above it — surplus PV exports at SEG and the battery refills from the **paid** force-charge instead. Pure post-solve Fox dispatch mapping (`_slot_fox_tuple`); the **LP objective is unchanged** (regression gate N/A — it's not an LP-solve change).

## Hardware research (forum + TonyM1958 work-modes wiki)
- Force Charge always uses PV ("charge from grid *less available PV*") → PV unavoidably displaces paid import; **no MPPT-off / PV-curtail** command on the H1.
- **No simultaneous grid import + export** (single net meter).
- So the `maxSoc`-pin is the **one real lever**.

## ⚠️ Caveat — needs empirical confirmation
The Fox wiki says Backup *normally lets PV charge*, and the `maxSoc=minSoc` pin is **undocumented**. So it must be **verified on the H1** that the pin actually clips PV in Backup before we trust it. Gated + kill-switch `LP_NEGATIVE_HOLD_PIN_MAXSOC` (default **true**). Today's test window is gone (legionella + force-charge); verify on the next day with a pre-force-charge solar-surplus Backup window.

## Tests
`negative_hold` pins `maxSoc=floor` when enabled / `None` when disabled; the no-maxSoc-invariant test updated to exclude `negative_hold`. Full suite: **1548 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)