### PR TITLE
feat(ui): lift the dispatch plan into its own Plan widget next to Weather

### DIFF
--- a/ui/src/components/cockpit/LivePowerWidget.tsx
+++ b/ui/src/components/cockpit/LivePowerWidget.tsx
@@ -5,7 +5,8 @@ import { useAnimatedNumber } from "../../lib/useAnimatedNumber";
 import { reducedMotion } from "../../lib/motion";
 import { kw, kwh, pct, gbp } from "../../lib/format";
 import type { CockpitState, CockpitNow, SchedulerTimeline, ExecutionTodayResponse, AgileTodayResponse, MetricsResponse, DhwScheduleRow, TodayCumulativeResponse } from "../../lib/types";
-import { formatRelativeSlot, endLabelFor, tankLabelOf } from "../../lib/slotLabels";
+import { formatRelativeSlot, tankLabelOf } from "../../lib/slotLabels";
+import { upcomingForcedWindows, labelForKind, kindColorVar, type ForcedWindow } from "../../lib/planHelpers";
 import "./cockpit.css";
 import "./live-power.css";
 
@@ -57,12 +58,9 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
 
   const todayRange = computeTodayRange(execution);
   const nextEvent = nextSocEvent(timeline);
-  const foxMode = cockpit.current_slot?.fox_mode ?? "—";
-  // SelfUse is the resting state already implied by the big net-power number up
-  // top — only surface the Fox mode pill when it's actively forcing the battery.
-  const foxActive = !["selfuse", "self_use", "idle", "—", ""].includes(foxMode.toLowerCase());
+  // Fox windows feed the quiet "Next" glance below; the full plan (Fox mode,
+  // windows, LP run) now lives in the standalone Plan widget.
   const forced = timeline ? upcomingForcedWindows(timeline, 4) : [];
-  const lpInfo = timeline ? { runId: timeline.run_id ?? null, runAt: timeline.run_at ?? null, planDate: timeline.plan_date ?? null } : null;
   const importP = agile?.current_import_p ?? null;
   const exportP = agile?.current_export_p ?? cockpit.current_slot?.price_export_p ?? null;
   const importBand = classifyBand(importP, metrics?.cheap_threshold_pence, metrics?.peak_threshold_pence);
@@ -162,77 +160,12 @@ export function LivePowerWidget({ state, cockpit, timeline, execution, agile, me
             )}
           </span>
         </div>
-        {(foxActive || forced.length > 0) && (
-        <div class="livepower-fox-row">
-          <span class="livepower-fox-label">Grid plan</span>
-          {foxActive && (
-            <span class={`livepower-fox-mode livepower-fox-mode--${foxMode.toLowerCase()}`}>
-              <span class="livepower-fox-mode-dot" />
-              {foxMode}
-            </span>
-          )}
-          {forced.length > 0 && (
-            <span class="livepower-fox-windows">
-              {forced.map((w) => {
-                const start = formatRelativeSlot(w.start_utc, cockpit.now_utc);
-                const endTime = endLabelFor(w.end_utc);
-                const range = w.slot_count > 1 ? `${start.timeLabel}–${endTime}` : start.timeLabel;
-                const tooltip = start.isToday
-                  ? `${w.kind} · ${range} · already uploaded to Fox (visible in the app now)`
-                  : `${w.kind} · ${start.dayLabel} ${range} · LP plan only — uploads to Fox at 00:05 UTC on the day`;
-                return (
-                  <span key={w.start_utc}
-                        class={`livepower-fox-window livepower-fox-window--${w.kind}${start.isToday ? "" : " livepower-fox-window--future"}`}
-                        title={tooltip}>
-                    {!start.isToday && <span class="livepower-fox-window-icon"><Icon name="schedule" size={12} /></span>}
-                    {labelForKind(w.kind)} {start.dayLabel ? `${start.dayLabel} ` : ""}{range}
-                  </span>
-                );
-              })}
-            </span>
-          )}
-        </div>
-        )}
-        {lpInfo && (lpInfo.runId != null || lpInfo.runAt) && (
-          <div class="livepower-fox-debug">
-            <span title="Last LP run id + wall time + plan target date">
-              LP&nbsp;
-              {lpInfo.runId != null && <strong>#{lpInfo.runId}</strong>}
-              {lpInfo.runAt && <> · {formatLocalTime(lpInfo.runAt)}</>}
-              {lpInfo.planDate && <> · plan {lpInfo.planDate}</>}
-            </span>
-          </div>
-        )}
+        {/* The committed dispatch plan (Fox battery windows + tank schedule +
+            LP run) moved out to its own Plan widget next to Weather. The quiet
+            "Next" glance at the top of this tile keeps the live awareness. */}
       </div>
     </div>
   );
