### PR TITLE
fix(ui): drop redundant Conta hoje, import price in consumption hover, de-dup tariffs

### DIFF
--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -462,7 +462,11 @@ function optionForDay(
           (price[i] != null ? ` · ${price[i]!.toFixed(1)}p/kWh` : "");
         const totalRow = totalActual[i] != null
           ? `<div style="margin-top:2px;font-size:11px;color:${t.text};">Total <strong>${totalActual[i]!.toFixed(2)} kWh</strong></div>` : "";
-        return head + totalRow +
+        // Explicit import-price row — the cost of each kWh drawn from the grid
+        // in this slot (the user couldn't find it in the hover otherwise).
+        const priceRow = price[i] != null
+          ? `<div style="margin-top:2px;font-size:11px;color:${t.importColor};">Import <strong>${price[i]!.toFixed(1)}p/kWh</strong></div>` : "";
+        return head + totalRow + priceRow +
           bar("Base", baseActual[i], t.house) +
           (hasAppliance ? bar("Appliances", applianceActual[i], t.accent) : "") +
           bar("Heat pump", daikinActual[i], t.warn) +

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -21,7 +21,7 @@ interface Props {
 // vs realised + grid export, with the Octopus EXPORT price slots on the right
 // axis and the cheap/peak/negative tariff zones shaded (from the import price —
 // the canonical tariff context). Week/month/year → daily solar + export bars.
-export function GenerationWidget({ period, periodData, periodLoading, agile, cheapP, peakP }: Props) {
+export function GenerationWidget({ period, periodData, periodLoading, agile }: Props) {
   const isDay = period.gran === "day";
   const dayArg = isCurrentPeriod(period) ? undefined : period.anchor;
   const day = useFetch(
@@ -53,8 +53,7 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, che
       const v = expBy.get(s.slot_utc);
       return v == null ? null : round2(v);
     });
-    // Prices: zones from import (pv.import_price_p); right-axis line = export.
-    const importPrice = slots.map((s) => s.import_price_p ?? null);
+    // Right-axis price line = the Octopus EXPORT slots (what export earns).
     const expPriceBy = new Map<string, number>();
     for (const es of agile?.export_slots ?? []) expPriceBy.set(normZ(es.valid_from), es.p);
     const exportPrice = slots.map((s) => {
@@ -79,13 +78,17 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, che
           <span class="tlw-summary-value tlw-pos">{exportedTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh export</span></span>
           <span class="tlw-summary-label">esperado hoje · {agile?.current_export_p != null ? `export ${agile.current_export_p.toFixed(1)}p agora` : ""}</span>
         </div>
-        <MetricTimeline labels={labels} lines={lines} prices={exportPrice} bandPrices={importPrice}
-                        priceLabel="Export price" nowIdx={nowIdx} cheapAt={cheapP} peakAt={peakP} height={270} />
+        {/* No cheap/peak/negative shading here — those are the IMPORT tariff
+            and belong on Consumption; Generation's tariff context is the export
+            price line (green), so the two timelines don't repeat the same bands. */}
+        <MetricTimeline labels={labels} lines={lines} prices={exportPrice}
+                        priceLabel="Export price" priceColor={t.exportColor} nowIdx={nowIdx} height={270} />
         <div class="tlw-legend">
           <span><i style={`border-color:${t.pv}`} /> solar actual</span>
           <span><i class="dashed" style={`border-color:${withAlpha(t.pv, 0.6)}`} /> solar plan</span>
-          <span><i style={`border-color:${t.exportColor}`} /> export</span>
-          <span><i class="dashed" style={`border-color:${t.importColor}`} /> export price · paid/cheap/peak shaded</span>
+          <span><i style={`border-color:${t.exportColor}`} /> export kWh</span>
+          <span><i class="dashed" style={`border-color:${t.exportColor}`} /> export price</span>
+          <span>◉ now</span>
         </div>
       </div>
     );

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -36,7 +36,6 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   // --- TODAY's real money (the hero money block, independent of the period
   // selector). Uses the CONFIGURED fixed-tariff (British Gas) comparison — NOT
   // the generic ~23p fixed shadow that mislabels + inflates the saving. ---
-  const gastoToday = todayCum?.realised_net_cost_gbp ?? null;          // net bill (<0 = credit)
   const savedVsBG = todayCum?.delta_vs_fixed_tariff_real_gbp ?? null;  // £ cheaper than British Gas
   const fixedLabel = todayCum?.fixed_tariff_label || metrics?.fixed_tariff?.label || "British Gas";
   const earningsToday = todayCum?.earnings_today_gbp ?? null;          // negative-import credit + export
@@ -78,7 +77,6 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
   // Smooth tweens for the refreshing figures.
   const periodNetAnim = useAnimatedNumber(periodNet);
   const savedVsBGAnim = useAnimatedNumber(savedVsBG);
-  const gastoTodayAnim = useAnimatedNumber(gastoToday);
   const gridImportTodayAnim = useAnimatedNumber(gridImportToday);
   const earningsTodayAnim = useAnimatedNumber(earningsToday);
   const solarAnim = useAnimatedNumber(lifetime?.solar_kwh ?? null);
@@ -143,15 +141,13 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
               )}
             </div>
           )}
-          <div class="hero-subline hero-subline-dma">
-            Conta hoje:&nbsp;
-            {gastoTodayAnim == null ? "—"
-              : gastoTodayAnim < 0
-                ? <strong class="hero-strong-pos">crédito {gbp(Math.abs(gastoTodayAnim))}</strong>
-                : <strong>{gbp(gastoTodayAnim)}</strong>}
-            {showEarnings && earningsTodayAnim != null && (
+          {/* "Conta hoje" removed — the headline above already IS today's net
+              bill (default period = day). Keep only the concrete "foi pago"
+              earnings, which is distinct info (money that came in). */}
+          {showEarnings && earningsTodayAnim != null && (
+            <div class="hero-subline hero-subline-dma">
               <span class="hero-earnings" title="Dinheiro que entrou hoje: crédito da importação a preço negativo + receita de export. A standing charge fixa do dia é descontada para chegar na conta.">
-                &nbsp;·&nbsp;⚡ foi pago&nbsp;<strong class="hero-strong-pos">{gbp(earningsTodayAnim)}</strong>
+                ⚡ foi pago&nbsp;<strong class="hero-strong-pos">{gbp(earningsTodayAnim)}</strong>
                 {(negCreditToday ?? 0) > 0.005 && (exportToday ?? 0) > 0.005
                   ? <> ({gbp(negCreditToday!)} negativo + {gbp(exportToday!)} export)</>
                   : (negCreditToday ?? 0) > 0.005
@@ -161,8 +157,8 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
                   <span class="hero-standing"> &minus; {gbp(standingToday!)} standing</span>
                 )}
               </span>
-            )}
-          </div>
+            </div>
+          )}
         </div>
 
         {(curImportP != null || socPct != null) && (

--- a/ui/src/components/home/MetricTimeline.tsx
+++ b/ui/src/components/home/MetricTimeline.tsx
@@ -32,11 +32,13 @@ interface MetricTimelineProps {
   /** Price per slot (p/kWh) drawn on the right axis — IMPORT on the consumption
    * widget, EXPORT (Octopus Outgoing) on the generation widget. */
   prices?: (number | null)[];
-  /** Optional separate price series that drives the cheap/peak/negative tariff
-   * SHADING (always the import price — the canonical tariff context). When
-   * omitted, `prices` is used for both the shading and the right-axis line. */
+  /** Optional price series that drives the cheap/peak/negative tariff SHADING
+   * (the import price). Shading appears ONLY when this is provided — so a
+   * widget can show a price LINE (e.g. export) without the import zones, which
+   * avoids both timelines repeating the same tariff bands. */
   bandPrices?: (number | null)[];
-  priceLabel?: string;          // right-axis suffix label intent (unused styling hook)
+  priceLabel?: string;          // right-axis price series name (Import/Export price)
+  priceColor?: string;          // right-axis line colour (import red / export green)
   /** Slot index of "now" (intraday only); -1 / undefined to hide. */
   nowIdx?: number;
   cheapAt?: number | null;
@@ -50,7 +52,7 @@ interface MetricTimelineProps {
 type Tier = "negative" | "cheap" | "standard" | "peak" | null;
 
 export function MetricTimeline({
-  labels, lines, prices, bandPrices, priceLabel = "Import price",
+  labels, lines, prices, bandPrices, priceLabel = "Import price", priceColor,
   nowIdx = -1, cheapAt, peakAt, barMode = false, height = 260, unit = "kWh",
 }: MetricTimelineProps) {
   const ref = useRef<HTMLDivElement | null>(null);
@@ -76,10 +78,10 @@ export function MetricTimeline({
     const base = baseOption();
     const animate = !reducedMotion();
     const hasPrice = !barMode && (prices?.some((p) => p != null) ?? false);
-    // The shading always follows the IMPORT price (the canonical cheap/peak/
-    // negative classification), even on the generation widget where the right-
-    // axis LINE is the export price.
-    const shadePrices = bandPrices ?? prices;
+    // Shading appears ONLY when bandPrices is given (the import price). A widget
+    // that just wants a price LINE (export) passes no bandPrices → no zones, so
+    // the two timelines don't both repeat the same tariff bands.
+    const shadePrices = bandPrices;
     const hasBands = !barMode && (shadePrices?.some((p) => p != null) ?? false);
 
     // --- Tariff-tier background bands (intraday only). Classify each slot by
@@ -194,8 +196,8 @@ export function MetricTimeline({
         // Price → dashed step on the right axis (intraday only). Named per the
         // widget (export on generation, import on consumption).
         ...(hasPrice ? [{
-          name: priceLabel, type: "line", step: "middle", showSymbol: false, color: t.importColor,
-          yAxisIndex: 1, data: prices, lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8, type: "dashed" }, z: 1,
+          name: priceLabel, type: "line", step: "middle", showSymbol: false, color: priceColor ?? t.importColor,
+          yAxisIndex: 1, data: prices, lineStyle: { color: priceColor ?? t.importColor, width: 1.5, opacity: 0.85, type: "dashed" }, z: 1,
         }] : []),
         // Pulsing "now" ripple at the current slot.
         ...(!barMode && nowIdx >= 0 ? [{


### PR DESCRIPTION
## Feedback fixes

- **Hero "Conta hoje" removed** — it duplicated the headline (which, with the day default, already *is* today's net bill). Kept the distinct **"⚡ foi pago"** earnings line on its own.
- **Consumption hover** now shows an explicit **`Import Xp/kWh`** row — the slot's grid-import price was only in the tooltip header and easy to miss.
- **De-duplicated the Octopus tariff across the two timelines.** Both widgets were drawing the same cheap/peak/negative shading (import-based) and both price lines were red, so they looked like they repeated the same tariff. Now:
  - the **zones are the import tariff → only on Consumption**;
  - **Generation shows just its export price line, in green** (distinct from Consumption's red import line).
  - `MetricTimeline` shades only when `bandPrices` is passed and accepts a `priceColor`.

UI-only; typecheck + build clean. Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)