### PR TITLE
feat(api,ui): export opportunity log + SEG-vs-Agile compare on Generation

### DIFF
--- a/src/analytics/pnl.py
+++ b/src/analytics/pnl.py
@@ -83,6 +83,39 @@ def export_revenues_for_day(day: date) -> dict[str, float]:
     }
 
 
+def record_export_opportunity_for_day(day: date) -> dict[str, float]:
+    """Compute + persist a day's export opportunity cost (Agile − SEG).
+
+    Uses :func:`export_revenues_for_day` (both valuations on the same measured
+    export) and writes one idempotent row to ``export_opportunity_log``. The
+    running tally is the money left on the table by being on flat SEG instead of
+    Outgoing Agile — surfaced via ``GET /api/v1/export/opportunity``. Returns the
+    computed values. Best-effort; callers (the nightly cron) swallow exceptions.
+    """
+    rev = export_revenues_for_day(day)
+    seg = float(rev.get("seg_flat_pence", 0.0) or 0.0)
+    agile = float(rev.get("agile_pence", 0.0) or 0.0)
+    kwh = float(rev.get("export_kwh", 0.0) or 0.0)
+    db.upsert_export_opportunity(day, kwh, seg, agile)
+    return {"export_kwh": kwh, "seg_pence": seg, "agile_pence": agile,
+            "opportunity_pence": agile - seg}
+
+
+def backfill_export_opportunity(start_day: date, end_day: date) -> int:
+    """Compute + persist export opportunity for every day in the range. Returns
+    the number of days written. Used to seed history on first run."""
+    n = 0
+    d = start_day
+    while d <= end_day:
+        try:
+            record_export_opportunity_for_day(d)
+            n += 1
+        except Exception:  # pragma: no cover - best-effort backfill
+            pass
+        d = d + timedelta(days=1)
+    return n
+
+
 def _realised_export_pence(day: date) -> tuple[float, float]:
     """Realised export revenue (pence) + kWh, valued at the ACTUAL export tariff
     the household is paid on (``config.EXPORT_TARIFF_MODE``): ``seg_flat`` → flat

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3136,6 +3136,73 @@ async def energy_today_cumulative():
     }
 
 
+@app.get("/api/v1/export/opportunity")
+async def export_opportunity(days: int = 60):
+    """Daily export opportunity cost (Outgoing Agile − flat SEG) + running totals.
+
+    The money left on the table by being on flat SEG export instead of Outgoing
+    Agile. Persisted nightly to ``export_opportunity_log``; this lazily backfills
+    on an empty table so the figure is there right after deploy. ``today`` is the
+    live in-progress accrual (not yet persisted).
+    """
+    from datetime import date as _date
+    from zoneinfo import ZoneInfo as _ZI
+
+    from src.analytics import pnl as _pnl
+
+    try:
+        tz = _ZI(config.BULLETPROOF_TIMEZONE)
+    except Exception:
+        tz = UTC
+    today = datetime.now(tz).date()
+    yesterday = today - timedelta(days=1)
+    window = max(1, min(int(days), 730))
+    start = yesterday - timedelta(days=window)
+    rows = await asyncio.to_thread(db.get_export_opportunity, start, yesterday)
+    if not rows:
+        bf_start = start
+        cfg_start = (getattr(config, "AGILE_TARIFF_START_DATE", "") or "").strip()
+        if cfg_start:
+            try:
+                bf_start = max(start, _date.fromisoformat(cfg_start))
+            except ValueError:
+                pass
+        await asyncio.to_thread(_pnl.backfill_export_opportunity, bf_start, yesterday)
+        rows = await asyncio.to_thread(db.get_export_opportunity, start, yesterday)
+    try:
+        tod = await asyncio.to_thread(_pnl.export_revenues_for_day, today)
+        today_opp = (float(tod.get("agile_pence", 0.0)) - float(tod.get("seg_flat_pence", 0.0))) / 100.0
+        today_kwh = float(tod.get("export_kwh", 0.0))
+    except Exception:
+        today_opp = 0.0
+        today_kwh = 0.0
+    daily = [
+        {"day": r["day"], "export_kwh": round(r["export_kwh"], 2),
+         "seg_gbp": round(r["seg_pence"] / 100, 4), "agile_gbp": round(r["agile_pence"] / 100, 4),
+         "opportunity_gbp": round(r["opportunity_pence"] / 100, 4)}
+        for r in rows
+    ]
+    opp_tot = sum(r["opportunity_pence"] for r in rows) / 100.0
+    kwh_tot = sum(r["export_kwh"] for r in rows)
+    seg_tot = sum(r["seg_pence"] for r in rows) / 100.0
+    agile_tot = sum(r["agile_pence"] for r in rows) / 100.0
+    n = len(rows)
+    return {
+        "export_mode": config.EXPORT_TARIFF_MODE,
+        "seg_rate_p": float(config.EXPORT_SEG_RATE_PENCE or 0),
+        "daily": daily,
+        "n_days": n,
+        "export_kwh": round(kwh_tot, 1),
+        "seg_gbp": round(seg_tot, 2),
+        "agile_gbp": round(agile_tot, 2),
+        "opportunity_gbp": round(opp_tot, 2),
+        "annualized_gbp": round(opp_tot / n * 365, 2) if n else 0.0,
+        "avg_seg_p": round(seg_tot * 100 / kwh_tot, 2) if kwh_tot > 0 else 0.0,
+        "avg_agile_p": round(agile_tot * 100 / kwh_tot, 2) if kwh_tot > 0 else 0.0,
+        "today": {"export_kwh": round(today_kwh, 2), "opportunity_gbp": round(today_opp, 4)},
+    }
+
+
 @app.get("/api/v1/energy/insights", response_model=EnergyInsightsTextResponse)
 async def energy_insights():
     """Short narrative summary for OpenClaw: this month cost and equivalent gas.

