### PR TITLE
chore(deploy): bind hem-ui to loopback only (TLS-only via Tailscale funnel)

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -80,8 +80,12 @@ services:
         condition: service_healthy
 
     ports:
+      # Loopback ONLY — the SPA is served to the world exclusively through the
+      # Tailscale funnel (https://<host>.ts.net:8443, valid TLS cert), which
+      # proxies to this loopback port. We deliberately do NOT bind the Tailscale
+      # interface here: that would expose the UI as plain HTTP (no TLS) to the
+      # tailnet. Funnel → 127.0.0.1:8080 is the only path in.
       - "127.0.0.1:8080:80"
-      - "${HEM_TAILSCALE_IP:-127.0.0.1}:8080:80"
 
     environment:
       HEM_API_URL: http://hem:8000


### PR DESCRIPTION
## What

The `hem-ui` SPA container bound **both** `127.0.0.1:8080` and `${HEM_TAILSCALE_IP}:8080` (the Tailscale interface). The latter exposed the UI as **plain HTTP (no TLS)** to the tailnet — redundant and a minor exposure, since the UI is served to the world only through the **Tailscale funnel at `:8443`** (valid TLS cert), which proxies to the loopback port.

Drop the Tailscale-interface bind; keep only `127.0.0.1:8080`. The funnel → loopback is the sole path in.

## Context
- Triggered by a prod incident: the `:8443` funnel had drifted to point at a dead `:8086`, taking the UI offline. Re-pointed the funnel to the live `:8080` (access restored, verified 200 over TLS), then hardened by dropping the plain-HTTP tailnet bind.
- **Already applied on the prod host** (`/srv/hem/compose.yaml` + `docker compose up -d hem-ui`); the Tailscale-IP:8080 listener is gone (verified refused), funnel still 200. This PR syncs the repo template so a re-provision doesn't re-introduce it.

No image change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)