### PR TITLE
fix(backfill): trailing-window sweep + meter-staleness brief alarm

### DIFF
--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -440,6 +440,14 @@ def build_night_payload() -> str:
     except Exception:
         _section_logger.exception("night brief PnL line failed")
 
+    # ── Meter-staleness alarm (#533) — must live on a DELIVERED surface.
+    # _format_pnl_block also carries it, but that helper has had no
+    # production callers since the 2026-05-21 brief redesign; the night
+    # brief is the daily eyeball on actuals, so the alarm rides here.
+    stale_line = _safe_call("meter_staleness", _meter_staleness_line, today)
+    if isinstance(stale_line, str) and "Meter audit" in stale_line:
+        lines.extend(["", stale_line])
+
     # ── Tomorrow heads-up: peaks ────────────────────────────────────────
     peaks = _safe_call(
         "tomorrow_peaks", _tariff_peak_windows_summary,

--- a/src/analytics/daily_brief.py
+++ b/src/analytics/daily_brief.py
@@ -549,6 +549,9 @@ def _format_pnl_block(pnl: dict[str, Any], *, day: date, tz: ZoneInfo) -> list[s
     audit_line = _fox_vs_meter_audit_line(day)
     if audit_line:
         out.append(audit_line)
+    stale_line = _meter_staleness_line(day)
+    if stale_line:
+        out.append(stale_line)
     skill_line = _forecast_skill_line(day)
     if skill_line:
         out.append(skill_line)
@@ -656,6 +659,34 @@ def _fox_vs_meter_audit_line(day: date) -> str | None:
     if exp:
         parts.append(f"export {exp}")
     return f"- Audit (Fox vs meter): {' | '.join(parts)}"
+
+
+def _meter_staleness_line(day: date) -> str | None:
+    """Warn when the newest cached Octopus daily-meter row lags ``day`` by
+    more than ``CONSUMPTION_METER_STALE_DAYS`` (#533).
+
+    Per-day "_not yet published_" notes look like routine publish lag, so a
+    month-long meter outage previously produced no alarm at all — the PnL
+    silently degraded to Fox CT-clamp data. This line only appears in the
+    failure mode, stays silent when the meter feed is healthy.
+    """
+    stale_days = int(getattr(config, "CONSUMPTION_METER_STALE_DAYS", 3))
+    if stale_days <= 0:
+        return None
+    last = db.get_octopus_meter_last_day()
+    if last is None:
+        return "- ⚠️ Meter audit: no Octopus smart-meter day cached yet — PnL is Fox-only"
+    try:
+        lag = (day - date.fromisoformat(last)).days
+    except ValueError:
+        return None
+    if lag <= stale_days:
+        return None
+    return (
+        f"- ⚠️ Meter audit: last metered day is {last} ({lag} days ago) — "
+        "PnL has been running on Fox CT-clamp data since; check the smart "
+        "meter / Octopus feed"
+    )
 
 
 def _mtd_summary(day: date) -> dict[str, Any] | None:

--- a/src/config.py
+++ b/src/config.py
@@ -384,6 +384,23 @@ class Config:
     # consumption data lands ~24 h after the slot; 04:00 local is safe.
     CONSUMPTION_BACKFILL_HOUR: int = int(os.getenv("CONSUMPTION_BACKFILL_HOUR", "4"))
     CONSUMPTION_BACKFILL_MINUTE: int = int(os.getenv("CONSUMPTION_BACKFILL_MINUTE", "0"))
+    # Octopus regularly publishes later than the ~24 h the single-shot design
+    # assumed (observed 2026-05/06: whole weeks landed days late after a
+    # meter-comms outage). The cron therefore sweeps a trailing window and
+    # re-attempts any local day that still lacks a daily-meter row or whose
+    # execution_log metered coverage is below the slot floor. Re-runs are
+    # idempotent (update_execution_log_metered upserts by half-hour bucket).
+    CONSUMPTION_BACKFILL_SWEEP_DAYS: int = int(
+        os.getenv("CONSUMPTION_BACKFILL_SWEEP_DAYS", "7")
+    )
+    CONSUMPTION_BACKFILL_MIN_METERED_SLOTS: int = int(
+        os.getenv("CONSUMPTION_BACKFILL_MIN_METERED_SLOTS", "40")
+    )
+    # Daily-brief warning when the newest plausible metered day is older than
+    # this — silence here previously hid a month of Fox-only PnL (#533).
+    CONSUMPTION_METER_STALE_DAYS: int = int(
+        os.getenv("CONSUMPTION_METER_STALE_DAYS", "3")
+    )
     BULLETPROOF_TIMEZONE: str = (os.getenv("BULLETPROOF_TIMEZONE") or "Europe/London").strip()
 
     # ── SmartThings smart-appliance scheduling — OAuth 2.0 (mirrors Daikin) ──

--- a/src/db.py
+++ b/src/db.py
@@ -3924,16 +3924,24 @@ def get_octopus_daily_meter(date_str: str) -> dict[str, Any] | None:
 
 
 def get_octopus_meter_last_day() -> str | None:
-    """Most recent local date with a cached Octopus daily-meter row, or None.
+    """Most recent local date with a PLAUSIBLE cached Octopus daily-meter
+    row (import ≥ 0.5 kWh), or None.
 
     Drives the brief's meter-staleness warning (#533): when this lags today
     by more than ``CONSUMPTION_METER_STALE_DAYS`` the PnL has silently been
-    running on Fox CT-clamp data alone.
+    running on Fox CT-clamp data alone. The plausibility filter matters:
+    during a meter outage Octopus can yield NULL-import rows (empty fetch)
+    or near-zero garbage rows (pre-floor legacy data, e.g. 2026-05-09..20) —
+    counting those would advance MAX(date) daily and mute the alarm in
+    exactly the failure mode it exists for. 0.5 kWh mirrors
+    PUBLISHED_FLOOR_KWH in the backfill.
     """
     with _lock:
         conn = get_connection()
         try:
-            cur = conn.execute("SELECT MAX(date) AS d FROM octopus_daily_meter")
+            cur = conn.execute(
+                "SELECT MAX(date) AS d FROM octopus_daily_meter WHERE import_kwh >= 0.5"
+            )
             r = cur.fetchone()
             return r["d"] if r and r["d"] else None
         finally:

--- a/src/db.py
+++ b/src/db.py
@@ -3923,6 +3923,43 @@ def get_octopus_daily_meter(date_str: str) -> dict[str, Any] | None:
             conn.close()
 
 
+def get_octopus_meter_last_day() -> str | None:
+    """Most recent local date with a cached Octopus daily-meter row, or None.
+
+    Drives the brief's meter-staleness warning (#533): when this lags today
+    by more than ``CONSUMPTION_METER_STALE_DAYS`` the PnL has silently been
+    running on Fox CT-clamp data alone.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute("SELECT MAX(date) AS d FROM octopus_daily_meter")
+            r = cur.fetchone()
+            return r["d"] if r and r["d"] else None
+        finally:
+            conn.close()
+
+
+def count_metered_execution_slots(start_utc_iso: str, end_utc_iso: str) -> int:
+    """Count ``execution_log`` rows already rewritten to metered truth in
+    ``[start, end)``. Includes ``metered_synthetic`` (issue #199 fallback
+    rows) — both mean Octopus data landed for the slot. Used by the backfill
+    sweep (#533) to decide whether a past day still needs a re-attempt.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT COUNT(*) AS n FROM execution_log
+                   WHERE timestamp >= ? AND timestamp < ?
+                     AND source LIKE 'metered%'""",
+                (start_utc_iso, end_utc_iso),
+            )
+            return int(cur.fetchone()["n"])
+        finally:
+            conn.close()
+
+
 def get_fox_energy_dates_for_month(year: int, month: int) -> set[str]:
     """Set of ``YYYY-MM-DD`` already cached for the given calendar month.
 

--- a/src/scheduler/consumption_backfill.py
+++ b/src/scheduler/consumption_backfill.py
@@ -194,7 +194,49 @@ def backfill_for_date(target_local_date: date) -> BackfillResult:
 
 
 def backfill_yesterday() -> BackfillResult:
-    """Default cron entry point — backfill the local-date that is 1 day before now."""
+    """Backfill the local-date that is 1 day before now (single-day helper)."""
     tz = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
     target = (datetime.now(tz) - timedelta(days=1)).date()
     return backfill_for_date(target)
+
+
+def _day_needs_backfill(target_local_date: date, tz: ZoneInfo) -> bool:
+    """A past local day still needs a backfill attempt when either signal of
+    completed reconciliation is missing:
+
+    * no ``octopus_daily_meter`` row (the day's totals were never cached —
+      includes the ``PUBLISHED_FLOOR_KWH`` "not yet published" skip), or
+    * fewer than ``CONSUMPTION_BACKFILL_MIN_METERED_SLOTS`` execution_log
+      rows carry metered truth (a partial publish was caught mid-flight).
+    """
+    if db.get_octopus_daily_meter(target_local_date.isoformat()) is None:
+        return True
+    period_from, period_to = _local_day_window_utc(target_local_date, tz)
+    min_slots = int(getattr(config, "CONSUMPTION_BACKFILL_MIN_METERED_SLOTS", 40))
+    n = db.count_metered_execution_slots(
+        period_from.isoformat(), period_to.isoformat()
+    )
+    return n < min_slots
+
+
+def backfill_sweep(window_days: int | None = None) -> list[BackfillResult]:
+    """Cron entry point (#533) — re-attempt every unreconciled day in the
+    trailing window, newest first.
+
+    The previous yesterday-only design permanently lost any day Octopus
+    published later than ~28 h (routine — and catastrophic across the May
+    2026 meter-comms outage backlog: a month of PnL silently ran Fox-only).
+    Re-runs are idempotent, days already reconciled are skipped without an
+    API call, so the steady-state cost is the same single fetch per day.
+    """
+    if window_days is None:
+        window_days = int(getattr(config, "CONSUMPTION_BACKFILL_SWEEP_DAYS", 7))
+    tz = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
+    today_local = datetime.now(tz).date()
+    results: list[BackfillResult] = []
+    for back in range(1, max(1, window_days) + 1):
+        target = today_local - timedelta(days=back)
+        if not _day_needs_backfill(target, tz):
+            continue
+        results.append(backfill_for_date(target))
+    return results

--- a/src/scheduler/consumption_backfill.py
+++ b/src/scheduler/consumption_backfill.py
@@ -171,11 +171,17 @@ def backfill_for_date(target_local_date: date) -> BackfillResult:
     # less than ~0.5 kWh/day, so a sum under that floor is the "no data yet"
     # signal — skip the upsert and let the next backfill run re-attempt.
     PUBLISHED_FLOOR_KWH = 0.5
-    if import_total is not None and import_total < PUBLISHED_FLOOR_KWH:
+    if import_total is None or import_total < PUBLISHED_FLOOR_KWH:
+        # ``None`` (empty fetch — meter comms down / nothing published) must
+        # be skipped too: writing a NULL-import row every night would advance
+        # MAX(date) and mute the staleness alarm (#533) in exactly the
+        # outage scenario it exists for.
         logger.info(
-            "consumption_backfill: date=%s import_total=%.3f kWh below "
+            "consumption_backfill: date=%s import_total=%s kWh below "
             "%.1f kWh floor — Octopus not yet published; skipping daily-meter upsert",
-            iso, import_total, PUBLISHED_FLOOR_KWH,
+            iso,
+            "none" if import_total is None else f"{import_total:.3f}",
+            PUBLISHED_FLOOR_KWH,
         )
     else:
         try:

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -675,18 +675,22 @@ def bulletproof_consumption_backfill_job() -> None:
     instead of single-sample × 0.5 h extrapolations. See
     ``src/scheduler/consumption_backfill.py`` for design details.
 
-    Fires at ``CONSUMPTION_BACKFILL_HOUR:MINUTE`` local (default 04:00) —
-    Octopus consumption data lands ~24 h after the slot, so 04:00 the
-    NEXT day reliably has yesterday's full set."""
-    from .consumption_backfill import backfill_yesterday
+    Fires at ``CONSUMPTION_BACKFILL_HOUR:MINUTE`` local (default 04:00) and
+    sweeps the trailing ``CONSUMPTION_BACKFILL_SWEEP_DAYS`` window (#533) —
+    Octopus routinely publishes later than 24 h, and the old yesterday-only
+    single attempt permanently lost those days."""
+    from .consumption_backfill import backfill_sweep
 
     try:
-        result = backfill_yesterday()
-        logger.info(
-            "consumption_backfill cron: date=%s fetched=%d updated=%d missing=%d error=%s",
-            result.target_date, result.slots_fetched, result.slots_updated,
-            result.slots_missing, result.error or "none",
-        )
+        results = backfill_sweep()
+        if not results:
+            logger.info("consumption_backfill cron: window fully reconciled, nothing to do")
+        for result in results:
+            logger.info(
+                "consumption_backfill cron: date=%s fetched=%d updated=%d missing=%d error=%s",
+                result.target_date, result.slots_fetched, result.slots_updated,
+                result.slots_missing, result.error or "none",
+            )
     except Exception as e:
         logger.warning("Consumption backfill failed (non-fatal): %s", e)
 

--- a/tests/test_brief_meter_staleness_line.py
+++ b/tests/test_brief_meter_staleness_line.py
@@ -1,0 +1,52 @@
+"""``_meter_staleness_line`` (#533) — the brief must ALARM when the Octopus
+metered feed stalls, instead of degrading silently to Fox-only PnL.
+
+Background: between 2026-05-09 and 2026-05-30 the smart meter stopped
+publishing half-hourly data; the per-day audit line just said "not yet
+published" every day, which reads as routine lag. Nobody noticed for a
+month. This line trips only on multi-day staleness.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.analytics import daily_brief
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    from src import db as _db
+    _db.init_db()
+    yield
+
+
+def test_silent_when_meter_fresh(monkeypatch):
+    from src import db
+    db.upsert_octopus_daily_meter("2026-06-09", import_kwh=9.0, export_kwh=1.0)
+    assert daily_brief._meter_staleness_line(date(2026, 6, 11)) is None
+
+
+def test_warns_when_meter_stale_beyond_threshold(monkeypatch):
+    from src import db
+    db.upsert_octopus_daily_meter("2026-05-25", import_kwh=9.0, export_kwh=1.0)
+    line = daily_brief._meter_staleness_line(date(2026, 6, 11))
+    assert line is not None
+    assert "2026-05-25" in line
+    assert "17 days" in line
+
+
+def test_warns_when_no_meter_rows_at_all():
+    line = daily_brief._meter_staleness_line(date(2026, 6, 11))
+    assert line is not None
+    assert "Fox-only" in line
+
+
+def test_disabled_by_zero_threshold(monkeypatch):
+    monkeypatch.setattr(app_config, "CONSUMPTION_METER_STALE_DAYS", 0, raising=False)
+    assert daily_brief._meter_staleness_line(date(2026, 6, 11)) is None

--- a/tests/test_brief_meter_staleness_line.py
+++ b/tests/test_brief_meter_staleness_line.py
@@ -50,3 +50,25 @@ def test_warns_when_no_meter_rows_at_all():
 def test_disabled_by_zero_threshold(monkeypatch):
     monkeypatch.setattr(app_config, "CONSUMPTION_METER_STALE_DAYS", 0, raising=False)
     assert daily_brief._meter_staleness_line(date(2026, 6, 11)) is None
+
+
+def test_null_and_garbage_rows_do_not_mute_the_alarm():
+    """During an outage Octopus can yield NULL-import or near-zero rows;
+    those must not advance the freshness anchor (review HIGH-2 on #535)."""
+    from src import db
+    db.upsert_octopus_daily_meter("2026-05-25", import_kwh=9.0, export_kwh=1.0)
+    # Outage artefacts AFTER the last good day:
+    db.upsert_octopus_daily_meter("2026-06-09", import_kwh=None, export_kwh=None)
+    db.upsert_octopus_daily_meter("2026-06-10", import_kwh=0.03, export_kwh=0.0)
+    assert db.get_octopus_meter_last_day() == "2026-05-25"
+    line = daily_brief._meter_staleness_line(date(2026, 6, 11))
+    assert line is not None and "2026-05-25" in line
+
+
+def test_alarm_rides_the_night_brief_surface():
+    """The line must reach a DELIVERED surface (review HIGH-1 on #535):
+    _format_pnl_block has no production callers, so the night brief carries
+    it. Empty DB → 'no Octopus day cached yet' variant must render."""
+    payload = daily_brief.build_night_payload()
+    assert "Meter audit" in payload
+    assert "Fox-only" in payload

--- a/tests/test_consumption_backfill.py
+++ b/tests/test_consumption_backfill.py
@@ -413,3 +413,26 @@ def test_sweep_window_size_from_config(monkeypatch):
     monkeypatch.setattr(_config.config, "CONSUMPTION_BACKFILL_SWEEP_DAYS", 2, raising=False)
     consumption_backfill.backfill_sweep()
     assert len(captured) == 2
+
+
+def test_empty_fetch_skips_daily_meter_upsert(monkeypatch):
+    """Octopus returning ZERO slots (meter comms down) must not write a
+    NULL-import daily row — that would advance MAX(date) nightly and mute
+    the #533 staleness alarm during the exact outage it guards against."""
+    from src import db
+    from src.scheduler import consumption_backfill
+
+    fake_roles = MagicMock(
+        import_mpan="2000000000000", import_serial="ABC123",
+        export_mpan=None, export_serial=None,
+    )
+    monkeypatch.setattr(consumption_backfill, "_octopus_credentials_ready", lambda: True)
+    fake_octopus = MagicMock()
+    fake_octopus.get_mpan_roles.return_value = fake_roles
+    fake_octopus.fetch_consumption.return_value = []
+    monkeypatch.setitem(__import__("sys").modules, "src.energy.octopus_client", fake_octopus)
+
+    result = consumption_backfill.backfill_for_date(date(2026, 6, 9))
+    assert result.slots_fetched == 0
+    assert result.error is None
+    assert db.get_octopus_daily_meter("2026-06-09") is None

--- a/tests/test_consumption_backfill.py
+++ b/tests/test_consumption_backfill.py
@@ -322,3 +322,94 @@ def test_backfill_yesterday_picks_local_yesterday(monkeypatch):
     # when the test runs, but it's bound by ±1 day from UTC today.
     today = datetime.now(UTC).date()
     assert captured[0] in (today - timedelta(days=1), today, today - timedelta(days=2))
+
+
+# ----------------------------------------------------------------------
+# backfill_sweep (#533) — trailing-window re-attempts for late publishes
+# ----------------------------------------------------------------------
+
+def _sweep_setup(monkeypatch):
+    """Patch backfill_for_date to record calls; return the captured list."""
+    from src.scheduler import consumption_backfill
+
+    captured: list[date] = []
+
+    def _fake_for_date(d: date):
+        captured.append(d)
+        return consumption_backfill.BackfillResult(
+            target_date=d.isoformat(),
+            slots_fetched=48, slots_updated=48, slots_missing=0,
+        )
+
+    monkeypatch.setattr(consumption_backfill, "backfill_for_date", _fake_for_date)
+    return captured
+
+
+def test_sweep_attempts_every_unreconciled_day(monkeypatch):
+    """No daily-meter rows at all → every day in the window is attempted."""
+    from src.scheduler import consumption_backfill
+
+    captured = _sweep_setup(monkeypatch)
+    results = consumption_backfill.backfill_sweep(window_days=5)
+    assert len(captured) == 5
+    assert len(results) == 5
+    # Newest first, contiguous trailing window.
+    assert captured == sorted(captured, reverse=True)
+
+
+def test_sweep_skips_fully_reconciled_days(monkeypatch):
+    """A day with a daily-meter row AND enough metered slots is skipped
+    without an API attempt."""
+    from src import db
+    from src.scheduler import consumption_backfill
+
+    captured = _sweep_setup(monkeypatch)
+
+    from zoneinfo import ZoneInfo
+    tz = ZoneInfo("Europe/London")
+    done_day = (datetime.now(tz) - timedelta(days=2)).date()
+    db.upsert_octopus_daily_meter(done_day.isoformat(), import_kwh=9.5, export_kwh=1.0)
+    # Seed >= MIN_METERED_SLOTS metered rows inside that local day.
+    from src.scheduler.consumption_backfill import _local_day_window_utc
+    start, _ = _local_day_window_utc(done_day, tz)
+    for i in range(41):
+        _seed_execution_row(
+            (start + timedelta(minutes=30 * i)).isoformat(), source="metered"
+        )
+
+    consumption_backfill.backfill_sweep(window_days=4)
+    assert done_day not in captured
+    assert len(captured) == 3
+
+
+def test_sweep_retries_day_with_meter_row_but_thin_slot_coverage(monkeypatch):
+    """A daily-meter row alone is not enough — partial publishes (3/48 slot
+    coverage, the observed May-2026 failure) must be re-attempted."""
+    from src import db
+    from src.scheduler import consumption_backfill
+
+    captured = _sweep_setup(monkeypatch)
+
+    from zoneinfo import ZoneInfo
+    tz = ZoneInfo("Europe/London")
+    thin_day = (datetime.now(tz) - timedelta(days=3)).date()
+    db.upsert_octopus_daily_meter(thin_day.isoformat(), import_kwh=9.5, export_kwh=None)
+    from src.scheduler.consumption_backfill import _local_day_window_utc
+    start, _ = _local_day_window_utc(thin_day, tz)
+    for i in range(3):
+        _seed_execution_row(
+            (start + timedelta(minutes=30 * i)).isoformat(), source="metered"
+        )
+
+    consumption_backfill.backfill_sweep(window_days=4)
+    assert thin_day in captured
+
+
+def test_sweep_window_size_from_config(monkeypatch):
+    from src import config as _config
+    from src.scheduler import consumption_backfill
+
+    captured = _sweep_setup(monkeypatch)
+    monkeypatch.setattr(_config.config, "CONSUMPTION_BACKFILL_SWEEP_DAYS", 2, raising=False)
+    consumption_backfill.backfill_sweep()
+    assert len(captured) == 2


### PR DESCRIPTION
Closes #533.

## Problem

The nightly consumption backfill attempted only **yesterday, once**. Octopus routinely publishes half-hourly data later than 28h — and during the May 2026 meter-comms outage, the backlog landed days late. Every late day was lost forever: `octopus_daily_meter` had no rows after 2026-05-25 and execution_log metered coverage was ~3/48 slots/day. **PnL ran on Fox CT-clamp data for a month with zero alarm** (the per-day "not yet published" audit note reads as routine lag).

## Fix

- **`backfill_sweep()`** — the cron re-attempts every local day in the trailing `CONSUMPTION_BACKFILL_SWEEP_DAYS` window (default 7) that is missing its daily-meter row **or** has metered slot coverage below `CONSUMPTION_BACKFILL_MIN_METERED_SLOTS` (default 40). Re-runs are idempotent (`update_execution_log_metered` upserts by half-hour bucket); fully reconciled days are skipped without an API call, so steady-state cost is unchanged.
- **Brief staleness alarm** — `_meter_staleness_line()` warns when the newest metered day lags by more than `CONSUMPTION_METER_STALE_DAYS` (default 3). Silent when healthy.
- db helpers: `get_octopus_meter_last_day()`, `count_metered_execution_slots()`.

## Verification

- Live probe on prod (2026-06-11) confirmed the fetch path is healthy: `backfill_for_date(2026-06-09)` → 49/49 slots rewritten; data matches Fox within ~5-10%.
- Manual catch-up for May 26 → Jun 11 already run on prod (user-approved) — this PR makes the recovery durable.
- New tests: sweep attempts unreconciled days, skips reconciled, retries thin-coverage days, honours config window; staleness line trips/stays-silent/disables correctly.
- Full suite: 1577 passed, 3 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)