### PR TITLE
feat(ui): cockpit P4b — Tesla-clean radial tank gauge

### DIFF
--- a/ui/src/components/common/RadialGauge.tsx
+++ b/ui/src/components/common/RadialGauge.tsx
@@ -10,41 +10,72 @@ interface RadialGaugeProps {
   tone?: "thermal" | "cool";
 }
 
-// Top-semicircle arc (sweep=1 verified). pathLength=100 lets us fill a fraction
-// with stroke-dasharray and place the target tick with dashoffset — no
-// getTotalLength / ref needed, so it renders correctly everywhere.
-const CX = 60, CY = 62, R = 50;
-const ARC = `M ${CX - R} ${CY} A ${R} ${R} 0 0 1 ${CX + R} ${CY}`;
+// Near-full-circle instrument dial (redesign "Tesla-clean radial", P4b): a 276°
+// sweep (−138°→138°, notch at the bottom) with a faint track, a domain-coloured
+// progress arc, a clean filled head dot at the progress end, a radial set-mark
+// tick at the target, and min/max limit labels at the foot. Geometry is pure
+// trig (no getTotalLength / ref) so it renders identically everywhere.
+const SIZE = 132;
+const CX = SIZE / 2;
+const CY = SIZE / 2;
+const R = SIZE * 0.37;
+const A0 = -138;
+const A1 = 138;
+const SWEEP = A1 - A0;
 
 function frac(v: number, min: number, max: number): number {
   if (max <= min) return 0;
   return Math.max(0, Math.min(1, (v - min) / (max - min)));
 }
 
