### PR TITLE
fix(ui): correct lifetime "vs fixed" + show standing in hero credit

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2766,6 +2766,22 @@ async def energy_monthly(month: str):
             detail="Failed to fetch monthly data from Fox ESS. Try again later.",
         )
     cost = insights.cost
+    # The authoritative slot-level PnL vs the configured fixed tariff (British
+    # Gas), import basis. The monthly `delta_vs_fixed_*` above is a coarser
+    # Fox-energy aggregate that can flip sign on Agile months and counts
+    # pre-Agile months too — so the hero's lifetime "saved vs fixed" must use
+    # THIS field. None for pre-Agile months (AGILE_TARIFF_START_DATE clamp).
+    delta_vs_fixed_real_pounds: float | None = None
+    try:
+        from datetime import date as _date
+
+        from ..analytics.pnl import compute_monthly_pnl
+
+        anchor = _date(year, month_num, 15)
+        mpnl = await asyncio.to_thread(compute_monthly_pnl, anchor)
+        delta_vs_fixed_real_pounds = mpnl.get("delta_vs_fixed_tariff_real_gbp")
+    except Exception as e:  # pragma: no cover - defensive; lifetime stat is non-critical
+        logger.debug("monthly BG-real delta unavailable for %s: %s", month, e)
     return MonthlyInsightsResponse(
         energy=MonthlyEnergySummaryResponse(
             year=insights.energy.year,
@@ -2790,6 +2806,7 @@ async def energy_monthly(month: str):
             fixed_shadow_pounds=cost.fixed_shadow_pounds,
             delta_vs_fixed_pence=cost.delta_vs_fixed_pence,
             delta_vs_fixed_pounds=cost.delta_vs_fixed_pounds,
+            delta_vs_fixed_real_pounds=delta_vs_fixed_real_pounds,
         ),
         heating_estimate_kwh=insights.heating_estimate_kwh,
         heating_estimate_cost_pence=insights.heating_estimate_cost_pence,
@@ -3069,6 +3086,10 @@ async def energy_today_cumulative():
         "export_revenue_gbp": pnl.get("export_revenue_gbp", 0.0),
         # The day's net bill so far (negative = a credit/paid day).
         "realised_net_cost_gbp": pnl.get("realised_net_cost_gbp", 0.0),
+        # The fixed daily standing charge baked into the net — surfaced so the
+        # money block is honest (e.g. earned £0.85 but £0.59 standing → only a
+        # £0.26 credit). Without this the credit "looks too small".
+        "standing_charge_gbp": pnl.get("standing_charge_gbp", 0.0),
         # Concrete earnings today (negative-import credit + export revenue).
         "earnings_today_gbp": round(neg_import_credit + export_rev, 4),
         "negative_import_credit_gbp": round(neg_import_credit, 4),

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -268,6 +268,13 @@ class MonthlyCostSummaryResponse(BaseModel):
     fixed_shadow_pounds: float | None = None
     delta_vs_fixed_pence: float | None = None
     delta_vs_fixed_pounds: float | None = None
+    # The authoritative slot-level PnL comparison vs the configured fixed tariff
+    # (British Gas) on the IMPORT basis — `compute_monthly_pnl`'s
+    # delta_vs_fixed_tariff_real_gbp. Differs from `delta_vs_fixed_*` above,
+    # which is a coarser Fox-energy aggregate that can flip sign on Agile months.
+    # None for pre-Agile months (clamped by AGILE_TARIFF_START_DATE). Positive =
+    # Agile cheaper. Use THIS for lifetime "saved vs British Gas".
+    delta_vs_fixed_real_pounds: float | None = None
 
 
 class MonthlyInsightsResponse(BaseModel):

--- a/tests/test_phase2_hero_appliance_api.py
+++ b/tests/test_phase2_hero_appliance_api.py
@@ -30,10 +30,51 @@ def test_today_cumulative_exposes_savings_fields(monkeypatch):
     for k in (
         "import_kwh", "export_kwh", "import_cost_gbp", "export_revenue_gbp",
         "realised_net_cost_gbp", "earnings_today_gbp", "negative_import_credit_gbp",
+        # The standing charge is surfaced so the credit math is explicit
+        # (earned − standing = net) and doesn't "look too small".
+        "standing_charge_gbp",
         # The CONFIGURED fixed tariff (British Gas) — correct shadow, not the generic.
         "fixed_tariff_label", "delta_vs_fixed_tariff_real_gbp", "fixed_tariff_shadow_real_gbp",
     ):
         assert k in body, f"hero needs {k} in today-cumulative"
+
+
+def test_monthly_exposes_bg_real_delta(monkeypatch):
+    """/energy/monthly must surface the authoritative slot-level British-Gas
+    delta (compute_monthly_pnl) as `delta_vs_fixed_real_pounds` — the hero's
+    lifetime "saved vs fixed" sums THIS, not the coarse Fox-energy delta which
+    flips sign on Agile months."""
+    db.init_db()
+    client = _client(monkeypatch)
+
+    from src.energy.monthly import (
+        MonthlyCostSummary,
+        MonthlyEnergySummary,
+        MonthlyInsights,
+    )
+
+    fake = MonthlyInsights(
+        energy=MonthlyEnergySummary(year=2026, month=5, month_str="2026-05"),
+        cost=MonthlyCostSummary(
+            net_cost_pence=8696.0,
+            # The coarse delta disagrees with the real one (the bug under test).
+            delta_vs_fixed_pence=-1263.0,
+        ),
+    )
+    monkeypatch.setattr("src.api.main._foxess_configured", lambda: True)
+    monkeypatch.setattr("src.api.main.get_monthly_insights", lambda y, m: fake)
+    monkeypatch.setattr(
+        "src.analytics.pnl.compute_monthly_pnl",
+        lambda anchor: {"delta_vs_fixed_tariff_real_gbp": 6.19},
+    )
+
+    r = client.get("/api/v1/energy/monthly?month=2026-05")
+    assert r.status_code == 200, r.text
+    cost = r.json()["cost"]
+    # The new authoritative field carries the real (positive = Agile won) delta…
+    assert cost["delta_vs_fixed_real_pounds"] == 6.19
+    # …while the legacy coarse field is left untouched (kept for other consumers).
+    assert cost["delta_vs_fixed_pounds"] == -12.63
 
 
 def _seed_rates(start_utc: datetime, prices: list[float]) -> None:

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -42,6 +42,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   const earningsToday = todayCum?.earnings_today_gbp ?? null;          // negative-import credit + export
   const negCreditToday = todayCum?.negative_import_credit_gbp ?? null;
   const exportToday = todayCum?.export_revenue_gbp ?? null;
+  const standingToday = todayCum?.standing_charge_gbp ?? null;         // fixed daily standing in the net
   const showEarnings = (earningsToday ?? 0) > 0.005;                   // hide on a plain spend day
 
   // --- The selected period, real money (NET, incl standing, measured grid) ---
@@ -58,7 +59,11 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
         export_kwh: activeMonths.reduce((s, m) => s + (m.energy?.export_kwh ?? 0), 0),
         export_earn: activeMonths.reduce((s, m) => s + (m.cost?.export_earnings_pounds ?? 0), 0),
         total_cost: activeMonths.reduce((s, m) => s + (m.cost?.net_cost_pounds ?? 0), 0),
-        saved_vs_fixed: activeMonths.reduce((s, m) => s + (m.cost?.delta_vs_fixed_pounds ?? 0), 0),
+        // Use the authoritative slot-level British-Gas comparison
+        // (delta_vs_fixed_real_pounds), NOT the coarse Fox-energy delta which
+        // flips sign on Agile months and counts pre-Agile months. null months
+        // (pre-Agile) contribute 0, so this is the on-Agile saving.
+        saved_vs_fixed: activeMonths.reduce((s, m) => s + (m.cost?.delta_vs_fixed_real_pounds ?? 0), 0),
       }
     : null;
 
