### PR TITLE
feat(ui): cockpit P4 framing — live band + scope divider + segmented period control

### DIFF
--- a/ui/src/components/home/home.css
+++ b/ui/src/components/home/home.css
@@ -16,6 +16,87 @@
   margin-top: var(--space-5);
 }
 
+/* ── Scope dividers (redesign P4) — the live/period separation made explicit.
+ * A tracked uppercase label + a coloured dot + a hairline that runs to the
+ * right edge. LIVE = accent (always-now, self-driving); PERIOD = muted (the
+ * timelines follow the day/week/month/year selector). */
+.scope {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  /* The .home flex column owns a uniform gap; pull the divider toward the
+   * section it heads (below) so the label reads as belonging to it. */
+  margin-top: var(--space-2);
+  margin-bottom: calc(-1 * var(--space-2));
+  font-size: var(--font-2xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.scope::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+.scope-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.scope-when {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 500;
+  color: var(--text-mute);
+  font-size: var(--font-xs);
+}
+.scope--live { color: var(--accent); }
+.scope--live .scope-dot { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.scope--period .scope-dot { background: var(--text-mute); }
+
+/* ── LIVE band (redesign P4) — wraps the always-now widgets in a faint accent
+ * wash + a left accent bar, so it reads as a distinct "self-driving" surface
+ * that ignores the period selector above. The nested .widget cards keep their
+ * own specular treatment on top of the wash. */
+.live-band {
+  position: relative;
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 7%, var(--bg)),
+    color-mix(in srgb, var(--accent) 3%, var(--bg))
+  );
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.live-band::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 14px;
+  bottom: 14px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--accent);
+  opacity: 0.55;
+}
+.live-band-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-2xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.live-band-head .grow { flex: 1; }
+.live-band-head .when {
+  color: var(--text-mute);
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  font-size: var(--font-xs);
+  font-variant-numeric: tabular-nums;
+}
+/* The live row inside the band drops its own top-margin (the band owns spacing). */
+.live-band .widget-grid { margin: 0; }
+
 /* Skeleton text — shown while a slow field loads */
 .skel-text {
   display: inline-block;

--- a/ui/src/components/shell/period-nav.css
+++ b/ui/src/components/shell/period-nav.css
@@ -42,29 +42,31 @@
   letter-spacing: -0.01em;
 }
 
-/* Segmented granularity toggle — reuses the echart-pill visual language. */
+/* Segmented granularity toggle — redesign P4 `.seg`: a recessed pill track with
+ * an accent-filled active segment (matches the cockpit chrome control). */
 .pnav-grans {
   display: inline-flex;
-  gap: var(--space-1);
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  gap: 2px;
+  background: var(--bg-card-2);
+  border: none;
+  border-radius: var(--radius-pill);
   padding: 3px;
 }
 .pnav-gran {
   position: relative;
-  padding: 4px 14px;
-  border-radius: var(--radius-sm);
+  padding: 5px 14px;
+  border-radius: var(--radius-pill);
   font-size: var(--font-sm);
-  font-weight: 600;
+  font-weight: 500;
   color: var(--text-dim);
   background: transparent;
   border: none;
   cursor: pointer;
+  white-space: nowrap;
   transition: background 140ms ease, color 140ms ease;
 }
 .pnav-gran:hover { color: var(--text); }
 .pnav-gran.is-active {
-  background: var(--bg-card-2);
-  color: var(--text);
+  background: var(--accent);
+  color: #fff;
 }

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -155,6 +155,9 @@ export default function Landing() {
   // forcing the battery (SelfUse is the resting state).
   const foxMode = data.current_slot?.fox_mode ?? undefined;
   const foxActive = foxMode ? !["selfuse", "self_use", "idle", "—", ""].includes(foxMode.toLowerCase()) : false;
+  const liveTime = data.now_utc
+    ? new Date(data.now_utc).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })
+    : undefined;
 
   return (
     <div class="home">
@@ -164,22 +167,31 @@ export default function Landing() {
             periodLoading={periodInsights.loading} todayCum={todayCum.data}
             weather={weather.data} pv={pvToday.data} />
 
-      {/* ── LIVE — split 50/50: live power flow + live heating (gauges + the
-          heating-plan timeline). Always "now"; ignore the period navigator. */}
-      <div class="widget-grid widget-band">
-        <Widget title="Live power" icon={<Icon name="power-live" size={14} />} tone="power" size="half"
-                badge={data.now_utc ? new Date(data.now_utc).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }) : undefined}
-                action={<RefreshCountdown lastFetchAt={now.lastFetchAt} intervalMs={now.intervalMs} loading={now.loading} onRefresh={() => void now.refresh()} />}>
-          <LivePowerWidget state={s} cockpit={data} timeline={timeline.data} execution={execution.data} agile={agile.data} metrics={metrics.data} dhwSchedule={dhwSched.data?.rows} todayCumulative={todayCum.data} />
-        </Widget>
+      {/* ── LIVE band (redesign P4) — split 50/50: live power flow + live heating
+          (gauges + the heating-plan timeline). Wrapped in the accent-wash band
+          so it reads as the always-now, self-driving surface that ignores the
+          period selector above. */}
+      <div class="widget-band live-band">
+        <div class="live-band-head">
+          <Icon name="power-live" size={13} /> Live · self-driving
+          <span class="grow" />
+          <span class="when">read-only · updates automatically{liveTime ? ` · ${liveTime}` : ""}</span>
+        </div>
+        <div class="widget-grid">
+          <Widget title="Live power" icon={<Icon name="power-live" size={14} />} tone="power" size="half"
+                  badge={liveTime}
+                  action={<RefreshCountdown lastFetchAt={now.lastFetchAt} intervalMs={now.intervalMs} loading={now.loading} onRefresh={() => void now.refresh()} />}>
+            <LivePowerWidget state={s} cockpit={data} timeline={timeline.data} execution={execution.data} agile={agile.data} metrics={metrics.data} dhwSchedule={dhwSched.data?.rows} todayCumulative={todayCum.data} />
+          </Widget>
 
