### PR TITLE
feat(ui,api): consumption by-source + SoC; hero solar fix; weather 4-day

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -476,10 +476,12 @@ async def api_v1_weather():
 
 
 def _api_v1_weather_sync():
-    from ..weather import fetch_forecast_cached
+    from ..weather import fetch_weather_panel_forecast_cached
 
-    # 96 h = a 4-day forecast for the redesign hero weather panel (was 48 h).
-    fc = fetch_forecast_cached(hours=96)
+    # 96 h = a 4-day forecast for the redesign hero weather panel. Open-meteo
+    # direct (not the Quartz-merged planning fetch, which caps at the ~2-day PV
+    # horizon) — the panel only needs temp/cloud.
+    fc = fetch_weather_panel_forecast_cached(hours=96)
     out = [{
         "time": f.time_utc.isoformat(),
         "temp_c": f.temperature_c,

--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -280,9 +280,13 @@ async def get_grid_today(date: str | None = None) -> dict[str, Any]:
     # (the same helpers the PnL engine costs against). Keys are ...Z form.
     act_imp: dict[str, float] = {}
     act_exp: dict[str, float] = {}
+    act_dis: dict[str, float] = {}
     try:
         act_imp = {_norm_z(k): float(v) for k, v in db.half_hourly_grid_import_kwh_for_day(d).items()}
         act_exp = {_norm_z(k): float(v) for k, v in db.half_hourly_grid_export_kwh_for_day(d).items()}
+        # Battery discharge — for the Consumption "by source" view (how much of
+        # the load the battery covered vs the grid).
+        act_dis = {_norm_z(k): float(v) for k, v in db.half_hourly_battery_discharge_kwh_for_day(d).items()}
     except Exception as e:
         logger.warning("grid/today: realised grid roll-up failed (%s)", e)
 
@@ -320,14 +324,17 @@ async def get_grid_today(date: str | None = None) -> dict[str, Any]:
         pe = plan_exp.get(key)
         ai_raw = act_imp.get(key)
         ae_raw = act_exp.get(key)
+        ad_raw = act_dis.get(key)
         ai = round(float(ai_raw), 4) if (elapsed and ai_raw is not None) else None
         ae = round(float(ae_raw), 4) if (elapsed and ae_raw is not None) else None
+        ad = round(float(ad_raw), 4) if (elapsed and ad_raw is not None) else None
         slots_out.append({
             "slot_utc": key,
             "import_planned_kwh": round(pi, 4) if pi is not None else None,
             "export_planned_kwh": round(pe, 4) if pe is not None else None,
             "import_actual_kwh": ai,
             "export_actual_kwh": ae,
+            "discharge_actual_kwh": ad,
             "import_price_p": price_by_start.get(key),
             "kind": kind_by.get(key),
         })

--- a/src/db.py
+++ b/src/db.py
@@ -3531,7 +3531,7 @@ def _half_hourly_grid_kwh_for_day(
     from collections import defaultdict
     from datetime import datetime as _dt
 
-    if column not in ("grid_export_kw", "grid_import_kw", "solar_power_kw"):
+    if column not in ("grid_export_kw", "grid_import_kw", "solar_power_kw", "battery_discharge_kw"):
         raise ValueError(f"unsupported column: {column}")
 
     day_iso = day.isoformat()
@@ -3641,6 +3641,20 @@ def half_hourly_grid_import_kwh_for_day(
     weeks (Octopus deprecated ``order_by=asc``).
     """
     return _half_hourly_grid_kwh_for_day(day, "grid_import_kw", max_gap_seconds=max_gap_seconds)
+
+
+def half_hourly_battery_discharge_kwh_for_day(
+    day: date,
+    *,
+    max_gap_seconds: int = 1800,
+) -> dict[str, float]:
+    """Per-slot battery-DISCHARGE kWh for ``day`` (UTC half-hour slots).
+
+    Trapezoidal integration of ``pv_realtime_history.battery_discharge_kw`` —
+    how much the battery contributed to covering load each slot. Used by the
+    Consumption "by source" view (solar self-use + battery + grid = load).
+    """
+    return _half_hourly_grid_kwh_for_day(day, "battery_discharge_kw", max_gap_seconds=max_gap_seconds)
 
 
 def upsert_fox_energy_daily(rows: list[dict[str, Any]]) -> int:

--- a/src/weather.py
+++ b/src/weather.py
@@ -411,6 +411,39 @@ def fetch_forecast_cached(
     return hit[1] if hit else fresh  # serve stale on a failed fetch
 
 
+# Separate TTL cache for the WEATHER PANEL forecast (open-meteo only — temp +
+# cloud over a multi-day horizon). The planning fetch above is merged with
+# Quartz, which caps the horizon to Quartz's ~2-day PV window; the panel only
+# needs temp/cloud, so it uses open-meteo direct for a real 4-day forecast.
+_weather_panel_cache: dict[int, tuple[float, list[HourlyForecast]]] = {}
+
+
+def fetch_weather_panel_forecast_cached(
+    lat: str | None = None,
+    lon: str | None = None,
+    hours: int = 96,
+    ttl_seconds: int | None = None,
+) -> list[HourlyForecast]:
+    """TTL-cached open-meteo-only forecast for the cockpit weather panel (temp +
+    cloud over ``hours``, default 96 h = 4 days). Bypasses the Quartz merge so
+    the multi-day forecast isn't truncated to the PV-forecast horizon."""
+    import time as _t
+    if ttl_seconds is None:
+        ttl_seconds = int(getattr(config, "WEATHER_FORECAST_CACHE_TTL_SECONDS", 900))
+    now = _t.monotonic()
+    hit = _weather_panel_cache.get(hours)
+    if ttl_seconds > 0 and hit and hit[1] and (now - hit[0]) < ttl_seconds:
+        return hit[1]
+    try:
+        fresh = _fetch_open_meteo_forecast(lat=lat, lon=lon, hours=hours)
+    except Exception:  # pragma: no cover - degrade gracefully
+        return hit[1] if hit else []
+    if fresh:
+        _weather_panel_cache[hours] = (now, fresh)
+        return fresh
+    return hit[1] if hit else fresh
+
+
 def fetch_forecast_snapshot(
     lat: str | None = None,
     lon: str | None = None,

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "preact/hooks";
-import { getEnergyPeriod, getDaikinConsumption } from "../../lib/endpoints";
+import { getEnergyPeriod, getDaikinConsumption, getGridToday } from "../../lib/endpoints";
 import { usePeriod, setGranularity, selectedPeriod } from "../../lib/period";
 import { makeChart, baseOption, chartTheme, barGradient, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
 import { Icon } from "../common/Icon";
@@ -9,6 +9,7 @@ import type {
   ExecutionTodayResponse,
   ExecutionSlot,
   PvTodayResponse,
+  GridTodayResponse,
   DaikinConsumptionResponse,
 } from "../../lib/types";
 import "./energy-chart.css";
@@ -53,6 +54,8 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
   const isToday = anchor === todayLocalISO;
   const [period, setPeriod] = useState<PeriodInsightsResponse | null>(null);
   const [daikin, setDaikin] = useState<DaikinConsumptionResponse | null>(null);
+  // Day view: per-slot grid import + battery discharge — for the "by source" stack.
+  const [grid, setGrid] = useState<GridTodayResponse | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const elRef = useRef<HTMLDivElement | null>(null);
@@ -74,11 +77,16 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
       ? Promise.resolve(null)
       : getEnergyPeriod(granularity, opts).catch(() => null);
     const daikinPromise = getDaikinConsumption(granularity, opts).catch(() => null);
+    // Grid import + battery discharge per slot for the day source-stack.
+    const gridPromise = granularity === "day" && isToday
+      ? getGridToday().catch(() => null)
+      : Promise.resolve(null);
 
-    Promise.all([periodPromise, daikinPromise]).then(([p, d]) => {
+    Promise.all([periodPromise, daikinPromise, gridPromise]).then(([p, d, g]) => {
       if (!alive) return;
       setPeriod(p);
       setDaikin(d);
+      setGrid(g);
       setLoading(false);
     });
     return () => { alive = false; };
@@ -89,13 +97,13 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
     if (!chartRef.current) chartRef.current = makeChart(elRef.current);
     const chart = chartRef.current;
     const option = granularity === "day" && isToday
-      ? optionForDay(execution, pv ?? null, daikin)
+      ? optionForDay(execution, pv ?? null, grid)
       : optionForPeriod(period, daikin, granularity);
     chart.setOption(option, true);
     const ro = new ResizeObserver(() => chart.resize());
     ro.observe(elRef.current);
     return () => ro.disconnect();
-  }, [granularity, period, daikin, execution, pv, isToday]);
+  }, [granularity, period, daikin, grid, execution, pv, isToday]);
 
   useEffect(() => () => {
     if (chartRef.current) {
@@ -169,12 +177,11 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
       )}
       {granularity === "day" && dayHasSlots && (
         <div class="echart-legend2">
-          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--house)" /> Base</span>
-          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--accent)" /> Appliances</span>
-          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--warn)" /> Heat pump</span>
-          <span class="echart-l2"><span class="echart-l2-line" /> Forecast</span>
-          <span class="echart-l2"><span class="echart-l2-line" style="border-top-color:var(--import)" /> Import price</span>
-          <span class="echart-l2-hint">stacked = where your energy goes · paid/cheap/peak shaded · ◉ now</span>
+          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--pv)" /> Solar</span>
+          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--batt)" /> Battery</span>
+          <span class="echart-l2"><span class="echart-l2-sw" style="background:var(--import)" /> Grid</span>
+          <span class="echart-l2"><span class="echart-l2-line" style="border-top-color:var(--batt);border-top-style:dashed" /> SoC %</span>
+          <span class="echart-l2-hint">stacked = who covered the load · SoC on right · paid/cheap/peak shaded · ◉ now</span>
         </div>
       )}
 