-// Onecta-style dial: a 180° arc that fills to the current value, a tick at the
-// target, and the reading in the centre.
+// 0° points up (12 o'clock); positive is clockwise.
+function gPolar(cx: number, cy: number, r: number, deg: number): [number, number] {
+  const a = ((deg - 90) * Math.PI) / 180;
+  return [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+}
+function gArc(cx: number, cy: number, r: number, a0: number, a1: number): string {
+  const [x0, y0] = gPolar(cx, cy, r, a0);
+  const [x1, y1] = gPolar(cx, cy, r, a1);
+  const large = Math.abs(a1 - a0) > 180 ? 1 : 0;
+  return `M ${x0.toFixed(1)} ${y0.toFixed(1)} A ${r} ${r} 0 ${large} 1 ${x1.toFixed(1)} ${y1.toFixed(1)}`;
+}
+
 export function RadialGauge({ label, value, min, max, target, unit = "°", tone = "thermal" }: RadialGaugeProps) {
   const has = value != null && Number.isFinite(value);
-  const f = has ? frac(value as number, min, max) : 0;
-  const tf = target != null && Number.isFinite(target) ? frac(target, min, max) : null;
+  const t = has ? frac(value as number, min, max) : 0;
+  const ang = A0 + t * SWEEP;
+
+  const [lx0, ly0] = gPolar(CX, CY, R, A0);
+  const [lx1, ly1] = gPolar(CX, CY, R, A1);
+  const yBase = Math.max(ly0, ly1) + 13; // one shared baseline for both limits
+  const [hx, hy] = gPolar(CX, CY, R, ang); // progress head — a clean filled dot
+
+  let tick: { x0: number; y0: number; x1: number; y1: number; dx: number; dy: number } | null = null;
+  if (target != null && Number.isFinite(target)) {
+    const sa = A0 + frac(target, min, max) * SWEEP;
+    const [x0, y0] = gPolar(CX, CY, R - 7, sa);
+    const [x1, y1] = gPolar(CX, CY, R + 7, sa);
+    const [dx, dy] = gPolar(CX, CY, R + 13, sa);
+    tick = { x0, y0, x1, y1, dx, dy };
+  }
+
   return (
     <div class={`rgauge rgauge--${tone}`}>
-      <svg viewBox="0 0 120 72" class="rgauge-svg" aria-hidden="true">
-        <path d={ARC} class="rgauge-track" pathLength="100" />
-        {has && (
-          <path d={ARC} class="rgauge-fill" pathLength="100"
-                stroke-dasharray={`${(f * 100).toFixed(1)} 100`} />
-        )}
-        {tf != null && (
-          <path d={ARC} class="rgauge-target" pathLength="100"
-                stroke-dasharray="1.2 100" stroke-dashoffset={`${-(tf * 100)}`} />
-        )}
+      <svg viewBox={`0 0 ${SIZE} ${SIZE * 0.9}`} class="rgauge-svg" aria-hidden="true">
+        <path d={gArc(CX, CY, R, A0, A1)} class="rgauge-track" />
+        {has && <path d={gArc(CX, CY, R, A0, ang)} class="rgauge-fill" />}
+        {has && <circle cx={hx} cy={hy} r="4.5" class="rgauge-head" />}
+        {tick && <line x1={tick.x0} y1={tick.y0} x2={tick.x1} y2={tick.y1} class="rgauge-tick" />}
+        {tick && <circle cx={tick.dx} cy={tick.dy} r="1.6" class="rgauge-tick-dot" />}
+        <text x={CX} y={CY + 1} text-anchor="middle" dominant-baseline="middle" class="rgauge-v">
+          {has ? Math.round(value as number) : "—"}
+          <tspan class="rgauge-deg" dy="-7">{unit}</tspan>
+        </text>
+        <text x={lx0} y={yBase} text-anchor="middle" class="rgauge-lim">{min}{unit}</text>
+        <text x={lx1} y={yBase} text-anchor="middle" class="rgauge-lim">{max}{unit}</text>
       </svg>
-      <div class="rgauge-center">
-        <span class="rgauge-value">{has ? `${Math.round(value as number)}${unit}` : "—"}</span>
-        <span class="rgauge-label">
-          {label}{target != null ? ` · set ${Math.round(target)}${unit}` : ""}
-        </span>
+      <div class="rgauge-label">
+        {label}{target != null ? ` · set ${Math.round(target)}${unit}` : ""}
       </div>
     </div>
   );

--- a/ui/src/components/common/radial-gauge.css
+++ b/ui/src/components/common/radial-gauge.css
@@ -1,8 +1,12 @@
 .rgauge {
   position: relative;
   width: 100%;
-  max-width: 200px;
+  max-width: 168px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
 }
 .rgauge-svg {
   display: block;
@@ -10,47 +14,64 @@
   height: auto;
   overflow: visible;
 }
+
+/* faint full-sweep track */
 .rgauge-track {
   fill: none;
   stroke: var(--bg-card-3, var(--bg-card-2));
-  stroke-width: 8;
+  stroke-width: 7;
   stroke-linecap: round;
 }
+/* domain-coloured progress arc */
 .rgauge-fill {
   fill: none;
-  stroke-width: 8;
+  stroke-width: 7;
   stroke-linecap: round;
-  transition: stroke-dasharray 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: d 420ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 .rgauge--thermal .rgauge-fill { stroke: var(--pv); }
 .rgauge--cool .rgauge-fill { stroke: var(--grid); }
-.rgauge-target {
-  fill: none;
-  stroke: var(--text);
-  stroke-width: 11;
-  stroke-linecap: butt;
-  opacity: 0.85;
+
+/* clean filled head dot at the progress end (card-fill core + domain ring) */
+.rgauge-head {
+  fill: var(--bg-card);
+  stroke-width: 2.5;
 }
-/* Centre readout sits inside the arc (arc spans y 12→62 in the 120×72 vb). */
-.rgauge-center {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 6%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
+.rgauge--thermal .rgauge-head { stroke: var(--pv); }
+.rgauge--cool .rgauge-head { stroke: var(--grid); }
+
+/* set-mark — a short radial tick + a small dot just beyond the rim */
+.rgauge-tick {
+  stroke: var(--text-mute);
+  stroke-width: 2;
+  stroke-linecap: round;
 }
-.rgauge-value {
-  font-size: 1.9rem;
-  font-weight: 700;
-  line-height: 1;
+.rgauge-tick-dot { fill: var(--text-mute); }
+
+/* centre read-out, rendered as SVG text so it sits dead-centre in the dial */
+.rgauge-v {
+  font-size: 27px;
+  font-weight: 600;
+  fill: var(--text);
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.02em;
-  color: var(--text);
 }
+.rgauge-deg {
+  font-size: 13px;
+  font-weight: 500;
+  fill: var(--text-mute);
+}
+.rgauge-lim {
+  font-size: 10px;
+  font-weight: 500;
+  fill: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+
 .rgauge-label {
   font-size: var(--font-xs);
-  color: var(--text-mute);
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+  text-align: center;
 }


### PR DESCRIPTION
## What
P4b gauge slice of the Claude Design cockpit redesign. Refines the live **Heating
tank dial** (`RadialGauge`) from a flat 180° top-semicircle into the redesign's
near-full-circle instrument dial.

- **276° sweep** (−138°→138°, notch at the bottom) — the "Tesla-clean" radial.
- Faint full-sweep track + domain-coloured progress arc.
- **Clean filled head dot** at the progress end (card-fill core + domain ring).
- **Radial set-mark tick** + a small dot at the target setpoint (replaces the old
  fat arc stub).
- Min/max **limit labels** at the foot; centre read-out rendered as SVG text so it
  sits dead-centre in the dial.

Pure-trig geometry (`gPolar`/`gArc`, no `getTotalLength`/ref) → renders identically
everywhere. **Props API unchanged** — `HeatingWidget` (the only call site, the tank
gauge) needs no change.

## Scope note
The other two P4 "refined gauge / animated" items were already faithful ports in
earlier work: `PowerFlow.tsx` (animated 2×2 node field with streaming particles +
glow) and `BatteryShape` (vertical battery glyph). This PR is the remaining delta.
The **chrome topbar merge** stays deferred (it overlaps the existing global
`TopNav` + per-route `PeriodNavigator` and needs a shell decision).

## Test
- `npm run build` (typecheck + bundle) clean.
- Geometry hand-verified (head/tick/limit coords within the viewBox).
- Visual review on the prod funnel after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)