### PR TITLE
feat(ui): cockpit redesign Phase 1 — visual foundation

### DIFF
--- a/ui/design/cockpit-brief.md
+++ b/ui/design/cockpit-brief.md
@@ -1,0 +1,95 @@
+# HEM cockpit — design brief (for claude.ai/design)
+
+A home-energy dashboard for a solar + battery + heat-pump house on Octopus Agile
+(import) + Outgoing Agile (export). Dark theme, "Apple/Tesla" glanceable feel.
+**Goal of the redesign:** make it cleaner / easier to read at a glance, keep all
+the data below, suggest a better information hierarchy + visual treatment.
+
+**Port target (don't design away from this):** Preact + TypeScript + **ECharts**
+(real charts), a **12-column responsive widget grid**. Mockup can be plain
+HTML/React/Tailwind — it gets translated back into this stack. Charts in the
+snapshot are SVG approximations; in the real app they're interactive ECharts.
+
+Companion file: `cockpit-snapshot.html` — the current layout with real data
+frozen 2026-06-08.
+
+---
+
+## Structure (top → bottom)
+
+### 0. Period navigator (sticky-ish, top)
+- Granularity tabs: **Day / Week / Month / Year** (default Day).
+- Prev/next stepper + the period label ("Today · 8 Jun 2026").
+- Drives the Hero + Generation + Consumption (NOT the live widgets).
+
+### 1. Hero (full width)
+The "how am I doing" headline.
+- **Big number:** the period's net bill so far — `£1.26` today.
+- **Key stat:** `4.0 kWh da rede hoje` (grid import — the billed kWh) · `standing £0.59/dia`.
+- **vs fixed:** `Gastou +£0.03 hoje vs British Gas Fixed v58` (green if saved, red if behind).
+- **Target line:** `🎯 meta: import médio ≤ 18.7p · hoje 16.9p ✓` — the avg import price needed to beat the fixed tariff (Agile loses on standing, must win on unit price).
+- **Live-now strip:** `import 15.4p · export 9.0p · battery 48%` (always current).
+- **Right panel:** today's import-price sparkline coloured by tier (paid/cheap/standard/peak) + now-marker.
+- **Lifetime strip:** solar produced, exported, £ saved vs fixed (on-Agile months).
+
+### 2. Row — Live power | Live heating (50/50)
+**Live power** (always "now"):
+- Power-flow schematic: solar → grid → house + battery (SoC 48%).
+- Import rate `15.4p` (4.0 kWh · £0.67) + Export rate `9.0p` (0.0 kWh).
+- "Next:" the soonest battery + tank action.
+
+**Live heating** (always "now") — gauges + the heating-plan timeline merged:
+- Gauges: **Tank** `50°C` (target 45, on/off) · **Outdoor** `16°C` · **LWT offset** `+3°` · Heating today `2.1 kWh est`.
+- **Heating-plan chart (today):** outdoor temp, weather-curve LWT, radiator LWT (the commanded line), tank target (step), import-price (right axis); tariff bands shaded (negative blue / peak amber).
+
+### 3. Row — Plan | Weather (50/50)
+**Plan** — the committed dispatch, forward-looking, 4 groups of chips:
+- **Battery:** upcoming forced windows (Force charge / discharge / drain) + Fox mode.
+- **Heating:** radiator LWT offset windows (Boost +N° / Setback −N°).
+- **Tank:** DHW schedule (Warmup/Setback/Boost + time + target °C).
+- **Appliances:** per machine — running / scheduled HH:MM–HH:MM · price / next window.
+- Footer: LP run id + plan date.
+
+**Weather:**
+- Current temp `14°`, condition, H/L, cloud %.
+- **Solar expected · rest of day** `6.2 kWh` (forward sum from now).
+- Today's solar curve (sunrise → peak → sunset) + now-marker.
+
+### 4. Generation (full width) — period-synced
+- Headline: `14.2 kWh solar esperado hoje` · `0.0 kWh export`.
+- **Chart (day):** solar plan (dashed) vs actual (area), grid export, and the
+  **export price** line on the right axis (Outgoing Agile curve — green dashed).
+  Week/month/year → daily solar + export bars.
+
+### 5. Consumption (full width) — period-synced
+- Headline: `9.6 kWh consumido so far today`.
+- **Chart (day):** stacked composition (base + appliances + heat-pump areas) +
+  load forecast (dashed) + **import price** on the right axis (red dashed) +
+  tariff bands (paid/cheap/peak). Week/month/year → daily load bars + Daikin heating/tank lines.
+
+> Generation + Consumption are **stacked full-width** and share an identical
+> x-axis (00:00–23:30) so a given time reads straight down the screen.
+
+---
+
+## Design tokens (dark theme — keep the palette)
+```
+bg #0b0f17 · card #111827 · card-2 #1f2937 · border #374151
+text #f3f4f6 · dim #9ca3af · mute #6b7280
+accent #3b82f6 · ok/cheap/export #10b981 · warn/peak #f59e0b · bad/import #ef4444
+neg-price #2563eb · pv #fbbf24 · grid #60a5fa · house #c084fc
+radius 10/16px · font: system-ui, tabular-nums
+```
+A light theme exists too (mirrors these). Spacing scale 0.25→3rem.
+
+## Constraints / notes for the designer
+- **Keep every data point above** — this is an info-dense control surface, not marketing.
+- Colour is **semantic**: import=red, export=green, solar=yellow, battery/cheap=green, peak=amber, paid/negative=blue, heating=purple/orange. Don't repurpose.
+- There are **NO manual controls** (climate/tank control removed — HEM/Daikin drive it). It's read-only + glanceable.
+- The 4 timeline charts (heating, generation, consumption + the hero sparkline) are real ECharts; redesign their *framing/composition*, not the chart engine.
+- Mobile: the 50/50 rows stack to full-width; the full-width charts stay full-width.
+
+## What to return
+An interactive **HTML/React Artifact** mockup of the redesigned cockpit (fake data
+fine) + a short note on the hierarchy decisions. I (Claude Code) port it into the
+real Preact + ECharts components and wire the live endpoints.

--- a/ui/design/cockpit-snapshot.html
+++ b/ui/design/cockpit-snapshot.html
@@ -1,0 +1,340 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>HEM cockpit — current state (design starting point)</title>
+<!--
+  Self-contained snapshot of the HEM energy cockpit as it is RIGHT NOW
+  (data frozen 2026-06-08). Real design tokens + layout + live numbers; the
+  ECharts canvases are approximated as inline SVG so this is one portable file.
+  Hand this to claude.ai/design as the starting point for a redesign.
+  Stack to port back to: Preact + TypeScript + ECharts, 12-col widget grid.
+-->
+<style>
+  :root {
+    --bg:#0b0f17; --bg-card:#111827; --bg-card-2:#1f2937; --bg-card-3:#2a3343;
+    --border:#374151; --border-strong:#4b5563;
+    --text:#f3f4f6; --text-dim:#9ca3af; --text-mute:#6b7280;
+    --accent:#3b82f6; --ok:#10b981; --warn:#f59e0b; --bad:#ef4444;
+    --neg:#2563eb; --cheap:#10b981; --peak:#f59e0b;
+    --pv:#fbbf24; --batt:#10b981; --grid:#60a5fa; --house:#c084fc;
+    --import:#ef4444; --export:#10b981;
+    --space-1:.25rem; --space-2:.5rem; --space-3:.75rem; --space-4:1rem; --space-5:1.5rem;
+    --radius:10px; --radius-lg:16px;
+    --font-xs:.75rem; --font-sm:.875rem; --font-md:1rem; --font-lg:1.125rem; --font-xl:1.5rem; --font-2xl:2rem; --font-hero:4rem;
+    --shadow:0 1px 2px rgba(0,0,0,.5), 0 8px 24px rgba(0,0,0,.35);
+  }
+  * { box-sizing:border-box; }
+  body {
+    margin:0; background:var(--bg); color:var(--text); padding:24px;
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    font-variant-numeric:tabular-nums; line-height:1.4;
+  }
+  .home { max-width:1180px; margin:0 auto; display:flex; flex-direction:column; gap:18px; }
+
+  /* period navigator */
+  .navbar { display:flex; align-items:center; justify-content:space-between; }
+  .gran { display:flex; gap:4px; }
+  .gran button { background:var(--bg-card-2); color:var(--text-dim); border:1px solid var(--border);
+    padding:5px 12px; border-radius:999px; font-size:var(--font-xs); cursor:pointer; }
+  .gran button.active { background:var(--accent); color:#fff; border-color:var(--accent); }
+  .navstep { display:flex; align-items:center; gap:10px; color:var(--text-dim); font-size:var(--font-sm); }
+  .navstep button { background:var(--bg-card-2); border:1px solid var(--border); color:var(--text); width:28px; height:28px; border-radius:8px; cursor:pointer; }
+
+  /* hero */
+  .hero { background:linear-gradient(160deg,var(--bg-card),var(--bg-card-2)); border:1px solid var(--border);
+    border-radius:var(--radius-lg); padding:22px 24px; box-shadow:var(--shadow); position:relative; overflow:hidden; }
+  .hero-eyebrow { font-size:var(--font-xs); color:var(--text-mute); text-transform:none; display:flex; align-items:center; gap:8px; }
+  .dot { width:8px; height:8px; border-radius:50%; background:var(--ok); box-shadow:0 0 8px var(--ok); }
+  .hero-headline { font-size:var(--font-hero); font-weight:800; letter-spacing:-.02em; line-height:1; margin:4px 0; }
+  .hero-keystat { display:flex; align-items:baseline; gap:.5rem; margin-top:2px; }
+  .hero-keystat b { font-size:1.35rem; font-weight:700; }
+  .muted { color:var(--text-mute); }
+  .dim { color:var(--text-dim); }
+  .pos { color:var(--ok); } .neg { color:var(--bad); }
+  .sub { font-size:var(--font-sm); color:var(--text-dim); margin-top:6px; display:flex; flex-direction:column; gap:3px; }
+  .hero-row { display:flex; gap:24px; align-items:flex-start; }
+  .hero-left { flex:1; }
+  .hero-right { width:340px; }
+  .livenow { margin-top:12px; font-size:var(--font-sm); color:var(--text-dim); display:flex; gap:8px; }
+  .livenow b { color:var(--text); }
+
+  /* grid */
+  .grid { display:grid; grid-template-columns:repeat(12,1fr); gap:18px; }
+  .half { grid-column:span 6; } .full { grid-column:span 12; }
+  @media (max-width:860px){ .half,.full{ grid-column:span 12; } .hero-row{ flex-direction:column; } .hero-right{ width:100%; } }
+
+  .card { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--radius-lg); box-shadow:var(--shadow); overflow:hidden; display:flex; flex-direction:column; }
+  .card-h { display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-bottom:1px solid var(--border); }
+  .card-t { display:flex; align-items:center; gap:8px; font-weight:600; font-size:var(--font-sm); }
+  .card-b { padding:14px 16px; display:flex; flex-direction:column; gap:12px; }
+  .badge { font-size:var(--font-xs); color:var(--text-mute); background:var(--bg-card-2); padding:2px 8px; border-radius:999px; }
+
+  /* gauges */
+  .gauges { display:flex; gap:16px; align-items:center; }
+  .ring { width:96px; height:96px; flex:none; }
+  .ring-label { text-anchor:middle; font-size:11px; fill:var(--text-mute); }
+  .ring-val { text-anchor:middle; font-size:18px; font-weight:700; fill:var(--text); }
+  .minigauges { display:flex; gap:18px; flex:1; }
+  .mg { display:flex; flex-direction:column; gap:2px; }
+  .mg-v { font-size:var(--font-lg); font-weight:700; }
+  .mg-l { font-size:var(--font-xs); color:var(--text-mute); }
+
+  /* plan chips */
+  .grp { display:flex; flex-direction:column; gap:6px; }
+  .grp-t { font-size:var(--font-xs); font-weight:700; letter-spacing:.04em; text-transform:uppercase; color:var(--text-mute); }
+  .chip { display:inline-flex; align-items:center; gap:6px; font-size:var(--font-xs); padding:3px 8px; border-radius:8px; background:rgba(55,65,81,.35); }
+  .cdot { width:7px; height:7px; border-radius:50%; flex:none; }
+  .when { color:var(--text-dim); }
+
+  .rate { display:flex; gap:18px; }
+  .rate .v { font-size:var(--font-lg); font-weight:700; }
+  .legend { display:flex; gap:14px; font-size:10px; color:var(--text-mute); flex-wrap:wrap; }
+  .legend i { display:inline-block; width:14px; border-top:2px solid; margin-right:4px; vertical-align:middle; }
+  svg { display:block; }
+  .chart { width:100%; height:200px; }
+  .chart-tall { width:100%; height:240px; }
+  h4 { margin:0 0 2px; font-size:var(--font-sm); }
+  .note { font-size:var(--font-xs); color:var(--warn); background:color-mix(in srgb,var(--warn) 12%,transparent); padding:3px 8px; border-radius:8px; align-self:flex-start; }
+</style>
+</head>
+<body>
+<div class="home">
+
+  <!-- PERIOD NAVIGATOR -->
+  <div class="navbar">
+    <div class="gran">
+      <button class="active">Day</button><button>Week</button><button>Month</button><button>Year</button>
+    </div>
+    <div class="navstep"><button>‹</button><span>Today · 8 Jun 2026</span><button>›</button></div>
+  </div>
+
+  <!-- HERO -->
+  <div class="hero">
+    <div class="hero-row">
+      <div class="hero-left">
+        <div class="hero-eyebrow"><span class="dot"></span> Today on Agile · net bill so far</div>
+        <div class="hero-headline">£1.26</div>
+        <div class="hero-keystat"><b>4.0</b><span class="dim">kWh da rede hoje</span><span class="muted">· standing £0.59/dia</span></div>
+        <div class="sub">
+          <div><span class="neg">Gastou +£0.03</span> hoje vs British Gas Fixed v58</div>
+          <div>🎯 meta: import médio ≤ <b>18.7p</b> · hoje <span class="pos"><b>16.9p ✓</b></span></div>
+        </div>
+        <div class="livenow"><span class="dot" style="background:var(--accent)"></span> import <b>15.4p</b> · export <b>9.0p</b> · battery <b>48%</b></div>
+      </div>
+      <div class="hero-right">
+        <div class="muted" style="font-size:var(--font-xs);margin-bottom:6px;">Preço de importação · hoje</div>
+        <!-- price tier sparkline -->
+        <svg viewBox="0 0 320 116" class="chart" style="height:116px" preserveAspectRatio="none">
+          <line x1="0" x2="320" y1="86" y2="86" stroke="var(--border)" stroke-dasharray="2 3" opacity=".5"/>
+          <!-- bars: cheap(green) overnight, standard(grey), peak(amber) evening, one neg(blue) -->
+          <g>
+            <rect x="2" y="60" width="11" height="26" fill="var(--cheap)" opacity=".85"/>
+            <rect x="15" y="58" width="11" height="28" fill="var(--cheap)" opacity=".85"/>
+            <rect x="28" y="62" width="11" height="24" fill="var(--cheap)" opacity=".85"/>
+            <rect x="41" y="40" width="11" height="46" fill="var(--neg)" opacity=".9"/>
+            <rect x="54" y="48" width="11" height="38" fill="var(--text-mute)" opacity=".7"/>
+            <rect x="80" y="44" width="11" height="42" fill="var(--text-mute)" opacity=".7"/>
+            <rect x="160" y="40" width="11" height="46" fill="var(--text-mute)" opacity=".7"/>
+            <rect x="232" y="20" width="11" height="66" fill="var(--peak)" opacity=".85"/>
+            <rect x="245" y="16" width="11" height="70" fill="var(--peak)" opacity=".85"/>
+            <rect x="258" y="24" width="11" height="62" fill="var(--peak)" opacity=".85"/>
+            <rect x="284" y="50" width="11" height="36" fill="var(--text-mute)" opacity=".7"/>
+            <rect x="297" y="54" width="11" height="32" fill="var(--text-mute)" opacity=".7"/>
+          </g>
+          <line x1="150" x2="150" y1="6" y2="112" stroke="var(--accent)" stroke-width="1.5" opacity=".9"/>
+        </svg>
+        <div class="legend" style="margin-top:6px;">
+          <span><i style="border-color:var(--neg)"></i>pago</span>
+          <span><i style="border-color:var(--cheap)"></i>barato</span>
+          <span><i style="border-color:var(--peak)"></i>pico</span>
+          <span>◉ now</span>
+        </div>
+        <div style="margin-top:14px;display:flex;gap:18px;font-size:var(--font-xs)" class="dim">
+          <div>Lifetime · 3 mo</div><div><b style="color:var(--text)">540 kWh</b> solar</div>
+          <div><b style="color:var(--pv)">68 kWh</b> export</div><div><b class="pos">£22</b> saved vs BG</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ROW 1: Live power | Live heating -->
+  <div class="grid">
+    <div class="card half">
+      <div class="card-h"><div class="card-t">⚡ Live power</div><span class="badge">12:34 · Live</span></div>
+      <div class="card-b">
+        <!-- power flow schematic -->
+        <svg viewBox="0 0 360 150" class="chart" style="height:150px">
+          <!-- nodes -->
+          <g font-size="11" fill="var(--text-dim)" text-anchor="middle">
+            <circle cx="60" cy="40" r="22" fill="none" stroke="var(--pv)" stroke-width="2"/><text x="60" y="44" fill="var(--pv)">☀</text><text x="60" y="78">solar</text>
+            <circle cx="180" cy="40" r="22" fill="none" stroke="var(--grid)" stroke-width="2"/><text x="180" y="44" fill="var(--grid)">⌁</text><text x="180" y="78">grid</text>
+            <circle cx="300" cy="40" r="22" fill="none" stroke="var(--house)" stroke-width="2"/><text x="300" y="44" fill="var(--house)">🏠</text><text x="300" y="78">house</text>
+            <rect x="150" y="105" width="60" height="30" rx="6" fill="none" stroke="var(--batt)" stroke-width="2"/><text x="180" y="124" fill="var(--batt)">battery 48%</text>
+          </g>
+          <g stroke-width="2" fill="none" opacity=".7">
+            <path d="M82,40 H158" stroke="var(--pv)"/>
+            <path d="M202,40 H278" stroke="var(--grid)"/>
+            <path d="M180,62 V105" stroke="var(--batt)"/>
+          </g>
+        </svg>
+        <div class="rate">
+          <div><div class="muted" style="font-size:var(--font-xs)">Import</div><div class="v" style="color:var(--import)">15.4p</div><div class="muted" style="font-size:var(--font-xs)">4.0 kWh · £0.67</div></div>
+          <div><div class="muted" style="font-size:var(--font-xs)">Export</div><div class="v" style="color:var(--export)">9.0p</div><div class="muted" style="font-size:var(--font-xs)">0.0 kWh · £0.00</div></div>
+        </div>
+        <div class="dim" style="font-size:var(--font-xs)">Next: Force charge 23:30–01:30 · Tank warmup 13:00</div>
+      </div>
+    </div>
+
+    <div class="card half">
+      <div class="card-h"><div class="card-t">♨ Live heating</div><span class="badge">Cache · 8m</span></div>
+      <div class="card-b">
+        <div class="gauges">
+          <svg viewBox="0 0 96 96" class="ring">
+            <circle cx="48" cy="48" r="40" fill="none" stroke="var(--border)" stroke-width="8"/>
+            <circle cx="48" cy="48" r="40" fill="none" stroke="var(--warn)" stroke-width="8" stroke-linecap="round"
+              stroke-dasharray="251" stroke-dashoffset="138" transform="rotate(-90 48 48)"/>
+            <text class="ring-val" x="48" y="46">50°</text><text class="ring-label" x="48" y="64">Tank · on</text>
+          </svg>
+          <div class="minigauges">
+            <div class="mg"><div class="mg-v">16°</div><div class="mg-l">Outdoor</div></div>
+            <div class="mg"><div class="mg-v" style="color:var(--house)">+3°</div><div class="mg-l">LWT offset</div></div>
+            <div class="mg"><div class="mg-v">2.1<span style="font-size:11px;color:var(--text-mute)"> kWh</span></div><div class="mg-l">Heating today</div></div>
+          </div>
+        </div>
+        <!-- heating plan timeline (temps + price right axis) -->
+        <h4>Heating plan · today</h4>
+        <svg viewBox="0 0 360 150" class="chart" style="height:150px" preserveAspectRatio="none">
+          <rect x="232" y="8" width="60" height="142" fill="var(--peak)" opacity=".07"/>
+          <rect x="40" y="8" width="40" height="142" fill="var(--neg)" opacity=".12"/>
+          <!-- outdoor (blue) -->
+          <polyline fill="none" stroke="var(--grid)" stroke-width="2" points="0,110 60,112 120,104 180,96 240,98 300,108 360,114"/>
+          <!-- radiator LWT (purple, bold) -->
+          <polyline fill="none" stroke="var(--house)" stroke-width="2.5" points="0,70 40,52 80,52 140,70 200,72 232,88 292,90 360,72"/>
+          <!-- tank (orange step) -->
+          <polyline fill="none" stroke="var(--warn)" stroke-width="1.5" stroke-dasharray="4 3" points="0,60 160,60 160,40 360,40"/>
+          <!-- import price (red dashed, right axis) -->
+          <polyline fill="none" stroke="var(--import)" stroke-width="1.25" stroke-dasharray="4 3" opacity=".7" points="0,118 60,120 120,112 180,104 240,100 280,60 320,64 360,116"/>
+        </svg>
+        <div class="legend">
+          <span><i style="border-color:var(--grid)"></i>outdoor</span>
+          <span><i style="border-color:var(--house)"></i>radiator LWT</span>
+          <span><i style="border-color:var(--warn);border-top-style:dashed"></i>tank</span>
+          <span><i style="border-color:var(--import);border-top-style:dashed"></i>import p</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ROW 2: Plan | Weather -->
+  <div class="grid">
+    <div class="card half">
+      <div class="card-h"><div class="card-t">🗓 Plan</div></div>
+      <div class="card-b">
+        <div class="grp"><div class="grp-t">Battery <span class="dim" style="font-weight:400;text-transform:none">· SelfUse</span></div>
+          <div><span class="chip"><span class="cdot" style="background:var(--ok)"></span>Force charge <span class="when">23:30–01:30</span></span>
+               <span class="chip"><span class="cdot" style="background:var(--warn)"></span>Force discharge <span class="when">17:00–19:00</span></span></div>
+        </div>
+        <div class="grp"><div class="grp-t">Heating</div>
+          <div><span class="chip"><span class="cdot" style="background:var(--ok)"></span>Boost <b>+3°</b> <span class="when">13:00–15:00</span></span>
+               <span class="chip"><span class="cdot" style="background:var(--warn)"></span>Setback <b>−2°</b> <span class="when">17:00–19:00</span></span></div>
+        </div>
+        <div class="grp"><div class="grp-t">Tank</div>
+          <div><span class="chip"><span class="cdot" style="background:var(--warn)"></span>Warmup <span class="when">13:00</span> <span class="muted">45°</span></span>
+               <span class="chip"><span class="cdot" style="background:var(--warn)"></span>Setback <span class="when">22:00</span> <span class="muted">37°</span></span></div>
+        </div>
+        <div class="grp"><div class="grp-t">Appliances</div>
+          <div><span class="chip"><span class="cdot" style="background:var(--cheap)"></span>🧺 Washing machine <span class="when">00:30–02:30 · 14.2p</span></span></div>
+        </div>
+        <div class="dim" style="font-size:10px">LP #4821 · plan 2026-06-08</div>
+      </div>
+    </div>
+
+    <div class="card half">
+      <div class="card-h"><div class="card-t">⛅ Weather</div></div>
+      <div class="card-b">
+        <div style="display:flex;align-items:center;gap:18px">
+          <div style="font-size:2.6rem;font-weight:300">14°</div>
+          <div><div class="dim">Partly cloudy</div><div class="muted" style="font-size:var(--font-xs)">H 18° · L 11° · 40% cloud</div></div>
+          <div style="margin-left:auto;text-align:right">
+            <div style="font-size:var(--font-xl);font-weight:700;color:var(--pv)">6.2<span style="font-size:.6em;color:var(--text-mute)"> kWh</span></div>
+            <div class="muted" style="font-size:var(--font-xs)">solar · rest of day</div>
+          </div>
+        </div>
+        <!-- solar curve -->
+        <svg viewBox="0 0 360 110" class="chart" style="height:110px" preserveAspectRatio="none">
+          <path d="M0,108 C60,108 90,40 180,28 C270,40 300,108 360,108 Z" fill="var(--pv)" opacity=".18"/>
+          <path d="M0,108 C60,108 90,40 180,28 C270,40 300,108 360,108" fill="none" stroke="var(--pv)" stroke-width="2"/>
+          <line x1="150" x2="150" y1="6" y2="108" stroke="var(--accent)" stroke-width="1.5" opacity=".8"/>
+        </svg>
+        <div class="legend"><span>sunrise 04:48</span><span>peak 13:00</span><span>sunset 21:18</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ROW 3: Generation (full) -->
+  <div class="grid">
+    <div class="card full">
+      <div class="card-h"><div class="card-t">☀ Generation</div></div>
+      <div class="card-b">
+        <div class="rate">
+          <div><div class="v">14.2<span style="font-size:11px;color:var(--text-mute)"> kWh solar</span></div><div class="muted" style="font-size:var(--font-xs)">esperado hoje</div></div>
+          <div><div class="v pos">0.0<span style="font-size:11px;color:var(--text-mute)"> kWh export</span></div></div>
+        </div>
+        <svg viewBox="0 0 1100 240" class="chart-tall" preserveAspectRatio="none">
+          <!-- solar plan (dashed) vs actual (area) -->
+          <path d="M0,238 C200,238 300,80 550,46 C800,80 900,238 1100,238 Z" fill="var(--pv)" opacity=".22"/>
+          <path d="M0,238 C200,238 300,80 550,46 C800,80 900,238 1100,238" fill="none" stroke="var(--pv)" stroke-width="3"/>
+          <path d="M0,238 C200,238 300,70 550,40 C800,70 900,238 1100,238" fill="none" stroke="var(--pv)" stroke-width="1.25" stroke-dasharray="5 4" opacity=".55"/>
+          <!-- export price line (green dashed, right axis) — Outgoing Agile now -->
+          <polyline fill="none" stroke="var(--export)" stroke-width="1.5" stroke-dasharray="5 4" points="0,150 200,156 400,120 550,96 700,110 900,70 1000,80 1100,150"/>
+          <line x1="500" x2="500" y1="6" y2="238" stroke="var(--accent)" stroke-width="1.5" opacity=".6"/>
+        </svg>
+        <div class="legend">
+          <span><i style="border-color:var(--pv)"></i>solar actual</span>
+          <span><i style="border-color:var(--pv);border-top-style:dashed"></i>solar plan</span>
+          <span><i style="border-color:var(--export)"></i>export kWh</span>
+          <span><i style="border-color:var(--export);border-top-style:dashed"></i>export price (Outgoing Agile)</span>
+          <span>◉ now</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ROW 3: Consumption (full) -->
+  <div class="grid">
+    <div class="card full">
+      <div class="card-h"><div class="card-t">📈 Consumption</div></div>
+      <div class="card-b">
+        <div class="rate"><div><div class="v">9.6<span style="font-size:11px;color:var(--text-mute)"> kWh</span></div><div class="muted" style="font-size:var(--font-xs)">consumido so far today</div></div></div>
+        <svg viewBox="0 0 1100 240" class="chart-tall" preserveAspectRatio="none">
+          <!-- tariff bands -->
+          <rect x="720" y="6" width="170" height="232" fill="var(--peak)" opacity=".07"/>
+          <rect x="120" y="6" width="80" height="232" fill="var(--neg)" opacity=".12"/>
+          <!-- stacked composition (base + appliances + heat pump) as areas -->
+          <path d="M0,238 L0,210 C200,205 400,200 550,196 C800,200 1000,206 1100,210 L1100,238 Z" fill="var(--house)" opacity=".5"/>
+          <path d="M0,210 C200,205 400,200 550,196 C800,200 1000,206 1100,210 C1000,180 800,150 550,140 C400,150 200,170 0,182 Z" fill="var(--warn)" opacity=".35"/>
+          <!-- forecast (grey dashed) -->
+          <polyline fill="none" stroke="var(--text-mute)" stroke-width="1.5" stroke-dasharray="5 4" points="0,190 200,176 400,168 550,150 700,168 900,180 1100,186"/>
+          <!-- import price (red dashed, right axis) -->
+          <polyline fill="none" stroke="var(--import)" stroke-width="1.5" stroke-dasharray="5 4" opacity=".8" points="0,150 200,156 400,120 550,96 720,90 780,46 900,52 1100,150"/>
+          <line x1="500" x2="500" y1="6" y2="238" stroke="var(--accent)" stroke-width="1.5" opacity=".6"/>
+        </svg>
+        <div class="legend">
+          <span><i style="border-color:var(--house)"></i>base</span>
+          <span><i style="border-color:var(--warn)"></i>heat pump</span>
+          <span><i style="border-color:var(--text-mute);border-top-style:dashed"></i>forecast</span>
+          <span><i style="border-color:var(--import);border-top-style:dashed"></i>import price</span>
+          <span>paid/cheap/peak shaded · ◉ now</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="muted" style="font-size:var(--font-xs);text-align:center;padding:8px">
+    HEM cockpit snapshot · data frozen 2026-06-08 · dark theme · port target: Preact + TS + ECharts, 12-col grid
+  </div>
+</div>
+</body>
+</html>

--- a/ui/src/components/common/Icon.tsx
+++ b/ui/src/components/common/Icon.tsx
@@ -23,6 +23,8 @@ export type IconName =
   | "settings"
   | "efficiency"
   | "house"
+  | "weather"
+  | "appliance"
   | "chevron"
   | "check"
   | "revert";
@@ -125,6 +127,20 @@ const PATHS: Record<IconName, JSX.Element> = {
     <>
       <path d="M5 11 L12 5 L19 11 V20 H5 Z" />
       <path d="M10 20 V15 H14 V20" />
+    </>
+  ),
+  weather: (
+    <>
+      <circle cx="9" cy="8" r="3" />
+      <path d="M9 3.2 V4.4 M4.2 8 H5.4 M5.6 4.6 L6.4 5.4 M12.4 4.6 L11.6 5.4" />
+      <path d="M8 19 H16.5 A3 3 0 0 0 16.5 13 A3.4 3.4 0 0 0 10 12.6 A3.2 3.2 0 0 0 8 19 Z" />
+    </>
+  ),
+  appliance: (
+    <>
+      <rect x="5" y="3.5" width="14" height="17" rx="2.5" />
+      <circle cx="12" cy="13" r="4" />
+      <path d="M8 6.5 H9 M11 6.5 H12" />
     </>
   ),
   chevron: <path d="M9 6 L15 12 L9 18" />,

--- a/ui/src/components/common/widget.css
+++ b/ui/src/components/common/widget.css
@@ -9,10 +9,12 @@
 
 .widget {
   position: relative;
-  /* De-chromed: flat surface, depth from the two-layer --shadow, no border,
-   * no per-card coloured accent edge or corner tint (monochrome-first). */
-  background: var(--bg-card);
-  border: 1px solid transparent;
+  /* De-chromed, monochrome-first: no grey border. Depth is the two-layer
+   * --shadow + an Apple/Tesla specular treatment (top sheen gradient + inset
+   * highlight + a faint white hairline) — the redesign card surface. */
+  background-color: var(--bg-card);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0) 42%);
+  border: 1px solid rgba(255, 255, 255, 0.045);
   border-radius: var(--radius-lg);
   overflow: hidden;
   display: flex;
