### PR TITLE
feat(ui): hero "saved today" + appliance-schedule widget (UI Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,18 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   across the 6 call sites; scenario variance from the spread. Kill-switch
   `LP_RESIDUAL_PROFILE_V2`; Insights "when you spend the most" heatmap.
 
+### Added — hero "saved today" + appliance-schedule widget (2026-06-07, UI Phase 2)
+- **Hero shows today's real-money savings** at a glance, independent of the period
+  selector: "Hoje: crédito £X · economizou £Y (Z% abaixo do fixo)". Reuses
+  `compute_daily_pnl` — `/api/v1/energy/today-cumulative` now also returns
+  `realised_net_cost_gbp` + `delta_vs_{fixed,svt}_real_gbp` + `*_shadow_real_gbp`.
+- **New Appliances widget** (medium, next to Heating) — at a glance: running /
+  scheduled (window + avg price, from `/appliances/jobs`) / idle-with-a-cheap-
+  window-ahead ("janela paga|barata HH:MM — carregue + Smart Control", from a new
+  read-only `GET /api/v1/appliances/suggestions` wrapping
+  `compute_appliance_window_suggestions`) / register hint when none. Best-effort:
+  degrades to empty when SmartThings/Fox unconfigured.
+
 ### Changed — cockpit performance: server-side TTL caches + Cache-Control (2026-06-07)
 - **The cockpit loaded slowly** because `/weather` + `/pv/today` hit Open-Meteo and
   `/energy/period` (day/week) hit Fox ESS on EVERY request with no server-side cache

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3061,6 +3061,15 @@ async def energy_today_cumulative():
         "export_kwh": pnl.get("export_kwh", 0.0),
         "import_cost_gbp": pnl.get("import_cost_gbp", 0.0),
         "export_revenue_gbp": pnl.get("export_revenue_gbp", 0.0),
+        # Real-money savings so the hero can show "saved £X today (Y% off)".
+        # net = realised net cost incl. standing (negative = a credit/paid day);
+        # delta_* = real money saved vs the fixed/SVT shadow (positive = Agile
+        # won); *_shadow_real = the counterfactual cost (for the % off).
+        "realised_net_cost_gbp": pnl.get("realised_net_cost_gbp", 0.0),
+        "delta_vs_fixed_real_gbp": pnl.get("delta_vs_fixed_real_gbp", 0.0),
+        "delta_vs_svt_real_gbp": pnl.get("delta_vs_svt_real_gbp", 0.0),
+        "fixed_shadow_real_gbp": pnl.get("fixed_shadow_real_gbp", 0.0),
+        "svt_shadow_real_gbp": pnl.get("svt_shadow_real_gbp", 0.0),
     }
 
 

--- a/src/api/routers/appliances.py
+++ b/src/api/routers/appliances.py
@@ -215,6 +215,53 @@ async def list_jobs(
     }
 
 
+@router.get("/appliances/suggestions")
+async def appliance_suggestions() -> dict[str, Any]:
+    """Cheapest upcoming run window per enabled + IDLE appliance, for the cockpit
+    widget ("Sem ciclo — próxima janela barata HH:MM"). Read-only wrapper over
+    ``compute_appliance_window_suggestions`` using the brief cheap threshold so it
+    surfaces cheap-but-not-negative windows too. Appliances with an active job are
+    already excluded by the compute (they're shown via /appliances/jobs instead).
+    DB-only (no SmartThings / external call) → fast.
+    """
+    import asyncio
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+    from datetime import timedelta as _td
+
+    now = _dt.now(_UTC)
+    thr = float(getattr(config, "APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P", 8.0))
+    horizon_h = float(getattr(config, "APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS", 24))
+    tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+    try:
+        rates = db.get_rates_for_period(
+            tariff, now, now + _td(hours=max(1.0, horizon_h))
+        ) if tariff else None
+    except Exception:
+        rates = None
+    try:
+        sugg = await asyncio.to_thread(
+            appliance_dispatch.compute_appliance_window_suggestions,
+            now, rates, max_price_p=thr, strict=False,
+        )
+    except Exception as e:  # never break the cockpit on a suggestion glitch
+        logger.debug("appliance suggestions failed: %s", e)
+        sugg = []
+    out = [{
+        "appliance_id": s["appliance_id"],
+        "appliance_name": s["appliance_name"],
+        "recommended_start_utc": s["recommended_start_utc"].isoformat(),
+        "recommended_end_utc": s["recommended_end_utc"].isoformat(),
+        "deadline_local": s["deadline_local"],
+        "duration_minutes": s["duration_minutes"],
+        "avg_price_pence": s["avg_price_pence"],
+        "est_kwh": s["est_kwh"],
+        "est_cost_pence": s["est_cost_pence"],
+        "is_negative": s["is_negative"],
+    } for s in sugg]
+    return {"suggestions": out, "count": len(out)}
+
+
 @router.post("/appliances/jobs/{job_id}/cancel")
 async def cancel_job(job_id: int) -> dict[str, Any]:
     job = db.get_appliance_job(job_id)