@@ -328,7 +335,7 @@ type DayTier = "negative" | "cheap" | "standard" | "peak" | null;
 function optionForDay(
   exec: ExecutionTodayResponse | null,
   pv: PvTodayResponse | null,
-  _daikinConsumption: DaikinConsumptionResponse | null,
+  grid: GridTodayResponse | null,
 ): Record<string, unknown> {
   const t = chartTheme();
   const base = baseOption();
@@ -346,46 +353,32 @@ function optionForDay(
 
   const execBy = new Map<string, ExecutionSlot>();
   for (const e of exec?.slots ?? []) if (e.slot_utc) execBy.set(e.slot_utc, e);
-  const fcastBy = new Map<string, number | null>();
   const priceBy = new Map<string, number | null>();
-  for (const s of pvSlots) {
-    fcastBy.set(s.slot_utc, s.base_load_kwh ?? null);
-    priceBy.set(s.slot_utc, s.import_price_p ?? null);
+  for (const s of pvSlots) priceBy.set(s.slot_utc, s.import_price_p ?? null);
+  // Grid import + battery discharge per slot, keyed by slot_utc (...Z form).
+  const gridImpBy = new Map<string, number | null>();
+  const battDisBy = new Map<string, number | null>();
+  for (const gs of grid?.slots ?? []) {
+    if (gs.slot_utc) { gridImpBy.set(gs.slot_utc, gs.import_actual_kwh); battDisBy.set(gs.slot_utc, gs.discharge_actual_kwh ?? null); }
   }
 
-  // Actual consumption split into a stacked composition — where the energy
-  // actually went, slot by slot: base (lights/fridge/always-on) + appliances
-  // (armed washer/dryer/dishwasher) + the Daikin heat pump.
-  const baseActual = axis.map((iso) => {
+  // Consumption BY SOURCE — how the load was covered, slot by slot:
+  //   solar self-use (free) + battery discharge + grid import = total load.
+  // solar self-use is the residual (load − grid − battery), so the stack always
+  // sums to the measured consumption. This shows whether the battery is pulling
+  // its weight vs the grid; the SoC line shows if charge was left unused.
+  const consumption = axis.map((iso) => {
     const e = execBy.get(iso);
-    if (!e) return null;
-    if (e.base_load_kwh_est != null) return round2(e.base_load_kwh_est);
-    if (e.consumption_kwh != null) return round2(Math.max(0, e.consumption_kwh - (e.daikin_kwh_est ?? 0) - (e.appliance_kwh_est ?? 0)));
-    return null;
+    return e?.consumption_kwh != null ? round2(e.consumption_kwh) : null;
   });
-  const applianceActual = axis.map((iso) => {
-    const e = execBy.get(iso);
-    return e?.appliance_kwh_est == null ? null : round2(e.appliance_kwh_est);
+  const gridImp = axis.map((iso) => { const v = gridImpBy.get(iso); return v == null ? null : round2(v); });
+  const battDis = axis.map((iso) => { const v = battDisBy.get(iso); return v == null ? null : round2(v); });
+  const solarSelf = axis.map((_iso, k) => {
+    const c = consumption[k]; if (c == null) return null;
+    return round2(Math.max(0, c - (gridImp[k] ?? 0) - (battDis[k] ?? 0)));
   });
-  const daikinActual = axis.map((iso) => {
-    const e = execBy.get(iso);
-    return e?.daikin_kwh_est == null ? null : round2(e.daikin_kwh_est);
-  });
-  const hasAppliance = applianceActual.some((v) => (v ?? 0) > 0);
-  const totalActual = axis.map((iso, k) => {
-    const e = execBy.get(iso);
-    if (!e) return null;
-    if (e.consumption_kwh != null) return round2(e.consumption_kwh);
-    const b = baseActual[k] ?? 0, a = applianceActual[k] ?? 0, d = daikinActual[k] ?? 0;
-    return (baseActual[k] == null && applianceActual[k] == null && daikinActual[k] == null)
-      ? null : round2(b + a + d);
-  });
-  // Forecast household demand (LP's residual load forecast, excludes heat pump)
-  // — overlaid as a dashed line to compare against the base+appliance stack.
-  const loadForecast = axis.map((iso) => {
-    const v = fcastBy.get(iso);
-    return v == null ? null : round2(v);
-  });
+  const soc = axis.map((iso) => { const e = execBy.get(iso); return e?.soc_percent ?? null; });
+  const totalActual = consumption;
   const price = axis.map((iso) => priceBy.get(iso) ?? null);
 
   // --- Tariff-tier background bands (paid / cheap / peak) — same context wash
@@ -449,7 +442,7 @@ function optionForDay(
       formatter: (params: Array<{ dataIndex: number }>) => {
         const i = params[0]?.dataIndex ?? 0;
         const tier = tierOf(price[i]);
-        const scale = Math.max(0.01, totalActual[i] ?? 0, loadForecast[i] ?? 0);
+        const scale = Math.max(0.01, totalActual[i] ?? 0);
         const bar = (label: string, val: number | null, col: string) => {
           if (val == null || !Number.isFinite(val) || val <= 0) return "";
           const w = Math.round(Math.max(0, Math.min(1, val / scale)) * 70);
@@ -461,30 +454,26 @@ function optionForDay(
         const head = `<strong>${labels[i]}</strong>${tier ? ` · ${tier}` : ""}` +
           (price[i] != null ? ` · ${price[i]!.toFixed(1)}p/kWh` : "");
         const totalRow = totalActual[i] != null
-          ? `<div style="margin-top:2px;font-size:11px;color:${t.text};">Total <strong>${totalActual[i]!.toFixed(2)} kWh</strong></div>` : "";
-        // Explicit import-price row — the cost of each kWh drawn from the grid
-        // in this slot (the user couldn't find it in the hover otherwise).
-        const priceRow = price[i] != null
-          ? `<div style="margin-top:2px;font-size:11px;color:${t.importColor};">Import <strong>${price[i]!.toFixed(1)}p/kWh</strong></div>` : "";
-        return head + totalRow + priceRow +
-          bar("Base", baseActual[i], t.house) +
-          (hasAppliance ? bar("Appliances", applianceActual[i], t.accent) : "") +
-          bar("Heat pump", daikinActual[i], t.warn) +
-          (loadForecast[i] != null
-            ? `<div style="margin-top:4px;border-top:1px solid ${withAlpha(t.textMute, 0.25)};padding-top:2px;"></div>` +
-              bar("Forecast", loadForecast[i], withAlpha(t.textMute, 0.7))
-            : "");
+          ? `<div style="margin-top:2px;font-size:11px;color:${t.text};">Load <strong>${totalActual[i]!.toFixed(2)} kWh</strong></div>` : "";
+        const socRow = soc[i] != null
+          ? `<div style="margin-top:2px;font-size:11px;color:${t.text};">Battery SoC <strong>${Math.round(soc[i]!)}%</strong></div>` : "";
+        return head + totalRow +
+          bar("Solar", solarSelf[i], t.pv) +
+          bar("Battery", battDis[i], t.batt) +
+          bar("Grid", gridImp[i], t.importColor) +
+          socRow;
       },
     },
     grid: { left: 16, right: 44, top: 16, bottom: 24, containLabel: true },
     xAxis: { ...(base.xAxis as object), data: labels, axisLabel: { color: t.textMute, fontSize: 10, interval: 5 } },
     yAxis: [
       { ...(base.yAxis as object), name: "kWh", position: "left" },
-      // Right axis: the Octopus IMPORT price slots — what each kWh of demand
-      // costs, the "import slots" overlay the user asked for on consumption.
+      // Right axis: battery SoC (%). Watching this against the source stack
+      // shows whether the battery was used (SoC falling while it discharges) or
+      // whether charge was left on the table (SoC high while the grid covers load).
       {
-        ...(base.yAxis as object), position: "right", splitLine: { show: false },
-        axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}p" },
+        ...(base.yAxis as object), position: "right", min: 0, max: 100, splitLine: { show: false },
+        axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}%" },
       },
     ],
     series: [
@@ -499,32 +488,25 @@ function optionForDay(
         } : undefined,
         z: 0,
       },
-      // Stacked composition — base (bottom) + appliances + heat pump. Smooth
-      // areas so the total reads as one filled shape; this is "where the energy
-      // went" through the day.
+      // Stacked BY SOURCE — solar self-use (bottom) + battery discharge + grid
+      // import (top). The stack height = total load; the split shows who covered it.
       {
-        name: "Base", type: "line", stack: "load", smooth: true, showSymbol: false,
-        data: baseActual, lineStyle: { width: 0 }, areaStyle: stackArea(t.house, 0.7), z: 2,
+        name: "Solar", type: "line", stack: "src", smooth: true, showSymbol: false,
+        data: solarSelf, lineStyle: { width: 0 }, areaStyle: stackArea(t.pv, 0.55), z: 2,
       },
-      ...(hasAppliance ? [{
-        name: "Appliances", type: "line", stack: "load", smooth: true, showSymbol: false,
-        data: applianceActual, lineStyle: { width: 0 }, areaStyle: stackArea(t.accent, 0.7), z: 2,
-      }] : []),
       {
-        name: "Heat pump", type: "line", stack: "load", smooth: true, showSymbol: false,
-        data: daikinActual, lineStyle: { width: 0 }, areaStyle: stackArea(t.warn, 0.75), z: 2,
+        name: "Battery", type: "line", stack: "src", smooth: true, showSymbol: false,
+        data: battDis, lineStyle: { width: 0 }, areaStyle: stackArea(t.batt, 0.6), z: 2,
       },
-      // Forecast household demand — a clean dashed line over the stack.
       {
-        name: "Forecast", type: "line", smooth: true, showSymbol: false, connectNulls: false,
-        data: loadForecast,
-        lineStyle: { color: withAlpha(t.textMute, 0.85), width: 1.5, type: "dashed", cap: "round" }, z: 5,
+        name: "Grid", type: "line", stack: "src", smooth: true, showSymbol: false,
+        data: gridImp, lineStyle: { width: 0 }, areaStyle: stackArea(t.importColor, 0.5), z: 2,
       },
-      // Import price → dashed step on the right axis (the "import slots" overlay).
+      // Battery SoC → solid line on the right axis.
       {
-        name: "Import price", type: "line", step: "middle", showSymbol: false, color: t.importColor,
-        yAxisIndex: 1, data: price,
-        lineStyle: { color: t.importColor, width: 1.5, opacity: 0.8, type: "dashed" }, z: 4,
+        name: "SoC", type: "line", smooth: true, showSymbol: false, connectNulls: true,
+        yAxisIndex: 1, data: soc,
+        lineStyle: { color: t.batt, width: 1.75, type: "dashed", cap: "round" }, z: 5,
       },
       // Pulsing "now".
       ...(nowIdx >= 0 ? [{

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -206,13 +206,22 @@ function HeroWeather({ weather, pv }: { weather?: WeatherResponse | null; pv?: P
     cond: condOf(e.clouds.length ? e.clouds.reduce((a, b) => a + b, 0) / e.clouds.length : null),
   }));
 
-  // Solar today: generated so far (pv actual) toward the day's forecast total.
+  // Solar today: generated so far (actual) toward the DAY total (locked actuals
+  // for elapsed slots + forecast for the rest). Using the day total — not the
+  // forward-only forecast — so it stays meaningful in the evening (forecast → 0).
   const pvNowMs = pv?.now_utc ? new Date(pv.now_utc).getTime() : nowMs;
   const slots = pv?.slots ?? [];
+  const elapsedOf = (s: { slot_utc: string }) => new Date(s.slot_utc).getTime() + 30 * 60_000 <= pvNowMs;
   const solarDone = slots.reduce((a, s) => a + (s.pv_actual_kwh ?? 0), 0);
-  const solarTotal = pv?.forecast_kwh_day_total ?? slots.reduce((a, s) => a + (s.pv_forecast_kwh ?? 0), 0);
-  const solarToGo = slots.reduce((a, s) => (new Date(s.slot_utc).getTime() >= pvNowMs ? a + (s.pv_forecast_kwh ?? 0) : a), 0);
-  const solarPct = solarTotal > 0 ? Math.round((solarDone / solarTotal) * 100) : 0;
+  const solarTotal = slots.length
+    ? slots.reduce((a, s) => a + ((elapsedOf(s) ? (s.pv_actual_kwh ?? s.pv_forecast_kwh) : s.pv_forecast_kwh) ?? 0), 0)
+    : (pv?.forecast_kwh_day_total ?? 0);
+  const solarToGo = slots.reduce((a, s) => (!elapsedOf(s) ? a + (s.pv_forecast_kwh ?? 0) : a), 0);
+  const solarPct = solarTotal > 0 ? Math.min(100, Math.round((solarDone / solarTotal) * 100)) : 0;
+  // Peak slot (max actual-or-forecast) → local HH:MM.
+  let peakV = -1, peakIso = "";
+  for (const s of slots) { const v = Math.max(s.pv_actual_kwh ?? 0, s.pv_forecast_kwh ?? 0); if (v > peakV) { peakV = v; peakIso = s.slot_utc; } }
+  const peakLabel = peakV > 0.05 && peakIso ? new Date(peakIso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }) : null;
 
   return (
     <div class="hw">
@@ -260,7 +269,10 @@ function HeroWeather({ weather, pv }: { weather?: WeatherResponse | null; pv?: P
             <span class="rate-sub"><b class="solar-done">{solarDone.toFixed(1)}</b> / {solarTotal.toFixed(1)} kWh forecast</span>
           </div>
           <div class="solar-prog-track"><div class="solar-prog-fill" style={{ width: `${solarPct}%` }} /></div>
-          <div class="thermo-row"><span class="dim small">{solarPct}% generated</span><span class="dim small">{solarToGo.toFixed(1)} kWh to go</span></div>
+          <div class="thermo-row">
+            <span class="dim small">{solarPct}% generated</span>
+            <span class="dim small">{solarToGo > 0.05 ? `${solarToGo.toFixed(1)} kWh to go` : "done for today"}{peakLabel ? ` · peak ${peakLabel}` : ""}</span>
+          </div>
         </div>
       )}
     </div>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -163,6 +163,7 @@ export interface GridTodaySlot {
   export_planned_kwh: number | null;
   import_actual_kwh: number | null;    // realised roll-up; null for future/no-telemetry
   export_actual_kwh: number | null;
+  discharge_actual_kwh?: number | null; // battery discharge (covers load) — for the by-source view
   import_price_p?: number | null;
   kind?: string | null;
 }


### PR DESCRIPTION
## Phase 3 (corrected) + two hero fixes

Per feedback, Phase 3 is **not** a combined chart — the **Consumption** widget should show **whether the battery is pulling its weight + whether SoC is left unused**.

### Consumption (day) — by SOURCE
- Stacked areas: **solar self-use** (free) + **battery discharge** + **grid import** = total load. Solar self-use is the residual (`load − grid − battery`), so the stack always sums to measured consumption — it shows *who covered the load*.
- **Battery SoC** on the right axis (dashed green) — falling while it discharges = battery used; high while the grid covers load = charge left on the table. Tariff bands + now-marker kept.
- New `db.half_hourly_battery_discharge_kwh_for_day` + `discharge_actual_kwh` on `GET /grid/today`.

### Hero fixes
- **(A) Solar:** the "solar today" progress used the forward-only forecast (= 0 in the evening → the bar vanished). Now uses the **day total** (locked actuals + remaining forecast) + a **peak HH:MM** label.
- **(B) Weather 4-day:** `/weather` now uses an open-meteo-only fetch (96 h) so the forecast isn't truncated to the Quartz PV horizon (~2 days).

Tests: grid/weather/pv/cache green; UI typecheck + build clean. Tracked by #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)