### PR TITLE
feat(ui): cockpit refinements — day default, gen/consumption fixes, hero kWh

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3080,6 +3080,9 @@ async def energy_today_cumulative():
     neg_import_credit = max(0.0, -import_cost)
     return {
         "date": today.isoformat(),
+        # Total household consumption (load) so far today — the headline kWh the
+        # hero leads with (the metric the user cares about most).
+        "consumption_kwh": pnl.get("kwh", 0.0),
         "import_kwh": pnl.get("import_kwh", 0.0),
         "export_kwh": pnl.get("export_kwh", 0.0),
         "import_cost_gbp": pnl.get("import_cost_gbp", 0.0),

--- a/tests/test_phase2_hero_appliance_api.py
+++ b/tests/test_phase2_hero_appliance_api.py
@@ -33,6 +33,8 @@ def test_today_cumulative_exposes_savings_fields(monkeypatch):
         # The standing charge is surfaced so the credit math is explicit
         # (earned − standing = net) and doesn't "look too small".
         "standing_charge_gbp",
+        # Total consumption — the headline kWh the hero leads with.
+        "consumption_kwh",
         # The CONFIGURED fixed tariff (British Gas) — correct shadow, not the generic.
         "fixed_tariff_label", "delta_vs_fixed_tariff_real_gbp", "fixed_tariff_shadow_real_gbp",
     ):

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -173,7 +173,7 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
           <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--accent)" /> Appliances</span>
           <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--warn)" /> Heat pump</span>
           <span class="echart-l2"><span class="echart-l2-line" /> Forecast</span>
-          <span class="echart-l2"><span class="echart-l2-line" style="border-color:var(--import)" /> Import price</span>
+          <span class="echart-l2"><span class="echart-l2-line" style="border-top-color:var(--import)" /> Import price</span>
           <span class="echart-l2-hint">stacked = where your energy goes · paid/cheap/peak shaded · ◉ now</span>
         </div>
       )}

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -80,7 +80,7 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, che
           <span class="tlw-summary-label">esperado hoje · {agile?.current_export_p != null ? `export ${agile.current_export_p.toFixed(1)}p agora` : ""}</span>
         </div>
         <MetricTimeline labels={labels} lines={lines} prices={exportPrice} bandPrices={importPrice}
-                        nowIdx={nowIdx} cheapAt={cheapP} peakAt={peakP} height={270} />
+                        priceLabel="Export price" nowIdx={nowIdx} cheapAt={cheapP} peakAt={peakP} height={270} />
         <div class="tlw-legend">
           <span><i style={`border-color:${t.pv}`} /> solar actual</span>
           <span><i class="dashed" style={`border-color:${withAlpha(t.pv, 0.6)}`} /> solar plan</span>

--- a/ui/src/components/home/HeatingPlanWidget.tsx
+++ b/ui/src/components/home/HeatingPlanWidget.tsx
@@ -42,7 +42,10 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
     if (!chartRef.current || !plan?.slots?.length) return;
     const t = chartTheme();
     const base = baseOption();
-    const slots = plan.slots;
+    // Today only — yesterday/tomorrow dropped (the user finds today enough).
+    const todayKey = new Date().toDateString();
+    const slots = plan.slots.filter((s) => new Date(s.slot_utc).toDateString() === todayKey);
+    if (!slots.length) return;
     const n = slots.length;
     const labels = slots.map((s) => localHM(s.slot_utc));
 
