### PR TITLE
feat(ui,api): hero grid-import kWh + break-even "meta a bater"

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3078,8 +3078,38 @@ async def energy_today_cumulative():
     # import credit (when the metered import cost went negative) + export revenue.
     # The UI hides this when both are ~0 (a plain spend day).
     neg_import_credit = max(0.0, -import_cost)
+
+    # --- "Meta a bater": the average grid-import price Agile needs to MATCH the
+    # configured fixed tariff (British Gas). Agile carries a higher daily
+    # standing, so it only wins if it beats the fixed unit rate by enough to
+    # absorb that gap — spread over the day's FORECAST grid import (the committed
+    # LP plan, stable all day) rather than the volatile realised-so-far:
+    #   beat ⇔ avg_import_p ≤ bg_rate − (agile_standing − bg_standing) / import_kwh
+    # (export cancels: both Agile and BG value export at flat SEG for this site).
+    import_kwh_realised = float(pnl.get("import_kwh", 0.0) or 0.0)
+    bg_rate_p = float(getattr(config, "FIXED_TARIFF_RATE_PENCE", 0) or 0)
+    bg_standing_p = float(getattr(config, "FIXED_TARIFF_STANDING_PENCE_PER_DAY", 0) or 0)
+    agile_standing_p = float(pnl.get("standing_charge_gbp", 0.0) or 0.0) * 100.0
+    forecast_import_kwh = 0.0
+    try:
+        forecast_import_kwh = sum(db.committed_lp_field_by_slot(today, "import_kwh").values())
+    except Exception:  # pragma: no cover - best-effort; the target is non-critical
+        forecast_import_kwh = 0.0
+    breakeven_avg_import_p = None
+    if bg_rate_p > 0 and forecast_import_kwh > 0.05:
+        breakeven_avg_import_p = round(bg_rate_p - (agile_standing_p - bg_standing_p) / forecast_import_kwh, 2)
+    realised_avg_import_p = (
+        round(import_cost * 100.0 / import_kwh_realised, 2) if import_kwh_realised > 0.01 else None
+    )
+
     return {
         "date": today.isoformat(),
+        # The break-even target: beat British Gas when the realised average import
+        # price stays at/under breakeven_avg_import_p (computed on the day's
+        # forecast grid import so it's stable, not jumpy early in the day).
+        "breakeven_avg_import_p": breakeven_avg_import_p,
+        "realised_avg_import_p": realised_avg_import_p,
+        "forecast_import_kwh": round(forecast_import_kwh, 2),
         # Total household consumption (load) so far today — the headline kWh the
         # hero leads with (the metric the user cares about most).
         "consumption_kwh": pnl.get("kwh", 0.0),

--- a/tests/test_phase2_hero_appliance_api.py
+++ b/tests/test_phase2_hero_appliance_api.py
@@ -35,10 +35,41 @@ def test_today_cumulative_exposes_savings_fields(monkeypatch):
         "standing_charge_gbp",
         # Total consumption — the headline kWh the hero leads with.
         "consumption_kwh",
+        # "Meta a bater": break-even import price vs the fixed tariff.
+        "breakeven_avg_import_p", "realised_avg_import_p", "forecast_import_kwh",
         # The CONFIGURED fixed tariff (British Gas) — correct shadow, not the generic.
         "fixed_tariff_label", "delta_vs_fixed_tariff_real_gbp", "fixed_tariff_shadow_real_gbp",
     ):
         assert k in body, f"hero needs {k} in today-cumulative"
