### PR TITLE
feat(ui): cockpit P4c — chrome topbar period control

### DIFF
--- a/ui/src/components/shell/PeriodNavigator.tsx
+++ b/ui/src/components/shell/PeriodNavigator.tsx
@@ -12,6 +12,13 @@ import "./period-nav.css";
 //   ‹  [period label]  ›        day | week | month | year
 // Stepping is bounded — "next" is disabled once the selected period contains
 // today (you can't browse the future). Granularity is a segmented toggle.
+//
+// Two render variants share the same global period signal (redesign P4c):
+//   • "chrome" — compact, lives inside the sticky TopNav on period-scoped
+//     routes (cockpit, insights). Hidden on narrow screens where the topnav
+//     collapses to a column (a 3-row sticky header would eat the viewport).
+//   • "page"  — the in-flow selector at the top of the route; shown ONLY on
+//     narrow screens, where it replaces the hidden chrome control.
 const GRANS: { key: Granularity; label: string }[] = [
   { key: "day", label: "Day" },
   { key: "week", label: "Week" },
@@ -19,12 +26,12 @@ const GRANS: { key: Granularity; label: string }[] = [
   { key: "year", label: "Year" },
 ];
 
-export function PeriodNavigator() {
+export function PeriodNavigator({ variant = "page" }: { variant?: "page" | "chrome" }) {
   const p = usePeriod();
   const atNow = isCurrentPeriod(p);
 
   return (
-    <div class="pnav" role="group" aria-label="Period selector">
+    <div class={`pnav pnav--${variant}`} role="group" aria-label="Period selector">
       <div class="pnav-stepper">
         <button class="pnav-arrow" onClick={() => stepPeriod(-1)} aria-label="Previous period">‹</button>
         <span class="pnav-label" aria-live="polite">{periodLabel(p)}</span>

--- a/ui/src/components/shell/TopNav.tsx
+++ b/ui/src/components/shell/TopNav.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from "wouter-preact";
 import { ThemeToggle } from "./ThemeToggle";
 import { AdminButton } from "./AdminButton";
+import { PeriodNavigator } from "./PeriodNavigator";
 import { role } from "../../lib/auth";
 
 const tabs = [
@@ -11,6 +12,11 @@ const tabs = [
   { href: "/settings", label: "Settings", adminOnly: true },
 ];
 
+// Routes whose content follows the shared period signal — these get the
+// compact period control in the chrome (redesign P4c). Other routes keep a
+// plain bar (the spacers collapse the gap).
+const periodRoutes = ["/", "/insights"];
+
 export function TopNav() {
   const [path] = useLocation();
   const isAdmin = role.value === "admin";
@@ -20,8 +26,11 @@ export function TopNav() {
       <div class="topnav-inner">
         <Link href="/" class="brand">
           <span class="brand-mark">H</span>
-          <span>Home Energy Manager</span>
+          <span class="brand-name">Home Energy Manager</span>
         </Link>
+        <span class="topnav-spacer" />
+        {periodRoutes.includes(path) && <PeriodNavigator variant="chrome" />}
+        <span class="topnav-spacer" />
         <nav class="topnav-tabs" aria-label="Primary">
           {visible.map((t) => (
             <Link

--- a/ui/src/components/shell/period-nav.css
+++ b/ui/src/components/shell/period-nav.css
@@ -70,3 +70,38 @@
   background: var(--accent);
   color: #fff;
 }
+
+/* ── chrome variant (redesign P4c) — compact form living inside the sticky
+ * TopNav: seg first then stepper (the redesign chrome order), quieter
+ * borderless arrows, dimmer label. One breakpoint (880px) swaps it with the
+ * in-flow page variant: below it the topnav hasn't the width (and collapses
+ * to a column at 640px), so the page selector takes over. ───────────────── */
+.pnav--chrome {
+  margin-bottom: 0;
+  flex-wrap: nowrap;
+  justify-content: center;
+  gap: var(--space-3);
+}
+.pnav--chrome .pnav-grans { order: -1; }
+.pnav--chrome .pnav-gran {
+  padding: 4px 12px;
+  font-size: var(--font-xs);
+}
+.pnav--chrome .pnav-arrow {
+  width: 28px;
+  height: 28px;
+  font-size: 16px;
+  border: none;
+  background: var(--bg-card-2);
+  color: var(--text-dim);
+}
+.pnav--chrome .pnav-arrow:hover { background: var(--bg-card-3); color: var(--text); }
+.pnav--chrome .pnav-arrow:disabled:hover { background: var(--bg-card-2); color: var(--text-dim); }
+.pnav--chrome .pnav-label {
+  font-size: var(--font-sm);
+  font-weight: 500;
+  color: var(--text-dim);
+}
+
+@media (max-width: 880px) { .pnav--chrome { display: none; } }
+@media (min-width: 881px) { .pnav--page { display: none; } }

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -38,7 +38,7 @@ export default function Insights() {
         </p>
       </header>
 
-      <PeriodNavigator />
+      <PeriodNavigator variant="page" />
 
       {cmp.loading && !data && <Spinner label="Comparing tariffs…" />}
       {cmp.error && <p class="insights-error">Couldn't load the comparison: {cmp.error.message}</p>}

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -161,7 +161,9 @@ export default function Landing() {
 
   return (
     <div class="home">
-      <PeriodNavigator />
+      {/* Narrow screens only — wide screens get the chrome variant in the
+          sticky TopNav (redesign P4c). Same global signal either way. */}
+      <PeriodNavigator variant="page" />
       <Hero metrics={metrics.data} metricsLoading={metrics.loading} cockpit={data} agile={agile.data} monthly={monthly.data}
             period={periodInsights.data} periodState={period}
             periodLoading={periodInsights.loading} todayCum={todayCum.data}

--- a/ui/src/styles/shell.css
+++ b/ui/src/styles/shell.css
@@ -49,10 +49,13 @@
   font-weight: 700;
   box-shadow: var(--glow-accent);
 }
+/* Flexible gaps either side of the chrome period control (redesign P4c) —
+ * they centre it between the brand and the tabs, and collapse the slot on
+ * routes that don't render it. */
+.topnav-spacer { flex: 1; }
 .topnav-tabs {
   display: flex;
   gap: var(--space-1);
-  margin-left: auto;
   margin-right: var(--space-3);
   flex-wrap: wrap;
 }
@@ -149,6 +152,12 @@
   flex-wrap: wrap;
 }
 
+/* Mid widths — while the chrome period control is in the bar (>880px) it
+ * needs the room the brand text takes. */
+@media (min-width: 881px) and (max-width: 1080px) {
+  .topnav .brand-name { display: none; }
+}
+
 /* Mobile-ish */
 @media (max-width: 640px) {
   .topnav-inner {
@@ -156,6 +165,7 @@
     align-items: flex-start;
     gap: var(--space-2);
   }
+  .topnav-spacer { display: none; }
   .topnav-tabs {
     margin-left: 0;
     width: 100%;


### PR DESCRIPTION
Final slice of the cockpit redesign chrome. Tracked by the redesign series: P1 #524 · P2 #525 · P3 #526/#527 · P4 #528 · P4b #529.

## What

Ports the redesign's `.chrome` bar behaviour: the **period segmented control + stepper move into the sticky TopNav**, centred between the brand and the route tabs — but only on the two routes whose content follows the period signal (`/` cockpit and `/insights`). The selector stays reachable while scrolling the period-synced widgets.

## How

- `PeriodNavigator` gains `variant`: **chrome** (compact — seg-before-stepper per the redesign, borderless 28 px arrows on `--bg-card-2`, dim `font-sm` label) vs **page** (the existing in-flow form). Same global signal either way, so they can never disagree.
- **One breakpoint (880 px)** swaps them: above it the chrome control shows and the in-flow one hides; below it the reverse (at 640 px the topnav collapses to a column — a 3-row sticky header would eat a phone viewport, so mobile keeps the in-flow selector).
- TopNav: flexible `.topnav-spacer`s centre the control and collapse the slot on routes without it (Journal/Settings unchanged); brand text yields at 881–1080 px to make room.

## Verify

- `tsc --noEmit` + `vite build` clean.
- Desktop `/`: selector in the bar, none in-flow; `/insights`: same; Journal/Settings: plain bar as before.
- Resize across 880 px: in-flow selector swaps in; at <640 px column topnav unchanged from today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)