--- a/src/db.py
+++ b/src/db.py
@@ -1066,6 +1066,20 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_pv_error_log_slot ON pv_error_log(slot_time_utc)"
     )
+    # Daily export opportunity cost: what the day's export earned on the current
+    # flat SEG tariff vs what it WOULD have earned on Outgoing Agile. The running
+    # tally of money left on the table by not being on Agile export — ammunition
+    # to push Octopus to switch. One row per local day, recomputed idempotently.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS export_opportunity_log (
+            day                TEXT PRIMARY KEY,
+            export_kwh         REAL,
+            seg_pence          REAL,
+            agile_pence        REAL,
+            opportunity_pence  REAL,
+            computed_at_utc    TEXT NOT NULL
+        )"""
+    )
     # Older DBs predate the Daikin LWT calibration table — idempotent CREATE.
     conn.execute(
         """CREATE TABLE IF NOT EXISTS daikin_lwt_kw_calibration (
@@ -4656,6 +4670,63 @@ def rebuild_pv_error_log_for_date(day: date) -> int:
         finally:
             conn.close()
     return written
+
+
+def upsert_export_opportunity(
+    day: date, export_kwh: float, seg_pence: float, agile_pence: float
+) -> None:
+    """Persist a day's export opportunity cost (Agile − SEG). Idempotent on day.
+
+    ``opportunity_pence`` = ``agile_pence − seg_pence`` (>0 = money left on the
+    table by being on flat SEG instead of Outgoing Agile). Best-effort.
+    """
+    opp = round(agile_pence - seg_pence, 4)
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """INSERT INTO export_opportunity_log
+                     (day, export_kwh, seg_pence, agile_pence, opportunity_pence, computed_at_utc)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(day) DO UPDATE SET
+                     export_kwh=excluded.export_kwh,
+                     seg_pence=excluded.seg_pence,
+                     agile_pence=excluded.agile_pence,
+                     opportunity_pence=excluded.opportunity_pence,
+                     computed_at_utc=excluded.computed_at_utc""",
+                (day.isoformat(), round(export_kwh, 4), round(seg_pence, 4),
+                 round(agile_pence, 4), opp, now),
+            )
+            conn.commit()
+        except sqlite3.Error as e:
+            logger.warning("upsert_export_opportunity write failed for %s: %s", day, e)
+        finally:
+            conn.close()
+
+
+def get_export_opportunity(start_day: date, end_day: date) -> list[dict[str, Any]]:
+    """Daily export-opportunity rows in ``[start_day, end_day]`` (inclusive)."""
+    with _lock:
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                """SELECT day, export_kwh, seg_pence, agile_pence, opportunity_pence
+                   FROM export_opportunity_log
+                   WHERE day >= ? AND day <= ?
+                   ORDER BY day""",
+                (start_day.isoformat(), end_day.isoformat()),
+            ).fetchall()
+        except sqlite3.Error as e:
+            logger.warning("get_export_opportunity query failed: %s", e)
+            return []
+        finally:
+            conn.close()
+    return [
+        {"day": r[0], "export_kwh": r[1], "seg_pence": r[2],
+         "agile_pence": r[3], "opportunity_pence": r[4]}
+        for r in rows
+    ]
 
 
 def get_pv_error_log_range(start_utc_iso: str, end_utc_iso: str) -> list[dict[str, Any]]:

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -731,6 +731,45 @@ def bulletproof_pv_error_log_job() -> None:
         logger.warning("pv_recent_bias refresh failed (non-fatal): %s", e)
 
 
