### PR TITLE
fix(ui,api): generation shows real SEG export rate, drop wholesale-mirror line

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -4317,6 +4317,16 @@ async def agile_today():
         ],
         "current_import_p": _slot_price_at(import_rows, now),
         "current_export_p": _slot_price_at(export_rows, now),
+        # The rate the household ACTUALLY earns for export. On seg_flat (the
+        # default) that's the flat SEG rate — NOT the per-slot Outgoing Agile
+        # `export_slots`/`current_export_p`, which track the wholesale curve and
+        # are only relevant if on Outgoing Agile. Null when on per-slot export.
+        "export_mode": getattr(config, "EXPORT_TARIFF_MODE", "seg_flat"),
+        "export_seg_rate_p": (
+            float(config.EXPORT_SEG_RATE_PENCE)
+            if getattr(config, "EXPORT_TARIFF_MODE", "seg_flat") == "seg_flat" and config.EXPORT_SEG_RATE_PENCE
+            else None
+        ),
         "now_utc": now.isoformat().replace("+00:00", "Z"),
     }
 

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -53,18 +53,16 @@ export function GenerationWidget({ period, periodData, periodLoading, agile }: P
       const v = expBy.get(s.slot_utc);
       return v == null ? null : round2(v);
     });
-    // Right-axis price line = the Octopus EXPORT slots (what export earns).
-    const expPriceBy = new Map<string, number>();
-    for (const es of agile?.export_slots ?? []) expPriceBy.set(normZ(es.valid_from), es.p);
-    const exportPrice = slots.map((s) => {
-      const v = expPriceBy.get(normZ(s.slot_utc));
-      return v == null ? null : v;
-    });
     const lines: TimelineLine[] = [
       { name: "Solar plan", color: withAlpha(t.pv, 0.5), data: solarPlan, dashed: true },
       { name: "Solar", color: t.pv, data: solarActual, area: true, width: 3 },
       { name: "Export", color: t.exportColor, data: exportActual, width: 1.75 },
     ];
+    // What export ACTUALLY earns: the flat SEG rate (the household isn't on
+    // Outgoing Agile, whose per-slot rates just track the import curve — that's
+    // why plotting them looked identical to the import line). Show it as a
+    // label, not a redundant wholesale-tracking price line.
+    const segRate = agile?.export_seg_rate_p ?? null;
     const nowMs = pv?.now_utc ? new Date(pv.now_utc).getTime() : Date.now();
     const genTotal = slots.reduce((sum, s) => {
       const elapsed = new Date(s.slot_utc).getTime() + 30 * 60_000 <= nowMs;
@@ -76,18 +74,17 @@ export function GenerationWidget({ period, periodData, periodLoading, agile }: P
         <div class="tlw-summary">
           <span class="tlw-summary-value">{genTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh solar</span></span>
           <span class="tlw-summary-value tlw-pos">{exportedTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh export</span></span>
-          <span class="tlw-summary-label">esperado hoje · {agile?.current_export_p != null ? `export ${agile.current_export_p.toFixed(1)}p agora` : ""}</span>
+          <span class="tlw-summary-label">esperado hoje{segRate != null ? ` · export pago a ${segRate.toFixed(1)}p/kWh (SEG flat)` : ""}</span>
         </div>
-        {/* No cheap/peak/negative shading here — those are the IMPORT tariff
-            and belong on Consumption; Generation's tariff context is the export
-            price line (green), so the two timelines don't repeat the same bands. */}
-        <MetricTimeline labels={labels} lines={lines} prices={exportPrice}
-                        priceLabel="Export price" priceColor={t.exportColor} nowIdx={nowIdx} height={270} />
+        {/* No price line / tariff zones here: the import tariff (cheap/peak/
+            negative) belongs on Consumption, and export earns a FLAT SEG rate
+            (shown above) — plotting the Outgoing Agile curve just mirrored the
+            import line. Generation stays about solar produced vs exported. */}
+        <MetricTimeline labels={labels} lines={lines} nowIdx={nowIdx} height={270} />
         <div class="tlw-legend">
           <span><i style={`border-color:${t.pv}`} /> solar actual</span>
           <span><i class="dashed" style={`border-color:${withAlpha(t.pv, 0.6)}`} /> solar plan</span>
           <span><i style={`border-color:${t.exportColor}`} /> export kWh</span>
-          <span><i class="dashed" style={`border-color:${t.exportColor}`} /> export price</span>
           <span>◉ now</span>
         </div>
       </div>
@@ -117,9 +114,6 @@ export function GenerationWidget({ period, periodData, periodLoading, agile }: P
   );
 }
 
-function normZ(iso: string): string {
-  try { return new Date(iso).toISOString().replace(".000Z", "Z"); } catch { return iso; }
-}
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -269,6 +269,8 @@ export interface AgileTodayResponse {
   export_slots: AgileSlot[];
   current_import_p?: number;
   current_export_p?: number;
+  export_mode?: string;             // "seg_flat" | "outgoing_agile"
+  export_seg_rate_p?: number | null; // the flat rate actually earned (seg_flat)
   now_utc?: string;
 }
 


### PR DESCRIPTION
## What

Root cause of "the dashed line also looks identical": the Generation export-price line plotted the per-slot **Outgoing Agile** export rates, which **(a)** the household doesn't actually earn (they're on **flat SEG 4.1p**) and **(b)** track the *same wholesale curve* as the Agile import price (export ≈ import × 0.55), so the two timelines' dashed lines had the same shape even after recolouring.

Fix:
- **Drop the export price line** from Generation entirely — export earns a flat rate, not a curve, so a line is misleading + redundant.
- Surface the **real rate as a label**: `export pago a 4.1p/kWh (SEG flat)`.
- `/agile/today` now exposes `export_seg_rate_p` + `export_mode` so the UI shows what's actually earned, not the Outgoing Agile reference curve (which is only relevant if you're on that tariff).

Generation now = solar produced vs exported (no price line / no zones). The import tariff (zones + price line) lives only on Consumption — the two no longer share any look-alike overlay.

## Tests
UI typecheck + build clean; small additive API field. Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)