-}
-
-interface ForcedWindow { kind: string; start_utc: string; end_utc: string; slot_count: number; }
-function upcomingForcedWindows(timeline: SchedulerTimeline, limit: number): ForcedWindow[] {
-  const out: ForcedWindow[] = [];
-  const interesting = new Set(["cheap", "negative", "peak_export", "pre_negative_export"]);
-  let current: ForcedWindow | null = null;
-  for (const s of timeline.planned || []) {
-    const k = (s.dispatched_kind || s.lp_kind || "").toLowerCase();
-    const iso = s.slot_time_utc;
-    if (!iso) continue;
-    if (interesting.has(k)) {
-      if (current && current.kind === k) {
-        current.end_utc = iso;
-        current.slot_count += 1;
-      } else {
-        if (current) out.push(current);
-        current = { kind: k, start_utc: iso, end_utc: iso, slot_count: 1 };
-      }
-    } else if (current) {
-      out.push(current);
-      current = null;
-      if (out.length >= limit) break;
-    }
-  }
-  if (current) out.push(current);
-  return out.slice(0, limit);
 }
 
 interface NextAction { label: string; when: string; whenMs: number; color: string; }
@@ -267,29 +200,6 @@ function buildNextActions(
   // Drop any entry whose timestamp failed to parse (whenMs NaN) — a NaN in the
   // comparator leaves the sort order undefined and could surface the wrong action.
   return out.filter((a) => Number.isFinite(a.whenMs)).sort((a, b) => a.whenMs - b.whenMs).slice(0, 2);
-}
-
-// Battery window kind → the same semantic colour the rest of the surface uses
-// (charge = ok/green, discharge/drain = warn/amber).
-function kindColorVar(k: string | undefined): string {
-  switch ((k || "").toLowerCase()) {
-    case "cheap":
-    case "negative":            return "var(--ok)";
-    case "peak_export":
-    case "pre_negative_export": return "var(--warn)";
-    default:                    return "var(--text-dim)";
-  }
-}
-
-// Kind conveyed by the leading coloured dot + band colour — no emoji.
-function labelForKind(k: string | undefined): string {
-  switch ((k || "").toLowerCase()) {
-    case "cheap":         return "Force charge";
-    case "negative":      return "Force charge";
-    case "peak_export":   return "Force discharge";
-    case "pre_negative_export": return "Drain (pre-neg)";
-    default:              return k || "?";
-  }
 }
 
 type Band = "negative" | "cheap" | "standard" | "peak" | "unknown";