+def bulletproof_export_opportunity_job() -> None:
+    """Persist yesterday's export opportunity cost (Outgoing Agile − flat SEG).
+
+    The running tally of money left on the table by being on flat SEG export
+    instead of Outgoing Agile — ammunition to push Octopus to switch. Backfills
+    the on-Agile history on first run (empty table). Best-effort; a failure must
+    not disturb the scheduler.
+    """
+    from datetime import date as _date
+
+    from ..analytics.pnl import (
+        backfill_export_opportunity,
+        record_export_opportunity_for_day,
+    )
+    try:
+        tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+    except Exception:
+        tz = UTC  # type: ignore[assignment]
+    yesterday = (datetime.now(tz) - timedelta(days=1)).date()
+    try:
+        existing = db.get_export_opportunity(_date(2000, 1, 1), yesterday)
+        if not existing:
+            # Seed history. Start at the Agile join date if configured, else 60d.
+            start = yesterday - timedelta(days=60)
+            cfg_start = (getattr(config, "AGILE_TARIFF_START_DATE", "") or "").strip()
+            if cfg_start:
+                try:
+                    start = max(start, _date.fromisoformat(cfg_start))
+                except ValueError:
+                    pass
+            n = backfill_export_opportunity(start, yesterday)
+            logger.info("export_opportunity backfill: %d days from %s", n, start.isoformat())
+        else:
+            record_export_opportunity_for_day(yesterday)
+            logger.info("export_opportunity recorded for %s", yesterday.isoformat())
+    except Exception as e:
+        logger.warning("export_opportunity job failed (non-fatal): %s", e)
+
+
 def bulletproof_pv_calibration_refresh_job() -> None:
     """Recompute the per-hour and per-(hour, cloud-bucket) PV calibration
     tables from fresh ``pv_realtime_history`` and ``meteo_forecast_value``
@@ -1874,6 +1913,14 @@ def start_background_scheduler() -> None:
                 id="bulletproof_pv_error_log",
             )
             logger.info("PV error-log rebuild cron scheduled (04:20 UTC daily)")
+            # Daily export opportunity cost (Agile vs SEG). 04:25 UTC — after the
+            # Fox/PV roll-ups (02:30) so the prior day's export is complete.
+            _background_scheduler.add_job(
+                bulletproof_export_opportunity_job,
+                CronTrigger(hour=4, minute=25, timezone=ZoneInfo("UTC")),
+                id="bulletproof_export_opportunity",
+            )
+            logger.info("Export-opportunity cron scheduled (04:25 UTC daily)")
             # PV calibration refresh — keeps pv_calibration_hourly +
             # pv_calibration_hourly_cloud current. Runs at 04:30 UTC, after
             # skill-log rebuild (04:15) and Fox/Daikin rollups (02:30 / 02:35)

--- a/tests/test_export_opportunity.py
+++ b/tests/test_export_opportunity.py
@@ -1,0 +1,68 @@
+"""Export opportunity log — the running tally of money left on the table by
+being on flat SEG export instead of Outgoing Agile.
+
+Covers the db upsert/get round-trip, the opportunity = agile − seg arithmetic,
+and the /api/v1/export/opportunity endpoint's aggregation + live-today field.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from fastapi.testclient import TestClient
+
+from src import db
+from src.config import config
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr(config, "HEM_UI_AUTH_REQUIRED", False, raising=False)
+    from src.api.main import app
+    return TestClient(app)
+
+
+def test_upsert_is_idempotent_and_computes_opportunity():
+    db.init_db()
+    d = date(2026, 6, 1)
+    db.upsert_export_opportunity(d, 5.0, 20.5, 60.0)
+    db.upsert_export_opportunity(d, 5.0, 20.5, 70.0)  # re-record (overwrite)
+    rows = db.get_export_opportunity(date(2026, 5, 1), date(2026, 6, 30))
+    assert len(rows) == 1                     # idempotent on day
+    assert rows[0]["opportunity_pence"] == 49.5   # 70.0 − 20.5
+
+
+def test_export_opportunity_endpoint_aggregates(monkeypatch):
+    db.init_db()
+    y = date.today() - timedelta(days=1)
+    db.upsert_export_opportunity(y - timedelta(days=1), 5.0, 20.5, 60.0)  # opp 39.5p
+    db.upsert_export_opportunity(y - timedelta(days=2), 3.0, 12.3, 30.0)  # opp 17.7p
+    # Live "today" accrual — mock the per-day revenue split.
+    monkeypatch.setattr(
+        "src.analytics.pnl.export_revenues_for_day",
+        lambda d: {"agile_pence": 10.0, "seg_flat_pence": 4.0, "export_kwh": 1.0, "agile_avg_p": 10.0},
+    )
+    client = _client(monkeypatch)
+    body = client.get("/api/v1/export/opportunity?days=30").json()
+
+    assert body["n_days"] == 2
+    assert round(body["opportunity_gbp"], 2) == round((39.5 + 17.7) / 100, 2)  # £0.57
+    assert round(body["seg_gbp"], 2) == round((20.5 + 12.3) / 100, 2)
+    assert round(body["agile_gbp"], 2) == round((60.0 + 30.0) / 100, 2)
+    # Annualized = period opp / n_days × 365.
+    assert body["annualized_gbp"] == round((57.2 / 100) / 2 * 365, 2)
+    # Live today: agile 10 − seg 4 = 6p = £0.06.
+    assert round(body["today"]["opportunity_gbp"], 2) == 0.06
+    assert len(body["daily"]) == 2
+
+
+def test_endpoint_lazy_backfills_when_empty(monkeypatch):
+    """An empty log triggers a one-shot backfill so the figure is there at once."""
+    db.init_db()
+    monkeypatch.setattr(
+        "src.analytics.pnl.export_revenues_for_day",
+        lambda d: {"agile_pence": 8.0, "seg_flat_pence": 4.1, "export_kwh": 1.0, "agile_avg_p": 8.0},
+    )
+    client = _client(monkeypatch)
+    body = client.get("/api/v1/export/opportunity?days=5").json()
+    # Backfill ran for the 5-day window → rows exist, each opp = 8.0 − 4.1 = 3.9p.
+    assert body["n_days"] >= 1
+    assert all(round(r["opportunity_gbp"], 3) == round(3.9 / 100, 3) for r in body["daily"])

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -3,7 +3,8 @@ import { useFetch } from "../../lib/poll";
 import { getPvToday, getGridToday } from "../../lib/endpoints";
 import { MetricTimeline, localHM, nowIndexOf, periodPointLabel, type TimelineLine } from "./MetricTimeline";
 import { Spinner } from "../common/Spinner";