+
+
+def test_today_cumulative_breakeven_target(monkeypatch):
+    """The "meta a bater": Agile must keep its average import price under the
+    break-even to beat the fixed tariff, since it loses on the daily standing.
+    break-even = bg_rate − (agile_standing − bg_standing) / forecast_import_kwh."""
+    db.init_db()
+    monkeypatch.setattr(config, "FIXED_TARIFF_RATE_PENCE", 20.7, raising=False)
+    monkeypatch.setattr(config, "FIXED_TARIFF_STANDING_PENCE_PER_DAY", 41.14, raising=False)
+    # 10 kWh imported at a net £1.50 → realised avg 15.0 p/kWh; agile standing 59.26p.
+    monkeypatch.setattr(
+        "src.analytics.pnl.compute_daily_pnl",
+        lambda day: {
+            "import_kwh": 10.0, "export_kwh": 0.0, "import_cost_gbp": 1.50,
+            "export_revenue_gbp": 0.0, "realised_net_cost_gbp": 2.0926,
+            "standing_charge_gbp": 0.5926, "kwh": 14.0,
+        },
+    )
+    # Forecast grid import for the day = 12 kWh (committed LP plan).
+    monkeypatch.setattr(db, "committed_lp_field_by_slot",
+                        lambda d, field: {"a": 5.0, "b": 7.0} if field == "import_kwh" else {})
+    client = _client(monkeypatch)
+    body = client.get("/api/v1/energy/today-cumulative").json()
+
+    # break-even = 20.7 − (59.26 − 41.14)/12 = 20.7 − 1.51 = 19.19 p/kWh.
+    assert body["breakeven_avg_import_p"] == 19.19
+    # realised avg = £1.50 × 100 / 10 kWh = 15.0 p/kWh → under target (Agile wins).
+    assert body["realised_avg_import_p"] == 15.0
+    assert body["forecast_import_kwh"] == 12.0
 
 
 def test_monthly_exposes_bg_real_delta(monkeypatch):

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -43,7 +43,14 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   const negCreditToday = todayCum?.negative_import_credit_gbp ?? null;
   const exportToday = todayCum?.export_revenue_gbp ?? null;
   const standingToday = todayCum?.standing_charge_gbp ?? null;         // fixed daily standing in the net
-  const consumptionToday = todayCum?.consumption_kwh ?? null;          // total load so far today (the headline kWh)
+  // The cost-relevant kWh: what was drawn FROM THE GRID (import), not total
+  // household load — solar self-consumption is free, only grid import is billed.
+  const gridImportToday = todayCum?.import_kwh ?? null;
+  // "Meta a bater": the avg import p/kWh needed to match British Gas (Agile
+  // loses on standing, must win on the unit price), vs the realised avg so far.
+  const breakevenP = todayCum?.breakeven_avg_import_p ?? null;
+  const realisedAvgP = todayCum?.realised_avg_import_p ?? null;
+  const beatingTarget = breakevenP != null && realisedAvgP != null && realisedAvgP <= breakevenP;
   const showEarnings = (earningsToday ?? 0) > 0.005;                   // hide on a plain spend day
 
   // --- The selected period, real money (NET, incl standing, measured grid) ---
@@ -72,7 +79,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   const periodNetAnim = useAnimatedNumber(periodNet);
   const savedVsBGAnim = useAnimatedNumber(savedVsBG);
   const gastoTodayAnim = useAnimatedNumber(gastoToday);
-  const consumptionTodayAnim = useAnimatedNumber(consumptionToday);
+  const gridImportTodayAnim = useAnimatedNumber(gridImportToday);
   const earningsTodayAnim = useAnimatedNumber(earningsToday);
   const solarAnim = useAnimatedNumber(lifetime?.solar_kwh ?? null);
   const exportKwhAnim = useAnimatedNumber(lifetime?.export_kwh ?? null);
@@ -99,12 +106,12 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
         <div class="hero-headline hero-headline--enter">
           {periodNetAnim == null ? (periodLoading ? <SkelHero /> : "—") : gbp(periodNetAnim)}
         </div>
