### PR TITLE
perf(cockpit): server-side TTL caches + Cache-Control; faster Fox snapshot (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,22 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   across the 6 call sites; scenario variance from the spread. Kill-switch
   `LP_RESIDUAL_PROFILE_V2`; Insights "when you spend the most" heatmap.
 
+### Changed — cockpit performance: server-side TTL caches + Cache-Control (2026-06-07)
+- **The cockpit loaded slowly** because `/weather` + `/pv/today` hit Open-Meteo and
+  `/energy/period` (day/week) hit Fox ESS on EVERY request with no server-side cache
+  (0.5–2 s blocking HTTP each). Added in-process TTL caches (no Redis — single
+  container): a shared forecast cache (`weather.fetch_forecast_cached`, 15 min) feeds
+  both `/weather` and `/pv/today` from one fetch; a day/week period-insights cache
+  (20 min, mirrors the existing 1 h month cache) makes period-nav instant. Plus short
+  `Cache-Control` (`private, max-age=…`) on the read-heavy cockpit GETs so a hard
+  refresh / tab-return doesn't re-hit everything. Knobs
+  `WEATHER_FORECAST_CACHE_TTL_SECONDS`, `ENERGY_PERIOD_CACHE_TTL_SECONDS`.
+- **Better Fox realtime freshness without a request-path fetch:** the pv-telemetry
+  background job is now the canonical Fox-snapshot refresher (forces a read older than
+  `FOX_SNAPSHOT_REFRESH_MAX_AGE_SECONDS`=60 s), so lowering `PV_TELEMETRY_INTERVAL_MINUTES`
+  (e.g. 5→2) tightens the cockpit snapshot to ~2 min while the API reads stay cache-only
+  (never fetch on the request path). ~720 Fox calls/day, well under budget; zero Daikin impact.
+
 ### Added — pin maxSoc on negative-hold so solar can't waste paid-import headroom (2026-06-07)
 - **`negative_hold` (Backup) slots now emit `maxSoc = reserve floor`** so PV can't
   trickle-charge the battery during the hold phase of a negative-price window

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -286,6 +286,36 @@ app.add_middleware(
     enabled=lambda: bool(config.HEM_UI_AUTH_REQUIRED),
 )
 
+
+# Short browser Cache-Control on the read-heavy cockpit GETs so a hard refresh /
+# tab-return doesn't re-hit every endpoint. `private` (bearer-gated, per-user) +
+# short max-age; the SPA's own polling still drives live updates. Server-side TTL
+# caches already make the misses cheap.
+_CACHE_CONTROL_MAX_AGE: dict[str, int] = {
+    "/api/v1/cockpit/now": 15,
+    "/api/v1/metrics": 120,
+    "/api/v1/weather": 900,
+    "/api/v1/pv/today": 180,
+    "/api/v1/energy/today-cumulative": 30,
+    "/api/v1/daikin/status": 120,
+    "/api/v1/daikin/heating-plan": 120,
+    "/api/v1/scheduler/timeline": 120,
+}
+
+
+@app.middleware("http")
+async def _cockpit_cache_headers(request, call_next):
+    resp = await call_next(request)
+    try:
+        if request.method == "GET" and resp.status_code == 200:
+            ma = _CACHE_CONTROL_MAX_AGE.get(request.url.path)
+            if ma is not None and "cache-control" not in resp.headers:
+                resp.headers["Cache-Control"] = f"private, max-age={ma}"
+    except Exception:
+        pass
+    return resp
+
+
 app.include_router(energy_providers_router.router)
 app.include_router(workbench_router.router)
 app.include_router(dispatch_router.router)
@@ -446,9 +476,9 @@ async def api_v1_weather():
 
 
 def _api_v1_weather_sync():
-    from ..weather import fetch_forecast
+    from ..weather import fetch_forecast_cached
 
-    fc = fetch_forecast(hours=48)
+    fc = fetch_forecast_cached(hours=48)
     out = [{
         "time": f.time_utc.isoformat(),
         "temp_c": f.temperature_c,
@@ -2769,6 +2799,28 @@ async def energy_monthly(month: str):
     )
 
 
+# In-process TTL cache for day/week period insights (Fox ESS HTTP). Month already
+# self-caches (get_cached_energy_month, 1 h). Keyed on the full param tuple; turns
+# repeat period-nav clicks into instant cache hits. Short TTL → ≤ minutes stale.
+_period_insights_cache: dict[tuple, tuple[float, object]] = {}
+
+
+def _get_period_insights_cached(period, date_str=None, month_str=None, year=None):
+    import time as _t
+    ttl = int(getattr(config, "ENERGY_PERIOD_CACHE_TTL_SECONDS", 1200))
+    if period not in ("day", "week") or ttl <= 0:
+        return get_period_insights(period, date_str=date_str, month_str=month_str, year=year)
+    key = (period, date_str, month_str, year)
+    now = _t.monotonic()
+    hit = _period_insights_cache.get(key)
+    if hit and (now - hit[0]) < ttl:
+        return hit[1]
+    out = get_period_insights(period, date_str=date_str, month_str=month_str, year=year)
+    if out is not None:
+        _period_insights_cache[key] = (now, out)
+    return out
+
+
 @app.get("/api/v1/energy/period", response_model=PeriodInsightsResponse)
 async def energy_period(
     period: str,
@@ -2797,7 +2849,7 @@ async def energy_period(
     if period in ("day", "week") and (len(date) != 10 or date[4] != "-" or date[7] != "-"):
         raise HTTPException(status_code=400, detail="Use date=YYYY-MM-DD")
     try:
-        out = await asyncio.to_thread(get_period_insights, period, date_str=date, month_str=month, year=year)
+        out = await asyncio.to_thread(_get_period_insights_cached, period, date, month, year)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -2920,7 +2972,7 @@ async def energy_report(
     if period in ("day", "week") and date and (len(date) != 10 or date[4] != "-" or date[7] != "-"):
         raise HTTPException(status_code=400, detail="Use date=YYYY-MM-DD")
     try:
-        out = await asyncio.to_thread(get_period_insights, period, date_str=date, month_str=month, year=year)
+        out = await asyncio.to_thread(_get_period_insights_cached, period, date, month, year)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -87,8 +87,9 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
         from ... import weather
 
         # Open-Meteo HTTP — offload so it doesn't block the event loop and
-        # serialize the other dashboard requests behind it.
-        fc = await asyncio.to_thread(weather.fetch_forecast, hours=48)
+        # serialize the other dashboard requests behind it. TTL-cached so the
+        # cockpit's /weather + /pv/today share one fetch.
+        fc = await asyncio.to_thread(weather.fetch_forecast_cached, hours=48)
         series = weather.forecast_to_lp_inputs(fc, slot_starts, pv_scale=1.0)
         pv = series.pv_kwh_per_slot
         for i in range(min(_SLOTS_PER_DAY, len(pv))):

--- a/src/config.py
+++ b/src/config.py
@@ -1799,6 +1799,24 @@ class Config:
     FOX_DAILY_BUDGET: int = int(os.getenv("FOX_DAILY_BUDGET", "1200"))
     # Default realtime data TTL — raised from 30 s to 300 s (5 min) to match heartbeat
     FOX_REALTIME_CACHE_TTL_SECONDS: int = int(os.getenv("FOX_REALTIME_CACHE_TTL_SECONDS", "300"))
+    # 2026-06-07: the pv-telemetry background job is the canonical Fox-snapshot
+    # refresher; it forces a read older than this so the cockpit serves a fresh
+    # snapshot at the telemetry cadence (PV_TELEMETRY_INTERVAL_MINUTES). Keeps the
+    # cockpit/API reads cache-only (they never fetch on the request path).
+    FOX_SNAPSHOT_REFRESH_MAX_AGE_SECONDS: int = int(
+        os.getenv("FOX_SNAPSHOT_REFRESH_MAX_AGE_SECONDS", "60")
+    )
+    # In-process TTL cache for the Open-Meteo forecast fetch (shared by /weather +
+    # /pv/today). Open-Meteo is hourly-deterministic, so a short cache turns the
+    # 0.5–2 s blocking HTTP call into ~0 ms for the cockpit. 0 disables.
+    WEATHER_FORECAST_CACHE_TTL_SECONDS: int = int(
+        os.getenv("WEATHER_FORECAST_CACHE_TTL_SECONDS", "900")
+    )
+    # In-process TTL cache for /energy/period day & week (Fox ESS HTTP). Month
+    # already has a 1 h cache; this mirrors it so period-nav clicks are instant.
+    ENERGY_PERIOD_CACHE_TTL_SECONDS: int = int(
+        os.getenv("ENERGY_PERIOD_CACHE_TTL_SECONDS", "1200")
+    )
     # Minimum interval between user-initiated "force refresh" calls
     FOX_FORCE_REFRESH_MIN_INTERVAL_SECONDS: int = int(
         os.getenv("FOX_FORCE_REFRESH_MIN_INTERVAL_SECONDS", "60")

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -1158,7 +1158,13 @@ def bulletproof_pv_telemetry_job() -> None:
     if get_scheduler_paused():
         return
     try:
-        rt = get_cached_realtime()
+        # This job is the canonical Fox-snapshot refresher: force a read older than
+        # FOX_SNAPSHOT_REFRESH_MAX_AGE_SECONDS so the cockpit serves a snapshot fresh
+        # to the telemetry cadence (PV_TELEMETRY_INTERVAL_MINUTES) WITHOUT the API
+        # reads ever fetching on the request path (they use the longer default TTL).
+        rt = get_cached_realtime(
+            max_age_seconds=int(config.FOX_SNAPSHOT_REFRESH_MAX_AGE_SECONDS)
+        )
     except Exception as e:
         logger.debug("pv telemetry: realtime unavailable: %s", e)
         return

--- a/src/weather.py
+++ b/src/weather.py
@@ -380,6 +380,37 @@ def fetch_forecast(
     return fetch_forecast_snapshot(lat=lat, lon=lon, hours=hours).forecast
 
 
+# In-process TTL cache for the forecast fetch — keyed on ``hours`` (lat/lon are
+# config-pinned). Shared by /weather + /pv/today so the cockpit doesn't make two
+# blocking Open-Meteo calls per load. Open-Meteo is hourly-deterministic, so a
+# ~15 min cache is safe; the LP/heartbeat keep using ``fetch_forecast`` directly.
+_forecast_cache: dict[int, tuple[float, list[HourlyForecast]]] = {}
+
+
+def fetch_forecast_cached(
+    lat: str | None = None,
+    lon: str | None = None,
+    hours: int = 48,
+    ttl_seconds: int | None = None,
+) -> list[HourlyForecast]:
+    """TTL-cached :func:`fetch_forecast` for the cockpit API endpoints. Serves the
+    last good value on a failed/empty refresh rather than an empty list."""
+    import time as _t
+    if ttl_seconds is None:
+        ttl_seconds = int(getattr(config, "WEATHER_FORECAST_CACHE_TTL_SECONDS", 900))
+    if ttl_seconds <= 0:
+        return fetch_forecast(lat=lat, lon=lon, hours=hours)
+    now = _t.monotonic()
+    hit = _forecast_cache.get(hours)
+    if hit and hit[1] and (now - hit[0]) < ttl_seconds:
+        return hit[1]
+    fresh = fetch_forecast(lat=lat, lon=lon, hours=hours)
+    if fresh:
+        _forecast_cache[hours] = (now, fresh)
+        return fresh
+    return hit[1] if hit else fresh  # serve stale on a failed fetch
+
+
 def fetch_forecast_snapshot(
     lat: str | None = None,
     lon: str | None = None,

--- a/tests/test_cockpit_cache.py
+++ b/tests/test_cockpit_cache.py
@@ -1,0 +1,94 @@
+"""Phase 1 cockpit performance: in-process TTL caches + Cache-Control headers.
+
+The cockpit was slow because /weather + /pv/today hit Open-Meteo and /energy/period
+(day/week) hit Fox ESS on every request with no server-side cache. These tests
+lock in the caching + headers (no Redis — single-container in-process TTL).
+"""
+from __future__ import annotations
+
+import src.weather as weather
+from src.config import config
+
+
+def test_fetch_forecast_cached_dedupes_within_ttl(monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setattr(config, "WEATHER_FORECAST_CACHE_TTL_SECONDS", 900, raising=False)
+
+    def _fake(**_k):
+        calls["n"] += 1
+        return [object()]  # non-empty
+
+    monkeypatch.setattr(weather, "fetch_forecast", _fake)
+    weather._forecast_cache.clear()
+    a = weather.fetch_forecast_cached(hours=48)
+    b = weather.fetch_forecast_cached(hours=48)
+    c = weather.fetch_forecast_cached(hours=48)
+    assert calls["n"] == 1, "three cached calls must hit Open-Meteo once"
+    assert a is b is c
+
+
+def test_fetch_forecast_cached_serves_stale_on_failed_refresh(monkeypatch):
+    monkeypatch.setattr(config, "WEATHER_FORECAST_CACHE_TTL_SECONDS", 0, raising=False)
+    # TTL=0 disables caching → always passes through.
+    seq = [[object()], []]  # first good, then empty (failed fetch)
+
+    def _fake(**_k):
+        return seq.pop(0) if seq else []
+
+    monkeypatch.setattr(weather, "fetch_forecast", _fake)
+    weather._forecast_cache.clear()
+    assert weather.fetch_forecast_cached(hours=48)  # passthrough, good
+    # Re-enable cache; prime it, then make the next fetch fail → stale served.
+    monkeypatch.setattr(config, "WEATHER_FORECAST_CACHE_TTL_SECONDS", 1, raising=False)
+    good = [object()]
+    state = {"fail": False}
+    monkeypatch.setattr(weather, "fetch_forecast", lambda **_k: ([] if state["fail"] else good))
+    weather._forecast_cache.clear()
+    primed = weather.fetch_forecast_cached(hours=48)
+    assert primed == good
+    state["fail"] = True
+    import time
+    time.sleep(1.05)  # expire the 1s TTL
+    served = weather.fetch_forecast_cached(hours=48)
+    assert served == good, "a failed refresh must serve the last good value, not []"
+
+
+def test_period_insights_cache_dedupes_day(monkeypatch):
+    import src.api.main as m
+    monkeypatch.setattr(config, "ENERGY_PERIOD_CACHE_TTL_SECONDS", 1200, raising=False)
+    calls = {"n": 0}
+    monkeypatch.setattr(m, "get_period_insights",
+                        lambda period, **k: (calls.__setitem__("n", calls["n"] + 1) or {"period": period}))
+    m._period_insights_cache.clear()
+    m._get_period_insights_cached("day", date_str="2026-06-07")
+    m._get_period_insights_cached("day", date_str="2026-06-07")
+    assert calls["n"] == 1  # cached
+    # A different date is a different key → recomputed.
+    m._get_period_insights_cached("day", date_str="2026-06-06")
+    assert calls["n"] == 2
+
+
+def test_period_insights_cache_passthrough_for_month(monkeypatch):
+    import src.api.main as m
+    monkeypatch.setattr(config, "ENERGY_PERIOD_CACHE_TTL_SECONDS", 1200, raising=False)
+    calls = {"n": 0}
+    monkeypatch.setattr(m, "get_period_insights",
+                        lambda period, **k: (calls.__setitem__("n", calls["n"] + 1) or {"period": period}))
+    m._period_insights_cache.clear()
+    # month self-caches downstream; the day/week wrapper must NOT cache it.
+    m._get_period_insights_cached("month", month_str="2026-06")
+    m._get_period_insights_cached("month", month_str="2026-06")
+    assert calls["n"] == 2
+
+
+def test_cache_control_header_on_weather(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from src.api.main import app
+    monkeypatch.setattr(config, "HEM_UI_AUTH_REQUIRED", False, raising=False)
+    monkeypatch.setattr(weather, "fetch_forecast", lambda **_k: [])  # no external call
+    weather._forecast_cache.clear()
+    client = TestClient(app)
+    r = client.get("/api/v1/weather")
+    assert r.status_code == 200
+    assert r.headers.get("Cache-Control") == "private, max-age=900"

--- a/tests/test_pv_telemetry.py
+++ b/tests/test_pv_telemetry.py
@@ -68,7 +68,7 @@ def test_pv_telemetry_job_persists_when_realtime_available(monkeypatch):
     from src import db
 
     fake_rt = MagicMock(soc=75.0, solar_power=2.0, load_power=0.5, grid_power=-1.5, battery_power=1.0, work_mode="SelfUse")
-    monkeypatch.setattr(runner, "get_cached_realtime", lambda: fake_rt)
+    monkeypatch.setattr(runner, "get_cached_realtime", lambda **_k: fake_rt)
     monkeypatch.setattr(runner, "_scheduler_paused", False)
 
     runner.bulletproof_pv_telemetry_job()
@@ -95,7 +95,7 @@ def test_pv_telemetry_job_silent_when_realtime_empty(monkeypatch):
     from src.scheduler import runner
 
     fake_rt = MagicMock(soc=None, solar_power=None, load_power=None, grid_power=None, battery_power=None, work_mode="unknown")
-    monkeypatch.setattr(runner, "get_cached_realtime", lambda: fake_rt)
+    monkeypatch.setattr(runner, "get_cached_realtime", lambda **_k: fake_rt)
     monkeypatch.setattr(runner, "_scheduler_paused", False)
 
     # Should not raise; should not write


### PR DESCRIPTION
Phase 1 of the UI-improvements plan — make the cockpit load fast. **No Redis** (single immutable container) — in-process TTL caches, mirroring the existing `_energy_month_cache` / `_last_realtime` patterns.

## Root cause
Several cockpit endpoints made **blocking external HTTP calls per request with no server-side cache** (0.5–2 s each):
- `/weather` + `/pv/today` → Open-Meteo every call.
- `/energy/period` (day/week) → Fox ESS every call (month already had a 1 h cache).

## Fixes
- **`weather.fetch_forecast_cached`** (15 min TTL, `WEATHER_FORECAST_CACHE_TTL_SECONDS`): one Open-Meteo fetch shared by `/weather` **and** `/pv/today`; serves the last good value on a failed refresh.
- **`_get_period_insights_cached`** (20 min, `ENERGY_PERIOD_CACHE_TTL_SECONDS`): day/week period insights → instant period-nav. Month still self-caches.
- **Cache-Control middleware** (`private, max-age=…`) on the read-heavy cockpit GETs → a hard refresh / tab-return doesn't re-hit everything.
- **Better Fox freshness without a request-path fetch:** the pv-telemetry background job is now the canonical Fox-snapshot refresher (forces a read older than `FOX_SNAPSHOT_REFRESH_MAX_AGE_SECONDS`=60 s). Lowering `PV_TELEMETRY_INTERVAL_MINUTES` (5→2 at deploy) tightens the cockpit snapshot to ~2 min while API reads stay cache-only. ~720 Fox calls/day (under the 1200 budget); **zero Daikin impact**.

## Tests
`tests/test_cockpit_cache.py` (5): forecast cache dedupe + stale-on-fail, period cache dedupe (day) + passthrough (month), Cache-Control header. `pv_telemetry` mock updated for the new kwarg. Full suite **1557 passed**.

Deploy note: set `PV_TELEMETRY_INTERVAL_MINUTES=2` (runtime) at restart for the faster Fox refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)