### PR TITLE
fix(ui): hero money reframe + correct British Gas comparison + appliance next-window (Phase 3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,28 @@ two control-side features ship **off by default** (`DAIKIN_LWT_PREHEAT_ENABLED`,
   across the 6 call sites; scenario variance from the spread. Kill-switch
   `LP_RESIDUAL_PROFILE_V2`; Insights "when you spend the most" heatmap.
 
+### Changed/Fixed — hero money reframe + correct British Gas comparison (2026-06-07, UI Phase 3a)
+- **The hero "saved vs fixed" used the wrong shadow.** It read the generic
+  `delta_vs_fixed_real` (~23p fixed rate + the *Agile* standing) and labelled it
+  "British Gas", inflating the saving (£5.80 vs the correct £5.10). The realised
+  net (−£0.26 credit) was always correct — the £0.59 standing charge legitimately
+  eats most of the negative-price energy credit. Fix: `/energy/today-cumulative`
+  now exposes the **configured fixed-tariff** fields (`delta_vs_fixed_tariff_real_gbp`,
+  `fixed_tariff_shadow_real_gbp`, `fixed_tariff_label` — British Gas's own
+  20.7p + 41.14p standing, import basis) + concrete `earnings_today_gbp`
+  (negative-import credit + export). No `pnl.py` change — the British-Gas fields
+  were already correct; the hero just used the wrong one.
+- **Hero reframed:** one deduped British-Gas line (was 4 "vs fixed" renders), the
+  day's bill ("Conta hoje: crédito £X"), and the concrete "⚡ foi pago £Y (£A
+  import negativo + £B export)" shown only on credit days. The
+  import/standing/export `CostBreakdownChart` is replaced by an **SVG price
+  timeline** (today's import price by tier + now-marker; no ECharts — the hero is
+  above the fold).
+- **Appliance widget** now shows the **next/cheapest available** window even when
+  none is below threshold ("próxima HH:MM · Xp (sem janela barata)") instead of
+  "Sem janela barata" — `compute_appliance_window_suggestions(always=True)` +
+  `meets_threshold`. The push/nudge path keeps the threshold.
+
 ### Added — hero "saved today" + appliance-schedule widget (2026-06-07, UI Phase 2)
 - **Hero shows today's real-money savings** at a glance, independent of the period
   selector: "Hoje: crédito £X · economizou £Y (Z% abaixo do fixo)". Reuses

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3055,21 +3055,30 @@ async def energy_today_cumulative():
 
     today = _dt.now(ZoneInfo(config.BULLETPROOF_TIMEZONE)).date()
     pnl = await asyncio.to_thread(compute_daily_pnl, today)
+    import_cost = float(pnl.get("import_cost_gbp", 0.0) or 0.0)
+    export_rev = float(pnl.get("export_revenue_gbp", 0.0) or 0.0)
+    # "Economia hoje" = money that actually came IN today: the negative-price
+    # import credit (when the metered import cost went negative) + export revenue.
+    # The UI hides this when both are ~0 (a plain spend day).
+    neg_import_credit = max(0.0, -import_cost)
     return {
         "date": today.isoformat(),
         "import_kwh": pnl.get("import_kwh", 0.0),
         "export_kwh": pnl.get("export_kwh", 0.0),
         "import_cost_gbp": pnl.get("import_cost_gbp", 0.0),
         "export_revenue_gbp": pnl.get("export_revenue_gbp", 0.0),
-        # Real-money savings so the hero can show "saved £X today (Y% off)".
-        # net = realised net cost incl. standing (negative = a credit/paid day);
-        # delta_* = real money saved vs the fixed/SVT shadow (positive = Agile
-        # won); *_shadow_real = the counterfactual cost (for the % off).
+        # The day's net bill so far (negative = a credit/paid day).
         "realised_net_cost_gbp": pnl.get("realised_net_cost_gbp", 0.0),
-        "delta_vs_fixed_real_gbp": pnl.get("delta_vs_fixed_real_gbp", 0.0),
-        "delta_vs_svt_real_gbp": pnl.get("delta_vs_svt_real_gbp", 0.0),
-        "fixed_shadow_real_gbp": pnl.get("fixed_shadow_real_gbp", 0.0),
-        "svt_shadow_real_gbp": pnl.get("svt_shadow_real_gbp", 0.0),
+        # Concrete earnings today (negative-import credit + export revenue).
+        "earnings_today_gbp": round(neg_import_credit + export_rev, 4),
+        "negative_import_credit_gbp": round(neg_import_credit, 4),
+        # The CONFIGURED fixed tariff (e.g. British Gas) — the correct shadow on
+        # the IMPORT basis with THAT tariff's own rate + standing. NOT the generic
+        # ~23p `delta_vs_fixed_real` (which mislabels a generic fixed as "British
+        # Gas" and inflates the saving).
+        "fixed_tariff_label": pnl.get("fixed_tariff_label"),
+        "delta_vs_fixed_tariff_real_gbp": pnl.get("delta_vs_fixed_tariff_real_gbp"),
+        "fixed_tariff_shadow_real_gbp": pnl.get("fixed_tariff_shadow_real_gbp"),
     }
 
 

--- a/src/api/routers/appliances.py
+++ b/src/api/routers/appliances.py
@@ -240,9 +240,11 @@ async def appliance_suggestions() -> dict[str, Any]:
     except Exception:
         rates = None
     try:
+        # always=True → surface the cheapest fitting window even when none is
+        # below threshold ("próxima janela") so the widget shows the best time.
         sugg = await asyncio.to_thread(
             appliance_dispatch.compute_appliance_window_suggestions,
-            now, rates, max_price_p=thr, strict=False,
+            now, rates, max_price_p=thr, strict=False, always=True,
         )
     except Exception as e:  # never break the cockpit on a suggestion glitch
         logger.debug("appliance suggestions failed: %s", e)
@@ -258,6 +260,7 @@ async def appliance_suggestions() -> dict[str, Any]:
         "est_kwh": s["est_kwh"],
         "est_cost_pence": s["est_cost_pence"],
         "is_negative": s["is_negative"],
+        "meets_threshold": s.get("meets_threshold", True),
     } for s in sugg]
     return {"suggestions": out, "count": len(out)}
 

