### PR TITLE
feat(ui,api): Phase 3b — 4 synced timeline widgets + per-slot grid rollup

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -231,6 +231,129 @@ async def get_pv_today(date: str | None = None) -> dict[str, Any]:
     }
 
 
+@router.get("/api/v1/grid/today")
+async def get_grid_today(date: str | None = None) -> dict[str, Any]:
+    """Per-slot planned-vs-realised GRID import/export for the UTC day.
+
+    The Home "Grid" widget's data: for each 30-min UTC slot, the *committed
+    plan's* grid import/export (stitched across the day's solves, like the PV
+    line) and the *realised* import/export (trapezoidal roll-up of
+    ``pv_realtime_history.grid_import_kw`` / ``grid_export_kw``). Closes the gap
+    where ``/execution/today`` carried load but no grid traffic.
+
+    Query params:
+      * ``date`` — optional ``YYYY-MM-DD`` (UTC day). Defaults to today UTC.
+
+    Response mirrors ``/pv/today``:
+      * ``slots[]`` — ``{slot_utc, import_planned_kwh, export_planned_kwh,
+        import_actual_kwh, export_actual_kwh, import_price_p, kind}``. Actuals
+        are ``null`` for future slots (and elapsed slots with no telemetry) so
+        the chart draws a clean planned-only line ahead of now.
+      * ``totals`` — day sums for planned + (elapsed-so-far) realised.
+      * ``now_utc``, ``plan_run_id``.
+    """
+    if date:
+        try:
+            d = _date_from_iso(date)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="date must be YYYY-MM-DD")
+    else:
+        d = datetime.now(UTC).date()
+
+    day_start = datetime(d.year, d.month, d.day, tzinfo=UTC)
+    slot_starts = [day_start + timedelta(minutes=_SLOT_MINUTES * i) for i in range(_SLOTS_PER_DAY)]
+    now = datetime.now(UTC)
+
+    # --- Committed plan: stitched per-slot grid import/export from the LP
+    # snapshots (same stitch the PV line uses, so elapsed slots keep the plan
+    # that was current when they began rather than a hole). Keys are stored
+    # (+00:00) form → normalise to the ...Z slot key.
+    plan_imp: dict[str, float] = {}
+    plan_exp: dict[str, float] = {}
+    try:
+        plan_imp = {_norm_z(k): float(v) for k, v in db.committed_lp_field_by_slot(d, "import_kwh").items()}
+        plan_exp = {_norm_z(k): float(v) for k, v in db.committed_lp_field_by_slot(d, "export_kwh").items()}
+    except Exception as e:
+        logger.warning("grid/today: committed-plan grid lookup failed (%s)", e)
+
+    # --- Realised import/export: trapezoidal roll-up of pv_realtime_history
+    # (the same helpers the PnL engine costs against). Keys are ...Z form.
+    act_imp: dict[str, float] = {}
+    act_exp: dict[str, float] = {}
+    try:
+        act_imp = {_norm_z(k): float(v) for k, v in db.half_hourly_grid_import_kwh_for_day(d).items()}
+        act_exp = {_norm_z(k): float(v) for k, v in db.half_hourly_grid_export_kwh_for_day(d).items()}
+    except Exception as e:
+        logger.warning("grid/today: realised grid roll-up failed (%s)", e)
+
+    # --- Import price + dispatch kind overlays (one endpoint feeds the chart).
+    price_by_start: dict[str, float] = {}
+    try:
+        tariff = (config.OCTOPUS_TARIFF_CODE or "").strip()
+        if tariff:
+            for r in db.get_rates_for_period(tariff, day_start, day_start + timedelta(days=1)):
+                price_by_start[_norm_z(r["valid_from"])] = float(r["value_inc_vat"])
+    except Exception as e:
+        logger.warning("grid/today: import-rate lookup failed (%s)", e)
+
+    rid: int | None = None
+    kind_by: dict[str, str] = {}
+    try:
+        when = _iso_z(min(day_start + timedelta(days=1), now))
+        rid = db.find_run_for_time(when) or db.find_latest_optimizer_run_id()
+        if rid is not None:
+            for dec in db.get_dispatch_decisions(rid):
+                k = dec.get("dispatched_kind") or dec.get("lp_kind")
+                stu = dec.get("slot_time_utc")
+                if k and stu:
+                    kind_by[_norm_z(stu)] = k
+    except Exception as e:
+        logger.warning("grid/today: run/kind lookup failed (%s)", e)
+
+    slots_out: list[dict[str, Any]] = []
+    t_pimp = t_pexp = t_aimp = t_aexp = 0.0
+    for st in slot_starts:
+        key = _iso_z(st)
+        slot_end = st + timedelta(minutes=_SLOT_MINUTES)
+        elapsed = slot_end <= now
+        pi = plan_imp.get(key)
+        pe = plan_exp.get(key)
+        ai_raw = act_imp.get(key)
+        ae_raw = act_exp.get(key)
+        ai = round(float(ai_raw), 4) if (elapsed and ai_raw is not None) else None
+        ae = round(float(ae_raw), 4) if (elapsed and ae_raw is not None) else None
+        slots_out.append({
+            "slot_utc": key,
+            "import_planned_kwh": round(pi, 4) if pi is not None else None,
+            "export_planned_kwh": round(pe, 4) if pe is not None else None,
+            "import_actual_kwh": ai,
+            "export_actual_kwh": ae,
+            "import_price_p": price_by_start.get(key),
+            "kind": kind_by.get(key),
+        })
+        if pi is not None:
+            t_pimp += pi
+        if pe is not None:
+            t_pexp += pe
+        if ai is not None:
+            t_aimp += ai
+        if ae is not None:
+            t_aexp += ae
+
+    return {
+        "date": d.isoformat(),
+        "now_utc": _iso_z(now),
+        "slots": slots_out,
+        "totals": {
+            "import_planned_kwh": round(t_pimp, 3),
+            "export_planned_kwh": round(t_pexp, 3),
+            "import_actual_kwh": round(t_aimp, 3),
+            "export_actual_kwh": round(t_aexp, 3),
+        },
+        "plan_run_id": rid,
+    }
+
+
 def _date_from_iso(s: str) -> date:
     return date.fromisoformat(s)
 

--- a/src/db.py
+++ b/src/db.py
@@ -4528,42 +4528,54 @@ def _parse_iso_utc(s: str | None) -> datetime | None:
         return None
 
 
-def committed_pv_forecast_by_slot(day: date) -> dict[str, float]:
-    """Per-slot committed PV-generation forecast for ``day`` (issue #462).
+# Numeric lp_solution_snapshot columns that may be stitched per-slot. Whitelisted
+# so the column name can be interpolated into SQL safely (never user-supplied).
+_STITCHABLE_LP_FIELDS = frozenset({
+    "pv_forecast_kwh", "import_kwh", "export_kwh", "charge_kwh", "discharge_kwh",
+    "pv_use_kwh", "dhw_kwh", "space_kwh", "soc_kwh", "tank_temp_c", "lwt_offset_c",
+})
+
+
+def committed_lp_field_by_slot(day: date, field: str) -> dict[str, float]:
+    """Per-slot committed value of an ``lp_solution_snapshot`` column for ``day``.
 
     The latest LP solve only covers ``run_at → horizon``, so a single snapshot
