### PR TITLE
feat(ui): Live heating + Plan merges; drop manual climate/tank controls

### DIFF
--- a/ui/src/components/common/Widget.tsx
+++ b/ui/src/components/common/Widget.tsx
@@ -2,7 +2,7 @@ import type { ComponentChildren } from "preact";
 import { WidgetBoundary } from "./WidgetBoundary";
 import "./widget.css";
 
-export type WidgetSize = "medium" | "large" | "wide";
+export type WidgetSize = "medium" | "half" | "large" | "wide";
 export type WidgetTone = "default" | "power" | "tariff" | "thermal" | "savings" | "plan" | "coming";
 
 interface WidgetProps {

--- a/ui/src/components/common/widget.css
+++ b/ui/src/components/common/widget.css
@@ -48,11 +48,13 @@
 
 @media (min-width: 720px) {
   .widget--medium { grid-column: span 6; }
+  .widget--half { grid-column: span 6; }
   .widget--large { grid-column: span 12; }
   .widget--wide { grid-column: span 12; }
 }
 @media (min-width: 1024px) {
   .widget--medium { grid-column: span 4; }
+  .widget--half { grid-column: span 6; }   /* exactly half — splits a row 50/50 */
   .widget--large { grid-column: span 8; }
   .widget--wide { grid-column: span 12; }
 }

--- a/ui/src/components/home/HeatingWidget.tsx
+++ b/ui/src/components/home/HeatingWidget.tsx
@@ -14,7 +14,6 @@ import { Pill } from "../common/Pill";
 import { Gauge } from "../common/Gauge";
 import { RadialGauge } from "../common/RadialGauge";
 import { Modal } from "../common/Modal";
-import { HeatingControls } from "./HeatingControls";
 import { RefreshCountdown } from "../common/RefreshCountdown";
 import "./heating.css";
 
@@ -175,8 +174,6 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
           </div>
         </div>
       )}
-
-      <HeatingControls dev={dev} controlMode={daikinQuota?.control_mode} onChanged={() => onRefresh?.()} />
 
       <Modal open={confirmingRefresh} onClose={() => { setConfirmingRefresh(false); setRefreshError(null); }} width="sm"
              title="Fetch live heat-pump data?"

--- a/ui/src/components/home/PlanWidget.tsx
+++ b/ui/src/components/home/PlanWidget.tsx
@@ -1,4 +1,7 @@
-import type { SchedulerTimeline, DhwScheduleRow, HeatingPlanResponse, HeatingPlanSlot } from "../../lib/types";
+import type {
+  SchedulerTimeline, DhwScheduleRow, HeatingPlanResponse, HeatingPlanSlot,
+  Appliance, ApplianceJob, ApplianceSuggestion,
+} from "../../lib/types";
 import { formatRelativeSlot, endLabelFor, tankLabelOf, tankKindOf } from "../../lib/slotLabels";
 import { upcomingForcedWindows, labelForKind, kindColorVar } from "../../lib/planHelpers";
 import "./plan-widget.css";
@@ -7,9 +10,19 @@ interface Props {
   timeline: SchedulerTimeline | null;
   dhwSchedule?: DhwScheduleRow[] | null;
   heatingPlan?: HeatingPlanResponse | null;
+  // Appliances (merged in from the standalone widget).
+  appliances?: Appliance[] | null;
+  applianceJobs?: ApplianceJob[] | null;
+  applianceSuggestions?: ApplianceSuggestion[] | null;
   nowUtc?: string;
   foxMode?: string;
   foxActive?: boolean;
+}
+
+function hm(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  try { return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }); }
+  catch { return "—"; }
 }
 
 interface LwtWindow { kind: "boost" | "setback"; start_utc: string; end_utc: string; slot_count: number; peak: number; }
@@ -48,7 +61,10 @@ function upcomingLwtWindows(slots: HeatingPlanSlot[], nowMs: number, limit = 3):
 // card next to Weather: the upcoming Fox battery windows + the tank (DHW)
 // schedule, side by side. Forward-looking only — "what the system is about to
 // do". The live power flow stays in the Live-power tile.