@@ -139,11 +142,6 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
 
   return (
     <div class="heating-plan-chart">
-      <div class="hpl-days">
-        {(plan?.days || []).map((d) => (
-          <span key={d.date} class={`hpl-day${d.label === "Today" ? " hpl-day--today" : ""}`}>{d.label}</span>
-        ))}
-      </div>
       <div ref={ref} style={{ width: "100%", height: "300px" }} />
       {plan?.slots?.length ? (
         <div class="hpl-legend" role="note" aria-label="Chart legend">

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -43,6 +43,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   const negCreditToday = todayCum?.negative_import_credit_gbp ?? null;
   const exportToday = todayCum?.export_revenue_gbp ?? null;
   const standingToday = todayCum?.standing_charge_gbp ?? null;         // fixed daily standing in the net
+  const consumptionToday = todayCum?.consumption_kwh ?? null;          // total load so far today (the headline kWh)
   const showEarnings = (earningsToday ?? 0) > 0.005;                   // hide on a plain spend day
 
   // --- The selected period, real money (NET, incl standing, measured grid) ---
@@ -71,6 +72,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   const periodNetAnim = useAnimatedNumber(periodNet);
   const savedVsBGAnim = useAnimatedNumber(savedVsBG);
   const gastoTodayAnim = useAnimatedNumber(gastoToday);
+  const consumptionTodayAnim = useAnimatedNumber(consumptionToday);
   const earningsTodayAnim = useAnimatedNumber(earningsToday);
   const solarAnim = useAnimatedNumber(lifetime?.solar_kwh ?? null);
   const exportKwhAnim = useAnimatedNumber(lifetime?.export_kwh ?? null);
@@ -97,6 +99,17 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
         <div class="hero-headline hero-headline--enter">
           {periodNetAnim == null ? (periodLoading ? <SkelHero /> : "—") : gbp(periodNetAnim)}
         </div>
+        {/* The metric the household cares about most: how much energy was used
+            today, with the fixed daily standing charge alongside it. */}
+        {consumptionTodayAnim != null && (
+          <div class="hero-keystat">
+            <span class="hero-keystat-value">{kwh(consumptionTodayAnim, 1)}</span>
+            <span class="hero-keystat-label">consumido{isNow ? " hoje" : ""}</span>
+            {standingToday != null && standingToday > 0.0001 && (
+              <span class="hero-keystat-aux">· standing {gbp(standingToday)}/dia</span>
+            )}
+          </div>
+        )}
         {/* TODAY money block — one British-Gas comparison (deduped), the day's
             bill, and the concrete money earned (negative-import credit + export). */}
         <div class="hero-sublines">

--- a/ui/src/components/home/MetricTimeline.tsx
+++ b/ui/src/components/home/MetricTimeline.tsx
@@ -50,7 +50,8 @@ interface MetricTimelineProps {
 type Tier = "negative" | "cheap" | "standard" | "peak" | null;
 
 export function MetricTimeline({
-  labels, lines, prices, bandPrices, nowIdx = -1, cheapAt, peakAt, barMode = false, height = 260, unit = "kWh",
+  labels, lines, prices, bandPrices, priceLabel = "Import price",
+  nowIdx = -1, cheapAt, peakAt, barMode = false, height = 260, unit = "kWh",
 }: MetricTimelineProps) {
   const ref = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
@@ -160,7 +161,22 @@ export function MetricTimeline({
       legend: { show: false },
       tooltip: {
         ...(base.tooltip as object),
-        valueFormatter: (v: number | null) => (v == null ? "—" : `${Number(v).toFixed(2)} ${unit}`),
+        // Hide the silent helper series (_bands / _now) and format the price
+        // series in pence, everything else in the energy unit.
+        formatter: (params: Array<{ axisValue?: string; seriesName?: string; value?: number | null; marker?: string }>) => {
+          const arr = Array.isArray(params) ? params : [params];
+          if (!arr.length) return "";
+          const rows = arr
+            .filter((p) => p.seriesName && !p.seriesName.startsWith("_"))
+            .map((p) => {
+              if (p.value == null || !Number.isFinite(p.value)) return "";
+              const isPrice = p.seriesName === priceLabel;
+              const txt = isPrice ? `${Number(p.value).toFixed(1)}p` : `${Number(p.value).toFixed(2)} ${unit}`;
+              return `<div>${p.marker ?? ""} ${p.seriesName}: <strong>${txt}</strong></div>`;
+            })
+            .join("");
+          return `<strong>${arr[0].axisValue ?? ""}</strong>${rows}`;
+        },
       },
       xAxis: {
         ...(base.xAxis as object), data: labels,
@@ -175,9 +191,10 @@ export function MetricTimeline({
           z: 0,
         }] : []),
         ...kwhSeries,
-        // Import price → dashed step on the right axis (intraday only).
+        // Price → dashed step on the right axis (intraday only). Named per the
+        // widget (export on generation, import on consumption).
         ...(hasPrice ? [{
-          name: "Import price", type: "line", step: "middle", showSymbol: false, color: t.importColor,
+          name: priceLabel, type: "line", step: "middle", showSymbol: false, color: t.importColor,
           yAxisIndex: 1, data: prices, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8, type: "dashed" }, z: 1,
         }] : []),
         // Pulsing "now" ripple at the current slot.

--- a/ui/src/components/home/WeatherWidget.tsx
+++ b/ui/src/components/home/WeatherWidget.tsx
@@ -31,11 +31,18 @@ export function WeatherWidget({ weather, pv }: Props) {
   const temps = today.map((s) => s.temp_c);
   const hi = temps.length ? Math.max(...temps) : null;
   const lo = temps.length ? Math.min(...temps) : null;
-  // Expected solar today — prefer the calibrated /pv/today total; fall back to
-  // integrating the hourly weather PV estimate.
+  // Solar still to come — expected generation from NOW to end of day (the
+  // forward-looking number that's actionable), summing the /pv/today forecast
+  // for the remaining slots. Falls back to the full-day total if slots absent.
+  const pvNowMs = pv?.now_utc ? new Date(pv.now_utc).getTime() : nowMs;
+  const solarRestOfDay = (pv?.slots ?? []).reduce((a, s) => {
+    const start = new Date(s.slot_utc).getTime();
+    return start >= pvNowMs ? a + Math.max(0, s.pv_forecast_kwh || 0) : a;
+  }, 0);
   const pvDayTotal = pv?.forecast_kwh_day_total ?? null;
   const pvFromForecast = today.reduce((a, s) => a + Math.max(0, s.pv_kw || 0), 0);
-  const solarKwh = pvDayTotal ?? pvFromForecast;
+  const hasSlots = (pv?.slots?.length ?? 0) > 0;
+  const solarKwh = hasSlots ? solarRestOfDay : (pvDayTotal ?? pvFromForecast);
 
   const next = fc.slice(curIdx, curIdx + 12);
 
@@ -56,7 +63,7 @@ export function WeatherWidget({ weather, pv }: Props) {
         <div class="wx-solar-sum">
           <SunIcon size={26} />
           <span class="wx-solar-kwh">{solarKwh.toFixed(1)}<span class="wx-solar-unit"> kWh</span></span>
-          <span class="wx-solar-label">solar expected today</span>
+          <span class="wx-solar-label">{hasSlots ? "solar expected · rest of day" : "solar expected today"}</span>
         </div>
       </div>
 

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -124,6 +124,23 @@
  * inline colour; surrounding label stays dim so only the figure carries it. */
 .hero-strong-pos { color: var(--ok); font-weight: 600; }
 .hero-strong-neg { color: var(--bad); font-weight: 600; }
+/* Today's consumption — the headline kWh, prominent right under the £ bill,
+ * with the daily standing charge alongside. */
+.hero-keystat {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-top: 2px;
+  flex-wrap: wrap;
+}
+.hero-keystat-value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+.hero-keystat-label { font-size: var(--font-xs); color: var(--text-dim); }
+.hero-keystat-aux { font-size: var(--font-xs); color: var(--text-mute); font-variant-numeric: tabular-nums; }
 /* The standing-charge deduction in the "foi pago" breakdown — recessed so the
  * earned figure stays prominent while the arithmetic (earned − standing = net)
  * still reads. */

--- a/ui/src/lib/period.ts
+++ b/ui/src/lib/period.ts
@@ -35,8 +35,10 @@ function parse(anchor: string): Date {
   return new Date(`${anchor}T00:00:00`);
 }
 
-// Default view: the current month (the figure backed by the most metered data).
-export const selectedPeriod = signal<PeriodState>({ gran: "month", anchor: todayISO() });
+// Default view: today — so the intraday detail (forecast-vs-actual + tariff
+// zones + export/import price slots) shows on the timelines without first
+// having to step down from a coarser granularity.
+export const selectedPeriod = signal<PeriodState>({ gran: "day", anchor: todayISO() });
 
 /** Subscribe to the selected period inside a component (re-renders on change). */
 export function usePeriod(): PeriodState {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -530,6 +530,7 @@ export interface HeatingPlanResponse {
 // money import cost goes NEGATIVE (a credit) on negative-price slots.
 export interface TodayCumulativeResponse {
   date: string;
+  consumption_kwh?: number;      // total household load so far today (hero headline)
   import_kwh: number;
   export_kwh: number;
   import_cost_gbp: number;       // <0 = we were paid to import (credit)

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -13,7 +13,6 @@ import {
   getEnergyPeriod,
   getDaikinStatus,
   getDaikinQuota,
-  getFairCompare,
   getPvToday,
   getDhwSchedule,
   getHeatingPlan,
@@ -22,18 +21,16 @@ import {
   getApplianceJobs,
   getAppliances,
 } from "../lib/endpoints";
-import { Link } from "wouter-preact";
 import { Widget } from "../components/common/Widget";
 import { Spinner } from "../components/common/Spinner";
 import { RefreshCountdown } from "../components/common/RefreshCountdown";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
-import { usePeriod, periodFetchOpts, periodLabel } from "../lib/period";
+import { usePeriod, periodFetchOpts } from "../lib/period";
 import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
 import { Hero } from "../components/home/Hero";
 import { HeatingWidget } from "../components/home/HeatingWidget";
 import { WeatherWidget } from "../components/home/WeatherWidget";
 import { ApplianceWidget } from "../components/home/ApplianceWidget";
-import { gbp } from "../lib/format";
 import type { MonthlyEnergy } from "../lib/types";
 import "../components/home/home.css";
 
@@ -136,13 +133,6 @@ export default function Landing() {
     () => getEnergyPeriod(period.gran, periodFetchOpts(period)),
     [period.gran, period.anchor],
   );
-  // Fair tariff comparison for the selected period — a light summary for the
-  // home link card; the full breakdown lives on the /insights tab. Deferred
-  // (network: catalogue) so it doesn't compete with the above-the-fold data.
-  const fairCmp = useFetch(
-    () => (deferred ? getFairCompare(period.gran, period.anchor) : Promise.resolve(null)),
-    [deferred, period.gran, period.anchor],
-  );
 
   if (now.loading && !now.data) {
     return <div class="home"><Spinner label="Loading dashboard…" /></div>;
@@ -213,28 +203,6 @@ export default function Landing() {
           <Suspense fallback={<Spinner label="Loading heating plan…" />}>
             <HeatingPlanWidget plan={heatingPlan.data} loading={heatingPlan.loading} />
           </Suspense>
-        </Widget>
-      </div>
-
-      {/* ── MONEY (bottom of page) — link to the full Insights tab ──── */}
-      <div class="widget-grid widget-band">
-        <Widget title="Tariff comparison" icon="📊" tone="savings" size="wide">
-          <Link href="/insights" class="tariff-link-card">
-            <div class="tariff-link-main">
-              {(() => {
-                const d = fairCmp.data;
-                if (!d || !d.tariffs.length) {
-                  return <span class="muted">Compare your usage against every tariff →</span>;
-                }
-                const winner = d.tariffs.find((r) => r.product_code === d.winner_product_code);
-                const onBest = winner?.is_current;
-                return onBest
-                  ? <span>You're on the cheapest tariff for {periodLabel(period)} — <strong>{winner?.display_name}</strong>.</span>
-                  : <span>Cheapest for {periodLabel(period)}: <strong>{winner?.display_name}</strong> — save <strong>{gbp(d.savings_vs_current_pounds)}</strong>.</span>;
-              })()}
-            </div>
-            <span class="tariff-link-cta">Compare →</span>
-          </Link>
         </Widget>
       </div>
     </div>


### PR DESCRIPTION
## Feedback fixes

- **Default period → DAY** (was month). The timelines' forecast-vs-actual + tariff zones + export/import price slots are intraday-only, so the month default hid them. Day default surfaces them immediately.
- **Generation price line** was mislabelled **"Import price"** and shown in **kWh**. Now it's the **Export price** (Octopus Outgoing), labelled correctly and formatted in **pence**. `MetricTimeline` gains a `priceLabel` + a tooltip formatter that (a) hides the silent `_bands`/`_now` helper series and (b) renders the price series in `p`, energy in `kWh`.
- **Consumption import price** line + legend now render (legend swatch needed `border-top-color`; day-default makes the day view — which carries the price line — the default).
- **Hero** now leads with **today's total consumption (kWh)** — the metric flagged as most important — plus the **daily standing charge**. New `consumption_kwh` on `/energy/today-cumulative` (from `compute_daily_pnl` `kwh`).
- **Heating plan**: today only (yesterday/tomorrow dropped — "today is enough").
- **Weather**: "solar expected · rest of day" (forward sum from now) instead of the full-day total.
- **Removed** the bottom Tariff-comparison link card (+ its fetch and now-unused imports).

## Tests
`today-cumulative` test asserts `consumption_kwh`; UI typecheck + build clean.

Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)