### PR TITLE
feat(dhw): recalibrate forecast shape + trailing measured/nominal auto-scale

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -903,6 +903,28 @@ class Config:
     DHW_NEGATIVE_PRICE_BOOST_C: float = float(
         os.getenv("DHW_NEGATIVE_PRICE_BOOST_C", "60")
     )
+    # --- DHW forecast auto-scale (#534) ---
+    # The per-slot draw constants in forecast_dhw_load_per_slot are static and
+    # drift seasonally (May 2026 measured ~3.0 kWh/day vs ~2.4 in June: warmer
+    # inlet water + lower standing loss). The auto-scale multiplies the
+    # schedule constants by clamp(median(measured kwh_dhw, window) / nominal
+    # mode total). Median is robust to negative-price boost days. Kill switch
+    # = false → factor 1.0 (raw constants).
+    DHW_FORECAST_AUTOSCALE_ENABLED: bool = os.getenv(
+        "DHW_FORECAST_AUTOSCALE_ENABLED", "true"
+    ).lower() in ("true", "1", "yes")
+    DHW_FORECAST_AUTOSCALE_WINDOW_DAYS: int = int(
+        os.getenv("DHW_FORECAST_AUTOSCALE_WINDOW_DAYS", "14")
+    )
+    DHW_FORECAST_AUTOSCALE_MIN_DAYS: int = int(
+        os.getenv("DHW_FORECAST_AUTOSCALE_MIN_DAYS", "5")
+    )
+    DHW_FORECAST_AUTOSCALE_MIN: float = float(
+        os.getenv("DHW_FORECAST_AUTOSCALE_MIN", "0.5")
+    )
+    DHW_FORECAST_AUTOSCALE_MAX: float = float(
+        os.getenv("DHW_FORECAST_AUTOSCALE_MAX", "1.6")
+    )
     # --- Legionella thermal-shock STAND-OFF (2026-06-07) ---
     # The Onecta firmware owns the DHW tank during its weekly thermal-shock
     # cycle. Any tank PATCH HEM sends in that window is arbitrated/overridden by