--- a/src/scheduler/appliance_dispatch.py
+++ b/src/scheduler/appliance_dispatch.py
@@ -1020,20 +1020,27 @@ def compute_appliance_window_suggestions(
     *,
     max_price_p: float,
     strict: bool,
+    always: bool = False,
 ) -> list[dict[str, Any]]:
-    """Pure compute (no notify, no debounce). When a qualifying (≤/< ``max_price_p``)
-    window exists in the next ``APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS``, return one
-    suggestion per enabled + idle appliance for its cheapest run window before the
-    deadline. Used by both the push path (negative-only) and the brief line
-    (cheap). Returns ``[]`` when nothing qualifies. Never raises on a single
-    appliance — bad rows are skipped.
+    """Pure compute (no notify, no debounce). For each enabled + idle appliance,
+    the cheapest run window before its deadline.
+
+    Two modes:
+    - ``always=False`` (push/nudge + brief): only surface a window that overlaps a
+      detected qualifying (≤/< ``max_price_p``) window; returns ``[]`` when none.
+    - ``always=True`` (cockpit widget): ALWAYS surface the cheapest fitting window
+      even when none is below threshold ("próxima janela") so the widget can show
+      the best available time instead of "no cheap window". ``meets_threshold``
+      flags whether the window is actually cheap.
+
+    Never raises on a single appliance — bad rows are skipped.
     """
     horizon_h = float(getattr(config, "APPLIANCE_WINDOW_NUDGE_HORIZON_HOURS", 24))
     horizon_end = now + timedelta(hours=max(1.0, horizon_h))
     windows = _detect_price_windows(
         rates, now, horizon_end, max_price_p=max_price_p, strict=strict,
     )
-    if not windows:
+    if not windows and not always:
         return []
     out: list[dict[str, Any]] = []
     for app in db.list_appliances(enabled_only=True):
@@ -1060,11 +1067,13 @@ def compute_appliance_window_suggestions(
                 )
             except ValueError:
                 continue  # no fit before the deadline
-            # Coherence guard: the recommended window MUST overlap a detected
-            # qualifying window, else the nudge would advertise a slot that isn't
-            # actually cheap/negative (kills the synthetic _fallback_window=0.0p
-            # case and the deadline-before-the-window case).
-            if not any(ws < end_utc and we > start_utc for ws, we in windows):
+            # Coherence guard (push/nudge only): the recommended window MUST overlap
+            # a detected qualifying window, else the nudge would advertise a slot
+            # that isn't actually cheap/negative (kills the synthetic
+            # _fallback_window=0.0p case + the deadline-before-the-window case). In
+            # ``always`` mode (widget) we surface the cheapest fit regardless.
+            overlaps = any(ws < end_utc and we > start_utc for ws, we in windows)
+            if not always and not overlaps:
                 continue
             kw, _n = _effective_typical_kw(
                 appliance_id, float(app.get("typical_kw") or 0.5),
@@ -1084,6 +1093,9 @@ def compute_appliance_window_suggestions(
                 "est_kwh": est_kwh,
                 "est_cost_pence": est_cost_p,
                 "is_negative": avg_p < 0,
+                # True when this window is genuinely cheap (overlaps a detected
+                # ≤-threshold window); False = "next/cheapest available" only.
+                "meets_threshold": overlaps,
             })
         except Exception as e:  # pragma: no cover — never break the scan
             logger.debug("appliance nudge compute skip #%s: %s", app.get("id"), e)

--- a/tests/test_appliance_window_nudge.py
+++ b/tests/test_appliance_window_nudge.py
@@ -204,6 +204,30 @@ def test_nudge_proceeds_when_smartthings_unavailable(monkeypatch):
     assert len(calls) == 1
 
 
+def test_always_mode_returns_cheapest_when_nothing_cheap(monkeypatch):
+    """always=True (widget): surface the cheapest fitting window even when NO
+    window is below threshold, flagged meets_threshold=False."""
+    _setup_cfg(monkeypatch)
+    now = _now_top_of_hour()
+    _add_washer()
+    _seed_rates(now + timedelta(hours=1), [20.0, 22.0, 25.0, 21.0, 30.0, 28.0])  # all expensive
+    # nudge mode (always=False) → nothing qualifies → empty
+    none_mode = appliance_dispatch.compute_appliance_window_suggestions(
+        now, db.get_rates_for_period("TEST-TARIFF", now, now + timedelta(hours=24)),
+        max_price_p=0.0, strict=True,
+    )
+    assert none_mode == []
+    # widget mode (always=True) → returns the cheapest fit, not cheap
+    sugg = appliance_dispatch.compute_appliance_window_suggestions(
+        now, db.get_rates_for_period("TEST-TARIFF", now, now + timedelta(hours=24)),
+        max_price_p=8.0, strict=False, always=True,
+    )
+    assert len(sugg) == 1
+    s = sugg[0]
+    assert s["meets_threshold"] is False
+    assert s["avg_price_pence"] > 8.0  # genuinely above the cheap threshold
+
+
 def test_nudge_skips_when_no_negative_window(monkeypatch):
     _setup_cfg(monkeypatch)
     calls = _capture_notify(monkeypatch)

--- a/tests/test_phase2_hero_appliance_api.py
+++ b/tests/test_phase2_hero_appliance_api.py
@@ -29,8 +29,9 @@ def test_today_cumulative_exposes_savings_fields(monkeypatch):
     body = r.json()
     for k in (
         "import_kwh", "export_kwh", "import_cost_gbp", "export_revenue_gbp",
-        "realised_net_cost_gbp", "delta_vs_fixed_real_gbp", "delta_vs_svt_real_gbp",
-        "fixed_shadow_real_gbp", "svt_shadow_real_gbp",
+        "realised_net_cost_gbp", "earnings_today_gbp", "negative_import_credit_gbp",
+        # The CONFIGURED fixed tariff (British Gas) — correct shadow, not the generic.
+        "fixed_tariff_label", "delta_vs_fixed_tariff_real_gbp", "fixed_tariff_shadow_real_gbp",
     ):
         assert k in body, f"hero needs {k} in today-cumulative"
 

--- a/ui/src/components/home/ApplianceWidget.tsx
+++ b/ui/src/components/home/ApplianceWidget.tsx
@@ -59,15 +59,27 @@ export function ApplianceWidget({ suggestions, jobs, appliances }: ApplianceWidg
               )
             ) : sug ? (
               <div class="appliance-state appliance-state--idle">
-                <span class={sug.is_negative ? "appliance-tag appliance-tag--paid" : "appliance-tag appliance-tag--cheap"}>
-                  {sug.is_negative ? "janela paga" : "janela barata"}
-                </span>
-                <strong>{fmtLocal(sug.recommended_start_utc)}–{fmtLocal(sug.recommended_end_utc)}</strong>
-                <span class="appliance-price"> · {sug.avg_price_pence.toFixed(1)}p</span>
-                <div class="appliance-cta">Carregue + Smart Control até {sug.deadline_local}</div>
+                {sug.meets_threshold === false ? (
+                  // No cheap window ahead → still show the NEXT/cheapest available.
+                  <>
+                    <span class="appliance-tag appliance-tag--next">próxima</span>
+                    <strong>{fmtLocal(sug.recommended_start_utc)}–{fmtLocal(sug.recommended_end_utc)}</strong>
+                    <span class="appliance-price"> · {sug.avg_price_pence.toFixed(1)}p (sem janela barata)</span>
+                    <div class="appliance-cta">Carregue + Smart Control até {sug.deadline_local}</div>
+                  </>
+                ) : (
+                  <>
+                    <span class={sug.is_negative ? "appliance-tag appliance-tag--paid" : "appliance-tag appliance-tag--cheap"}>
+                      {sug.is_negative ? "janela paga" : "janela barata"}
+                    </span>
+                    <strong>{fmtLocal(sug.recommended_start_utc)}–{fmtLocal(sug.recommended_end_utc)}</strong>
+                    <span class="appliance-price"> · {sug.avg_price_pence.toFixed(1)}p</span>
+                    <div class="appliance-cta">Carregue + Smart Control até {sug.deadline_local}</div>
+                  </>
+                )}
               </div>
             ) : (
-              <div class="appliance-state appliance-state--none muted">Sem janela barata à frente</div>
+              <div class="appliance-state appliance-state--none muted">Sem janela disponível antes do prazo</div>
             )}
           </div>
         );

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -2,7 +2,7 @@ import type { MetricsResponse, CockpitNow, AgileTodayResponse, MonthlyEnergy, Pe
 import { gbp, kwh } from "../../lib/format";
 import { useAnimatedNumber } from "../../lib/useAnimatedNumber";
 import { isCurrentPeriod, periodLabel, type PeriodState } from "../../lib/period";
-import { CostBreakdownChart } from "./CostBreakdownChart";
+import { PriceTimeline } from "./PriceTimeline";
 import "./hero.css";
 
 interface HeroProps {
@@ -33,31 +33,19 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   const isNow = isCurrentPeriod(periodState);
   const label = periodLabel(periodState);
 
-  // --- Always-today real-money savings (independent of the period selector) ---
-  // saved = £ vs the fixed-tariff shadow on the same metered kWh; pct = how much
-  // of that fixed bill we erased (>100% on a paid/negative day → "100+").
-  const savedToday = todayCum?.delta_vs_fixed_real_gbp ?? null;
-  const netToday = todayCum?.realised_net_cost_gbp ?? null;
-  const shadowToday = todayCum?.fixed_shadow_real_gbp ?? null;
-  const pctOffToday = (savedToday != null && shadowToday != null && shadowToday > 0)
-    ? Math.round((savedToday / shadowToday) * 100)
-    : null;
+  // --- TODAY's real money (the hero money block, independent of the period
+  // selector). Uses the CONFIGURED fixed-tariff (British Gas) comparison — NOT
+  // the generic ~23p fixed shadow that mislabels + inflates the saving. ---
+  const gastoToday = todayCum?.realised_net_cost_gbp ?? null;          // net bill (<0 = credit)
+  const savedVsBG = todayCum?.delta_vs_fixed_tariff_real_gbp ?? null;  // £ cheaper than British Gas
+  const fixedLabel = todayCum?.fixed_tariff_label || metrics?.fixed_tariff?.label || "British Gas";
+  const earningsToday = todayCum?.earnings_today_gbp ?? null;          // negative-import credit + export
+  const negCreditToday = todayCum?.negative_import_credit_gbp ?? null;
+  const exportToday = todayCum?.export_revenue_gbp ?? null;
+  const showEarnings = (earningsToday ?? 0) > 0.005;                   // hide on a plain spend day
 
   // --- The selected period, real money (NET, incl standing, measured grid) ---
   const periodNet = period?.cost?.net_cost_pounds ?? null;
-  const periodExport = period?.cost?.export_earnings_pounds ?? null;
-
-  // --- Saved vs the fixed tariff — computed BY THE BACKEND on the same metered
-  // kWh + day-window as the realised cost (no Fox-vs-Octopus meter mixing). ---
-  const savedVsFixed = period?.cost?.delta_vs_fixed_pounds ?? null;
-  const ft = metrics?.fixed_tariff;
-  const fixedLabel = ft?.label || "fixed tariff";
-
-  // --- Today so far — estimate only (realised lands next-day). Shown only when
-  // the current period is in view, so historical browsing stays clean. ---
-  const todayEst = isNow && periodState.gran !== "day"
-    ? (metrics?.pnl?.daily?.delta_vs_fixed_pounds ?? null)
-    : null;
 
   // --- Lifetime totals on Agile (folded in from the old Lifetime widget) ---
   const activeMonths = monthly.filter(
@@ -76,8 +64,9 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
 
   // Smooth tweens for the refreshing figures.
   const periodNetAnim = useAnimatedNumber(periodNet);
-  const savedAnim = useAnimatedNumber(savedVsFixed);
-  const todayAnim = useAnimatedNumber(todayEst);
+  const savedVsBGAnim = useAnimatedNumber(savedVsBG);
+  const gastoTodayAnim = useAnimatedNumber(gastoToday);
+  const earningsTodayAnim = useAnimatedNumber(earningsToday);
   const solarAnim = useAnimatedNumber(lifetime?.solar_kwh ?? null);
   const exportKwhAnim = useAnimatedNumber(lifetime?.export_kwh ?? null);
   const exportEarnAnim = useAnimatedNumber(lifetime?.export_earn ?? null);
@@ -103,28 +92,34 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
         <div class="hero-headline hero-headline--enter">
           {periodNetAnim == null ? (periodLoading ? <SkelHero /> : "—") : gbp(periodNetAnim)}
         </div>
+        {/* TODAY money block — one British-Gas comparison (deduped), the day's
+            bill, and the concrete money earned (negative-import credit + export). */}
         <div class="hero-sublines">
-          {savedAnim != null && (
+          {savedVsBGAnim != null && (
             <div class="hero-subline">
-              <strong class={savedAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
-                {savedAnim >= 0 ? "Saved " : "Extra "}{gbp(Math.abs(savedAnim))}
+              <strong class={savedVsBGAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
+                {savedVsBGAnim >= 0 ? "Economizou " : "Gastou +"}{gbp(Math.abs(savedVsBGAnim))}
               </strong>
-              &nbsp;vs {fixedLabel}
-              {periodExport != null && periodExport > 0 && (
-                <>&nbsp;·&nbsp;<strong class="hero-strong-pos">{gbp(periodExport)}</strong> exported</>
-              )}
+              &nbsp;hoje vs {fixedLabel}
             </div>
           )}
-          {todayAnim != null && (
-            <div class="hero-subline hero-subline-dma">
-              Today so far:&nbsp;
-              <strong class={todayAnim >= 0 ? "hero-strong-pos" : "hero-strong-neg"}>
-                {todayAnim >= 0 ? "Saved " : "Extra "}{gbp(Math.abs(todayAnim))}
-              </strong>
-              &nbsp;vs {fixedLabel}
-              <span class="hero-est-tag" title="Estimate — today's metered cost confirms after the next-day Octopus backfill.">est</span>
-            </div>
-          )}
+          <div class="hero-subline hero-subline-dma">
+            Conta hoje:&nbsp;
+            {gastoTodayAnim == null ? "—"
+              : gastoTodayAnim < 0
+                ? <strong class="hero-strong-pos">crédito {gbp(Math.abs(gastoTodayAnim))}</strong>
+                : <strong>{gbp(gastoTodayAnim)}</strong>}
+            {showEarnings && earningsTodayAnim != null && (
+              <span class="hero-earnings" title="Dinheiro que entrou hoje: crédito da importação a preço negativo + receita de export.">
+                &nbsp;·&nbsp;⚡ foi pago&nbsp;<strong class="hero-strong-pos">{gbp(earningsTodayAnim)}</strong>
+                {(negCreditToday ?? 0) > 0.005 && (exportToday ?? 0) > 0.005
+                  ? <> ({gbp(negCreditToday!)} negativo + {gbp(exportToday!)} export)</>
+                  : (negCreditToday ?? 0) > 0.005
+                    ? <> (import negativo)</>
+                    : <> (export)</>}
+              </span>
+            )}
+          </div>
         </div>
 
         {(curImportP != null || socPct != null) && (
@@ -136,25 +131,6 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
           </div>
         )}
 
-        {savedToday != null && (savedToday > 0.005 || (netToday != null && netToday < 0)) && (
-          <div class="hero-savedtoday" title="Economia real de hoje vs a tarifa fixa — sobre o consumo medido, incluindo standing charge.">
-            <span class="hero-savedtoday-ico" aria-hidden="true">💚</span>
-            <span>
-              Hoje:&nbsp;
-              {netToday != null && netToday < 0
-                ? <strong class="hero-strong-pos">crédito {gbp(Math.abs(netToday))}</strong>
-                : netToday != null ? <strong>{gbp(netToday)}</strong> : null}
-              {savedToday > 0.005 && (
-                <>&nbsp;·&nbsp;economizou&nbsp;
-                  <strong class="hero-strong-pos">{gbp(savedToday)}</strong>
-                  {pctOffToday != null && pctOffToday > 0 && (
-                    <>&nbsp;({pctOffToday > 100 ? "100+" : pctOffToday}% abaixo do {fixedLabel})</>
-                  )}
-                </>
-              )}
-            </span>
-          </div>
-        )}
 
         {lifetime && (
           <div class="hero-lifetime" title={`Sums across ${lifetime.months} active months on Agile`}>
@@ -179,7 +155,11 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
 
       <div class="hero-status">
         <div class="hero-chart">
-          <CostBreakdownChart period={period} label={label} loading={periodLoading} />
+          <PriceTimeline
+            agile={agile}
+            cheapP={metrics?.cheap_threshold_pence}
+            peakP={metrics?.peak_threshold_pence}
+          />
         </div>
       </div>
     </section>

--- a/ui/src/components/home/PriceTimeline.tsx
+++ b/ui/src/components/home/PriceTimeline.tsx
@@ -1,0 +1,91 @@
+import type { AgileTodayResponse } from "../../lib/types";
+import "./price-timeline.css";
+
+interface PriceTimelineProps {
+  agile: AgileTodayResponse | null;
+  cheapP?: number;
+  peakP?: number;
+}
+
+const TIER_COLOR: Record<string, string> = {
+  negative: "var(--neg, #38bdf8)",
+  cheap: "var(--cheap, #36d399)",
+  standard: "var(--text-mute, #8a8f98)",
+  peak: "var(--peak, #f87171)",
+};
+
+function tierOf(p: number, cheapP?: number, peakP?: number): string {
+  if (p < 0) return "negative";
+  if (cheapP != null && p <= cheapP) return "cheap";
+  if (peakP != null && p >= peakP) return "peak";
+  return "standard";
+}
+
+// SVG mini price-timeline (no ECharts — the hero is above the fold). Today's
+// per-slot import price as a tier-coloured bar sparkline with a now-marker.
+// Replaces the import/standing/export cost bars, which "didn't say much".
+export function PriceTimeline({ agile, cheapP, peakP }: PriceTimelineProps) {
+  const slots = agile?.import_slots ?? [];
+  if (slots.length === 0) {
+    return (
+      <div class="price-tl price-tl--empty">
+        <span class="muted">Preços de hoje indisponíveis</span>
+      </div>
+    );
+  }
+
+  const W = 320, H = 116, padT = 6, padB = 4, padX = 3;
+  const prices = slots.map((s) => s.p);
+  const min = Math.min(0, ...prices);
+  const max = Math.max(...prices, 1);
+  const span = max - min || 1;
+  const n = slots.length;
+  const bw = (W - 2 * padX) / n;
+  const y = (p: number) => padT + (1 - (p - min) / span) * (H - padT - padB);
+  const zeroY = y(0);
+
+  const nowMs = agile?.now_utc ? Date.parse(agile.now_utc) : Date.now();
+  let nowIdx = -1;
+  for (let i = 0; i < n; i++) {
+    const a = Date.parse(slots[i].valid_from);
+    const b = Date.parse(slots[i].valid_to);
+    if (nowMs >= a && nowMs < b) { nowIdx = i; break; }
+  }
+
+  return (
+    <div class="price-tl">
+      <div class="price-tl-head">
+        <span>Preço de importação · hoje</span>
+        {agile?.current_import_p != null && (
+          <strong>{agile.current_import_p.toFixed(1)}p</strong>
+        )}
+      </div>
+      <svg viewBox={`0 0 ${W} ${H}`} class="price-tl-svg" preserveAspectRatio="none"
+           role="img" aria-label="Preço de importação por slot, hoje">
+        <line x1={padX} x2={W - padX} y1={zeroY} y2={zeroY}
+              stroke="var(--border)" stroke-width="1" stroke-dasharray="2 3" opacity="0.5" />
+        {slots.map((s, i) => {
+          const tier = s.kind || tierOf(s.p, cheapP, peakP);
+          const col = TIER_COLOR[tier] || TIER_COLOR.standard;
+          const yp = y(s.p);
+          const top = Math.min(yp, zeroY);
+          const h = Math.max(0.6, Math.abs(yp - zeroY));
+          const past = nowIdx >= 0 && i < nowIdx;
+          return (
+            <rect key={i} x={padX + i * bw} y={top} width={Math.max(0.5, bw - 0.4)}
+                  height={h} fill={col} opacity={past ? 0.4 : 0.92} rx={0.4} />
+          );
+        })}
+        {nowIdx >= 0 && (
+          <line x1={padX + (nowIdx + 0.5) * bw} x2={padX + (nowIdx + 0.5) * bw}
+                y1={padT} y2={H - padB} stroke="var(--accent)" stroke-width="1.5" opacity="0.9" />
+        )}
+      </svg>
+      <div class="price-tl-legend">
+        <span><i style="background:var(--neg,#38bdf8)" />pago</span>
+        <span><i style="background:var(--cheap,#36d399)" />barato</span>
+        <span><i style="background:var(--peak,#f87171)" />pico</span>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/home/appliance.css
+++ b/ui/src/components/home/appliance.css
@@ -58,3 +58,7 @@
   color: var(--cheap, #36d399);
   background: color-mix(in srgb, var(--cheap, #36d399) 16%, transparent);
 }
+.appliance-tag--next {
+  color: var(--text-mute, #8a8f98);
+  background: color-mix(in srgb, var(--text-mute, #8a8f98) 16%, transparent);
+}

--- a/ui/src/components/home/price-timeline.css
+++ b/ui/src/components/home/price-timeline.css
@@ -1,0 +1,45 @@
+.price-tl {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  height: 100%;
+  justify-content: center;
+}
+.price-tl--empty {
+  align-items: center;
+  min-height: 120px;
+}
+.price-tl-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: var(--font-xs);
+  color: var(--text-mute);
+}
+.price-tl-head strong {
+  color: var(--text);
+  font-size: var(--font-sm);
+  font-variant-numeric: tabular-nums;
+}
+.price-tl-svg {
+  width: 100%;
+  height: 116px;
+  display: block;
+}
+.price-tl-legend {
+  display: flex;
+  gap: var(--space-3);
+  font-size: 10px;
+  color: var(--text-mute);
+}
+.price-tl-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.price-tl-legend i {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  display: inline-block;
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -505,12 +505,14 @@ export interface TodayCumulativeResponse {
   export_kwh: number;
   import_cost_gbp: number;       // <0 = we were paid to import (credit)
   export_revenue_gbp: number;
-  // Real-money savings so far today (for the hero "saved £X today" chip).
-  realised_net_cost_gbp?: number;       // net incl. standing; <0 = a credit/paid day
-  delta_vs_fixed_real_gbp?: number;     // £ saved vs the fixed-tariff shadow (>0 = Agile won)
-  delta_vs_svt_real_gbp?: number;       // £ saved vs SVT shadow
-  fixed_shadow_real_gbp?: number;       // counterfactual cost on fixed (for the % off)
-  svt_shadow_real_gbp?: number;
+  // Real-money figures for the hero money block (Phase 3a).
+  realised_net_cost_gbp?: number;            // the day's net bill so far; <0 = a credit/paid day
+  earnings_today_gbp?: number;               // money IN today: negative-import credit + export
+  negative_import_credit_gbp?: number;       // the negative-price import credit part
+  // The CONFIGURED fixed tariff (British Gas) — the correct comparison.
+  fixed_tariff_label?: string | null;
+  delta_vs_fixed_tariff_real_gbp?: number | null;  // £ cheaper than British Gas (>0 = Agile won)
+  fixed_tariff_shadow_real_gbp?: number | null;    // what British Gas would have cost
 }
 
 // GET /appliances/suggestions — cheapest upcoming run window per idle appliance.
@@ -525,6 +527,7 @@ export interface ApplianceSuggestion {
   est_kwh: number;
   est_cost_pence: number;        // signed: <0 = paid to run
   is_negative: boolean;
+  meets_threshold?: boolean;     // true = genuinely cheap; false = "next/cheapest available"
 }
 export interface ApplianceSuggestionsResponse {
   suggestions: ApplianceSuggestion[];


### PR DESCRIPTION
Cockpit redesign Phase 3a (fixes first). Backend + UI (two images).

## The money bug (the user's "credit seems small / review the math")
The hero's "saved vs fixed" read the **generic** `delta_vs_fixed_real` (~23p fixed rate + the **Agile** standing) and labelled it "British Gas" → inflated **£5.80**. The **correct** British Gas comparison (the configured `FIXED_TARIFF_*`: 20.7p + 41.14p standing, import basis) was already computed as `delta_vs_fixed_tariff_real_gbp` = **£5.10**. The realised net (**−£0.26** credit) was always correct — the £0.59 standing charge legitimately eats most of the −£0.75 negative-price energy credit. **No `pnl.py` change** — just use the right field.

## Hero reframe (the user's spec)
- **Conta hoje** = the day's net bill ("crédito £0.26" when paid).
- **Economia** = concrete money in = negative-import credit + export, shown only on credit days ("⚡ foi pago £0.86 (£0.75 negativo + £0.11 export)").
- **vs British Gas** = ONE deduped line (was 4 "vs fixed" renders), now the correct £5.10.
- The import/standing/export `CostBreakdownChart` → a new **SVG `PriceTimeline`** (today's import price by tier + now-marker). SVG, not ECharts — the hero is above the fold.

## Appliance widget
Shows the **next/cheapest available** window even when none is below threshold ("próxima HH:MM · Xp (sem janela barata)") instead of "Sem janela barata" — `compute_appliance_window_suggestions(always=True)` + `meets_threshold`. The push/nudge path keeps the threshold.

## Tests
today-cumulative BG/earnings fields; always-mode returns the cheapest + `meets_threshold=False`. UI `tsc` + `vite build` clean. Full suite **1561 passed**.

Deploy: backend + UI images (pin both `HEM_IMAGE_TAG` + `HEM_UI_IMAGE_TAG`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)