@@ -110,13 +115,16 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
                 ? <strong class="hero-strong-pos">crédito {gbp(Math.abs(gastoTodayAnim))}</strong>
                 : <strong>{gbp(gastoTodayAnim)}</strong>}
             {showEarnings && earningsTodayAnim != null && (
-              <span class="hero-earnings" title="Dinheiro que entrou hoje: crédito da importação a preço negativo + receita de export.">
+              <span class="hero-earnings" title="Dinheiro que entrou hoje: crédito da importação a preço negativo + receita de export. A standing charge fixa do dia é descontada para chegar na conta.">
                 &nbsp;·&nbsp;⚡ foi pago&nbsp;<strong class="hero-strong-pos">{gbp(earningsTodayAnim)}</strong>
                 {(negCreditToday ?? 0) > 0.005 && (exportToday ?? 0) > 0.005
                   ? <> ({gbp(negCreditToday!)} negativo + {gbp(exportToday!)} export)</>
                   : (negCreditToday ?? 0) > 0.005
                     ? <> (import negativo)</>
                     : <> (export)</>}
+                {(standingToday ?? 0) > 0.005 && (
+                  <span class="hero-standing"> &minus; {gbp(standingToday!)} standing</span>
+                )}
               </span>
             )}
           </div>

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -124,6 +124,10 @@
  * inline colour; surrounding label stays dim so only the figure carries it. */
 .hero-strong-pos { color: var(--ok); font-weight: 600; }
 .hero-strong-neg { color: var(--bad); font-weight: 600; }
