### PR TITLE
fix(appliance): don't nudge to load a machine that's already running/loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,10 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   gap was the heads-up. New `AlertType.APPLIANCE_WINDOW_NUDGE`; knobs
   `APPLIANCE_WINDOW_NUDGE_{ENABLED,PRICE_THRESHOLD_P,HORIZON_HOURS,BRIEF_THRESHOLD_P}`.
   Note: the deadline already rolls to tomorrow when passed, so a stale 07:00
-  deadline was never the blocker — the missing load + nudge was.
+  deadline was never the blocker — the missing load + nudge was. Skips the nudge
+  when the machine is already running/paused or loaded with remote control on
+  (live SmartThings check — the active-job check alone misses a manually started
+  cycle); degrades to nudging if SmartThings is unreachable.
 
 ### Added — legionella tank stand-off (2026-06-07)
 - **HEM stands off the DHW tank during the firmware's weekly thermal-shock

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -1074,6 +1074,7 @@ def compute_appliance_window_suggestions(
             out.append({
                 "appliance_id": appliance_id,
                 "appliance_name": app.get("name") or f"appliance #{appliance_id}",
+                "vendor_device_id": app.get("vendor_device_id"),
                 "recommended_start_utc": start_utc,
                 "recommended_end_utc": end_utc,
                 "deadline_utc": deadline_utc,
@@ -1088,6 +1089,35 @@ def compute_appliance_window_suggestions(
             logger.debug("appliance nudge compute skip #%s: %s", app.get("id"), e)
             continue
     return out
+
+
+def _appliance_busy_or_loaded(device_id: str | None) -> bool:
+    """True when a cycle is already running/paused, OR the machine is loaded with
+    remote control enabled (about to be armed by the next reconcile) — either way
+    "load the machine" would be wrong, so suppress the nudge.
+
+    Degrades to False (nudge proceeds) when SmartThings is unreachable / the
+    device id is missing — better a rare redundant nudge than silence on an ST
+    blip (the whole feature exists because the user wasn't being told in time).
+    """
+    if not device_id:
+        return False
+    try:
+        client = _get_st_client()
+    except Exception:
+        return False
+    try:
+        state, _ts = client.get_machine_state(device_id)
+        if state in ("run", "pause"):  # a cycle is already in progress
+            return True
+    except Exception:
+        pass
+    try:
+        if client.get_remote_control_enabled(device_id):  # loaded + ready → will be armed
+            return True
+    except Exception:
+        pass
+    return False
 
 
 def nudge_appliance_windows(
@@ -1126,6 +1156,13 @@ def nudge_appliance_windows(
     )
     fired: list[dict[str, Any]] = []
     for s in suggestions:
+        # Don't tell the user to load a machine that's already running/loaded.
+        # (The active-job check only catches HEM-scheduled runs; a manually
+        # started cycle has no job — so check the LIVE SmartThings state too.)
+        # Skipped WITHOUT setting the debounce, so once the cycle ends a later
+        # fetch can still nudge for a window that's still upcoming.
+        if _appliance_busy_or_loaded(s.get("vendor_device_id")):
+            continue
         key = f"appliance_nudge_last_{s['appliance_id']}"
         # Debounce on the RECOMMENDED window the user actually sees — one push per
         # recommended window. A genuinely new (cheaper) window shifts the start →

--- a/tests/test_appliance_window_nudge.py
+++ b/tests/test_appliance_window_nudge.py
@@ -144,6 +144,66 @@ def test_nudge_skips_when_flag_off(monkeypatch):
     assert calls == []
 
 
+def _mock_st(monkeypatch, *, machine_state="stop", remote_enabled=False, raises=False):
+    from unittest.mock import MagicMock
+    cli = MagicMock()
+    cli.get_machine_state = MagicMock(return_value=(machine_state, None))
+    cli.get_remote_control_enabled = MagicMock(return_value=remote_enabled)
+    if raises:
+        monkeypatch.setattr(
+            appliance_dispatch, "_get_st_client",
+            MagicMock(side_effect=RuntimeError("ST down")),
+        )
+    else:
+        monkeypatch.setattr(appliance_dispatch, "_get_st_client", MagicMock(return_value=cli))
+    return cli
+
+
+def test_nudge_skips_when_machine_running(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    _mock_st(monkeypatch, machine_state="run")  # a cycle is already washing
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+    assert appliance_dispatch.nudge_appliance_windows(now=now) == []
+    assert calls == []
+
+
+def test_nudge_skips_when_remote_control_enabled(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    _mock_st(monkeypatch, machine_state="stop", remote_enabled=True)  # loaded, will be armed
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+    assert appliance_dispatch.nudge_appliance_windows(now=now) == []
+    assert calls == []
+
+
+def test_nudge_proceeds_when_machine_stopped_and_idle(monkeypatch):
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    _mock_st(monkeypatch, machine_state="stop", remote_enabled=False)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+    assert len(appliance_dispatch.nudge_appliance_windows(now=now)) == 1
+    assert len(calls) == 1
+
+
+def test_nudge_proceeds_when_smartthings_unavailable(monkeypatch):
+    """Graceful degrade: an ST blip must not silence the nudge."""
+    _setup_cfg(monkeypatch)
+    calls = _capture_notify(monkeypatch)
+    _mock_st(monkeypatch, raises=True)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0])
+    assert len(appliance_dispatch.nudge_appliance_windows(now=now)) == 1
+    assert len(calls) == 1
+
+
 def test_nudge_skips_when_no_negative_window(monkeypatch):
     _setup_cfg(monkeypatch)
     calls = _capture_notify(monkeypatch)


### PR DESCRIPTION
The load nudge (#504) only checked for an active HEM **job**, so a **manually started** cycle (no job row) still got "🧺⚡ Carregue a máquina" pushed at it while it was mid-wash (user-reported).

## Fix
Check the **live SmartThings state** before pushing: skip when `machineState` is `run`/`pause` (cycle in progress) **OR** `remoteControlEnabled` is true (loaded + about to be armed by the next reconcile). Degrades to nudging when SmartThings is unreachable / the device id is missing — better a rare redundant nudge than silence on an ST blip (the whole feature exists because the user wasn't being told in time). Skipped **without** setting the debounce, so a later fetch can still nudge once the cycle ends and a window is still upcoming.

## Tests
Skip when running / remote-enabled; proceed when stopped+idle; proceed on ST outage. 17 nudge tests pass.

Tracked by #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)