-        {/* The metric the household cares about most: how much energy was used
-            today, with the fixed daily standing charge alongside it. */}
-        {consumptionTodayAnim != null && (
+        {/* The cost-relevant metric: kWh drawn from the grid (what's billed),
+            with the fixed daily standing charge alongside it. */}
+        {gridImportTodayAnim != null && (
           <div class="hero-keystat">
-            <span class="hero-keystat-value">{kwh(consumptionTodayAnim, 1)}</span>
-            <span class="hero-keystat-label">consumido{isNow ? " hoje" : ""}</span>
+            <span class="hero-keystat-value">{kwh(gridImportTodayAnim, 1)}</span>
+            <span class="hero-keystat-label">da rede{isNow ? " hoje" : ""}</span>
             {standingToday != null && standingToday > 0.0001 && (
               <span class="hero-keystat-aux">· standing {gbp(standingToday)}/dia</span>
             )}
@@ -119,6 +126,21 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
                 {savedVsBGAnim >= 0 ? "Economizou " : "Gastou +"}{gbp(Math.abs(savedVsBGAnim))}
               </strong>
               &nbsp;hoje vs {fixedLabel}
+            </div>
+          )}
+          {/* The target to beat: Agile loses on standing, so it must keep the
+              average import price under this break-even to win vs the fixed
+              tariff. Spread over the day's forecast grid import (stable). */}
+          {breakevenP != null && (
+            <div class="hero-subline hero-subline-dma" title={`Para bater ${fixedLabel}, o preço médio de import precisa ficar ≤ ${breakevenP.toFixed(1)}p/kWh — a Agile paga ~${gbp(standingToday ?? 0)}/dia de standing, mais que a tarifa fixa, então tem que ganhar na energia. Diluído no forecast de import do dia (${todayCum?.forecast_import_kwh ?? 0} kWh).`}>
+              🎯 meta: import médio ≤ <strong>{breakevenP.toFixed(1)}p</strong>
+              {realisedAvgP != null && (
+                <>&nbsp;·&nbsp;hoje&nbsp;
+                  <strong class={beatingTarget ? "hero-strong-pos" : "hero-strong-neg"}>
+                    {realisedAvgP.toFixed(1)}p {beatingTarget ? "✓" : "✗"}
+                  </strong>
+                </>
+              )}
             </div>
           )}
           <div class="hero-subline hero-subline-dma">

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -544,6 +544,11 @@ export interface TodayCumulativeResponse {
   fixed_tariff_label?: string | null;
   delta_vs_fixed_tariff_real_gbp?: number | null;  // £ cheaper than British Gas (>0 = Agile won)
   fixed_tariff_shadow_real_gbp?: number | null;    // what British Gas would have cost
+  // "Meta a bater": avg import p/kWh Agile needs to match British Gas (standing
+  // gap spread over the day's forecast grid import), vs the realised avg so far.
+  breakeven_avg_import_p?: number | null;
+  realised_avg_import_p?: number | null;
+  forecast_import_kwh?: number;
 }
 
 // GET /appliances/suggestions — cheapest upcoming run window per idle appliance.


### PR DESCRIPTION
## What

Two hero changes from feedback on the cost framing, plus a confirmation that the tariff comparison is already fair.

- **Hero kWh → grid import.** Shows what was drawn **from the grid** (the billed figure) instead of total household load — solar self-consumption is free and identical under any tariff, so it's not the cost-relevant number.
- **New "meta a bater" (target to beat).** Agile loses on the daily standing (≈59p vs BG's 41p), so to win it must beat the fixed unit rate by enough to absorb that gap. The target is the **average import price** Agile must stay under, spreading the standing gap over the day's **forecast** grid import (committed LP plan — stable all day, not jumpy early on):
  ```
  beat British Gas ⇔ avg_import_p ≤ bg_rate − (agile_standing − bg_standing) / import_kwh
  ```
  Rendered next to the (kept) realised £-saved line: `🎯 meta: import médio ≤ 19.2p · hoje 15.0p ✓`.
- `/energy/today-cumulative` exposes `breakeven_avg_import_p`, `realised_avg_import_p`, `forecast_import_kwh`.

## Fairness (the question raised)
Confirmed via code audit that the comparison is **already fair** — no change needed:
- Both the BG shadow (`pnl.py`) and the Insights multi-tariff (`fair_compare.py`) price each tariff as **standing + grid_import × that tariff's rate − grid_export × that tariff's export rate**.
- **Grid-import basis** (measured `pv_realtime_history`), **not** total load → **solar PV self-consumption is excluded** (constant across tariffs).
- Each tariff uses its **own** standing + import rate (per-slot for time-of-use) + export rate. The Insights view surfaces whichever tariff is genuinely cheapest for our usage — Agile is not forced to win.

## Tests
`test_today_cumulative_breakeven_target` verifies the break-even math (19.19p target, 15.0p realised); field-presence assertions extended. Full backend suite + UI typecheck/build clean.

Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)