--- a/src/db.py
+++ b/src/db.py
@@ -3727,6 +3727,12 @@ def upsert_daikin_consumption_daily(
 
     ``source`` is the provenance flag: ``onecta`` | ``telemetry_integral`` |
     ``unknown``. Lets the cockpit show "from cloud" vs "estimated locally".
+
+    NULL never clobbers a known split: ``sync_daikin_daily`` (the on-demand
+    insights path) upserts with ``kwh_dhw=None``/``cop_daily=None``, which
+    used to overwrite the nightly rollup's real heating/DHW split — silently
+    starving the DHW forecast auto-scale (#534) of its input. COALESCE keeps
+    the best-known value per column.
     """
     now = datetime.now(UTC).isoformat()
     with _lock:
@@ -3737,10 +3743,10 @@ def upsert_daikin_consumption_daily(
                    (date, kwh_total, kwh_heating, kwh_dhw, cop_daily, source, fetched_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(date) DO UPDATE SET
-                     kwh_total=excluded.kwh_total,
-                     kwh_heating=excluded.kwh_heating,
-                     kwh_dhw=excluded.kwh_dhw,
-                     cop_daily=excluded.cop_daily,
+                     kwh_total=COALESCE(excluded.kwh_total, kwh_total),
+                     kwh_heating=COALESCE(excluded.kwh_heating, kwh_heating),
+                     kwh_dhw=COALESCE(excluded.kwh_dhw, kwh_dhw),
+                     cop_daily=COALESCE(excluded.cop_daily, cop_daily),
                      source=excluded.source,
                      fetched_at=excluded.fetched_at""",
                 (date, kwh_total, kwh_heating, kwh_dhw, cop_daily, source, now),

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -460,6 +460,14 @@ def _dhw_autoscale_factor(mode: str) -> float:
             lo = float(getattr(config, "DHW_FORECAST_AUTOSCALE_MIN", 0.5))
             hi = float(getattr(config, "DHW_FORECAST_AUTOSCALE_MAX", 1.6))
             factor = max(lo, min(hi, statistics.median(vals) / nominal))
+            # The numerator is mode-blind (measured days don't say which mode
+            # they ran in) while the denominator is mode-aware. Right after a
+            # normal→guests flip the median still reflects normal-mode days
+            # and would scale the (higher) guests nominal DOWN — under-pinning
+            # DHW exactly when the house is fullest. Guests is comfort-
+            # critical: never scale it below the unscaled constants.
+            if mode == "guests":
+                factor = max(factor, 1.0)
             logger.debug(
                 "dhw_policy autoscale: mode=%s median=%.2f nominal=%.2f factor=%.3f (n=%d)",
                 mode, statistics.median(vals), nominal, factor, len(vals),
@@ -589,6 +597,15 @@ def forecast_dhw_load_per_slot(
             e_dhw.append(WARMUP_MAINTENANCE_KWH)
         else:  # setback
             e_dhw.append(SETBACK_MAINTENANCE_KWH)
+
+    # The LP pins ``e_dhw[i] == forecast[i]`` as a hard equality against a
+    # variable whose upBound is the heater's per-slot electric capacity
+    # (``DAIKIN_MAX_HP_KW × 0.5``). A scaled-up transition slot
+    # (0.45 × autoscale-max 1.6 = 0.72 kWh) must never exceed that bound or
+    # every solve goes Infeasible on small-heater configs. The boost ramp
+    # below clamps itself; the plain schedule values are clamped here.
+    _max_hp_kwh = max(0.05, float(getattr(config, "DAIKIN_MAX_HP_KW", 2.0)) * 0.5)
+    e_dhw = [min(v, _max_hp_kwh) for v in e_dhw]
 
     # ----- Initial-tank "warm credit" adjustment ---------------------------
     # If the tank arrives at the LP horizon ABOVE its scheduled target, the

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import json
 import logging
+import statistics
+import time as _time
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -363,6 +365,111 @@ def generate_daily_tank_schedule(
     return rows
 
 
+# --- Per-slot electric draws (kWh / 30 min), schedule phases ---------------
+# Recalibrated 2026-06 (#534) against measured Onecta 2-hourly splits: almost
+# all DHW electric lands in the 12:00-16:00 warmup window (~1.4-1.8 kWh);
+# evening shower slots only draw ~0.35-0.45 kWh TOTAL because the firmware's
+# hysteresis lets the tank ride through the draws and repays the heat at the
+# NEXT day's warmup. The old shape (0.50/slot in shower windows) reserved
+# ~2 kWh of battery for a phantom evening load and under-credited the real
+# PV-window load.
+_WARMUP_TRANSITION_KWH = 0.45   # × 2 slots (13:00 + 13:30) = deferred reheat + lift
+_WARMUP_MAINTENANCE_KWH = 0.06
+_SHOWER_REHEAT_KWH = 0.12       # per slot during shower window
+_SETBACK_MAINTENANCE_KWH = 0.03
+_BOOST_KWH = 0.80               # physics-bound (max heating), NOT auto-scaled
+_VACATION_KWH = 0.00            # firmware-only; legionella cycle excluded from LP horizon
+
+# Shower windows (local hours, slot-start basis). 20:00→22:00 covers the
+# household's "after-dinner shower" pattern; guests adds 07:00→09:00.
+_EVENING_SHOWER_START_H = 20
+_EVENING_SHOWER_END_H = 22  # exclusive
+_GUESTS_MORNING_SHOWER_START_H = 7
+_GUESTS_MORNING_SHOWER_END_H = 9  # exclusive
+
+# 6 h TTL cache for the auto-scale factor — one cheap DB read per LP-solve
+# burst instead of per call. Keyed by (mode, window_days).
+_autoscale_cache: dict[tuple[str, int], tuple[float, float]] = {}
+_AUTOSCALE_TTL_SECONDS = 6 * 3600
+
+
+def _nominal_daily_total_kwh(mode: str) -> float:
+    """Un-scaled kWh/day the schedule constants imply for ``mode``.
+
+    Walks a generic 48-slot local day through the same phase rules as
+    :func:`forecast_dhw_load_per_slot` (no boost, no warm credit) so the
+    auto-scale denominator can never drift from the forecast shape.
+    """
+    if mode == "vacation":
+        return 0.0
+    warmup_hour = int(getattr(config, "DHW_WARMUP_START_HOUR_LOCAL", 13))
+    setback_hour = int(getattr(config, "DHW_SETBACK_START_HOUR_LOCAL", 22))
+    total = 0.0
+    for half_slot in range(48):
+        h = half_slot // 2
+        if _EVENING_SHOWER_START_H <= h < _EVENING_SHOWER_END_H or (
+            mode == "guests"
+            and _GUESTS_MORNING_SHOWER_START_H <= h < _GUESTS_MORNING_SHOWER_END_H
+        ):
+            total += _SHOWER_REHEAT_KWH
+        elif mode == "guests":
+            total += _WARMUP_MAINTENANCE_KWH
+        elif warmup_hour <= h < setback_hour:
+            # Both half-slots of the warmup hour are transition slots —
+            # mirrors _phase_for_slot.
+            total += (
+                _WARMUP_TRANSITION_KWH if h == warmup_hour else _WARMUP_MAINTENANCE_KWH
+            )
+        else:
+            total += _SETBACK_MAINTENANCE_KWH
+    return total
+
+
+def _dhw_autoscale_factor(mode: str) -> float:
+    """Trailing measured-vs-nominal scale for the schedule constants (#534).
+
+    ``clamp(median(daikin_consumption_daily.kwh_dhw over the window) /
+    nominal_mode_total)``. Median is robust to negative-boost outlier days
+    (e.g. 7 kWh on 2026-06-07) and to Onecta's integer-kWh rounding. Returns
+    1.0 when disabled, in vacation mode, or with fewer than
+    ``DHW_FORECAST_AUTOSCALE_MIN_DAYS`` measured days.
+    """
+    if mode == "vacation":
+        return 1.0
+    if not bool(getattr(config, "DHW_FORECAST_AUTOSCALE_ENABLED", True)):
+        return 1.0
+    window_days = int(getattr(config, "DHW_FORECAST_AUTOSCALE_WINDOW_DAYS", 14))
+    key = (mode, window_days)
+    cached = _autoscale_cache.get(key)
+    now = _time.time()
+    if cached is not None and now - cached[1] < _AUTOSCALE_TTL_SECONDS:
+        return cached[0]
+
+    factor = 1.0
+    try:
+        tz = _tz_local()
+        end = (datetime.now(tz) - timedelta(days=1)).date()
+        start = end - timedelta(days=window_days - 1)
+        rows = db.get_daikin_consumption_daily_range(start.isoformat(), end.isoformat())
+        vals = [float(r["kwh_dhw"]) for r in rows if r.get("kwh_dhw") is not None]
+        min_days = int(getattr(config, "DHW_FORECAST_AUTOSCALE_MIN_DAYS", 5))
+        nominal = _nominal_daily_total_kwh(mode)
+        if len(vals) >= min_days and nominal > 0:
+            lo = float(getattr(config, "DHW_FORECAST_AUTOSCALE_MIN", 0.5))
+            hi = float(getattr(config, "DHW_FORECAST_AUTOSCALE_MAX", 1.6))
+            factor = max(lo, min(hi, statistics.median(vals) / nominal))
+            logger.debug(
+                "dhw_policy autoscale: mode=%s median=%.2f nominal=%.2f factor=%.3f (n=%d)",
+                mode, statistics.median(vals), nominal, factor, len(vals),
+            )
+    except Exception as exc:  # pragma: no cover - defensive: forecast must not fail
+        logger.debug("dhw_policy autoscale failed, using 1.0: %s", exc)
+        factor = 1.0
+
+    _autoscale_cache[key] = (factor, now)
+    return factor
+
+
 def forecast_dhw_load_per_slot(
     slot_starts_utc: list[datetime],
     *,
@@ -385,24 +492,25 @@ def forecast_dhw_load_per_slot(
     dhw_policy schedule. Used by the LP solver to pin its tank/e_dhw
     decision variables instead of letting it drift from reality.
 
-    Energy model (typical 200 L tank, COP ~3.0, ~50 W standing loss):
-        * Warmup transition (first slot of warmup window): heat from
-          SETBACK→NORMAL = ~0.4 kWh electric (~1.5 kWh thermal)
-        * Steady-state warmup at NORMAL, no draws: ~0.04 kWh electric
-          per slot (standing-loss replacement only)
-        * Evening shower window slots: ~0.5 kWh electric per slot —
-          tank reheats the heat lost to taps. ~4 showers × 35 L × ΔT37 °C
-          ≈ 6 kWh thermal ≈ 2 kWh electric over ~4 evening slots.
-        * Guests-mode morning shower window: same ~0.5 kWh per slot.
-        * Setback at 37 °C, no draws: ~0.02 kWh electric per slot
-          (smaller standing loss than at 45 °C).
-        * Negative-price boost slot: ~0.8 kWh electric (max heating)
+    Energy model (typical 200 L tank, COP ~3.0; recalibrated 2026-06 #534
+    against measured Onecta 2-hourly splits):
+        * Warmup transition (both half-slots of the warmup hour): the
+          SETBACK→NORMAL lift PLUS the previous evening's deferred shower
+          reheat — measured 12:00-16:00 local carries ~1.4-1.8 kWh, the
+          dominant load. 2 × 0.45 kWh electric.
+        * Steady-state warmup at NORMAL, no draws: ~0.06 kWh/slot.
+        * Shower window slots: ~0.12 kWh/slot — firmware hysteresis lets
+          the tank ride through the draws (measured 20:00-22:00 total is
+          only ~0.35-0.45 kWh); the heat is repaid at the next warmup.
+        * Setback at 37 °C: ~0.03 kWh/slot.
+        * Negative-price boost slot: ~0.8 kWh electric (max heating).
         * Vacation: 0 kWh (firmware-only; legionella out of horizon).
 
-    Daily total under normal mode: ~3.7-4 kWh, matching prod Daikin
-    telemetry. Without the shower term we under-forecast by ~2 kWh
-    (LP would think PV is 2 kWh more available than reality → over-
-    aggressive battery arbitrage).
+    Daily total: ~3.0 kWh normal / ~3.4 guests before auto-scale. The
+    schedule constants are further multiplied by the trailing
+    measured/nominal auto-scale (:func:`_dhw_autoscale_factor`) so the
+    pinned forecast tracks seasonal drift (May 2026 measured ~3.0,
+    June ~2.0-2.4) instead of going stale.
     """
     if mode is None:
         mode = (config.OPTIMIZATION_PRESET or "normal").strip().lower()
@@ -418,22 +526,22 @@ def forecast_dhw_load_per_slot(
     setback_c = float(getattr(config, "DHW_TEMP_SETBACK_C", 37.0))
     boost_c = float(getattr(config, "DHW_NEGATIVE_PRICE_BOOST_C", 60.0))
 
-    # Per-slot electric draws (kWh / 30 min). Calibrated to ~3.7-4 kWh
-    # daily total which matches prod Daikin telemetry.
-    WARMUP_TRANSITION_KWH = 0.40
-    WARMUP_MAINTENANCE_KWH = 0.04
-    SHOWER_REHEAT_KWH = 0.50            # per slot during shower window
-    SETBACK_MAINTENANCE_KWH = 0.02
-    BOOST_KWH = 0.80
-    VACATION_KWH = 0.00  # firmware-only; legionella cycle excluded from LP horizon
+    # Schedule constants × trailing measured/nominal auto-scale (#534). The
+    # scaled values feed every phase INCLUDING the pre-cool/boost caps below
+    # so the whole trajectory stays internally consistent. BOOST stays
+    # physics-bound (max heating) — see _BOOST_KWH.
+    _scale = _dhw_autoscale_factor(mode)
+    WARMUP_TRANSITION_KWH = _WARMUP_TRANSITION_KWH * _scale
+    WARMUP_MAINTENANCE_KWH = _WARMUP_MAINTENANCE_KWH * _scale
+    SHOWER_REHEAT_KWH = _SHOWER_REHEAT_KWH * _scale
+    SETBACK_MAINTENANCE_KWH = _SETBACK_MAINTENANCE_KWH * _scale
+    BOOST_KWH = _BOOST_KWH
+    VACATION_KWH = _VACATION_KWH
 
-    # Typical evening shower window (local hours, slot-start basis).
-    # 20:00→22:00 BST covers the household's "after-dinner shower" pattern.
-    # Guests mode adds a morning window 07:00→08:30.
-    EVENING_SHOWER_START_H = 20
-    EVENING_SHOWER_END_H = 22  # exclusive
-    GUESTS_MORNING_SHOWER_START_H = 7
-    GUESTS_MORNING_SHOWER_END_H = 9  # exclusive
+    EVENING_SHOWER_START_H = _EVENING_SHOWER_START_H
+    EVENING_SHOWER_END_H = _EVENING_SHOWER_END_H
+    GUESTS_MORNING_SHOWER_START_H = _GUESTS_MORNING_SHOWER_START_H
+    GUESTS_MORNING_SHOWER_END_H = _GUESTS_MORNING_SHOWER_END_H
 
     def _phase_for_slot(slot_utc: datetime) -> str:
         """Return one of: 'vacation', 'warmup_transition', 'shower_reheat',
@@ -457,7 +565,9 @@ def forecast_dhw_load_per_slot(
 
         # Normal mode: warmup window [warmup_hour, setback_hour), setback otherwise.
         if warmup_hour <= h < setback_hour:
-            if h == warmup_hour and slot_local.minute < 30:
+            # Both half-slots of the warmup hour are transition (#534): the
+            # measured lift + deferred-reheat load spans ~1 h, not 30 min.
+            if h == warmup_hour:
                 return "warmup_transition"
             return "warmup_maintenance"
         return "setback"

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -389,7 +389,7 @@ _GUESTS_MORNING_SHOWER_END_H = 9  # exclusive
 
 # 6 h TTL cache for the auto-scale factor — one cheap DB read per LP-solve
 # burst instead of per call. Keyed by (mode, window_days).
-_autoscale_cache: dict[tuple[str, int], tuple[float, float]] = {}
+_autoscale_cache: dict[tuple[str, int, str], tuple[float, float]] = {}
 _AUTOSCALE_TTL_SECONDS = 6 * 3600
 
 
@@ -439,7 +439,9 @@ def _dhw_autoscale_factor(mode: str) -> float:
     if not bool(getattr(config, "DHW_FORECAST_AUTOSCALE_ENABLED", True)):
         return 1.0
     window_days = int(getattr(config, "DHW_FORECAST_AUTOSCALE_WINDOW_DAYS", 14))
-    key = (mode, window_days)
+    # DB_PATH in the key: tests swap databases under one process, and prod
+    # never changes it — costs nothing, prevents cross-DB cache bleed.
+    key = (mode, window_days, str(getattr(config, "DB_PATH", "")))
     cached = _autoscale_cache.get(key)
     now = _time.time()
     if cached is not None and now - cached[1] < _AUTOSCALE_TTL_SECONDS:

--- a/tests/test_dhw_forecast_autoscale.py
+++ b/tests/test_dhw_forecast_autoscale.py
@@ -1,0 +1,147 @@
+"""DHW forecast recalibration + trailing auto-scale (#534).
+
+The 2026-06 audit showed the static per-slot constants over-budgeted ~45%
+with the wrong intra-day shape: measured Onecta 2-hourly splits put almost
+all DHW electric in the 12:00-16:00 warmup window (~1.4-1.8 kWh) while the
+old model charged 0.50 kWh/slot to the 20:00-22:00 shower window where the
+firmware's hysteresis draws only ~0.35-0.45 kWh total. These tests pin the
+reshaped totals and the measured/nominal auto-scale loop.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    from src import db as _db
+    from src import dhw_policy
+    _db.init_db()
+    dhw_policy._autoscale_cache.clear()
+    yield
+    dhw_policy._autoscale_cache.clear()
+
+
+def _day_slots(n: int = 48) -> list[datetime]:
+    base = datetime(2026, 6, 17, 0, 0, tzinfo=UTC)  # a Wednesday, BST
+    return [base + timedelta(minutes=30 * i) for i in range(n)]
+
+
+def _seed_measured_dhw(values: list[float]) -> None:
+    """Seed kwh_dhw for the trailing days ending yesterday (local)."""
+    from src import db, dhw_policy
+    tz = dhw_policy._tz_local()
+    yesterday = (datetime.now(tz) - timedelta(days=1)).date()
+    for i, v in enumerate(values):
+        db.upsert_daikin_consumption_daily(
+            date=(yesterday - timedelta(days=i)).isoformat(),
+            kwh_total=v, kwh_dhw=v, source="onecta",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reshaped constants
+# ---------------------------------------------------------------------------
+
+def test_normal_day_total_matches_measured_reality():
+    from src import dhw_policy
+    e_dhw, _ = dhw_policy.forecast_dhw_load_per_slot(_day_slots(), mode="normal")
+    assert sum(e_dhw) == pytest.approx(3.0, abs=0.05)
+
+
+def test_guests_day_total_no_longer_doubles_normal():
+    from src import dhw_policy
+    e_dhw, _ = dhw_policy.forecast_dhw_load_per_slot(_day_slots(), mode="guests")
+    assert sum(e_dhw) == pytest.approx(3.36, abs=0.05)
+
+
+def test_warmup_hour_carries_the_dominant_load():
+    """Both half-slots of the warmup hour are transition slots; the warmup
+    window must out-weigh the evening shower window (measured shape)."""
+    from src import dhw_policy
+    slots = _day_slots()
+    e_dhw, _ = dhw_policy.forecast_dhw_load_per_slot(slots, mode="normal")
+    tz = dhw_policy._tz_local()
+    warmup_h = int(getattr(app_config, "DHW_WARMUP_START_HOUR_LOCAL", 13))
+    warmup_kwh = sum(
+        e for s, e in zip(slots, e_dhw) if s.astimezone(tz).hour == warmup_h
+    )
+    shower_kwh = sum(
+        e for s, e in zip(slots, e_dhw) if 20 <= s.astimezone(tz).hour < 22
+    )
+    assert warmup_kwh == pytest.approx(0.9, abs=0.01)   # 2 × 0.45
+    assert shower_kwh == pytest.approx(0.48, abs=0.01)  # 4 × 0.12
+    assert warmup_kwh > shower_kwh
+
+
+# ---------------------------------------------------------------------------
+# Auto-scale loop
+# ---------------------------------------------------------------------------
+
+def test_autoscale_tracks_measured_median():
+    from src import dhw_policy
+    _seed_measured_dhw([2.0] * 10)  # June-like reality vs nominal 3.0
+    factor = dhw_policy._dhw_autoscale_factor("normal")
+    assert factor == pytest.approx(2.0 / 3.0, abs=0.01)
+    e_dhw, _ = dhw_policy.forecast_dhw_load_per_slot(_day_slots(), mode="normal")
+    assert sum(e_dhw) == pytest.approx(2.0, abs=0.1)
+
+
+def test_autoscale_median_is_robust_to_boost_outliers():
+    """A negative-price boost day (7 kWh) must not drag the factor up."""
+    from src import dhw_policy
+    _seed_measured_dhw([2.0, 2.0, 7.0, 2.0, 2.0, 2.0, 2.0])
+    factor = dhw_policy._dhw_autoscale_factor("normal")
+    assert factor == pytest.approx(2.0 / 3.0, abs=0.01)
+
+
+def test_autoscale_clamped():
+    from src import dhw_policy
+    _seed_measured_dhw([0.0] * 8)  # zero-draw stretch → would be factor 0
+    assert dhw_policy._dhw_autoscale_factor("normal") == pytest.approx(
+        float(getattr(app_config, "DHW_FORECAST_AUTOSCALE_MIN", 0.5))
+    )
+    dhw_policy._autoscale_cache.clear()
+    _seed_measured_dhw([30.0] * 8)
+    assert dhw_policy._dhw_autoscale_factor("normal") == pytest.approx(
+        float(getattr(app_config, "DHW_FORECAST_AUTOSCALE_MAX", 1.6))
+    )
+
+
+def test_autoscale_needs_min_days():
+    from src import dhw_policy
+    _seed_measured_dhw([2.0] * 3)  # below DHW_FORECAST_AUTOSCALE_MIN_DAYS=5
+    assert dhw_policy._dhw_autoscale_factor("normal") == 1.0
+
+
+def test_autoscale_kill_switch(monkeypatch):
+    from src import dhw_policy
+    _seed_measured_dhw([2.0] * 10)
+    monkeypatch.setattr(app_config, "DHW_FORECAST_AUTOSCALE_ENABLED", False, raising=False)
+    assert dhw_policy._dhw_autoscale_factor("normal") == 1.0
+
+
+def test_autoscale_inert_in_vacation():
+    from src import dhw_policy
+    _seed_measured_dhw([2.0] * 10)
+    assert dhw_policy._dhw_autoscale_factor("vacation") == 1.0
+    e_dhw, _ = dhw_policy.forecast_dhw_load_per_slot(_day_slots(), mode="vacation")
+    assert sum(e_dhw) == 0.0
+
+
+def test_nominal_matches_forecast_shape():
+    """The auto-scale denominator must never drift from the forecast's own
+    phase rules — equality between the closed-form walk and a real forecast."""
+    from src import dhw_policy
+    for mode in ("normal", "guests"):
+        e_dhw, _ = dhw_policy.forecast_dhw_load_per_slot(_day_slots(), mode=mode)
+        assert sum(e_dhw) == pytest.approx(
+            dhw_policy._nominal_daily_total_kwh(mode), abs=1e-6
+        )

--- a/tests/test_dhw_forecast_autoscale.py
+++ b/tests/test_dhw_forecast_autoscale.py
@@ -145,3 +145,50 @@ def test_nominal_matches_forecast_shape():
         assert sum(e_dhw) == pytest.approx(
             dhw_policy._nominal_daily_total_kwh(mode), abs=1e-6
         )
+
+
+# ---------------------------------------------------------------------------
+# Review fixes (#536)
+# ---------------------------------------------------------------------------
+
+def test_guests_factor_never_scales_below_one():
+    """Mode-blind numerator: right after a normal→guests flip the median
+    still reflects normal-mode days. Guests is comfort-critical — the
+    factor floors at 1.0 there (review MED-1)."""
+    from src import dhw_policy
+    _seed_measured_dhw([2.0] * 10)  # normal-mode history, median 2.0
+    assert dhw_policy._dhw_autoscale_factor("guests") == 1.0
+    dhw_policy._autoscale_cache.clear()
+    # Scaling UP still allowed in guests.
+    _seed_measured_dhw([6.0] * 10)
+    assert dhw_policy._dhw_autoscale_factor("guests") > 1.0
+
+
+def test_pinned_e_dhw_never_exceeds_heater_capacity(monkeypatch):
+    """LP pins e_dhw == forecast against a variable bounded by
+    DAIKIN_MAX_HP_KW × 0.5; a scaled-up transition slot must clamp or the
+    solve goes Infeasible on small-heater configs (review MED-2)."""
+    from src import dhw_policy
+    monkeypatch.setattr(app_config, "DAIKIN_MAX_HP_KW", 0.8, raising=False)  # 0.4 kWh/slot
+    _seed_measured_dhw([4.8] * 10)  # pushes factor to the 1.6 clamp
+    e_dhw, _ = dhw_policy.forecast_dhw_load_per_slot(_day_slots(), mode="normal")
+    cap = 0.8 * 0.5
+    assert max(e_dhw) <= cap + 1e-9
+
+
+def test_null_upsert_does_not_clobber_dhw_split():
+    """sync_daikin_daily upserts kwh_dhw=None; that must not erase the
+    nightly rollup's real split the auto-scale feeds on (review LOW-3)."""
+    from src import db, dhw_policy
+    tz = dhw_policy._tz_local()
+    day = (datetime.now(tz) - timedelta(days=1)).date().isoformat()
+    db.upsert_daikin_consumption_daily(
+        date=day, kwh_total=5.0, kwh_heating=3.0, kwh_dhw=2.0, source="onecta",
+    )
+    db.upsert_daikin_consumption_daily(
+        date=day, kwh_total=5.5, kwh_heating=5.5, kwh_dhw=None, cop_daily=None,
+        source="telemetry_integral",
+    )
+    row = db.get_daikin_consumption_daily_by_date(day)
+    assert row["kwh_dhw"] == 2.0
+    assert row["kwh_total"] == 5.5

--- a/tests/test_realistic_day_scenarios.py
+++ b/tests/test_realistic_day_scenarios.py
@@ -274,8 +274,11 @@ def test_scenario_vacation_no_dhw_but_lp_still_optimises(monkeypatch):
 
 
 def test_scenario_guests_mode_forecasts_morning_reheat(monkeypatch):
-    """Guests preset includes morning shower window (07-09 BST). The
-    forecast should attribute ~0.5 kWh/slot to those windows."""
+    """Guests preset includes morning shower window (07-09 BST). Recalibrated
+    2026-06 (#534): measured Onecta 2-hourly splits show the firmware's
+    hysteresis draws only ~0.12 kWh/slot during shower windows (the heat is
+    repaid at the next warmup), so the window must still out-weigh adjacent
+    maintenance slots but no longer carries ~0.5 kWh/slot."""
     monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "guests", raising=False)
     # Slots covering 06:00 - 11:00 BST (= 05:00-10:00 UTC in summer)
     base_local = datetime(2026, 6, 1, 6, 0, tzinfo=TZ_LOCAL)
@@ -285,8 +288,8 @@ def test_scenario_guests_mode_forecasts_morning_reheat(monkeypatch):
     # Slot 2-5 = 07:00-09:00 BST → shower window
     shower_load = sum(e_dhw[2:6])
     other_load = sum(e_dhw[0:2]) + sum(e_dhw[6:])
-    assert shower_load > 1.0, (
-        f"Guests morning shower window should attribute ≥1 kWh; got {shower_load:.2f}"
+    assert shower_load == pytest.approx(4 * 0.12, abs=0.01), (
+        f"Guests morning shower window should attribute ~0.48 kWh; got {shower_load:.2f}"
     )
     assert shower_load > other_load, (
         f"Shower window should dominate; shower={shower_load:.2f} other={other_load:.2f}"


### PR DESCRIPTION
Closes #534.

## Problem (2026-06-11 estimates-vs-actuals audit)

`forecast_dhw_load_per_slot` budgets 3.5 kWh/day (normal) vs ~2.0-2.4 measured in June, with the wrong intra-day **shape** (measured Onecta 2-hourly splits):

| window (local) | old budget | measured |
|---|---|---|
| evening showers 20–22 | 2.0 kWh (4 × 0.50) | ~0.35–0.45 kWh |
| warmup 12–16 | ~0.5 kWh | ~1.4–1.8 kWh |

Firmware hysteresis lets the tank ride through evening showers; the heat is repaid at the next day's 13:00 warmup — the PV window. The LP therefore reserved ~2 kWh of battery for a phantom evening load and under-credited the real PV-window load, distorting battery sizing + PV routing on every solve.

## Fix

1. **Reshape constants** to the measured shape: shower reheat 0.50→0.12 kWh/slot; warmup transition 0.40×1 → 0.45×2 slots (absorbs the deferred reheat); maintenance 0.04→0.06 / 0.02→0.03. Normal ≈ 3.0 kWh/day; guests ≈ 3.36 (was 5.6+).
2. **Close the loop** (same pattern as the PV recent-bias corrector #486): constants × `clamp(median(measured kwh_dhw, trailing 14d) / nominal mode total)`. Median is robust to negative-boost outliers (e.g. 7 kWh on Jun 7) and Onecta integer rounding. 6 h TTL cache; `DHW_FORECAST_AUTOSCALE_ENABLED` kill switch; inert in vacation and below 5 measured days.
3. `_nominal_daily_total_kwh` walks the exact phase rules of the forecast — equality between denominator and forecast shape is pinned by a test, so the two can't drift apart (the K2-era lesson about scattered tank constants).

Boost ramp + warm-credit stay physics-bound and unscaled; the pre-cool/boost caps use the scaled maintenance values so the trajectory stays internally consistent.

## Verification

- New tests: per-mode totals, warmup-dominates-shower shape, autoscale tracks median / robust to outliers / clamped / min-days / kill switch / vacation-inert, nominal≡forecast equality.
- 161 DHW/LP-pinning tests pass; full suite in CI.
- Expected on prod (June data): factor ≈ 0.67 → pinned DHW ≈ 2.0 kWh/day, matching measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)