--- a/ui/src/components/home/PlanWidget.tsx
+++ b/ui/src/components/home/PlanWidget.tsx
@@ -1,0 +1,94 @@
+import type { SchedulerTimeline, DhwScheduleRow } from "../../lib/types";
+import { formatRelativeSlot, endLabelFor, tankLabelOf, tankKindOf } from "../../lib/slotLabels";
+import { upcomingForcedWindows, labelForKind, kindColorVar } from "../../lib/planHelpers";
+import "./plan-widget.css";
+
+interface Props {
+  timeline: SchedulerTimeline | null;
+  dhwSchedule?: DhwScheduleRow[] | null;
+  nowUtc?: string;
+  foxMode?: string;
+  foxActive?: boolean;
+}
+
+// The committed dispatch PLAN, lifted out of the Live-power tile into its own
+// card next to Weather: the upcoming Fox battery windows + the tank (DHW)
+// schedule, side by side. Forward-looking only — "what the system is about to
+// do". The live power flow stays in the Live-power tile.
+export function PlanWidget({ timeline, dhwSchedule, nowUtc, foxMode, foxActive }: Props) {
+  const forced = timeline ? upcomingForcedWindows(timeline, 4) : [];
+  const nowMs = nowUtc ? Date.parse(nowUtc) : Date.now();
+  const tank = (dhwSchedule || [])
+    .filter((r) => r.start_utc && Date.parse(r.start_utc) > nowMs)
+    .sort((a, b) => Date.parse(a.start_utc!) - Date.parse(b.start_utc!))
+    .slice(0, 4);
+
+  const runId = timeline?.run_id ?? null;
+  const planDate = timeline?.plan_date ?? null;
+  const nothing = forced.length === 0 && tank.length === 0;
+
+  return (
+    <div class="planw">
+      {/* BATTERY (Fox) */}
+      <div class="planw-group">
+        <div class="planw-head">
+          <span class="planw-title">Battery</span>
+          {foxActive && foxMode && (
+            <span class={`planw-mode planw-mode--${foxMode.toLowerCase()}`}>
+              <span class="planw-mode-dot" />{foxMode}
+            </span>
+          )}
+        </div>
+        {forced.length > 0 ? (
+          <div class="planw-chips">
+            {forced.map((w) => {
+              const start = formatRelativeSlot(w.start_utc, nowUtc);
+              const endTime = endLabelFor(w.end_utc);
+              const range = w.slot_count > 1 ? `${start.timeLabel}–${endTime}` : start.timeLabel;
+              return (
+                <span key={w.start_utc} class={`planw-chip${start.isToday ? "" : " planw-chip--future"}`}
+                      title={`${w.kind} · ${start.dayLabel ? start.dayLabel + " " : ""}${range}`}>
+                  <span class="planw-dot" style={`background:${kindColorVar(w.kind)}`} />
+                  {labelForKind(w.kind)} <span class="planw-when">{start.dayLabel ? `${start.dayLabel} ` : ""}{range}</span>
+                </span>
+              );
+            })}
+          </div>
+        ) : (
+          <span class="planw-empty">Self-use — no forced windows ahead</span>
+        )}
+      </div>
+
+      {/* TANK (DHW) */}
+      <div class="planw-group">
+        <div class="planw-head"><span class="planw-title">Tank</span></div>
+        {tank.length > 0 ? (
+          <div class="planw-chips">
+            {tank.map((r) => {
+              const start = formatRelativeSlot(r.start_utc!, nowUtc);
+              const kind = tankKindOf(r.action_type);
+              return (
+                <span key={r.start_utc} class={`planw-chip planw-chip--tank-${kind}`}
+                      title={`${tankLabelOf(r.action_type)} · ${start.dayLabel ? start.dayLabel + " " : ""}${start.timeLabel}${r.tank_temp_c != null ? ` → ${r.tank_temp_c}°C` : ""}`}>
+                  <span class="planw-dot planw-dot--tank" />
+                  {tankLabelOf(r.action_type)} <span class="planw-when">{start.dayLabel ? `${start.dayLabel} ` : ""}{start.timeLabel}</span>
+                  {r.tank_temp_c != null && <span class="planw-temp">{r.tank_temp_c}°</span>}
+                </span>
+              );
+            })}
+          </div>
+        ) : (
+          <span class="planw-empty">No tank changes ahead</span>
+        )}
+      </div>
+
+      {nothing && <span class="planw-allquiet">Plan steady — nothing scheduled soon</span>}
+
+      {(runId != null || planDate) && (
+        <div class="planw-foot" title="The LP run this plan came from">
+          LP{runId != null ? ` #${runId}` : ""}{planDate ? ` · plan ${planDate}` : ""}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/home/plan-widget.css
+++ b/ui/src/components/home/plan-widget.css
@@ -1,0 +1,58 @@
+.planw {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.planw-group { display: flex; flex-direction: column; gap: var(--space-2); }
+.planw-head { display: flex; align-items: center; gap: var(--space-2); }
+.planw-title {
+  font-size: var(--font-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.planw-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+.planw-mode-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--warn);
+}
+.planw-chips { display: flex; flex-direction: column; gap: 4px; }
+.planw-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-xs);
+  color: var(--text);
+  padding: 2px 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--border) 35%, transparent);
+}
+.planw-chip--future { opacity: 0.78; }
+.planw-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.planw-dot--tank { background: var(--thermal, #fb923c); }
+.planw-when { color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.planw-temp {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-mute);
+  font-size: 10px;
+}
+.planw-empty, .planw-allquiet {
+  font-size: var(--font-xs);
+  color: var(--text-mute);
+  font-style: italic;
+}
+.planw-foot {
+  margin-top: 2px;
+  font-size: 10px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}

--- a/ui/src/lib/planHelpers.ts
+++ b/ui/src/lib/planHelpers.ts
@@ -1,0 +1,63 @@
+// Shared helpers for reading the committed dispatch plan (Fox battery windows)
+// out of the scheduler timeline. Used by both the Live-power "next" glance and
+// the standalone Plan widget so the kind/label/colour vocabulary stays in sync.
+import type { SchedulerTimeline } from "./types";
+
+export interface ForcedWindow {
+  kind: string;
+  start_utc: string;
+  end_utc: string;
+  slot_count: number;
+}
+
+// Collapse the planned slots into contiguous "interesting" battery windows
+// (force-charge on cheap/negative, force-discharge on peak_export, drain ahead
+// of a negative window), oldest-first, capped at `limit`.
+export function upcomingForcedWindows(timeline: SchedulerTimeline, limit: number): ForcedWindow[] {
+  const out: ForcedWindow[] = [];
+  const interesting = new Set(["cheap", "negative", "peak_export", "pre_negative_export"]);
+  let current: ForcedWindow | null = null;
+  for (const s of timeline.planned || []) {
+    const k = (s.dispatched_kind || s.lp_kind || "").toLowerCase();
+    const iso = s.slot_time_utc;
+    if (!iso) continue;
+    if (interesting.has(k)) {
+      if (current && current.kind === k) {
+        current.end_utc = iso;
+        current.slot_count += 1;
+      } else {
+        if (current) out.push(current);
+        current = { kind: k, start_utc: iso, end_utc: iso, slot_count: 1 };
+      }
+    } else if (current) {
+      out.push(current);
+      current = null;
+      if (out.length >= limit) break;
+    }
+  }
+  if (current) out.push(current);
+  return out.slice(0, limit);
+}
+
+// Battery window kind → the same semantic colour the rest of the surface uses
+// (charge = ok/green, discharge/drain = warn/amber).
+export function kindColorVar(k: string | undefined): string {
+  switch ((k || "").toLowerCase()) {
+    case "cheap":
+    case "negative":            return "var(--ok)";
+    case "peak_export":
+    case "pre_negative_export": return "var(--warn)";
+    default:                    return "var(--text-dim)";
+  }
+}
+
+// Kind conveyed by the leading coloured dot + band colour — no emoji.
+export function labelForKind(k: string | undefined): string {
+  switch ((k || "").toLowerCase()) {
+    case "cheap":         return "Force charge";
+    case "negative":      return "Force charge";
+    case "peak_export":   return "Force discharge";
+    case "pre_negative_export": return "Drain (pre-neg)";
+    default:              return k || "?";
+  }
+}

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -31,6 +31,7 @@ import { Hero } from "../components/home/Hero";
 import { HeatingWidget } from "../components/home/HeatingWidget";
 import { WeatherWidget } from "../components/home/WeatherWidget";
 import { ApplianceWidget } from "../components/home/ApplianceWidget";
+import { PlanWidget } from "../components/home/PlanWidget";
 import type { MonthlyEnergy } from "../lib/types";
 import "../components/home/home.css";
 
@@ -148,6 +149,10 @@ export default function Landing() {
 
   const data = now.data;
   const s = data.state;
+  // Fox inverter mode for the Plan widget — only surface the pill when actively
+  // forcing the battery (SelfUse is the resting state).
+  const foxMode = data.current_slot?.fox_mode ?? undefined;
+  const foxActive = foxMode ? !["selfuse", "self_use", "idle", "—", ""].includes(foxMode.toLowerCase()) : false;
 
   return (
     <div class="home">
@@ -176,6 +181,11 @@ export default function Landing() {
 
         <Widget title="Weather" icon="⛅" tone="thermal" size="medium">
           <WeatherWidget weather={weather.data} pv={pvToday.data} />
+        </Widget>
+
+        <Widget title="Plan" icon="🗓" tone="plan" size="medium">
+          <PlanWidget timeline={timeline.data} dhwSchedule={dhwSched.data?.rows} nowUtc={data.now_utc}
+                      foxMode={foxMode} foxActive={foxActive} />
         </Widget>
       </div>
 


### PR DESCRIPTION
## What

The committed dispatch plan (Fox battery windows + LP run) was buried inside the **Live-power** tile. Lift it into a standalone **Plan** widget in the LIVE band, **next to Weather**, and complete it with the **tank (DHW) schedule** alongside the Fox plan — so the row reads "now (live power) → what's planned (battery + tank)".

- **New `PlanWidget`**: a **Battery** group (upcoming forced windows charge/discharge/drain + the active Fox-mode pill) and a **Tank** group (next DHW warmup/setback/boost with target temps), plus the LP-run footer. Forward-looking only.
- Extracted the shared plan helpers (`upcomingForcedWindows`, `labelForKind`, `kindColorVar`, `ForcedWindow`) to `lib/planHelpers.ts`; `LivePowerWidget` now imports them.
- `LivePowerWidget` drops the "Grid plan" row + LP-run debug; keeps the quiet **"Next"** glance + live power flow + import/export rates.

No echarts (lightweight, bundled in main chunk). 

## Tests
UI typecheck + build clean. Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)