-import type { PeriodInsightsResponse, PvTodayResponse, GridTodayResponse, AgileTodayResponse } from "../../lib/types";
+import { gbp } from "../../lib/format";
+import type { PeriodInsightsResponse, PvTodayResponse, GridTodayResponse, AgileTodayResponse, ExportOpportunityResponse } from "../../lib/types";
 import { isCurrentPeriod, type PeriodState } from "../../lib/period";
 import "./timeline-widget.css";
 
@@ -13,15 +14,29 @@ interface Props {
   periodLoading: boolean;
   // Octopus rates — export_slots drives the price line, import_slots the zones.
   agile: AgileTodayResponse | null;
+  // Running tally of export £ lost on flat SEG vs Outgoing Agile.
+  opportunity?: ExportOpportunityResponse | null;
   cheapP?: number | null;
   peakP?: number | null;
+}
+
+// The "money left on the table" line — only meaningful while on flat SEG.
+function OppyLine({ o }: { o?: ExportOpportunityResponse | null }) {
+  if (!o || o.export_mode !== "seg_flat" || o.opportunity_gbp <= 0.01) return null;
+  return (
+    <div class="tlw-oppy" title={`Sobre ${o.n_days} dias de export: SEG pagou ${gbp(o.seg_gbp)} vs Outgoing Agile ${gbp(o.agile_gbp)}. A diferença é o que deixamos de ganhar por não estar na Agile (média SEG ${o.avg_seg_p}p vs Agile ${o.avg_agile_p}p/kWh).`}>
+      💸 perdido vs Agile: <strong>{gbp(o.opportunity_gbp)}</strong> em {o.n_days}d
+      {o.annualized_gbp > 0 && <> · ~{gbp(o.annualized_gbp)}/ano</>}
+      {o.today.opportunity_gbp > 0.005 && <> · hoje {gbp(o.today.opportunity_gbp)}</>}
+    </div>
+  );
 }
 
 // GENERATION = what the house produced and fed back. Day → solar committed-plan
 // vs realised + grid export, with the Octopus EXPORT price slots on the right
 // axis and the cheap/peak/negative tariff zones shaded (from the import price —
 // the canonical tariff context). Week/month/year → daily solar + export bars.