+/* The standing-charge deduction in the "foi pago" breakdown — recessed so the
+ * earned figure stays prominent while the arithmetic (earned − standing = net)
+ * still reads. */
+.hero-standing { color: var(--text-mute); white-space: nowrap; }
 /* "est" tag on the intraday today figure — quiet, italic, recessed. */
 .hero-est-tag {
   margin-left: 6px;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -368,6 +368,10 @@ export interface MonthlyEnergyCost {
   fixed_shadow_pounds?: number | null;
   delta_vs_fixed_pence?: number | null;
   delta_vs_fixed_pounds?: number | null;
+  // Authoritative slot-level PnL vs the configured fixed tariff (British Gas),
+  // import basis. Use THIS for "saved vs fixed" — the coarse delta_vs_fixed_*
+  // above can flip sign on Agile months. null for pre-Agile months.
+  delta_vs_fixed_real_pounds?: number | null;
 }
 export interface MonthlyEnergy {
   energy: MonthlyEnergyEnergy;
@@ -507,6 +511,7 @@ export interface TodayCumulativeResponse {
   export_revenue_gbp: number;
   // Real-money figures for the hero money block (Phase 3a).
   realised_net_cost_gbp?: number;            // the day's net bill so far; <0 = a credit/paid day
+  standing_charge_gbp?: number;              // fixed daily standing charge baked into the net
   earnings_today_gbp?: number;               // money IN today: negative-import credit + export
   negative_import_credit_gbp?: number;       // the negative-price import credit part
   // The CONFIGURED fixed tariff (British Gas) — the correct comparison.


### PR DESCRIPTION
## What

Two hero money-display fixes flagged on the live cockpit:

### (a) Lifetime "extra/saved vs fixed" was wrong (`£105.67 extra`)
The hero's lifetime stat summed each month's `delta_vs_fixed_pounds` — the **coarse Fox-energy** monthly delta. That figure flips sign vs the authoritative slot-level PnL on Agile months (e.g. Apr: coarse −£8.32 vs real **+£13.12**) and also counts **pre-Agile** months (Jan–Mar, before the household joined Agile), summing to a bogus **−£105.67 "extra vs fixed"**.

The correct British-Gas comparison already exists: `compute_monthly_pnl().delta_vs_fixed_tariff_real_gbp` (import basis, 20.7p + 41.14p standing, clamped to `AGILE_TARIFF_START_DATE` → `None` pre-Agile). `/energy/monthly` now exposes it as `delta_vs_fixed_real_pounds`, and the hero lifetime sums **that** → the real **+£22 saved** on Agile. `None` months contribute 0, so only on-Agile months count.

### (b) Standing charge invisible in the "foi pago" credit
On a negative-price day the hero showed `⚡ foi pago £0.85 (£0.75 negativo + £0.11 export)` but the resulting net credit was only £0.26 — looking "too small" because the £0.59 daily standing charge was invisible. `/energy/today-cumulative` now returns `standing_charge_gbp` and the hero shows it in the breakdown (`earned £0.85 − £0.59 standing → crédito £0.26`), closing the arithmetic.

## Notes
- **Realised PnL is unchanged** — both are display/aggregation fixes.
- The legacy coarse `delta_vs_fixed_*` fields are kept untouched for other consumers.

## Tests
- `tests/test_phase2_hero_appliance_api.py`: `today-cumulative` now asserts `standing_charge_gbp`; new `test_monthly_exposes_bg_real_delta` asserts `/energy/monthly` surfaces the real delta while leaving the coarse one intact.
- UI typecheck + build clean; pnl/monthly/cache suites green.

Tracked by #469 (Home/period engine unification — same "correct vs-fixed basis" theme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)