--- a/tests/test_phase2_hero_appliance_api.py
+++ b/tests/test_phase2_hero_appliance_api.py
@@ -1,0 +1,85 @@
+"""Phase 2 backend: today-cumulative savings fields + /appliances/suggestions.
+
+The hero needs today's real-money savings; the appliance widget needs the
+cheapest upcoming run window per idle appliance. Both reuse existing computations
+(compute_daily_pnl, compute_appliance_window_suggestions).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from fastapi.testclient import TestClient
+
+from src import db
+from src.config import config
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr(config, "HEM_UI_AUTH_REQUIRED", False, raising=False)
+    from src.api.main import app
+    return TestClient(app)
+
+
+def test_today_cumulative_exposes_savings_fields(monkeypatch):
+    db.init_db()
+    client = _client(monkeypatch)
+    r = client.get("/api/v1/energy/today-cumulative")
+    assert r.status_code == 200
+    body = r.json()
+    for k in (
+        "import_kwh", "export_kwh", "import_cost_gbp", "export_revenue_gbp",
+        "realised_net_cost_gbp", "delta_vs_fixed_real_gbp", "delta_vs_svt_real_gbp",
+        "fixed_shadow_real_gbp", "svt_shadow_real_gbp",
+    ):
+        assert k in body, f"hero needs {k} in today-cumulative"
+
+
+def _seed_rates(start_utc: datetime, prices: list[float]) -> None:
+    rates, t = [], start_utc
+    for p in prices:
+        rates.append({
+            "valid_from": t.isoformat().replace("+00:00", "Z"),
+            "valid_to": (t + timedelta(minutes=30)).isoformat().replace("+00:00", "Z"),
+            "value_inc_vat": p,
+        })
+        t += timedelta(minutes=30)
+    db.save_agile_rates(rates, "TEST-TARIFF")
+
+
+def test_appliance_suggestions_endpoint(monkeypatch):
+    db.init_db()
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "TEST-TARIFF", raising=False)
+    monkeypatch.setattr(config, "APPLIANCE_WINDOW_NUDGE_BRIEF_THRESHOLD_P", 8.0, raising=False)
+    monkeypatch.setattr(config, "BULLETPROOF_TIMEZONE", "Europe/London", raising=False)
+    # idle, enabled washer with a far deadline + an upcoming cheap window
+    db.add_appliance(
+        vendor="smartthings", vendor_device_id="dev-x", name="Washer",
+        device_type="washer", default_duration_minutes=120,
+        deadline_local_time=(datetime.now(ZoneInfo("Europe/London")) + timedelta(hours=12)).strftime("%H:%M"),
+        typical_kw=0.5,
+    )
+    now = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    _seed_rates(now + timedelta(hours=1), [-4.0, -4.5, -3.0, -2.0, 8.0, 8.0])
+
+    client = _client(monkeypatch)
+    r = client.get("/api/v1/appliances/suggestions")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 1
+    s = body["suggestions"][0]
+    assert s["appliance_name"] == "Washer"
+    assert s["is_negative"] is True
+    assert s["est_cost_pence"] < 0  # paid to run
+    # ISO strings, parseable
+    datetime.fromisoformat(s["recommended_start_utc"])
+    assert "deadline_local" in s
+
+
+def test_appliance_suggestions_empty_when_no_appliance(monkeypatch):
+    db.init_db()
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "TEST-TARIFF", raising=False)
+    client = _client(monkeypatch)
+    r = client.get("/api/v1/appliances/suggestions")
+    assert r.status_code == 200
+    assert r.json() == {"suggestions": [], "count": 0}

--- a/ui/src/components/home/ApplianceWidget.tsx
+++ b/ui/src/components/home/ApplianceWidget.tsx
@@ -1,0 +1,77 @@
+import type { ApplianceSuggestion, ApplianceJob, Appliance } from "../../lib/types";
+import "./appliance.css";
+
+interface ApplianceWidgetProps {
+  suggestions?: ApplianceSuggestion[] | null;  // cheapest window per idle appliance
+  jobs?: ApplianceJob[] | null;                 // recent jobs (we filter to active)
+  appliances?: Appliance[] | null;
+}
+
+function fmtLocal(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+  } catch {
+    return "—";
+  }
+}
+
+// "Is there an appliance scheduled?" — at a glance, per enabled machine:
+//   running → it's washing now
+//   scheduled → HEM picked a window (start–end · avg price)
+//   idle + cheap window ahead → "load it" prompt (the consent gate is physical)
+//   idle, no window → quiet
+export function ApplianceWidget({ suggestions, jobs, appliances }: ApplianceWidgetProps) {
+  const enabled = (appliances ?? []).filter((a) => a.enabled);
+
+  if (enabled.length === 0) {
+    return (
+      <div class="appliance appliance--empty">
+        <p class="muted">Nenhum eletrodoméstico registrado.</p>
+        <p class="appliance-hint">Registre a máquina (SmartThings) para agendar lavagens nas janelas baratas.</p>
+      </div>
+    );
+  }
+
+  const activeJobs = (jobs ?? []).filter((j) => j.status === "scheduled" || j.status === "running");
+  const jobByApp = new Map(activeJobs.map((j) => [j.appliance_id, j]));
+  const sugByApp = new Map((suggestions ?? []).map((s) => [s.appliance_id, s]));
+
+  return (
+    <div class="appliance">
+      {enabled.map((a) => {
+        const job = jobByApp.get(a.id);
+        const sug = sugByApp.get(a.id);
+        return (
+          <div class="appliance-row" key={a.id}>
+            <div class="appliance-name">🧺 {a.name}</div>
+
+            {job ? (
+              job.status === "running" ? (
+                <div class="appliance-state appliance-state--run">Rodando agora</div>
+              ) : (
+                <div class="appliance-state appliance-state--sched">
+                  Programado <strong>{fmtLocal(job.planned_start_utc)}–{fmtLocal(job.planned_end_utc)}</strong>
+                  {job.avg_price_pence != null && (
+                    <span class="appliance-price"> · {job.avg_price_pence.toFixed(1)}p/kWh</span>
+                  )}
+                </div>
+              )
+            ) : sug ? (
+              <div class="appliance-state appliance-state--idle">
+                <span class={sug.is_negative ? "appliance-tag appliance-tag--paid" : "appliance-tag appliance-tag--cheap"}>
+                  {sug.is_negative ? "janela paga" : "janela barata"}
+                </span>
+                <strong>{fmtLocal(sug.recommended_start_utc)}–{fmtLocal(sug.recommended_end_utc)}</strong>
+                <span class="appliance-price"> · {sug.avg_price_pence.toFixed(1)}p</span>
+                <div class="appliance-cta">Carregue + Smart Control até {sug.deadline_local}</div>
+              </div>
+            ) : (
+              <div class="appliance-state appliance-state--none muted">Sem janela barata à frente</div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -1,4 +1,4 @@
-import type { MetricsResponse, CockpitNow, AgileTodayResponse, MonthlyEnergy, PeriodInsightsResponse } from "../../lib/types";
+import type { MetricsResponse, CockpitNow, AgileTodayResponse, MonthlyEnergy, PeriodInsightsResponse, TodayCumulativeResponse } from "../../lib/types";
 import { gbp, kwh } from "../../lib/format";
 import { useAnimatedNumber } from "../../lib/useAnimatedNumber";
 import { isCurrentPeriod, periodLabel, type PeriodState } from "../../lib/period";
@@ -15,6 +15,8 @@ interface HeroProps {
   period: PeriodInsightsResponse | null;
   periodState: PeriodState;
   periodLoading: boolean;
+  // Today's real-money cumulative (for the always-current "saved today" chip).
+  todayCum?: TodayCumulativeResponse | null;
 }
 
 // The hero answers ONE question for the SELECTED period: how is it going on
@@ -27,9 +29,19 @@ interface HeroProps {
 //   4. Today so far (only when viewing the current period) — explicit estimate
 //   5. Lifetime totals on Agile
 //   6. The cost-composition chart for the selected period
-export function Hero({ metrics, cockpit, agile, monthly, period, periodState, periodLoading }: HeroProps) {
+export function Hero({ metrics, cockpit, agile, monthly, period, periodState, periodLoading, todayCum }: HeroProps) {
   const isNow = isCurrentPeriod(periodState);
   const label = periodLabel(periodState);
+
+  // --- Always-today real-money savings (independent of the period selector) ---
+  // saved = £ vs the fixed-tariff shadow on the same metered kWh; pct = how much
+  // of that fixed bill we erased (>100% on a paid/negative day → "100+").
+  const savedToday = todayCum?.delta_vs_fixed_real_gbp ?? null;
+  const netToday = todayCum?.realised_net_cost_gbp ?? null;
+  const shadowToday = todayCum?.fixed_shadow_real_gbp ?? null;
+  const pctOffToday = (savedToday != null && shadowToday != null && shadowToday > 0)
+    ? Math.round((savedToday / shadowToday) * 100)
+    : null;
 
   // --- The selected period, real money (NET, incl standing, measured grid) ---
   const periodNet = period?.cost?.net_cost_pounds ?? null;
@@ -121,6 +133,26 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
             {curImportP != null && <span>import <strong>{curImportP.toFixed(1)}p</strong></span>}
             {curExportP != null && <span>· export <strong>{curExportP.toFixed(1)}p</strong></span>}
             {socPct != null && <span>· battery <strong>{Math.round(socPct)}%</strong></span>}
+          </div>
+        )}
+
+        {savedToday != null && (savedToday > 0.005 || (netToday != null && netToday < 0)) && (
+          <div class="hero-savedtoday" title="Economia real de hoje vs a tarifa fixa — sobre o consumo medido, incluindo standing charge.">
+            <span class="hero-savedtoday-ico" aria-hidden="true">💚</span>
+            <span>
+              Hoje:&nbsp;
+              {netToday != null && netToday < 0
+                ? <strong class="hero-strong-pos">crédito {gbp(Math.abs(netToday))}</strong>
+                : netToday != null ? <strong>{gbp(netToday)}</strong> : null}
+              {savedToday > 0.005 && (
+                <>&nbsp;·&nbsp;economizou&nbsp;
+                  <strong class="hero-strong-pos">{gbp(savedToday)}</strong>
+                  {pctOffToday != null && pctOffToday > 0 && (
+                    <>&nbsp;({pctOffToday > 100 ? "100+" : pctOffToday}% abaixo do {fixedLabel})</>
+                  )}
+                </>
+              )}
+            </span>
           </div>
         )}
 

--- a/ui/src/components/home/appliance.css
+++ b/ui/src/components/home/appliance.css
@@ -1,0 +1,60 @@
+.appliance {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.appliance--empty {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  justify-content: center;
+  min-height: 80px;
+}
+.appliance-hint {
+  font-size: var(--font-xs);
+  color: var(--text-mute);
+  line-height: 1.4;
+}
+.appliance-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+.appliance-row:last-child { border-bottom: none; padding-bottom: 0; }
+.appliance-name {
+  font-weight: 600;
+  font-size: var(--font-sm);
+}
+.appliance-state {
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+}
+.appliance-state strong { color: var(--text); font-weight: 700; }
+.appliance-state--run { color: var(--ok, #36d399); font-weight: 600; }
+.appliance-price { color: var(--text-mute); }
+.appliance-cta {
+  margin-top: 2px;
+  font-size: var(--font-xs);
+  color: var(--text-mute);
+}
+.appliance-tag {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.appliance-tag--paid {
+  color: var(--neg, #38bdf8);
+  background: color-mix(in srgb, var(--neg, #38bdf8) 16%, transparent);
+}
+.appliance-tag--cheap {
+  color: var(--cheap, #36d399);
+  background: color-mix(in srgb, var(--cheap, #36d399) 16%, transparent);
+}

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -251,6 +251,25 @@
   font-variant-numeric: tabular-nums;
 }
 .hero-livenow strong { color: var(--text); font-weight: 700; }
+
+/* Always-current "saved today" chip — distinct pill so today's win reads at a
+   glance regardless of the period selector. */
+.hero-savedtoday {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ok, #36d399) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ok, #36d399) 28%, transparent);
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.3;
+}
+.hero-savedtoday-ico { font-size: 14px; line-height: 1; }
+
 .hero-livenow-dot {
   width: 6px;
   height: 6px;

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -33,6 +33,9 @@ import type {
   WorkbenchPromoteResult,
   TodayCumulativeResponse,
   ActionLogResponse,
+  ApplianceSuggestionsResponse,
+  ApplianceJobsResponse,
+  AppliancesResponse,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -114,6 +117,17 @@ export const getEnergyMonthly = (month: string) =>
   getJson<MonthlyEnergy>(`/energy/monthly?month=${encodeURIComponent(month)}`);
 export const getEnergyTodayCumulative = () =>
   getJson<TodayCumulativeResponse>("/energy/today-cumulative");
+export const getApplianceSuggestions = () =>
+  getJson<ApplianceSuggestionsResponse>("/appliances/suggestions");
+export const getApplianceJobs = (opts?: { status?: string; limit?: number }) => {
+  const p = new URLSearchParams();
+  if (opts?.status) p.set("status", opts.status);
+  if (opts?.limit != null) p.set("limit", String(opts.limit));
+  const qs = p.toString();
+  return getJson<ApplianceJobsResponse>(`/appliances/jobs${qs ? `?${qs}` : ""}`);
+};
+export const getAppliances = () =>
+  getJson<AppliancesResponse>("/appliances");
 export const getActionLog = (opts?: { device?: string; days?: number; limit?: number }) => {
   const p = new URLSearchParams();
   if (opts?.device) p.set("device", opts.device);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -505,6 +505,59 @@ export interface TodayCumulativeResponse {
   export_kwh: number;
   import_cost_gbp: number;       // <0 = we were paid to import (credit)
   export_revenue_gbp: number;
+  // Real-money savings so far today (for the hero "saved £X today" chip).
+  realised_net_cost_gbp?: number;       // net incl. standing; <0 = a credit/paid day
+  delta_vs_fixed_real_gbp?: number;     // £ saved vs the fixed-tariff shadow (>0 = Agile won)
+  delta_vs_svt_real_gbp?: number;       // £ saved vs SVT shadow
+  fixed_shadow_real_gbp?: number;       // counterfactual cost on fixed (for the % off)
+  svt_shadow_real_gbp?: number;
+}
+
+// GET /appliances/suggestions — cheapest upcoming run window per idle appliance.
+export interface ApplianceSuggestion {
+  appliance_id: number;
+  appliance_name: string;
+  recommended_start_utc: string;
+  recommended_end_utc: string;
+  deadline_local: string;
+  duration_minutes: number;
+  avg_price_pence: number;
+  est_kwh: number;
+  est_cost_pence: number;        // signed: <0 = paid to run
+  is_negative: boolean;
+}
+export interface ApplianceSuggestionsResponse {
+  suggestions: ApplianceSuggestion[];
+  count: number;
+}
+
+// GET /appliances/jobs — a scheduled/running/completed appliance cycle.
+export interface ApplianceJob {
+  id: number;
+  appliance_id: number;
+  status: string;                // scheduled | running | completed | cancelled | …
+  planned_start_utc: string | null;
+  planned_end_utc: string | null;
+  avg_price_pence: number | null;
+  duration_minutes: number | null;
+  deadline_utc: string | null;
+}
+export interface ApplianceJobsResponse {
+  jobs: ApplianceJob[];
+  count: number;
+}
+
+// GET /appliances — registered appliances.
+export interface Appliance {
+  id: number;
+  name: string;
+  device_type: string;
+  enabled: boolean;
+  effective_typical_kw?: number;
+  deadline_local_time?: string;
+}
+export interface AppliancesResponse {
+  appliances: Appliance[];
 }
 
 // One executed action from action_log — GET /action-log.

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -18,6 +18,9 @@ import {
   getDhwSchedule,
   getHeatingPlan,
   getEnergyTodayCumulative,
+  getApplianceSuggestions,
+  getApplianceJobs,
+  getAppliances,
 } from "../lib/endpoints";
 import { Link } from "wouter-preact";
 import { Widget } from "../components/common/Widget";
@@ -29,6 +32,7 @@ import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
 import { Hero } from "../components/home/Hero";
 import { HeatingWidget } from "../components/home/HeatingWidget";
 import { WeatherWidget } from "../components/home/WeatherWidget";
+import { ApplianceWidget } from "../components/home/ApplianceWidget";
 import { gbp } from "../lib/format";
 import type { MonthlyEnergy } from "../lib/types";
 import "../components/home/home.css";
@@ -116,6 +120,12 @@ export default function Landing() {
   const heatingPlan = usePoll(getHeatingPlan, 5 * 60_000);
   // Today's grid import/export so far (kWh + real £, credit on negative slots).
   const todayCum = usePoll(getEnergyTodayCumulative, 60_000);
+  // Appliance status: registered list (once) + active jobs + cheapest-window
+  // suggestions for idle machines. All optional/best-effort (SmartThings may be
+  // unconfigured → the widget shows an empty/register hint).
+  const appliances = useFetch(getAppliances, []);
+  const applianceJobs = usePoll(() => getApplianceJobs({ limit: 20 }), 5 * 60_000);
+  const applianceSug = usePoll(getApplianceSuggestions, 5 * 60_000);
   // The shared period navigator drives the Hero headline + cost breakdown +
   // energy chart + tariff comparison. Re-fetch whenever the selection changes.
   const period = usePeriod();
@@ -151,7 +161,7 @@ export default function Landing() {
       <PeriodNavigator />
       <Hero metrics={metrics.data} metricsLoading={metrics.loading} cockpit={data} agile={agile.data} monthly={monthly.data}
             period={periodInsights.data} periodState={period}
-            periodLoading={periodInsights.loading} />
+            periodLoading={periodInsights.loading} todayCum={todayCum.data} />
 
       {/* ── WEATHER (ambient context) ──────────────────────────────── */}
       <div class="widget-grid widget-band">
@@ -171,6 +181,10 @@ export default function Landing() {
         <Widget title="Heating" icon="♨" tone="thermal" size="medium">
           <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data}
                          onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} />
+        </Widget>
+
+        <Widget title="Appliances" icon="🧺" tone="power" size="medium">
+          <ApplianceWidget suggestions={applianceSug.data?.suggestions} jobs={applianceJobs.data?.jobs} appliances={appliances.data?.appliances} />
         </Widget>
       </div>
 


### PR DESCRIPTION
UI-improvements plan, Phase 2 (after the perf phase #507). Backend + UI (two images).

## Hero — "saved today" (item 1)
A prominent, always-current chip independent of the period selector: **"Hoje: crédito £X · economizou £Y (Z% abaixo do fixo)"**. Reuses `compute_daily_pnl`; `/api/v1/energy/today-cumulative` now also returns `realised_net_cost_gbp`, `delta_vs_{fixed,svt}_real_gbp`, `*_shadow_real_gbp`. (On a paid/negative day the % can exceed 100 → shown as "100+".)

## Appliances widget (item 2)
New `medium` widget next to Heating — at a glance per enabled machine:
- **running** → "Rodando agora"
- **scheduled** → "Programado HH:MM–HH:MM · Np/kWh" (from `/appliances/jobs`)
- **idle + cheap window ahead** → "🏷 janela paga|barata HH:MM — Carregue + Smart Control até <deadline>" (new read-only `GET /api/v1/appliances/suggestions` wrapping `compute_appliance_window_suggestions`)
- **none registered** → register hint.
Best-effort — degrades to empty when SmartThings/Fox unconfigured (no external call on the suggestions path).

## Tests
`tests/test_phase2_hero_appliance_api.py` — today-cumulative savings fields; `/appliances/suggestions` shape (negative window → paid) + empty. UI `tsc` typecheck + `vite build` clean. Full suite **1560 passed**.

Deploy: backend image + **UI image** (`ui-publish.yml`) — pin both `HEM_IMAGE_TAG` + `HEM_UI_IMAGE_TAG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)