-export function GenerationWidget({ period, periodData, periodLoading, agile }: Props) {
+export function GenerationWidget({ period, periodData, periodLoading, agile, opportunity }: Props) {
   const isDay = period.gran === "day";
   const dayArg = isCurrentPeriod(period) ? undefined : period.anchor;
   const day = useFetch(
@@ -53,20 +68,22 @@ export function GenerationWidget({ period, periodData, periodLoading, agile }: P
       const v = expBy.get(s.slot_utc);
       return v == null ? null : round2(v);
     });
+    // Export prices on the right axis. SEG flat (what we earn today) = the green
+    // line; the Outgoing Agile curve (what we WOULD earn) overlaid in amber so
+    // the gap between them is the opportunity. On Outgoing Agile the green line
+    // IS the curve and there's no separate comparison.
+    const segRate = agile?.export_seg_rate_p ?? null;
+    const onSeg = segRate != null;
+    const expPriceBy = new Map<string, number>();
+    for (const es of agile?.export_slots ?? []) expPriceBy.set(normZ(es.valid_from), es.p);
+    const agileExportPrice = slots.map((s) => expPriceBy.get(normZ(s.slot_utc)) ?? null);
+    const exportPrice = onSeg ? slots.map(() => segRate) : agileExportPrice;
     const lines: TimelineLine[] = [
       { name: "Solar plan", color: withAlpha(t.pv, 0.5), data: solarPlan, dashed: true },
       { name: "Solar", color: t.pv, data: solarActual, area: true, width: 3 },
       { name: "Export", color: t.exportColor, data: exportActual, width: 1.75 },
+      ...(onSeg ? [{ name: "Outgoing Agile", color: t.warn, data: agileExportPrice, dashed: true, isPrice: true } as TimelineLine] : []),
     ];
-    // Export price line (right axis, green dashed) = the rate ACTUALLY earned.
-    // On SEG flat it's a flat line at that rate (4.1p) — flat, so it does NOT
-    // mirror the import curve. If/when on Outgoing Agile, it tracks the per-slot
-    // export_slots automatically. Mirrors Consumption's import price line.
-    const segRate = agile?.export_seg_rate_p ?? null;
-    const expPriceBy = new Map<string, number>();
-    for (const es of agile?.export_slots ?? []) expPriceBy.set(normZ(es.valid_from), es.p);
-    const exportPrice = slots.map((s) =>
-      segRate != null ? segRate : (expPriceBy.get(normZ(s.slot_utc)) ?? null));
     const nowMs = pv?.now_utc ? new Date(pv.now_utc).getTime() : Date.now();
     const genTotal = slots.reduce((sum, s) => {
       const elapsed = new Date(s.slot_utc).getTime() + 30 * 60_000 <= nowMs;
@@ -80,16 +97,19 @@ export function GenerationWidget({ period, periodData, periodLoading, agile }: P
           <span class="tlw-summary-value tlw-pos">{exportedTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh export</span></span>
           <span class="tlw-summary-label">esperado hoje{segRate != null ? ` · export pago a ${segRate.toFixed(1)}p/kWh (SEG flat)` : ""}</span>
         </div>
+        <OppyLine o={opportunity} />
         {/* Export price line (green, right axis) mirrors Consumption's import
             line; the cheap/peak/negative ZONES stay on Consumption only (that's
             the import tariff) so the two timelines don't repeat the same bands. */}
         <MetricTimeline labels={labels} lines={lines} prices={exportPrice}
-                        priceLabel="Export price" priceColor={t.exportColor} nowIdx={nowIdx} height={270} />
+                        priceLabel={onSeg ? "Export (SEG)" : "Export price"} priceColor={t.exportColor}
+                        nowIdx={nowIdx} height={270} />
         <div class="tlw-legend">
           <span><i style={`border-color:${t.pv}`} /> solar actual</span>
           <span><i class="dashed" style={`border-color:${withAlpha(t.pv, 0.6)}`} /> solar plan</span>
           <span><i style={`border-color:${t.exportColor}`} /> export kWh</span>
-          <span><i class="dashed" style={`border-color:${t.exportColor}`} /> export price{segRate != null ? ` (${segRate.toFixed(1)}p SEG)` : ""}</span>
+          <span><i class="dashed" style={`border-color:${t.exportColor}`} /> export {onSeg ? `${segRate.toFixed(1)}p SEG` : "price"}</span>
+          {onSeg && <span><i class="dashed" style={`border-color:${t.warn}`} /> Outgoing Agile (alvo)</span>}
           <span>◉ now</span>
         </div>
       </div>
@@ -114,6 +134,7 @@ export function GenerationWidget({ period, periodData, periodLoading, agile }: P
         <span class="tlw-summary-value tlw-pos">{expTot.toFixed(0)}<span class="tlw-summary-unit"> kWh export</span></span>
         <span class="tlw-summary-label">geração · {periodData?.period_label}</span>
       </div>
+      <OppyLine o={opportunity} />
       <MetricTimeline labels={labels} lines={lines} barMode height={240} />
     </div>
   );

--- a/ui/src/components/home/MetricTimeline.tsx
+++ b/ui/src/components/home/MetricTimeline.tsx
@@ -24,6 +24,7 @@ export interface TimelineLine {
   area?: boolean;        // gradient fill (the one bold "actual" line)
   step?: boolean;        // price reference
   yAxis?: number;        // 0 = left (kWh), 1 = right (price p)
+  isPrice?: boolean;     // a price series: forced onto the right p-axis + p-formatted in the tooltip
 }
 
 interface MetricTimelineProps {
@@ -77,7 +78,12 @@ export function MetricTimeline({
     const t = chartTheme();
     const base = baseOption();
     const animate = !reducedMotion();
-    const hasPrice = !barMode && (prices?.some((p) => p != null) ?? false);
+    // Right p-axis exists when there's a `prices` series OR any isPrice line.
+    const hasPriceLines = lines.some((l) => l.isPrice);
+    const hasPrice = !barMode && ((prices?.some((p) => p != null) ?? false) || hasPriceLines);
+    // Series rendered as prices (pence-formatted, right axis): the `prices`
+    // series (named priceLabel) plus any line flagged isPrice.
+    const priceNames = new Set<string>([priceLabel, ...lines.filter((l) => l.isPrice).map((l) => l.name)]);
     // Shading appears ONLY when bandPrices is given (the import price). A widget
     // that just wants a price LINE (export) passes no bandPrices → no zones, so
     // the two timelines don't both repeat the same tariff bands.
@@ -136,8 +142,8 @@ export function MetricTimeline({
       }
       return {
         name: ln.name, type: "line", smooth: true, showSymbol: false, connectNulls: false,
-        color: ln.color, data: ln.data, yAxisIndex: ln.yAxis ?? 0,
-        step: ln.step ? "middle" : undefined,
+        color: ln.color, data: ln.data, yAxisIndex: ln.isPrice ? 1 : (ln.yAxis ?? 0),
+        step: ln.step || ln.isPrice ? "middle" : undefined,
         lineStyle: {
           color: ln.color, width: ln.width ?? (ln.dashed ? 1.25 : 2.5),
           type: ln.dashed ? "dashed" : "solid", opacity: ln.dashed ? 0.8 : 1,
@@ -172,7 +178,7 @@ export function MetricTimeline({
             .filter((p) => p.seriesName && !p.seriesName.startsWith("_"))
             .map((p) => {
               if (p.value == null || !Number.isFinite(p.value)) return "";
-              const isPrice = p.seriesName === priceLabel;
+              const isPrice = p.seriesName != null && priceNames.has(p.seriesName);
               const txt = isPrice ? `${Number(p.value).toFixed(1)}p` : `${Number(p.value).toFixed(2)} ${unit}`;
               return `<div>${p.marker ?? ""} ${p.seriesName}: <strong>${txt}</strong></div>`;
             })

--- a/ui/src/components/home/timeline-widget.css
+++ b/ui/src/components/home/timeline-widget.css
@@ -25,6 +25,16 @@
 }
 .tlw-pos { color: var(--ok, #36d399); }
 .tlw-neg { color: var(--bad, #f87171); }
+/* "Money left on the table" — export £ lost on flat SEG vs Outgoing Agile. */
+.tlw-oppy {
+  font-size: var(--font-xs);
+  color: var(--warn, #f59e0b);
+  font-variant-numeric: tabular-nums;
+  padding: 3px 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--warn, #f59e0b) 12%, transparent);
+}
+.tlw-oppy strong { color: var(--warn, #f59e0b); font-weight: 700; }
 /* The "week/month/year shows actuals only" note — quiet, italic. */
 .tlw-mode-note {
   font-size: 10px;

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -25,6 +25,7 @@ import type {
   HeatingPlanResponse,
   PvTodayResponse,
   GridTodayResponse,
+  ExportOpportunityResponse,
   OptimizationInputsResponse,
   ActionResult,
   DaikinOperationMode,
@@ -52,6 +53,9 @@ export const getPvToday = (date?: string) =>
 // /pv/today; powers the synced Grid timeline widget.
 export const getGridToday = (date?: string) =>
   getJson<GridTodayResponse>(`/grid/today${date ? `?date=${encodeURIComponent(date)}` : ""}`);
+// Running tally of export £ left on the table by being on flat SEG vs Agile.
+export const getExportOpportunity = (days = 60) =>
+  getJson<ExportOpportunityResponse>(`/export/opportunity?days=${days}`);
 export const getOptimizationInputs = () =>
   getJson<OptimizationInputsResponse>("/optimization/inputs");
 export const getDaikinStatus = () => getJson<DaikinDevice[]>("/daikin/status");

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -138,6 +138,23 @@ export interface PvTodayResponse {
   plan_run_id?: number | null;
 }
 
+/* ----- /export/opportunity — money lost on flat SEG vs Outgoing Agile ----- */
+
+export interface ExportOpportunityResponse {
+  export_mode: string;             // "seg_flat" | "outgoing_agile"
+  seg_rate_p: number;
+  daily: Array<{ day: string; export_kwh: number; seg_gbp: number; agile_gbp: number; opportunity_gbp: number }>;
+  n_days: number;
+  export_kwh: number;
+  seg_gbp: number;
+  agile_gbp: number;
+  opportunity_gbp: number;         // total Agile − SEG over the window (>0 = lost on SEG)
+  annualized_gbp: number;
+  avg_seg_p: number;
+  avg_agile_p: number;
+  today: { export_kwh: number; opportunity_gbp: number };
+}
+
 /* ----- /grid/today — per-slot planned-vs-realised grid import/export ----- */
 
 export interface GridTodaySlot {

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -17,6 +17,7 @@ import {
   getDhwSchedule,
   getHeatingPlan,
   getEnergyTodayCumulative,
+  getExportOpportunity,
   getApplianceSuggestions,
   getApplianceJobs,
   getAppliances,
@@ -111,6 +112,8 @@ export default function Landing() {
   // Lifetime rollup = 6 sequential /energy/monthly calls — deferred (it's a
   // small stats strip low in the hero, not the headline).
   const monthly = useMonthlyHistory(6, deferred);
+  // Export opportunity (SEG-vs-Agile money left on the table) — deferred, slow.
+  const exportOppy = useFetch(() => (deferred ? getExportOpportunity(60) : Promise.resolve(null)), [deferred]);
   // Daikin cached read — no refresh=true, so no live cloud call (30-min cache TTL).
   const daikin = useFetch(getDaikinStatus, []);
   const daikinQuota = useFetch(getDaikinQuota, []);
@@ -198,7 +201,7 @@ export default function Landing() {
         <Widget title="Generation" icon="☀" tone="plan" size="wide">
           <Suspense fallback={<Spinner label="Loading generation…" />}>
             <GenerationWidget period={period} periodData={periodInsights.data} periodLoading={periodInsights.loading}
-                              agile={agile.data}
+                              agile={agile.data} opportunity={exportOppy.data}
                               cheapP={metrics.data?.cheap_threshold_pence} peakP={metrics.data?.peak_threshold_pence} />
           </Suspense>
         </Widget>


### PR DESCRIPTION
## What

Two asks: (1) show **both** the current export tariff **and** Outgoing Agile on the Generation chart to compare; (2) keep a **daily record of the £ opportunity lost** by being on flat SEG instead of Agile export.

### Backend
- New `export_opportunity_log` table (day PK) + `db.upsert_export_opportunity` / `get_export_opportunity`. `pnl.record_export_opportunity_for_day` computes **Agile − SEG** via `export_revenues_for_day`; `backfill_export_opportunity` seeds history.
- Nightly cron `bulletproof_export_opportunity_job` (04:25 UTC) records yesterday; **backfills** the on-Agile history on first run (empty table).
- **`GET /api/v1/export/opportunity`**: daily rows + running totals (period £, annualized, avg SEG vs Agile p/kWh) + live **"today"** accrual. Lazily backfills on an empty log so the figure shows right after deploy.

### UI
- The Generation chart overlays the **Outgoing Agile** export curve (amber dashed) over the flat **SEG** line (green) — the gap between them is the opportunity. `MetricTimeline` gains `isPrice` so multiple price series share the right p-axis + pence-formatted tooltip.
- **"💸 perdido vs Agile: £X em Nd · ~£Y/ano · hoje £Z"** line on the Generation widget (only while on `seg_flat`), from the new endpoint.

## Why
Confirmed ~**£62/yr** at the current export profile (Agile pays ~**2.9×** the flat 4.1p SEG, since export lands in solar hours). `EXPORT_TARIFF_MODE` stays `seg_flat` until Octopus actually switches the household — flipping it then makes HEM value export correctly **and** lets the LP time export to high slots.

## Tests
`tests/test_export_opportunity.py`: db round-trip + opportunity math + endpoint aggregation + lazy backfill. Full backend suite + UI typecheck/build clean.

Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)