-export function PlanWidget({ timeline, dhwSchedule, heatingPlan, nowUtc, foxMode, foxActive }: Props) {
+export function PlanWidget({
+  timeline, dhwSchedule, heatingPlan, appliances, applianceJobs, applianceSuggestions,
+  nowUtc, foxMode, foxActive,
+}: Props) {
   const forced = timeline ? upcomingForcedWindows(timeline, 4) : [];
   const nowMs = nowUtc ? Date.parse(nowUtc) : Date.now();
   const tank = (dhwSchedule || [])
@@ -59,6 +75,13 @@ export function PlanWidget({ timeline, dhwSchedule, heatingPlan, nowUtc, foxMode
   const lwt = upcomingLwtWindows(
     (heatingPlan?.slots || []).filter((s) => !!s.slot_utc), nowMs, 3,
   );
+
+  const apps = (appliances || []).filter((a) => a.enabled);
+  const jobByApp = new Map(
+    (applianceJobs || []).filter((j) => j.status === "scheduled" || j.status === "running")
+      .map((j) => [j.appliance_id, j]),
+  );
+  const sugByApp = new Map((applianceSuggestions || []).map((s) => [s.appliance_id, s]));
 
   const runId = timeline?.run_id ?? null;
   const planDate = timeline?.plan_date ?? null;
@@ -144,7 +167,52 @@ export function PlanWidget({ timeline, dhwSchedule, heatingPlan, nowUtc, foxMode
         )}
       </div>
 
-      {nothing && <span class="planw-allquiet">Plan steady — nothing scheduled soon</span>}
+      {/* APPLIANCES (merged from the standalone widget) */}
+      {apps.length > 0 && (
+        <div class="planw-group">
+          <div class="planw-head"><span class="planw-title">Appliances</span></div>
+          <div class="planw-chips">
+            {apps.map((a) => {
+              const job = jobByApp.get(a.id);
+              const sug = sugByApp.get(a.id);
+              if (job?.status === "running") {
+                return (
+                  <span key={a.id} class="planw-chip planw-chip--run">
+                    <span class="planw-dot" style="background:var(--ok)" />🧺 {a.name} <span class="planw-when">running</span>
+                  </span>
+                );
+              }
+              if (job) {
+                return (
+                  <span key={a.id} class="planw-chip"
+                        title={`Scheduled ${hm(job.planned_start_utc)}–${hm(job.planned_end_utc)}${job.avg_price_pence != null ? ` · ${job.avg_price_pence.toFixed(1)}p/kWh` : ""}`}>
+                    <span class="planw-dot" style="background:var(--cheap,#36d399)" />🧺 {a.name}
+                    <span class="planw-when">{hm(job.planned_start_utc)}–{hm(job.planned_end_utc)}</span>
+                  </span>
+                );
+              }
+              if (sug) {
+                const paid = sug.is_negative;
+                const cheap = sug.meets_threshold !== false;
+                return (
+                  <span key={a.id} class="planw-chip"
+                        title={`${cheap ? (paid ? "Paid" : "Cheap") + " window" : "Next window (no cheap window ahead)"} ${hm(sug.recommended_start_utc)}–${hm(sug.recommended_end_utc)} · ${sug.avg_price_pence.toFixed(1)}p · load + Smart Control by ${sug.deadline_local}`}>
+                    <span class="planw-dot" style={`background:${paid ? "var(--neg,#38bdf8)" : cheap ? "var(--cheap,#36d399)" : "var(--text-mute)"}`} />🧺 {a.name}
+                    <span class="planw-when">{cheap ? "" : "next "}{hm(sug.recommended_start_utc)} · {sug.avg_price_pence.toFixed(1)}p</span>
+                  </span>
+                );
+              }
+              return (
+                <span key={a.id} class="planw-chip planw-chip--idle">
+                  <span class="planw-dot" style="background:var(--text-mute)" />🧺 {a.name} <span class="planw-when">idle</span>
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {nothing && apps.length === 0 && <span class="planw-allquiet">Plan steady — nothing scheduled soon</span>}
 
       {(runId != null || planDate) && (
         <div class="planw-foot" title="The LP run this plan came from">

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -31,7 +31,6 @@ import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
 import { Hero } from "../components/home/Hero";
 import { HeatingWidget } from "../components/home/HeatingWidget";
 import { WeatherWidget } from "../components/home/WeatherWidget";
-import { ApplianceWidget } from "../components/home/ApplianceWidget";
 import { PlanWidget } from "../components/home/PlanWidget";
 import type { MonthlyEnergy } from "../lib/types";
 import "../components/home/home.css";
@@ -164,39 +163,41 @@ export default function Landing() {
             period={periodInsights.data} periodState={period}
             periodLoading={periodInsights.loading} todayCum={todayCum.data} />
 
-      {/* ── LIVE (glanceable now-state, up top — Apple/Tesla) ──────────
-          These three IGNORE the period navigator: they're always "now". */}
+      {/* ── LIVE — split 50/50: live power flow + live heating (gauges + the
+          heating-plan timeline). Always "now"; ignore the period navigator. */}
       <div class="widget-grid widget-band">
-        <Widget title="Live power" icon="⚡" tone="power" size="large"
+        <Widget title="Live power" icon="⚡" tone="power" size="half"
                 badge={data.now_utc ? new Date(data.now_utc).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }) : undefined}
                 action={<RefreshCountdown lastFetchAt={now.lastFetchAt} intervalMs={now.intervalMs} loading={now.loading} onRefresh={() => void now.refresh()} />}>
           <LivePowerWidget state={s} cockpit={data} timeline={timeline.data} execution={execution.data} agile={agile.data} metrics={metrics.data} dhwSchedule={dhwSched.data?.rows} todayCumulative={todayCum.data} />
         </Widget>
 
-        <Widget title="Heating" icon="♨" tone="thermal" size="medium">
+        <Widget title="Live heating" icon="♨" tone="thermal" size="half">
           <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data}
                          onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} />
-        </Widget>
-
-        <Widget title="Appliances" icon="🧺" tone="power" size="medium">
-          <ApplianceWidget suggestions={applianceSug.data?.suggestions} jobs={applianceJobs.data?.jobs} appliances={appliances.data?.appliances} />
-        </Widget>
-
-        <Widget title="Weather" icon="⛅" tone="thermal" size="medium">
-          <WeatherWidget weather={weather.data} pv={pvToday.data} />
-        </Widget>
-
-        <Widget title="Plan" icon="🗓" tone="plan" size="medium">
-          <PlanWidget timeline={timeline.data} dhwSchedule={dhwSched.data?.rows} heatingPlan={heatingPlan.data}
-                      nowUtc={data.now_utc} foxMode={foxMode} foxActive={foxActive} />
+          <Suspense fallback={<Spinner label="Loading heating plan…" />}>
+            <HeatingPlanWidget plan={heatingPlan.data} loading={heatingPlan.loading} />
+          </Suspense>
         </Widget>
       </div>
 
-      {/* ── TIMELINES — Generation + Consumption, both synced to the period
-          navigator (navigate one → navigate all). Heating keeps its own
-          D-1/D/D+1 frame. Day = forecast-vs-actual + cheap/peak/negative tariff
-          zones + the Octopus export/import price slots; week/month/year =
-          actuals bars (no historical intraday forecast). ─────────────────── */}
+      {/* ── PLAN + WEATHER (50/50). Plan = the committed dispatch (battery +
+          heating LWT + tank + appliances). No manual climate/tank controls. */}
+      <div class="widget-grid widget-band">
+        <Widget title="Plan" icon="🗓" tone="plan" size="half">
+          <PlanWidget timeline={timeline.data} dhwSchedule={dhwSched.data?.rows} heatingPlan={heatingPlan.data}
+                      appliances={appliances.data?.appliances} applianceJobs={applianceJobs.data?.jobs}
+                      applianceSuggestions={applianceSug.data?.suggestions}
+                      nowUtc={data.now_utc} foxMode={foxMode} foxActive={foxActive} />
+        </Widget>
+
+        <Widget title="Weather" icon="⛅" tone="thermal" size="half">
+          <WeatherWidget weather={weather.data} pv={pvToday.data} />
+        </Widget>
+      </div>
+
+      {/* ── TIMELINES — Generation + Consumption, synced to the period navigator.
+          Stacked full-width so a given time reads straight down the screen. ── */}
       <div class="widget-grid widget-band">
         <Widget title="Generation" icon="☀" tone="plan" size="wide">
           <Suspense fallback={<Spinner label="Loading generation…" />}>
@@ -209,12 +210,6 @@ export default function Landing() {
         <Widget title="Consumption" icon="📈" tone="power" size="wide">
           <Suspense fallback={<Spinner label="Loading consumption…" />}>
             <EnergyChartWidget execution={execution.data} pv={pvToday.data} />
-          </Suspense>
-        </Widget>
-
-        <Widget title="Heating plan" icon="♨" tone="thermal" size="wide">
-          <Suspense fallback={<Spinner label="Loading heating plan…" />}>
-            <HeatingPlanWidget plan={heatingPlan.data} loading={heatingPlan.loading} />
           </Suspense>
         </Widget>
       </div>


### PR DESCRIPTION
## What (user-confirmed layout)

- **Row 1 (50/50):** **Live power** + **Live heating**. Live heating merges the heating **gauges** (tank/outdoor/LWT) with the **heating-plan timeline** in one card.
- **Row 2 (50/50):** **Plan** + **Weather**. The Plan widget **absorbs Appliances** as a 4th group (running / scheduled / next-window per machine), alongside Battery, Heating (LWT) and Tank.
- **Row 3:** Generation + Consumption (unchanged, stacked full-width).
- New **`half`** widget size (`span 6` = exactly half a row) drives the 50/50 rows.

**Removed the manual climate + tank controls** (`HeatingControls`) — "we won't control that from there anymore"; HEM/Daikin drive it. The standalone Appliances widget and HeatingControls are **unmounted** (left on disk for rollback, tree-shaken out).

UI-only; typecheck + build clean. Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)