### PR TITLE
feat(ui): align heating plan x-axis + add LWT plan to the Plan widget

### DIFF
--- a/ui/src/components/home/HeatingPlanWidget.tsx
+++ b/ui/src/components/home/HeatingPlanWidget.tsx
@@ -50,6 +50,7 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
     const labels = slots.map((s) => localHM(s.slot_utc));
 
     const outdoor = slots.map((s) => (s.outdoor_c == null ? null : s.outdoor_c));
+    const price = slots.map((s) => (s.price_p == null ? null : s.price_p));
     const lwtBase = slots.map((s) => (s.lwt_base_c == null ? null : s.lwt_base_c));
     const lwtSet = slots.map((s) => (s.lwt_setpoint_c == null ? null : s.lwt_setpoint_c));
     const tank = slots.map((s) => (s.tank_temp_c == null ? null : s.tank_temp_c));
@@ -89,7 +90,10 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
     chartRef.current.setOption({
       ...base,
       legend: { show: false },
-      grid: { left: 14, right: 16, top: 14, bottom: 22, containLabel: true },
+      // Match the Generation/Consumption grid (incl. the right:44 the price axis
+      // reserves there) so all three intraday charts line up on the x-axis and
+      // a given time reads straight down the screen.
+      grid: { left: 16, right: 44, top: 16, bottom: 24, containLabel: true },
       tooltip: {
         ...(base.tooltip as object),
         formatter: (params: Array<{ dataIndex: number }>) => {
@@ -108,9 +112,16 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
           return rows.join("<br/>");
         },
       },
-      xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 11 } },
-      yAxis: [{ ...(base.yAxis as object), name: "°C", nameTextStyle: { color: t.textMute, fontSize: 10 },
-        axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}" } }],
+      xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
+      yAxis: [
+        { ...(base.yAxis as object), name: "°C", nameTextStyle: { color: t.textMute, fontSize: 10 },
+          axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}" } },
+        // Right import-price axis — mirrors Generation/Consumption so all three
+        // intraday charts share the same plot box + the heating plan reads
+        // against the price it's responding to (boost cheap / setback peak).
+        { ...(base.yAxis as object), position: "right", splitLine: { show: false },
+          axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}p" } },
+      ],
       series: [
         { name: "_bg", type: "line", data: slots.map(() => null), silent: true, z: 0,
           markArea: bands.length ? { silent: true, data: bands } : undefined,
@@ -129,6 +140,9 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
         // Tank target — orange step.
         { name: "Tank", type: "line", step: "middle", showSymbol: false, connectNulls: false,
           data: tank, lineStyle: { color: t.thermal, width: 1.5, type: "dashed", cap: "round" }, z: 4 },
+        // Import price on the right axis (faint) — the signal HEM offsets against.
+        { name: "Import price", type: "line", step: "middle", showSymbol: false, yAxisIndex: 1,
+          data: price, lineStyle: { color: t.importColor, width: 1.25, opacity: 0.7, type: "dashed" }, z: 1 },
         ...(nowIdx >= 0 ? [{
           name: "_now", type: "effectScatter", silent: true, coordinateSystem: "cartesian2d",
           symbolSize: 8, z: 6, showEffectOn: "render",
@@ -149,6 +163,7 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
           <span class="hpl-tok"><span class="hpl-line hpl-line--lwt" /> radiator LWT</span>
           <span class="hpl-tok"><span class="hpl-line hpl-line--curve" /> curve (no offset)</span>
           <span class="hpl-tok"><span class="hpl-line hpl-line--tank" /> tank</span>
+          <span class="hpl-tok"><span class="hpl-line" style="border-top:1.5px dashed var(--import)" /> import p</span>
           <span class="hpl-tok"><span class="hpl-sw hpl-sw--heat" /> heating</span>
           <span class="hpl-tok"><span class="hpl-sw hpl-sw--neg" /> paid to import</span>
           <span class="hpl-hint">◉ now · hover for detail</span>

--- a/ui/src/components/home/PlanWidget.tsx
+++ b/ui/src/components/home/PlanWidget.tsx
@@ -1,4 +1,4 @@
-import type { SchedulerTimeline, DhwScheduleRow } from "../../lib/types";
+import type { SchedulerTimeline, DhwScheduleRow, HeatingPlanResponse, HeatingPlanSlot } from "../../lib/types";
 import { formatRelativeSlot, endLabelFor, tankLabelOf, tankKindOf } from "../../lib/slotLabels";
 import { upcomingForcedWindows, labelForKind, kindColorVar } from "../../lib/planHelpers";
 import "./plan-widget.css";
@@ -6,16 +6,49 @@ import "./plan-widget.css";
 interface Props {
   timeline: SchedulerTimeline | null;
   dhwSchedule?: DhwScheduleRow[] | null;
+  heatingPlan?: HeatingPlanResponse | null;
   nowUtc?: string;
   foxMode?: string;
   foxActive?: boolean;
+}
+
+interface LwtWindow { kind: "boost" | "setback"; start_utc: string; end_utc: string; slot_count: number; peak: number; }
+
+// Upcoming space-heating LWT offset windows: contiguous future slots where HEM
+// nudges the radiator water temp up (boost, on cheap/negative) or down (setback,
+// on peak). Neutral (offset 0) slots break a run.
+function upcomingLwtWindows(slots: HeatingPlanSlot[], nowMs: number, limit = 3): LwtWindow[] {
+  const out: LwtWindow[] = [];
+  let cur: LwtWindow | null = null;
+  for (const s of slots) {
+    const st = s.slot_utc ? Date.parse(s.slot_utc) : NaN;
+    if (!Number.isFinite(st) || st <= nowMs) continue;   // future only
+    const off = s.lwt_offset ?? 0;
+    const kind = off > 0 ? "boost" : off < 0 ? "setback" : null;
+    if (kind) {
+      if (cur && cur.kind === kind) {
+        cur.end_utc = s.slot_utc!;
+        cur.slot_count += 1;
+        if (Math.abs(off) > Math.abs(cur.peak)) cur.peak = off;
+      } else {
+        if (cur) out.push(cur);
+        cur = { kind, start_utc: s.slot_utc!, end_utc: s.slot_utc!, slot_count: 1, peak: off };
+      }
+    } else if (cur) {
+      out.push(cur);
+      cur = null;
+      if (out.length >= limit) break;
+    }
+  }
+  if (cur) out.push(cur);
+  return out.slice(0, limit);
 }
 
 // The committed dispatch PLAN, lifted out of the Live-power tile into its own
 // card next to Weather: the upcoming Fox battery windows + the tank (DHW)
 // schedule, side by side. Forward-looking only — "what the system is about to
 // do". The live power flow stays in the Live-power tile.
-export function PlanWidget({ timeline, dhwSchedule, nowUtc, foxMode, foxActive }: Props) {
+export function PlanWidget({ timeline, dhwSchedule, heatingPlan, nowUtc, foxMode, foxActive }: Props) {
   const forced = timeline ? upcomingForcedWindows(timeline, 4) : [];
   const nowMs = nowUtc ? Date.parse(nowUtc) : Date.now();
   const tank = (dhwSchedule || [])
@@ -23,9 +56,13 @@ export function PlanWidget({ timeline, dhwSchedule, nowUtc, foxMode, foxActive }
     .sort((a, b) => Date.parse(a.start_utc!) - Date.parse(b.start_utc!))
     .slice(0, 4);
 
+  const lwt = upcomingLwtWindows(
+    (heatingPlan?.slots || []).filter((s) => !!s.slot_utc), nowMs, 3,
+  );
+
   const runId = timeline?.run_id ?? null;
   const planDate = timeline?.plan_date ?? null;
-  const nothing = forced.length === 0 && tank.length === 0;
+  const nothing = forced.length === 0 && tank.length === 0 && lwt.length === 0;
 
   return (
     <div class="planw">
@@ -56,6 +93,31 @@ export function PlanWidget({ timeline, dhwSchedule, nowUtc, foxMode, foxActive }
           </div>
         ) : (
           <span class="planw-empty">Self-use — no forced windows ahead</span>
+        )}
+      </div>
+
+      {/* HEATING (space-heating LWT offset) */}
+      <div class="planw-group">
+        <div class="planw-head"><span class="planw-title">Heating</span></div>
+        {lwt.length > 0 ? (
+          <div class="planw-chips">
+            {lwt.map((w) => {
+              const start = formatRelativeSlot(w.start_utc, nowUtc);
+              const endTime = endLabelFor(w.end_utc);
+              const range = w.slot_count > 1 ? `${start.timeLabel}–${endTime}` : start.timeLabel;
+              const label = w.kind === "boost" ? "Boost" : "Setback";
+              return (
+                <span key={w.start_utc} class={`planw-chip planw-chip--lwt-${w.kind}`}
+                      title={`Radiator ${label} ${w.peak > 0 ? "+" : ""}${w.peak}°C · ${start.dayLabel ? start.dayLabel + " " : ""}${range}`}>
+                  <span class="planw-dot" style={`background:${w.kind === "boost" ? "var(--ok)" : "var(--warn)"}`} />
+                  {label} <span class="planw-temp-inline">{w.peak > 0 ? "+" : ""}{w.peak}°</span>
+                  <span class="planw-when">{start.dayLabel ? `${start.dayLabel} ` : ""}{range}</span>
+                </span>
+              );
+            })}
+          </div>
+        ) : (
+          <span class="planw-empty">Weather curve — no LWT offset ahead</span>
         )}
       </div>
 

--- a/ui/src/components/home/plan-widget.css
+++ b/ui/src/components/home/plan-widget.css
@@ -39,6 +39,7 @@
 .planw-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
 .planw-dot--tank { background: var(--thermal, #fb923c); }
 .planw-when { color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.planw-temp-inline { color: var(--text); font-weight: 600; font-variant-numeric: tabular-nums; }
 .planw-temp {
   margin-left: auto;
   font-variant-numeric: tabular-nums;

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -187,8 +187,8 @@ export default function Landing() {
         </Widget>
 
         <Widget title="Plan" icon="🗓" tone="plan" size="medium">
-          <PlanWidget timeline={timeline.data} dhwSchedule={dhwSched.data?.rows} nowUtc={data.now_utc}
-                      foxMode={foxMode} foxActive={foxActive} />
+          <PlanWidget timeline={timeline.data} dhwSchedule={dhwSched.data?.rows} heatingPlan={heatingPlan.data}
+                      nowUtc={data.now_utc} foxMode={foxMode} foxActive={foxActive} />
         </Widget>
       </div>
 


### PR DESCRIPTION
## What
Two tweaks:

1. **Heating plan x-axis aligned** with Generation/Consumption. The three intraday charts now share the same plot box — same grid margins (`left:16 right:44 top:16 bottom:24`), same x-label interval (5), and a matching **right import-price axis** (+ a faint price line). They were off because Gen/Consumption reserve `right:44` for their price axis while Heating used `right:16` with no right axis. Today's heating slots already span the same 48 (00:00–23:30), so only the chart box differed. Bonus: the heating plan now reads against the price it offsets to (boost cheap / setback peak).
2. **LWT plan added to the Plan widget.** It had Battery + Tank but no space-heating — now a **Heating** group shows the upcoming radiator LWT offset windows (`Boost +N°` / `Setback −N°` with times), derived from the heating plan slots.

UI-only; typecheck + build clean. Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)