@@ -20,13 +22,19 @@
   transition: transform 160ms ease-out, box-shadow 160ms ease-out;
   grid-column: span 12;
   min-width: 0;
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+:root.theme-light .widget {
+  background-image: none;
+  border: 1px solid rgba(15, 23, 42, 0.06);
   box-shadow: var(--shadow);
 }
 /* Hover = a depth lift, never a colour change. */
 .widget:hover {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-lg), inset 0 1px 0 rgba(255, 255, 255, 0.07);
 }
+:root.theme-light .widget:hover { box-shadow: var(--shadow-lg); }
 
 /* Choreographed entrance — every card rises + fades in once on mount, staggered
  * so the grid settles in sequence. Animates transform/opacity ONLY over a

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -25,7 +25,7 @@ function OppyLine({ o }: { o?: ExportOpportunityResponse | null }) {
   if (!o || o.export_mode !== "seg_flat" || o.opportunity_gbp <= 0.01) return null;
   return (
     <div class="tlw-oppy" title={`Sobre ${o.n_days} dias de export: SEG pagou ${gbp(o.seg_gbp)} vs Outgoing Agile ${gbp(o.agile_gbp)}. A diferença é o que deixamos de ganhar por não estar na Agile (média SEG ${o.avg_seg_p}p vs Agile ${o.avg_agile_p}p/kWh).`}>
-      💸 perdido vs Agile: <strong>{gbp(o.opportunity_gbp)}</strong> em {o.n_days}d
+      Perdido vs Agile: <strong>{gbp(o.opportunity_gbp)}</strong> em {o.n_days}d
       {o.annualized_gbp > 0 && <> · ~{gbp(o.annualized_gbp)}/ano</>}
       {o.today.opportunity_gbp > 0.005 && <> · hoje {gbp(o.today.opportunity_gbp)}</>}
     </div>

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -131,7 +131,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
               tariff. Spread over the day's forecast grid import (stable). */}
           {breakevenP != null && (
             <div class="hero-subline hero-subline-dma" title={`Para bater ${fixedLabel}, o preço médio de import precisa ficar ≤ ${breakevenP.toFixed(1)}p/kWh — a Agile paga ~${gbp(standingToday ?? 0)}/dia de standing, mais que a tarifa fixa, então tem que ganhar na energia. Diluído no forecast de import do dia (${todayCum?.forecast_import_kwh ?? 0} kWh).`}>
-              🎯 meta: import médio ≤ <strong>{breakevenP.toFixed(1)}p</strong>
+              Meta: import médio ≤ <strong>{breakevenP.toFixed(1)}p</strong>
               {realisedAvgP != null && (
                 <>&nbsp;·&nbsp;hoje&nbsp;
                   <strong class={beatingTarget ? "hero-strong-pos" : "hero-strong-neg"}>
@@ -147,7 +147,7 @@ export function Hero({ metrics, cockpit, agile, monthly, period, periodState, pe
           {showEarnings && earningsTodayAnim != null && (
             <div class="hero-subline hero-subline-dma">
               <span class="hero-earnings" title="Dinheiro que entrou hoje: crédito da importação a preço negativo + receita de export. A standing charge fixa do dia é descontada para chegar na conta.">
-                ⚡ foi pago&nbsp;<strong class="hero-strong-pos">{gbp(earningsTodayAnim)}</strong>
+                Foi pago&nbsp;<strong class="hero-strong-pos">{gbp(earningsTodayAnim)}</strong>
                 {(negCreditToday ?? 0) > 0.005 && (exportToday ?? 0) > 0.005
                   ? <> ({gbp(negCreditToday!)} negativo + {gbp(exportToday!)} export)</>
                   : (negCreditToday ?? 0) > 0.005

--- a/ui/src/components/home/PlanWidget.tsx
+++ b/ui/src/components/home/PlanWidget.tsx
@@ -178,7 +178,7 @@ export function PlanWidget({
               if (job?.status === "running") {
                 return (
                   <span key={a.id} class="planw-chip planw-chip--run">
-                    <span class="planw-dot" style="background:var(--ok)" />🧺 {a.name} <span class="planw-when">running</span>
+                    <span class="planw-dot" style="background:var(--ok)" />{a.name} <span class="planw-when">running</span>
                   </span>
                 );
               }
@@ -186,7 +186,7 @@ export function PlanWidget({
                 return (
                   <span key={a.id} class="planw-chip"
                         title={`Scheduled ${hm(job.planned_start_utc)}–${hm(job.planned_end_utc)}${job.avg_price_pence != null ? ` · ${job.avg_price_pence.toFixed(1)}p/kWh` : ""}`}>
-                    <span class="planw-dot" style="background:var(--cheap,#36d399)" />🧺 {a.name}
+                    <span class="planw-dot" style="background:var(--cheap,#36d399)" />{a.name}
                     <span class="planw-when">{hm(job.planned_start_utc)}–{hm(job.planned_end_utc)}</span>
                   </span>
                 );
@@ -197,14 +197,14 @@ export function PlanWidget({
                 return (
                   <span key={a.id} class="planw-chip"
                         title={`${cheap ? (paid ? "Paid" : "Cheap") + " window" : "Next window (no cheap window ahead)"} ${hm(sug.recommended_start_utc)}–${hm(sug.recommended_end_utc)} · ${sug.avg_price_pence.toFixed(1)}p · load + Smart Control by ${sug.deadline_local}`}>
-                    <span class="planw-dot" style={`background:${paid ? "var(--neg,#38bdf8)" : cheap ? "var(--cheap,#36d399)" : "var(--text-mute)"}`} />🧺 {a.name}
+                    <span class="planw-dot" style={`background:${paid ? "var(--neg,#38bdf8)" : cheap ? "var(--cheap,#36d399)" : "var(--text-mute)"}`} />{a.name}
                     <span class="planw-when">{cheap ? "" : "next "}{hm(sug.recommended_start_utc)} · {sug.avg_price_pence.toFixed(1)}p</span>
                   </span>
                 );
               }
               return (
                 <span key={a.id} class="planw-chip planw-chip--idle">
-                  <span class="planw-dot" style="background:var(--text-mute)" />🧺 {a.name} <span class="planw-when">idle</span>
+                  <span class="planw-dot" style="background:var(--text-mute)" />{a.name} <span class="planw-when">idle</span>
                 </span>
               );
             })}

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -11,8 +11,10 @@
   padding: var(--space-7) var(--space-6);
   border-radius: var(--radius-lg);
   overflow: hidden;
-  background: var(--bg-card);
-  box-shadow: var(--shadow);
+  background-color: var(--bg-card);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0) 42%);
+  border: 1px solid rgba(255, 255, 255, 0.045);
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
   min-height: 340px;
 }
 @media (max-width: 960px) {

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -23,6 +23,7 @@ import {
   getAppliances,
 } from "../lib/endpoints";
 import { Widget } from "../components/common/Widget";
+import { Icon } from "../components/common/Icon";
 import { Spinner } from "../components/common/Spinner";
 import { RefreshCountdown } from "../components/common/RefreshCountdown";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
@@ -166,13 +167,13 @@ export default function Landing() {
       {/* ── LIVE — split 50/50: live power flow + live heating (gauges + the
           heating-plan timeline). Always "now"; ignore the period navigator. */}
       <div class="widget-grid widget-band">
-        <Widget title="Live power" icon="⚡" tone="power" size="half"
+        <Widget title="Live power" icon={<Icon name="power-live" size={14} />} tone="power" size="half"
                 badge={data.now_utc ? new Date(data.now_utc).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }) : undefined}
                 action={<RefreshCountdown lastFetchAt={now.lastFetchAt} intervalMs={now.intervalMs} loading={now.loading} onRefresh={() => void now.refresh()} />}>
           <LivePowerWidget state={s} cockpit={data} timeline={timeline.data} execution={execution.data} agile={agile.data} metrics={metrics.data} dhwSchedule={dhwSched.data?.rows} todayCumulative={todayCum.data} />
         </Widget>
 
-        <Widget title="Live heating" icon="♨" tone="thermal" size="half">
+        <Widget title="Live heating" icon={<Icon name="heating" size={14} />} tone="thermal" size="half">
           <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data}
                          onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} />
           <Suspense fallback={<Spinner label="Loading heating plan…" />}>
@@ -184,14 +185,14 @@ export default function Landing() {
       {/* ── PLAN + WEATHER (50/50). Plan = the committed dispatch (battery +
           heating LWT + tank + appliances). No manual climate/tank controls. */}
       <div class="widget-grid widget-band">
-        <Widget title="Plan" icon="🗓" tone="plan" size="half">
+        <Widget title="Plan" icon={<Icon name="schedule" size={14} />} tone="plan" size="half">
           <PlanWidget timeline={timeline.data} dhwSchedule={dhwSched.data?.rows} heatingPlan={heatingPlan.data}
                       appliances={appliances.data?.appliances} applianceJobs={applianceJobs.data?.jobs}
                       applianceSuggestions={applianceSug.data?.suggestions}
                       nowUtc={data.now_utc} foxMode={foxMode} foxActive={foxActive} />
         </Widget>
 
-        <Widget title="Weather" icon="⛅" tone="thermal" size="half">
+        <Widget title="Weather" icon={<Icon name="weather" size={14} />} tone="thermal" size="half">
           <WeatherWidget weather={weather.data} pv={pvToday.data} />
         </Widget>
       </div>
@@ -199,7 +200,7 @@ export default function Landing() {
       {/* ── TIMELINES — Generation + Consumption, synced to the period navigator.
           Stacked full-width so a given time reads straight down the screen. ── */}
       <div class="widget-grid widget-band">
-        <Widget title="Generation" icon="☀" tone="plan" size="wide">
+        <Widget title="Generation" icon={<Icon name="solar" size={14} />} tone="plan" size="wide">
           <Suspense fallback={<Spinner label="Loading generation…" />}>
             <GenerationWidget period={period} periodData={periodInsights.data} periodLoading={periodInsights.loading}
                               agile={agile.data} opportunity={exportOppy.data}
@@ -207,7 +208,7 @@ export default function Landing() {
           </Suspense>
         </Widget>
 
-        <Widget title="Consumption" icon="📈" tone="power" size="wide">
+        <Widget title="Consumption" icon={<Icon name="chart-bars" size={14} />} tone="power" size="wide">
           <Suspense fallback={<Spinner label="Loading consumption…" />}>
             <EnergyChartWidget execution={execution.data} pv={pvToday.data} />
           </Suspense>

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -8,12 +8,24 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background: var(--bg);
+  /* Redesign: a quiet top spotlight + a bottom vignette over a deep gradient
+   * (Apple/Tesla instrument-panel depth). Fixed so it doesn't scroll. */
+  background:
+    radial-gradient(1100px 620px at 50% -8%, #18202f 0%, rgba(24, 32, 47, 0) 58%),
+    radial-gradient(1400px 900px at 50% 120%, rgba(0, 0, 0, 0.5) 0%, transparent 60%),
+    linear-gradient(180deg, #0c0f17 0%, #07090e 100%);
+  background-attachment: fixed;
   color: var(--text);
   font: var(--font-md)/1.5 system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+:root.theme-light body {
+  background:
+    radial-gradient(1100px 620px at 50% -8%, #ffffff 0%, rgba(255, 255, 255, 0) 60%),
+    linear-gradient(180deg, #eef0f4 0%, #f6f7f9 100%);
+  background-attachment: fixed;
 }
 
 /* Ambient body background — ONE faint near-neutral accent glow. Domain colours

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -3,13 +3,14 @@
  * Tariff/energy/chart colours stay the same in both themes for legibility. */
 
 :root, :root.theme-dark {
-  /* surfaces */
-  --bg: #0b0f17;
-  --bg-card: #111827;
-  --bg-card-2: #1f2937;
-  --bg-card-3: #2a3343;
-  --border: #374151;
-  --border-strong: #4b5563;
+  /* surfaces — redesign (Claude Design handoff): richer, cooler near-black with
+   * more elevation separation. */
+  --bg: #090b11;
+  --bg-card: #141926;
+  --bg-card-2: #1c2330;
+  --bg-card-3: #29313f;
+  --border: #2b3340;
+  --border-strong: #3a4350;
 
   /* text */
   --text: #f3f4f6;
@@ -49,7 +50,7 @@
   /* radius */
   --radius-sm: 6px;
   --radius: 10px;
-  --radius-lg: 16px;
+  --radius-lg: 18px;
   --radius-pill: 999px;
 
   /* type scale — hierarchy carried by SIZE + WEIGHT contrast, not colour.
@@ -76,14 +77,14 @@
   /* effects — cards float on two-layer depth now that coloured accent edges
    * are gone (Tesla soft-depth). Accent glow dialed back: blue is an
    * interaction signal, not ambient decoration. */
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.5), 0 8px 24px rgba(0, 0, 0, 0.35);
-  --shadow-lg: 0 2px 4px rgba(0, 0, 0, 0.5), 0 18px 48px rgba(0, 0, 0, 0.45);
+  --shadow: 0 1px 1px rgba(0, 0, 0, 0.5), 0 12px 32px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 2px 6px rgba(0, 0, 0, 0.55), 0 26px 64px rgba(0, 0, 0, 0.6);
   --glow-accent: 0 0 16px rgba(59, 130, 246, 0.18);
 }
 
 /* Light theme — applied when src/lib/theme.ts sets .theme-light on <html>. */
 :root.theme-light {
-  --bg: #f8fafc;
+  --bg: #f5f6f8;
   --bg-card: #ffffff;
   --bg-card-2: #f1f5f9;
   --bg-card-3: #e2e8f0;


### PR DESCRIPTION
## Phase 1 of the Claude Design cockpit redesign

The **foundation layer**, applied across the whole cockpit **without restructuring** (layout unchanged) — the look changes immediately, low risk.

- **Tokens (dark):** deeper, cooler near-black surfaces (`--bg #090b11`, card `#141926`, …, border `#2b3340`) + `--radius-lg` 16→**18** + deeper two-layer shadows. Light bg → `#f5f6f8`.
- **Cards** (widget + hero): Apple/Tesla **specular surface** — top sheen gradient + inset highlight + a faint white hairline (no grey border); light-theme variant.
- **Body:** layered background — quiet top spotlight + bottom vignette over a deep gradient (fixed); light variant.
- **No emoji:** widget-title emoji → the thin-line **`Icon`** family (added `weather` + `appliance` icons); decorative in-text emoji (🎯⚡💸🧺) removed. Uppercase tracked headers were already in place.

Source: the `claude.ai/design` handoff bundle (read README + chats + `redesign/cockpit.css` + the PNG mockups).

**Next:** P2 Hero + Weather · P3 combined Generation+Consumption · P4 chrome topbar + scope dividers + refined gauges.

UI-only; typecheck + build clean. Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)