### PR TITLE
fix(ui): chrome header wrapped into multiple lines on period routes

### DIFF
--- a/ui/src/components/shell/period-nav.css
+++ b/ui/src/components/shell/period-nav.css
@@ -73,7 +73,7 @@
 
 /* ── chrome variant (redesign P4c) — compact form living inside the sticky
  * TopNav: seg first then stepper (the redesign chrome order), quieter
- * borderless arrows, dimmer label. One breakpoint (880px) swaps it with the
+ * borderless arrows, dimmer label. One breakpoint (960px) swaps it with the
  * in-flow page variant: below it the topnav hasn't the width (and collapses
  * to a column at 640px), so the page selector takes over. ───────────────── */
 .pnav--chrome {
@@ -101,7 +101,8 @@
   font-size: var(--font-sm);
   font-weight: 500;
   color: var(--text-dim);
+  white-space: nowrap;
 }
 
-@media (max-width: 880px) { .pnav--chrome { display: none; } }
-@media (min-width: 881px) { .pnav--page { display: none; } }
+@media (max-width: 960px) { .pnav--chrome { display: none; } }
+@media (min-width: 961px) { .pnav--page { display: none; } }

--- a/ui/src/styles/shell.css
+++ b/ui/src/styles/shell.css
@@ -19,10 +19,12 @@
   border-bottom: 1px solid var(--border);
   padding-top: env(safe-area-inset-top);
 }
+/* Full-width chrome (redesign): brand far left, period control centred, nav
+ * far right — NOT constrained to the page's content column. The old 1100px
+ * cap left no room for seg+stepper+tabs+admin on period routes, so the row
+ * wrapped into a multi-line mess. */
 .topnav-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-3) var(--space-5);
   display: flex;
   align-items: center;
   gap: var(--space-4);
@@ -35,6 +37,8 @@
   font-size: var(--font-sm);
   color: var(--text);
   letter-spacing: -0.01em;
+  white-space: nowrap;
+  flex: none;
 }
 .brand-mark {
   width: 26px;
@@ -60,7 +64,8 @@
   align-items: center;
   gap: var(--space-1);
   margin-right: var(--space-3);
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  flex: none;
 }
 /* quiet borderless route links (redesign chrome .nav-link) */
 .nav-link {
@@ -72,6 +77,7 @@
   font-size: var(--font-sm);
   font-weight: 500;
   color: var(--text-dim);
+  white-space: nowrap;
   transition: color 140ms, background 140ms;
 }
 .nav-link:hover {
@@ -109,6 +115,8 @@
   background: transparent;
   border: 1px solid var(--border);
   cursor: pointer;
+  white-space: nowrap;
+  flex: none;
   transition: color 100ms, background 100ms, border-color 100ms;
 }
 .admin-badge:hover { color: var(--text); background: var(--bg-card); }
@@ -171,9 +179,10 @@
   flex-wrap: wrap;
 }
 
-/* Mid widths — while the chrome period control is in the bar (>880px) it
- * needs the room the brand text takes. */
-@media (min-width: 881px) and (max-width: 1080px) {
+/* Mid widths — while the chrome period control is in the bar (>960px) it
+ * needs the room the brand text takes (admin unlocked adds Journal +
+ * Settings + the Admin pill). */
+@media (min-width: 961px) and (max-width: 1180px) {
   .topnav .brand-name { display: none; }
 }
 


### PR DESCRIPTION
Follow-up to #531 (cockpit P5). User-reported: the chrome header broke (multi-line wrap) on insights/journal/settings.

**Cause:** with admin unlocked, period routes need brand + seg + stepper + Insights/Journal/Settings + Admin pill + theme in one row; the `topnav-inner` 1100px `max-width` couldn't hold it, so flex items wrapped internally (brand name, stepper label, tabs, Admin pill each broke onto two lines).

**Fix (matches the redesign mockup):** the chrome is full-width — brand far left, period control centred, nav far right, not constrained to the content column — plus `white-space: nowrap`/`flex: none` on brand, nav-links and the admin pill so width sheds via breakpoints instead of mid-item wraps. Chrome↔in-flow selector swap raised 880→960px; brand-name yield window now 961–1180px (accounts for the admin tab set).

**Verify:** screenshots at 1280/1024/900 on `/` and `/insights` as admin — single clean row at every width; below 960 the in-flow selector takes over; mobile column unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)