-        <Widget title="Live heating" icon={<Icon name="heating" size={14} />} tone="thermal" size="half">
-          <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data}
-                         onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} />
-          <Suspense fallback={<Spinner label="Loading heating plan…" />}>
-            <HeatingPlanWidget plan={heatingPlan.data} loading={heatingPlan.loading} />
-          </Suspense>
-        </Widget>
+          <Widget title="Live heating" icon={<Icon name="heating" size={14} />} tone="thermal" size="half">
+            <HeatingWidget state={s} daikin={daikin.data} daikinQuota={daikinQuota.data} report={report.data} weather={weather.data} execution={execution.data}
+                           onRefresh={() => { void daikin.refresh(); void daikinQuota.refresh(); }} />
+            <Suspense fallback={<Spinner label="Loading heating plan…" />}>
+              <HeatingPlanWidget plan={heatingPlan.data} loading={heatingPlan.loading} />
+            </Suspense>
+          </Widget>
+        </div>
       </div>
 
       {/* ── PLAN (full width). Weather moved into the hero (redesign P2). Plan =
@@ -191,6 +203,14 @@ export default function Landing() {
                       applianceSuggestions={applianceSug.data?.suggestions}
                       nowUtc={data.now_utc} foxMode={foxMode} foxActive={foxActive} />
         </Widget>
+      </div>
+
+      {/* ── PERIOD scope divider (redesign P4) — everything below follows the
+          day/week/month/year selector at the top, in contrast to the live band. */}
+      <div class="scope scope--period">
+        <span class="scope-dot" />
+        Period · energy
+        <span class="scope-when">follows the selector above</span>
       </div>
 
       {/* ── TIMELINES — Generation + Consumption, synced to the period navigator.

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -53,6 +53,9 @@
   --radius-lg: 18px;
   --radius-pill: 999px;
 
+  /* tracked uppercase eyebrow/widget-header label spacing (redesign P4) */
+  --tracking-eyebrow: 0.12em;
+
   /* type scale — hierarchy carried by SIZE + WEIGHT contrast, not colour.
    * --font-display = the one focal number per card; --font-hero = the single
    * anchor number of a whole surface (live net power, today's saving). */


### PR DESCRIPTION
## What
Phase 4 (framing slice) of the Claude Design cockpit redesign — continuing the
P1–P3 lineage (#524 foundation, #525 hero+weather, #526/#527 consumption). This
slice is the **structural "instrument-panel" framing**; CSS + markup only, no
deep component rewrites.

- **Live band** — Live power + Live heating now sit inside an accent-wash
  surface with a left accent bar and an uppercase tracked head
  *"Live · self-driving · read-only · updates automatically · HH:MM"*. Reads as
  the always-now, self-driving section that ignores the period selector above.
- **Period scope divider** — a tracked uppercase *"PERIOD · ENERGY · follows the
  selector above"* hairline before the period-synced Generation/Consumption
  timelines, making the live/period contrast explicit.
- **Segmented period control** — the granularity toggle (day/week/month/year)
  restyled to the redesign `.seg` pattern: recessed pill track, accent-filled
  active segment.
- New `--tracking-eyebrow` token (0.12em) shared by the tracked labels.

## Deferred to P4b
The deeper Phase-4 items — chrome topbar merge (conflicts with the existing
global `TopNav` + per-route `PeriodNavigator`), refined SVG gauges (battery SOC
glyph + Tesla-clean radial), and animated power-flow wires — touch the app shell
and the live SVG components, so they get their own follow-up PR.

## Test
- `npm run build` (typecheck + bundle) clean.
- Visual verification on prod funnel after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)