-    leaves a hole over the morning by evening (why /pv/today showed "0 expected
-    by now"). This STITCHES across every solve of the day: for each slot it
-    returns the ``pv_forecast_kwh`` from the most recent solve whose ``run_at <=
-    slot_start`` (the forecast as known when the slot began); if none qualifies
-    (e.g. the day's first solve fired after that slot), it falls back to the
-    EARLIEST solve that forecast the slot. Future slots naturally resolve to the
-    latest committed plan (their start is after every run_at).
+    leaves a hole over the morning by evening. This STITCHES across every solve
+    of the day: for each slot it returns the column from the most recent solve
+    whose ``run_at <= slot_start`` (the plan as known when the slot began); if
+    none qualifies (the day's first solve fired after that slot), it falls back
+    to the EARLIEST solve that covered the slot. Future slots naturally resolve
+    to the latest committed plan (their start is after every run_at).
 
-    Returns ``{slot_time_utc (stored form): pv_forecast_kwh}``. Empty on error.
+    ``field`` must be one of :data:`_STITCHABLE_LP_FIELDS` (whitelisted — the
+    name is interpolated into SQL). Returns ``{slot_time_utc (stored form):
+    value}``. Empty on error or unknown field.
     """
+    if field not in _STITCHABLE_LP_FIELDS:
+        logger.warning("committed_lp_field_by_slot: refusing unknown field %r", field)
+        return {}
     day_start = datetime(day.year, day.month, day.day, tzinfo=UTC)
     day_end = day_start + timedelta(days=1)
     with _lock:
         conn = get_connection()
         try:
             rows = conn.execute(
-                """SELECT s.slot_time_utc, s.pv_forecast_kwh, o.run_at
+                f"""SELECT s.slot_time_utc, s.{field}, o.run_at
                    FROM lp_solution_snapshot s
                    JOIN optimizer_log o ON s.run_id = o.id
                    WHERE s.slot_time_utc >= ? AND s.slot_time_utc < ?
-                     AND s.pv_forecast_kwh IS NOT NULL""",
+                     AND s.{field} IS NOT NULL""",
                 (day_start.isoformat(), day_end.isoformat()),
             ).fetchall()
         except sqlite3.Error as e:
-            logger.warning("committed_pv_forecast_by_slot query failed: %s", e)
+            logger.warning("committed_lp_field_by_slot(%s) query failed: %s", field, e)
             return {}
         finally:
             conn.close()
 
     # Per slot, pick: latest eligible run (run_at <= slot_start); else earliest.
     best: dict[str, tuple[datetime, float, bool]] = {}
-    for slot_iso, kwh, run_at in rows:
+    for slot_iso, val, run_at in rows:
         slot_dt = _parse_iso_utc(slot_iso)
         run_dt = _parse_iso_utc(run_at)
         if slot_dt is None or run_dt is None:
@@ -4571,19 +4583,29 @@ def committed_pv_forecast_by_slot(day: date) -> dict[str, float]:
         eligible = run_dt <= slot_dt
         cur = best.get(slot_iso)
         if cur is None:
-            best[slot_iso] = (run_dt, float(kwh), eligible)
+            best[slot_iso] = (run_dt, float(val), eligible)
             continue
-        c_run, _c_kwh, c_elig = cur
+        c_run, _c_val, c_elig = cur
         if eligible and not c_elig:
-            best[slot_iso] = (run_dt, float(kwh), True)  # eligible beats not
+            best[slot_iso] = (run_dt, float(val), True)  # eligible beats not
         elif eligible and c_elig:
-            if run_dt > c_run:  # most recent forecast known at slot start
-                best[slot_iso] = (run_dt, float(kwh), True)
+            if run_dt > c_run:  # most recent value known at slot start
+                best[slot_iso] = (run_dt, float(val), True)
         elif (not eligible) and (not c_elig):
-            if run_dt < c_run:  # earliest forecast ever made for the slot
-                best[slot_iso] = (run_dt, float(kwh), False)
+            if run_dt < c_run:  # earliest value ever planned for the slot
+                best[slot_iso] = (run_dt, float(val), False)
         # else: keep the existing eligible row over a non-eligible newcomer
     return {k: v[1] for k, v in best.items()}
+
+
+def committed_pv_forecast_by_slot(day: date) -> dict[str, float]:
+    """Per-slot committed PV-generation forecast for ``day`` (issue #462).
+
+    Thin wrapper over :func:`committed_lp_field_by_slot` for ``pv_forecast_kwh``
+    — kept as a named entry point for the many existing callers (/pv/today,
+    rebuild_pv_error_log_for_date). Returns ``{slot_time_utc: pv_forecast_kwh}``.
+    """
+    return committed_lp_field_by_slot(day, "pv_forecast_kwh")
 
 
 def rebuild_pv_error_log_for_date(day: date) -> int:

--- a/tests/test_grid_today.py
+++ b/tests/test_grid_today.py
@@ -1,0 +1,97 @@
+"""Phase 3b backend: GET /api/v1/grid/today per-slot planned-vs-realised grid.
+
+The Grid widget needs per-slot grid import/export — which /execution/today
+never carried. This endpoint stitches the committed LP plan (import_kwh /
+export_kwh) and rolls up realised grid traffic from pv_realtime_history. The
+partition rule (actuals only for ELAPSED slots, planned for all) is the bit
+worth pinning, so the chart never plots a future actual or a hole in the plan.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from src import db
+from src.config import config
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr(config, "HEM_UI_AUTH_REQUIRED", False, raising=False)
+    from src.api.main import app
+    return TestClient(app)
+
+
+def _z(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def test_grid_today_partitions_planned_and_actual(monkeypatch):
+    db.init_db()
+    client = _client(monkeypatch)
+
+    # A past UTC day → every slot is elapsed, so seeded actuals must surface.
+    day = (datetime.now(UTC) - timedelta(days=2)).date()
+    day_start = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    s0 = _z(day_start)                                   # 00:00
+    s1 = _z(day_start + timedelta(minutes=30))           # 00:30
+
+    # Committed plan covers both slots; realised only seeded for slot 0.
+    monkeypatch.setattr(db, "committed_lp_field_by_slot",
+                        lambda d, field: {s0: 0.8, s1: 0.5} if field == "import_kwh"
+                        else {s0: 0.0, s1: 0.2})
+    monkeypatch.setattr(db, "half_hourly_grid_import_kwh_for_day", lambda d: {s0: 0.91})
+    monkeypatch.setattr(db, "half_hourly_grid_export_kwh_for_day", lambda d: {})
+    monkeypatch.setattr(db, "get_rates_for_period", lambda *a, **k: [])
+    monkeypatch.setattr(db, "find_run_for_time", lambda when: None)
+    monkeypatch.setattr(db, "find_latest_optimizer_run_id", lambda: None)
+
+    r = client.get(f"/api/v1/grid/today?date={day.isoformat()}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    by = {s["slot_utc"]: s for s in body["slots"]}
+
+    # Slot 0: plan + realised import both present; no export realised → null.
+    assert by[s0]["import_planned_kwh"] == 0.8
+    assert by[s0]["import_actual_kwh"] == 0.91
+    assert by[s0]["export_actual_kwh"] is None
+    # Slot 1: plan present, but NO realised import seeded → actual stays null
+    # even though the slot is elapsed (no telemetry, not a zero).
+    assert by[s1]["import_planned_kwh"] == 0.5
+    assert by[s1]["export_planned_kwh"] == 0.2
+    assert by[s1]["import_actual_kwh"] is None
+
+    # Totals: planned sums everything; realised sums only what was measured.
+    assert round(body["totals"]["import_planned_kwh"], 3) == 1.3
+    assert round(body["totals"]["import_actual_kwh"], 3) == 0.91
+
+
+def test_grid_today_future_day_has_plan_but_no_actuals(monkeypatch):
+    """A future day: every slot is ahead of now → actuals null, plan still drawn."""
+    db.init_db()
+    client = _client(monkeypatch)
+
+    day = (datetime.now(UTC) + timedelta(days=1)).date()
+    day_start = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    s0 = _z(day_start)
+
+    monkeypatch.setattr(db, "committed_lp_field_by_slot",
+                        lambda d, field: {s0: 1.2} if field == "import_kwh" else {})
+    # Even if telemetry somehow existed, a future slot must not show an actual.
+    monkeypatch.setattr(db, "half_hourly_grid_import_kwh_for_day", lambda d: {s0: 99.0})
+    monkeypatch.setattr(db, "half_hourly_grid_export_kwh_for_day", lambda d: {})
+    monkeypatch.setattr(db, "get_rates_for_period", lambda *a, **k: [])
+    monkeypatch.setattr(db, "find_run_for_time", lambda when: None)
+    monkeypatch.setattr(db, "find_latest_optimizer_run_id", lambda: None)
+
+    body = client.get(f"/api/v1/grid/today?date={day.isoformat()}").json()
+    by = {s["slot_utc"]: s for s in body["slots"]}
+    assert by[s0]["import_planned_kwh"] == 1.2
+    assert by[s0]["import_actual_kwh"] is None        # future → null, never 99
+    assert body["totals"]["import_actual_kwh"] == 0.0
+
+
+def test_committed_lp_field_by_slot_rejects_unknown_column():
+    """Defensive: the field name is interpolated into SQL → must be whitelisted."""
+    from datetime import date
+    assert db.committed_lp_field_by_slot(date(2026, 1, 1), "import_kwh; DROP TABLE x") == {}

--- a/ui/src/components/home/GridWidget.tsx
+++ b/ui/src/components/home/GridWidget.tsx
@@ -1,0 +1,91 @@
+import { chartTheme, withAlpha } from "../../lib/charts";
+import { useFetch } from "../../lib/poll";
+import { getGridToday } from "../../lib/endpoints";
+import { MetricTimeline, localHM, nowIndexOf, periodPointLabel, type TimelineLine } from "./MetricTimeline";
+import { Spinner } from "../common/Spinner";
+import type { PeriodInsightsResponse } from "../../lib/types";
+import { isCurrentPeriod, type PeriodState } from "../../lib/period";
+import "./timeline-widget.css";
+
+interface Props {
+  period: PeriodState;
+  periodData: PeriodInsightsResponse | null;
+  periodLoading: boolean;
+  cheapP?: number | null;
+  peakP?: number | null;
+}
+
+// Grid timeline, synced to the period navigator. Day → committed-plan vs
+// realised import/export (the new /grid/today rollup — closes "Today's plan had
+// no grid"). Week/month/year → daily import/export actuals as bars.
+export function GridWidget({ period, periodData, periodLoading, cheapP, peakP }: Props) {
+  const isDay = period.gran === "day";
+  // Current day → endpoint UTC-today default; historical → anchor (see SolarWidget).
+  const dayArg = isCurrentPeriod(period) ? undefined : period.anchor;
+  const day = useFetch(() => (isDay ? getGridToday(dayArg) : Promise.resolve(null)), [isDay, dayArg]);
+  const t = chartTheme();
+
+  if (isDay) {
+    const slots = day.data?.slots ?? [];
+    if (day.loading && !slots.length) return <Spinner label="Loading grid…" />;
+    if (!slots.length) return <p class="muted">No grid data for this day yet.</p>;
+    const labels = slots.map((s) => localHM(s.slot_utc));
+    const nowIdx = nowIndexOf(slots, day.data?.now_utc);
+    const prices = slots.map((s) => s.import_price_p ?? null);
+    // Export drawn negative so import-above / export-below reads instantly.
+    const impPlan = slots.map((s) => (s.import_planned_kwh == null ? null : round2(s.import_planned_kwh)));
+    const impAct = slots.map((s) => (s.import_actual_kwh == null ? null : round2(s.import_actual_kwh)));
+    const expPlan = slots.map((s) => (s.export_planned_kwh == null ? null : -round2(s.export_planned_kwh)));
+    const expAct = slots.map((s) => (s.export_actual_kwh == null ? null : -round2(s.export_actual_kwh)));
+    const lines: TimelineLine[] = [
+      { name: "Import plan", color: withAlpha(t.importColor, 0.5), data: impPlan, dashed: true },
+      { name: "Import", color: t.importColor, data: impAct, area: true, width: 2.5 },
+      { name: "Export plan", color: withAlpha(t.exportColor, 0.5), data: expPlan, dashed: true },
+      { name: "Export", color: t.exportColor, data: expAct, area: true, width: 2.5 },
+    ];
+    const tot = day.data?.totals;
+    return (
+      <div class="tlw">
+        <div class="tlw-summary">
+          <span class="tlw-summary-value tlw-neg">{(tot?.import_actual_kwh ?? 0).toFixed(1)}<span class="tlw-summary-unit"> kWh in</span></span>
+          <span class="tlw-summary-value tlw-pos">{(tot?.export_actual_kwh ?? 0).toFixed(1)}<span class="tlw-summary-unit"> kWh out</span></span>
+          <span class="tlw-summary-label">grid so far today</span>
+        </div>
+        <MetricTimeline labels={labels} lines={lines} prices={prices} nowIdx={nowIdx}
+                        cheapAt={cheapP} peakAt={peakP} height={260} />
+        <div class="tlw-legend">
+          <span><i style={`border-color:${t.importColor}`} /> import</span>
+          <span><i style={`border-color:${t.exportColor}`} /> export (below 0)</span>
+          <span><i class="dashed" style={`border-color:${t.textMute}`} /> plan</span>
+          <span>◉ now</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Period mode: daily import + export actuals (grouped bars; export negative).
+  const pts = periodData?.chart_data ?? [];
+  if (periodLoading && !pts.length) return <Spinner label="Loading grid…" />;
+  if (!pts.length) return <p class="muted">No grid data for this period.</p>;
+  const labels = pts.map((p) => periodPointLabel(p.date, period.gran));
+  const lines: TimelineLine[] = [
+    { name: "Import", color: t.importColor, data: pts.map((p) => round2(p.import_kwh)) },
+    { name: "Export", color: t.exportColor, data: pts.map((p) => -round2(p.export_kwh)), area: true },
+  ];
+  const impTot = pts.reduce((s, p) => s + (p.import_kwh ?? 0), 0);
+  const expTot = pts.reduce((s, p) => s + (p.export_kwh ?? 0), 0);
+  return (
+    <div class="tlw">
+      <div class="tlw-summary">
+        <span class="tlw-summary-value tlw-neg">{impTot.toFixed(0)}<span class="tlw-summary-unit"> kWh in</span></span>
+        <span class="tlw-summary-value tlw-pos">{expTot.toFixed(0)}<span class="tlw-summary-unit"> kWh out</span></span>
+        <span class="tlw-summary-label">grid · {periodData?.period_label}</span>
+      </div>
+      <MetricTimeline labels={labels} lines={lines} barMode height={240} />
+    </div>
+  );
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/ui/src/components/home/LoadWidget.tsx
+++ b/ui/src/components/home/LoadWidget.tsx
@@ -1,0 +1,96 @@
+import { chartTheme, withAlpha } from "../../lib/charts";
+import { useFetch } from "../../lib/poll";
+import { getExecutionToday, getPvToday } from "../../lib/endpoints";
+import { MetricTimeline, localHM, nowIndexOf, periodPointLabel, type TimelineLine } from "./MetricTimeline";
+import { Spinner } from "../common/Spinner";
+import type { PeriodInsightsResponse, ExecutionTodayResponse, PvTodayResponse } from "../../lib/types";
+import { isCurrentPeriod, type PeriodState } from "../../lib/period";
+import "./timeline-widget.css";
+
+interface Props {
+  period: PeriodState;
+  periodData: PeriodInsightsResponse | null;
+  periodLoading: boolean;
+  cheapP?: number | null;
+  peakP?: number | null;
+}
+
+// Household load timeline, synced to the period navigator. Day → measured total
+// consumption (bold) vs the LP's base-load forecast (dashed), on the /pv/today
+// time axis with /execution/today overlaying measured kWh. Week/month/year →
+// daily load actuals as bars.
+export function LoadWidget({ period, periodData, periodLoading, cheapP, peakP }: Props) {
+  const isDay = period.gran === "day";
+  // Current day → endpoint UTC-today default; historical → anchor (see SolarWidget).
+  const dayArg = isCurrentPeriod(period) ? undefined : period.anchor;
+  const day = useFetch(
+    () => (isDay
+      ? Promise.all([getExecutionToday(dayArg), getPvToday(dayArg)])
+          .then(([e, p]) => ({ e, p }) as { e: ExecutionTodayResponse; p: PvTodayResponse })
+      : Promise.resolve(null)),
+    [isDay, dayArg],
+  );
+  const t = chartTheme();
+
+  if (isDay) {
+    const pv = day.data?.p;
+    const exec = day.data?.e;
+    const slots = pv?.slots ?? [];
+    if (day.loading && !slots.length) return <Spinner label="Loading load…" />;
+    if (!slots.length) return <p class="muted">No load data for this day yet.</p>;
+    const labels = slots.map((s) => localHM(s.slot_utc));
+    const nowIdx = nowIndexOf(slots, pv?.now_utc);
+    const prices = slots.map((s) => s.import_price_p ?? null);
+    // Measured total consumption, aligned to the pv time axis by slot_utc.
+    const consBy = new Map<string, number>();
+    for (const e of exec?.slots ?? []) {
+      if (e.slot_utc && e.consumption_kwh != null) consBy.set(e.slot_utc, e.consumption_kwh);
+    }
+    const actual = slots.map((s) => {
+      const v = consBy.get(s.slot_utc);
+      return v == null ? null : round2(v);
+    });
+    const fcast = slots.map((s) => (s.base_load_kwh == null ? null : round2(s.base_load_kwh)));
+    const lines: TimelineLine[] = [
+      { name: "Base-load forecast", color: withAlpha(t.house, 0.55), data: fcast, dashed: true },
+      { name: "Total load", color: t.house, data: actual, area: true, width: 2.5 },
+    ];
+    const consumed = (exec?.slots ?? []).reduce((s, e) => s + (e.consumption_kwh ?? 0), 0);
+    return (
+      <div class="tlw">
+        <div class="tlw-summary">
+          <span class="tlw-summary-value">{consumed.toFixed(1)}<span class="tlw-summary-unit"> kWh</span></span>
+          <span class="tlw-summary-label">consumed so far today</span>
+        </div>
+        <MetricTimeline labels={labels} lines={lines} prices={prices} nowIdx={nowIdx}
+                        cheapAt={cheapP} peakAt={peakP} height={260} unit="kWh" />
+        <div class="tlw-legend">
+          <span><i style={`border-color:${t.house}`} /> total load</span>
+          <span><i class="dashed" style={`border-color:${withAlpha(t.house, 0.6)}`} /> base-load forecast</span>
+          <span>◉ now · paid/cheap/peak shaded</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Period mode: daily total-load actuals (bars).
+  const pts = periodData?.chart_data ?? [];
+  if (periodLoading && !pts.length) return <Spinner label="Loading load…" />;
+  if (!pts.length) return <p class="muted">No load data for this period.</p>;
+  const labels = pts.map((p) => periodPointLabel(p.date, period.gran));
+  const lines: TimelineLine[] = [{ name: "Load", color: t.house, data: pts.map((p) => round2(p.load_kwh)), area: true }];
+  const total = pts.reduce((s, p) => s + (p.load_kwh ?? 0), 0);
+  return (
+    <div class="tlw">
+      <div class="tlw-summary">
+        <span class="tlw-summary-value">{total.toFixed(0)}<span class="tlw-summary-unit"> kWh</span></span>
+        <span class="tlw-summary-label">consumed · {periodData?.period_label}</span>
+      </div>
+      <MetricTimeline labels={labels} lines={lines} barMode height={240} />
+    </div>
+  );
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/ui/src/components/home/MetricTimeline.tsx
+++ b/ui/src/components/home/MetricTimeline.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useRef } from "preact/hooks";
+import { makeChart, baseOption, chartTheme, areaGradient, withAlpha, barGradient, type EChartsType } from "../../lib/charts";
+import { useResolvedTheme } from "../../lib/theme";
+import { reducedMotion } from "../../lib/motion";
+
+// One reusable timeline chart shared by the Solar / Grid / Load widgets so the
+// three read identically (the user's "4 widgets, same forecast-vs-actual line"
+// ask) without each re-implementing the tier-band + now-marker machinery that
+// used to live only in TodayPlanWidget.
+//
+// Two modes:
+//   * INTRADAY (barMode=false): per 30-min slot — plan-vs-actual lines, an
+//     import-price reference on the right axis, cheap/peak/negative tariff
+//     background bands, and a pulsing "now" marker. For the "day" granularity.
+//   * PERIOD (barMode=true): one bar group per point (day-of-week / day-of-month
+//     / month) — actuals only, since historical intraday forecast isn't kept.
+
+export interface TimelineLine {
+  name: string;
+  color: string;
+  data: (number | null)[];
+  dashed?: boolean;      // forecast/plan styling
+  width?: number;
+  area?: boolean;        // gradient fill (the one bold "actual" line)
+  step?: boolean;        // price reference
+  yAxis?: number;        // 0 = left (kWh), 1 = right (price p)
+}
+
+interface MetricTimelineProps {
+  labels: string[];
+  lines: TimelineLine[];
+  /** Import price per slot (p/kWh) — drives the tariff bands + right axis. */
+  prices?: (number | null)[];
+  /** Slot index of "now" (intraday only); -1 / undefined to hide. */
+  nowIdx?: number;
+  cheapAt?: number | null;
+  peakAt?: number | null;
+  /** Render `lines` as grouped bars (period mode) instead of an intraday chart. */
+  barMode?: boolean;
+  height?: number;
+  unit?: string;
+}
+
+type Tier = "negative" | "cheap" | "standard" | "peak" | null;
+
+export function MetricTimeline({
+  labels, lines, prices, nowIdx = -1, cheapAt, peakAt, barMode = false, height = 260, unit = "kWh",
+}: MetricTimelineProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+  const theme = useResolvedTheme();
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const ch = makeChart(ref.current);
+    chartRef.current = ch;
+    const onResize = () => ch.resize();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      ch.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current || !labels.length) return;
+    const t = chartTheme();
+    const base = baseOption();
+    const animate = !reducedMotion();
+    const hasPrice = !barMode && (prices?.some((p) => p != null) ?? false);
+
+    // --- Tariff-tier background bands (intraday only). Classify each slot by
+    // import price into negative / cheap / peak; shade contiguous runs. Mirrors
+    // TodayPlanWidget so all timelines share one tariff ribbon.
+    const bands: Array<[{ xAxis: number; itemStyle: object }, { xAxis: number }]> = [];
+    if (hasPrice && prices) {
+      const known = prices.filter((p): p is number => p != null).slice().sort((a, b) => a - b);
+      const pct = (q: number) => (known.length ? known[Math.min(known.length - 1, Math.floor(q * known.length))] : null);
+      const cAt = cheapAt ?? pct(0.33);
+      const pAt = peakAt ?? pct(0.75);
+      const tierOf = (p: number | null): Tier => {
+        if (p == null) return null;
+        if (p < 0) return "negative";
+        if (cAt != null && p <= cAt) return "cheap";
+        if (pAt != null && p >= pAt) return "peak";
+        return "standard";
+      };
+      const tierColor = (k: Tier): string =>
+        k === "negative" ? t.neg : k === "cheap" ? t.cheap : k === "peak" ? t.peak : t.textMute;
+      const tierFill = (k: Tier): object =>
+        k === "negative"
+          ? { color: withAlpha(t.neg, 0.26), borderColor: withAlpha(t.neg, 0.9), borderWidth: 1 }
+          : k === "standard"
+          ? { color: withAlpha(t.textMute, 0.05) }
+          : { color: withAlpha(tierColor(k), 0.1) };
+      let runStart = -1;
+      let runTier: Tier = null;
+      const flush = (endIdx: number) => {
+        if (runStart < 0 || runTier == null) return;
+        bands.push([{ xAxis: runStart - 0.5, itemStyle: tierFill(runTier) }, { xAxis: endIdx + 0.5 }]);
+      };
+      labels.forEach((_, i) => {
+        const cur = tierOf(prices[i] ?? null);
+        if (cur !== runTier) {
+          if (runTier != null) flush(i - 1);
+          runTier = cur;
+          runStart = cur != null ? i : -1;
+        }
+      });
+      if (runTier != null) flush(labels.length - 1);
+    }
+
+    const kwhSeries = lines.map((ln) => {
+      if (barMode) {
+        return {
+          name: ln.name, type: "bar", data: ln.data, color: ln.color,
+          itemStyle: { color: barGradient(ln.color), borderRadius: [3, 3, 0, 0] },
+          barMaxWidth: 22, z: ln.area ? 3 : 2,
+        };
+      }
+      return {
+        name: ln.name, type: "line", smooth: true, showSymbol: false, connectNulls: false,
+        color: ln.color, data: ln.data, yAxisIndex: ln.yAxis ?? 0,
+        step: ln.step ? "middle" : undefined,
+        lineStyle: {
+          color: ln.color, width: ln.width ?? (ln.dashed ? 1.25 : 2.5),
+          type: ln.dashed ? "dashed" : "solid", opacity: ln.dashed ? 0.8 : 1,
+        },
+        areaStyle: ln.area ? { color: areaGradient(ln.color, 0.4, 0.04) } : undefined,
+        z: ln.area ? 4 : ln.dashed ? 2 : 3,
+      };
+    });
+
+    const yAxes: object[] = [
+      { ...(base.yAxis as object), axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}" } },
+    ];
+    if (hasPrice) {
+      yAxes.push({
+        ...(base.yAxis as object), position: "right", splitLine: { show: false },
+        axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}p" },
+      });
+    }
+
+    chartRef.current.setOption({
+      ...base,
+      grid: { left: 16, right: hasPrice ? 44 : 16, top: 16, bottom: 24, containLabel: true },
+      legend: { show: false },
+      tooltip: {
+        ...(base.tooltip as object),
+        valueFormatter: (v: number | null) => (v == null ? "—" : `${Number(v).toFixed(2)} ${unit}`),
+      },
+      xAxis: {
+        ...(base.xAxis as object), data: labels,
+        axisLabel: { color: t.textMute, fontSize: 10, interval: barMode ? "auto" : 5 },
+      },
+      yAxis: yAxes,
+      series: [
+        // Silent baseline carries the tariff bands + now marker (intraday only).
+        ...(!barMode ? [{
+          name: "_bands", type: "line", data: labels.map(() => null), silent: true,
+          markArea: bands.length ? { silent: true, data: bands } : undefined,
+          z: 0,
+        }] : []),
+        ...kwhSeries,
+        // Import price → dashed step on the right axis (intraday only).
+        ...(hasPrice ? [{
+          name: "Import price", type: "line", step: "middle", showSymbol: false, color: t.importColor,
+          yAxisIndex: 1, data: prices, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8, type: "dashed" }, z: 1,
+        }] : []),
+        // Pulsing "now" ripple at the current slot.
+        ...(!barMode && nowIdx >= 0 ? [{
+          name: "_now", type: "effectScatter", silent: true, coordinateSystem: "cartesian2d",
+          symbolSize: 9, z: 6, showEffectOn: "render",
+          rippleEffect: { period: animate ? 2.4 : 0, scale: animate ? 3 : 1, brushType: "stroke" },
+          itemStyle: { color: t.accent, shadowBlur: 8, shadowColor: t.accent },
+          data: [[nowIdx, 0]],
+        }] : []),
+      ],
+    }, { notMerge: true });
+  }, [labels, lines, prices, nowIdx, cheapAt, peakAt, barMode, theme, unit]);
+
+  return <div ref={ref} style={{ width: "100%", height: `${height}px` }} />;
+}
+
+export function localHM(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+/** Slot index of "now" within a day's slots, or -1 if outside. */
+export function nowIndexOf(slots: { slot_utc: string }[], nowUtc?: string): number {
+  if (!slots.length) return -1;
+  const nowMs = nowUtc ? new Date(nowUtc).getTime() : Date.now();
+  const firstMs = new Date(slots[0].slot_utc).getTime();
+  const lastMs = new Date(slots[slots.length - 1].slot_utc).getTime() + 30 * 60_000;
+  if (nowMs < firstMs || nowMs >= lastMs) return -1;
+  const idx = slots.findIndex((s) => new Date(s.slot_utc).getTime() > nowMs);
+  return idx <= 0 ? slots.length - 1 : idx - 1;
+}
+
+/** Short label for a period chart point's `date` given the granularity. */
+export function periodPointLabel(dateISO: string, gran: string): string {
+  const d = new Date(`${dateISO}T00:00:00`);
+  if (gran === "year") return d.toLocaleDateString([], { month: "short" });
+  if (gran === "week") return d.toLocaleDateString([], { weekday: "short" });
+  return String(d.getDate()); // month → day-of-month
+}

--- a/ui/src/components/home/SolarWidget.tsx
+++ b/ui/src/components/home/SolarWidget.tsx
@@ -1,0 +1,89 @@
+import { chartTheme, withAlpha } from "../../lib/charts";
+import { useFetch } from "../../lib/poll";
+import { getPvToday } from "../../lib/endpoints";
+import { MetricTimeline, localHM, nowIndexOf, periodPointLabel, type TimelineLine } from "./MetricTimeline";
+import { Spinner } from "../common/Spinner";
+import type { PeriodInsightsResponse } from "../../lib/types";
+import { isCurrentPeriod, type PeriodState } from "../../lib/period";
+import "./timeline-widget.css";
+
+interface Props {
+  period: PeriodState;
+  periodData: PeriodInsightsResponse | null;
+  periodLoading: boolean;
+  cheapP?: number | null;
+  peakP?: number | null;
+}
+
+// Solar timeline, synced to the period navigator. Day → committed-plan vs
+// realised PV (intraday, the /pv/today line). Week/month/year → daily solar
+// actuals as bars (historical intraday forecast isn't kept).
+export function SolarWidget({ period, periodData, periodLoading, cheapP, peakP }: Props) {
+  const isDay = period.gran === "day";
+  // For the CURRENT day pass no date → the endpoint's UTC-today default (the
+  // proven live behaviour). Only historical days pass the anchor. This avoids
+  // the "local date read as a UTC day" blank window right after local midnight.
+  const dayArg = isCurrentPeriod(period) ? undefined : period.anchor;
+  const day = useFetch(() => (isDay ? getPvToday(dayArg) : Promise.resolve(null)), [isDay, dayArg]);
+  const t = chartTheme();
+
+  if (isDay) {
+    const slots = day.data?.slots ?? [];
+    if (day.loading && !slots.length) return <Spinner label="Loading solar…" />;
+    if (!slots.length) return <p class="muted">No solar data for this day yet.</p>;
+    const labels = slots.map((s) => localHM(s.slot_utc));
+    const nowIdx = nowIndexOf(slots, day.data?.now_utc);
+    const planLine = slots.map((s, i) =>
+      nowIdx >= 0 && i > nowIdx ? round2(s.pv_forecast_kwh) : round2(s.pv_planned_kwh ?? s.pv_forecast_kwh));
+    const actual = slots.map((s) => (s.pv_actual_kwh == null ? null : round2(s.pv_actual_kwh)));
+    const prices = slots.map((s) => s.import_price_p ?? null);
+    const lines: TimelineLine[] = [
+      { name: "Plan", color: withAlpha(t.pv, 0.5), data: planLine, dashed: true },
+      { name: "Actual", color: t.pv, data: actual, area: true, width: 3 },
+    ];
+    // Day total = locked actuals + forecast for the rest (steady headline).
+    const nowMs = day.data?.now_utc ? new Date(day.data.now_utc).getTime() : Date.now();
+    const total = slots.reduce((sum, s) => {
+      const elapsed = new Date(s.slot_utc).getTime() + 30 * 60_000 <= nowMs;
+      return sum + ((elapsed ? (s.pv_actual_kwh ?? s.pv_forecast_kwh) : s.pv_forecast_kwh) ?? 0);
+    }, 0);
+    const generated = slots.reduce((sum, s) => sum + (s.pv_actual_kwh ?? 0), 0);
+    return (
+      <div class="tlw">
+        <div class="tlw-summary">
+          <span class="tlw-summary-value">{total.toFixed(1)}<span class="tlw-summary-unit"> kWh</span></span>
+          <span class="tlw-summary-label">expected today · {generated.toFixed(1)} generated so far</span>
+        </div>
+        <MetricTimeline labels={labels} lines={lines} prices={prices} nowIdx={nowIdx}
+                        cheapAt={cheapP} peakAt={peakP} height={260} />
+        <div class="tlw-legend">
+          <span><i style={`border-color:${t.pv}`} /> actual</span>
+          <span><i class="dashed" style={`border-color:${withAlpha(t.pv, 0.6)}`} /> plan</span>
+          <span>◉ now · paid/cheap/peak shaded</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Period mode: daily solar actuals (bars).
+  const pts = periodData?.chart_data ?? [];
+  if (periodLoading && !pts.length) return <Spinner label="Loading solar…" />;
+  if (!pts.length) return <p class="muted">No solar data for this period.</p>;
+  const labels = pts.map((p) => periodPointLabel(p.date, period.gran));
+  const lines: TimelineLine[] = [{ name: "Solar", color: t.pv, data: pts.map((p) => round2(p.solar_kwh)), area: true }];
+  const total = pts.reduce((s, p) => s + (p.solar_kwh ?? 0), 0);
+  return (
+    <div class="tlw">
+      <div class="tlw-summary">
+        <span class="tlw-summary-value">{total.toFixed(0)}<span class="tlw-summary-unit"> kWh</span></span>
+        <span class="tlw-summary-label">solar generated · {periodData?.period_label}</span>
+        {!isCurrentPeriod(period) ? null : <span class="tlw-mode-note">actuals to date</span>}
+      </div>
+      <MetricTimeline labels={labels} lines={lines} barMode height={240} />
+    </div>
+  );
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/ui/src/components/home/timeline-widget.css
+++ b/ui/src/components/home/timeline-widget.css
@@ -1,0 +1,50 @@
+/* Shared chrome for the synced Solar / Grid / Load timeline widgets. */
+.tlw {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.tlw-summary {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.tlw-summary-value {
+  font-size: var(--font-xl, 1.5rem);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+.tlw-summary-unit { font-size: 0.6em; color: var(--text-mute); font-weight: 600; }
+.tlw-summary-label { font-size: var(--font-xs); color: var(--text-mute); }
+.tlw-summary-aux {
+  font-size: var(--font-xs);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+.tlw-pos { color: var(--ok, #36d399); }
+.tlw-neg { color: var(--bad, #f87171); }
+/* The "week/month/year shows actuals only" note — quiet, italic. */
+.tlw-mode-note {
+  font-size: 10px;
+  font-style: italic;
+  color: var(--text-mute);
+}
+.tlw-legend {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  font-size: 10px;
+  color: var(--text-mute);
+}
+.tlw-legend span { display: inline-flex; align-items: center; gap: 4px; }
+.tlw-legend i {
+  width: 14px;
+  height: 0;
+  border-top-width: 2px;
+  border-top-style: solid;
+  display: inline-block;
+}
+.tlw-legend i.dashed { border-top-style: dashed; }
+.tlw-legend i.bar { height: 9px; width: 9px; border-radius: 2px; border: none; }

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -24,6 +24,7 @@ import type {
   DhwScheduleResponse,
   HeatingPlanResponse,
   PvTodayResponse,
+  GridTodayResponse,
   OptimizationInputsResponse,
   ActionResult,
   DaikinOperationMode,
@@ -45,7 +46,12 @@ export const getSchedulerTimeline = () => getJson<SchedulerTimeline>("/scheduler
 export const getDecisionsLatest = () =>
   getJson<DispatchDecisionsResponse>("/optimization/decisions/latest");
 export const getMetrics = () => getJson<MetricsResponse>("/metrics");
-export const getPvToday = () => getJson<PvTodayResponse>("/pv/today");
+export const getPvToday = (date?: string) =>
+  getJson<PvTodayResponse>(`/pv/today${date ? `?date=${encodeURIComponent(date)}` : ""}`);
+// Per-slot planned-vs-realised GRID import/export for a UTC day (#3b). Mirrors
+// /pv/today; powers the synced Grid timeline widget.
+export const getGridToday = (date?: string) =>
+  getJson<GridTodayResponse>(`/grid/today${date ? `?date=${encodeURIComponent(date)}` : ""}`);
 export const getOptimizationInputs = () =>
   getJson<OptimizationInputsResponse>("/optimization/inputs");
 export const getDaikinStatus = () => getJson<DaikinDevice[]>("/daikin/status");
@@ -92,8 +98,8 @@ export const getDaikinConsumption = (
 /* ----- Forecast vs actuals ----- */
 
 export const getWeather = () => getJson<WeatherResponse>("/weather");
-export const getExecutionToday = () =>
-  getJson<ExecutionTodayResponse>("/execution/today");
+export const getExecutionToday = (date?: string) =>
+  getJson<ExecutionTodayResponse>(`/execution/today${date ? `?date=${encodeURIComponent(date)}` : ""}`);
 export const getAgileToday = () => getJson<AgileTodayResponse>("/agile/today");
 export const getAgileDay = (date: string) =>
   getJson<AgileDaySlotsResponse>(`/agile/day?date=${encodeURIComponent(date)}`);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -138,6 +138,31 @@ export interface PvTodayResponse {
   plan_run_id?: number | null;
 }
 
+/* ----- /grid/today — per-slot planned-vs-realised grid import/export ----- */
+
+export interface GridTodaySlot {
+  slot_utc: string;
+  import_planned_kwh: number | null;   // committed LP plan (stitched across solves)
+  export_planned_kwh: number | null;
+  import_actual_kwh: number | null;    // realised roll-up; null for future/no-telemetry
+  export_actual_kwh: number | null;
+  import_price_p?: number | null;
+  kind?: string | null;
+}
+
+export interface GridTodayResponse {
+  date: string;
+  now_utc: string;
+  slots: GridTodaySlot[];
+  totals: {
+    import_planned_kwh: number;
+    export_planned_kwh: number;
+    import_actual_kwh: number;
+    export_actual_kwh: number;
+  };
+  plan_run_id?: number | null;
+}
+
 /* ----- /optimization/inputs ----- */
 
 export interface OptimizationInputSlot {

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -37,19 +37,19 @@ import { gbp } from "../lib/format";
 import type { MonthlyEnergy } from "../lib/types";
 import "../components/home/home.css";
 
-// Energy chart owns the echarts dependency (~193 KB gzip). Lazy-load it so
-// the hero + money tiles paint immediately and the chart streams in after.
-const EnergyChartWidget = lazy(() =>
-  import("../components/home/EnergyChartWidget").then((m) => ({ default: m.EnergyChartWidget })),
+// The four timeline widgets (Solar / Grid / Load / Heating) each own echarts
+// (~193 KB gzip, shared chunk). Lazy-load so the hero + live band paint first
+// and the charts stream in below the fold. Solar/Grid/Load sync to the period
+// navigator; Heating keeps its own D-1/D/D+1 frame (not period-synced).
+const SolarWidget = lazy(() =>
+  import("../components/home/SolarWidget").then((m) => ({ default: m.SolarWidget })),
 );
-
-// Combined "today's plan" chart also owns echarts — lazy-load alongside the
-// energy chart so the hero + money tiles paint first.
-const TodayPlanWidget = lazy(() =>
-  import("../components/home/TodayPlanWidget").then((m) => ({ default: m.TodayPlanWidget })),
+const GridWidget = lazy(() =>
+  import("../components/home/GridWidget").then((m) => ({ default: m.GridWidget })),
 );
-
-// Heating-plan timeline (D-1/D/D+1) — also echarts-backed, lazy-loaded.
+const LoadWidget = lazy(() =>
+  import("../components/home/LoadWidget").then((m) => ({ default: m.LoadWidget })),
+);
 const HeatingPlanWidget = lazy(() =>
   import("../components/home/HeatingPlanWidget").then((m) => ({ default: m.HeatingPlanWidget })),
 );
@@ -163,14 +163,8 @@ export default function Landing() {
             period={periodInsights.data} periodState={period}
             periodLoading={periodInsights.loading} todayCum={todayCum.data} />
 
-      {/* ── WEATHER (ambient context) ──────────────────────────────── */}
-      <div class="widget-grid widget-band">
-        <Widget title="Weather" icon="⛅" tone="thermal" size="wide">
-          <WeatherWidget weather={weather.data} pv={pvToday.data} />
-        </Widget>
-      </div>
-
-      {/* ── LIVE ───────────────────────────────────────────────────── */}
+      {/* ── LIVE (glanceable now-state, up top — Apple/Tesla) ──────────
+          These three IGNORE the period navigator: they're always "now". */}
       <div class="widget-grid widget-band">
         <Widget title="Live power" icon="⚡" tone="power" size="large"
                 badge={data.now_utc ? new Date(data.now_utc).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }) : undefined}
@@ -186,31 +180,41 @@ export default function Landing() {
         <Widget title="Appliances" icon="🧺" tone="power" size="medium">
           <ApplianceWidget suggestions={applianceSug.data?.suggestions} jobs={applianceJobs.data?.jobs} appliances={appliances.data?.appliances} />
         </Widget>
+
+        <Widget title="Weather" icon="⛅" tone="thermal" size="medium">
+          <WeatherWidget weather={weather.data} pv={pvToday.data} />
+        </Widget>
       </div>
 
-      {/* ── PLAN ───────────────────────────────────────────────────── */}
+      {/* ── TIMELINES — Solar / Grid / Load, all synced to the period
+          navigator (navigate one → navigate all). Heating keeps its own
+          D-1/D/D+1 frame as the visual 4th. Day = forecast-vs-actual; week/
+          month/year = actuals only (no historical intraday forecast). ─────── */}
       <div class="widget-grid widget-band">
-        <Widget title="Today's plan" icon="🗓" tone="plan" size="wide">
-          <Suspense fallback={<Spinner label="Loading plan…" />}>
-            <TodayPlanWidget pv={pvToday.data} loading={pvToday.loading}
-                             execution={execution.data}
-                             cheapThresholdP={metrics.data?.cheap_threshold_pence}
-                             peakThresholdP={metrics.data?.peak_threshold_pence} />
+        <Widget title="Solar" icon="☀" tone="plan" size="wide">
+          <Suspense fallback={<Spinner label="Loading solar…" />}>
+            <SolarWidget period={period} periodData={periodInsights.data} periodLoading={periodInsights.loading}
+                         cheapP={metrics.data?.cheap_threshold_pence} peakP={metrics.data?.peak_threshold_pence} />
+          </Suspense>
+        </Widget>
+
+        <Widget title="Grid" icon="🔌" tone="power" size="wide">
+          <Suspense fallback={<Spinner label="Loading grid…" />}>
+            <GridWidget period={period} periodData={periodInsights.data} periodLoading={periodInsights.loading}
+                        cheapP={metrics.data?.cheap_threshold_pence} peakP={metrics.data?.peak_threshold_pence} />
+          </Suspense>
+        </Widget>
+
+        <Widget title="Load" icon="📈" tone="power" size="wide">
+          <Suspense fallback={<Spinner label="Loading load…" />}>
+            <LoadWidget period={period} periodData={periodInsights.data} periodLoading={periodInsights.loading}
+                        cheapP={metrics.data?.cheap_threshold_pence} peakP={metrics.data?.peak_threshold_pence} />
           </Suspense>
         </Widget>
 
         <Widget title="Heating plan" icon="♨" tone="thermal" size="wide">
           <Suspense fallback={<Spinner label="Loading heating plan…" />}>
             <HeatingPlanWidget plan={heatingPlan.data} loading={heatingPlan.loading} />
-          </Suspense>
-        </Widget>
-      </div>
-
-      {/* ── ENERGY ─────────────────────────────────────────────────── */}
-      <div class="widget-grid widget-band">
-        <Widget title="Load details" icon="📈" tone="power" size="wide">
-          <Suspense fallback={<Spinner label="Loading chart…" />}>
-            <EnergyChartWidget execution={execution.data} pv={pvToday.data} />
           </Suspense>
         </Widget>
       </div>


### PR DESCRIPTION
## What

The cockpit redesign Phase 3b (the big one). Breaks the cluttered **Today's plan** + **Load details** into **four peer timeline widgets — Solar / Grid / Load / Heating** — all in the same forecast-vs-actual style, with a glanceable **LIVE band** (Live power + Heating + Appliances + Weather) up top (Apple/Tesla layout).

### Backend
- **NEW `GET /api/v1/grid/today`** — per-30-min-slot **committed-plan vs realised grid import/export** for the day, mirroring `/pv/today`. Closes the long-standing gap where `/execution/today` carried load but **no grid traffic**. Planned values stitched across the day's LP solves; realised rolled up from `pv_realtime_history` (the same helpers the PnL engine costs against).
- **`db.committed_lp_field_by_slot(day, field)`** — generalises the PV-only `committed_pv_forecast_by_slot` stitch to **any whitelisted `lp_solution_snapshot` column** (`import_kwh`/`export_kwh`/…). The PV function now delegates to it (exact passthrough). Field name is whitelisted before SQL interpolation.

### UI
- **`MetricTimeline`** — one reusable ECharts timeline (tariff bands + now-marker + price axis, or period bars) shared by Solar/Grid/Load so the three read identically instead of each re-implementing `TodayPlanWidget`'s machinery.
- **`SolarWidget` / `GridWidget` / `LoadWidget`** — each **syncs to the period navigator** (navigate one → navigate all). **Day** = intraday plan-vs-actual; **week/month/year** = daily actual bars (historical intraday forecast isn't kept — stated in the UI, not fabricated). **Heating** keeps its own D-1/D/D+1 frame as the visual 4th (the live heating gauges + appliances stay current too).
- **Layout** — LIVE band (always "now", ignores the navigator) on top; the four synced timelines below. **Weather demoted** wide→medium (less space, as requested).
- `EnergyChartWidget` + `TodayPlanWidget` are no longer mounted (kept on disk for rollback, tree-shaken out of the build).

## Review + a known limitation
An independent review pass cleared the SQL whitelist, the stitch tie-break, the PV-wrapper delegation, the grid totals/partition/export-sign, the MetricTimeline alignment, and the landing fetch wiring. It flagged one **pre-existing** wart: `/pv/today` + `/execution/today` treat their `date` param as a **UTC** day, while the navigator anchor (and the PnL/`/energy/period` day) is **local**. Mitigated here by passing **no date for the current day** (the proven UTC-today default — no regression vs the old cockpit) and only the anchor for historical days (≤1h boundary offset under BST). A full local-day windowing reconciliation across the intraday endpoints is left as a follow-up (DST edge cases, test churn) — **Tracked by #469**.

## Tests
- `tests/test_grid_today.py` — endpoint partition (plan-for-all-slots, actuals-only-for-elapsed, future-day → null actuals) + `committed_lp_field_by_slot` whitelist guard.
- Full backend suite green (1565 passed); UI typecheck + build clean.

Tracked by #469 (cockpit unification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)