### PR TITLE
feat(daikin): LWT pre-heat demand gate + k decontamination + measured thermal constants

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1124,6 +1124,20 @@ class Config:
     DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS: int = int(
         os.getenv("DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS", "4")
     )
+    # Demand gate (#540 quick win, June-2026 incident): a positive LWT offset
+    # can WAKE the compressor the firmware would have left off — measured
+    # space heating went 0 → 3-8 kWh/day in June within days of enabling the
+    # pre-heat. There is no point pre-heating thermal mass the house is not
+    # draining, so offset action rows are only written when the trailing
+    # window shows real measured space-heating demand (Onecta split). When a
+    # cold snap starts, the firmware heats naturally within hours and the
+    # gate opens on the next plan. Set the kWh floor to 0 to disable.
+    DAIKIN_LWT_PREHEAT_MIN_TRAILING_HEATING_KWH: float = float(
+        os.getenv("DAIKIN_LWT_PREHEAT_MIN_TRAILING_HEATING_KWH", "0.5")
+    )
+    DAIKIN_LWT_PREHEAT_DEMAND_LOOKBACK_HOURS: int = int(
+        os.getenv("DAIKIN_LWT_PREHEAT_DEMAND_LOOKBACK_HOURS", "48")
+    )
     OPTIMIZATION_DISABLE_WEATHER_REGULATION: bool = os.getenv(
         "OPTIMIZATION_DISABLE_WEATHER_REGULATION", "false"
     ).lower() in ("true", "1", "yes")
@@ -1254,11 +1268,17 @@ class Config:
     LP_COP_SPACE_LWT_CEILING_C: float = float(os.getenv("LP_COP_SPACE_LWT_CEILING_C", "50.0"))
     DHW_TANK_LITRES: float = float(os.getenv("DHW_TANK_LITRES", "200"))
     DHW_WATER_CP: float = float(os.getenv("DHW_WATER_CP", "4186"))  # J/(kg·K)
-    # CALIBRATION REQUIRED — building envelope + thermal mass for the LP single-zone model.
-    # Tune from bills / heat-loss survey / co-heating test; defaults are placeholders.
-    BUILDING_UA_W_PER_K: float = float(os.getenv("BUILDING_UA_W_PER_K", "180"))
-    # CALIBRATION REQUIRED — effective thermal inertia (kWh/K) driving indoor temperature dynamics.
-    BUILDING_THERMAL_MASS_KWH_PER_K: float = float(os.getenv("BUILDING_THERMAL_MASS_KWH_PER_K", "8.0"))
+    # Building envelope + thermal mass for the single-zone model (estimator
+    # fallback today; the LP t_in restore in #540 will consume these too).
+    # MEASURED 2026-06-12 (docs/WINTER_THERMAL_MODEL.md §2.1): 120-day
+    # regression of fox daily load vs heating degree-days gives
+    # UA_eff ≈ 520-730 W/K (≈630 @ COP 3, R²=0.66). The old 180 W/K
+    # placeholder made the estimator ~3.5× too optimistic about heat
+    # retention. Thermal mass 12 kWh/K encodes a τ ≈ 20 h prior for UK
+    # masonry at this UA; both get replaced by the W2 thermal learner once
+    # the indoor sensors land (#540).
+    BUILDING_UA_W_PER_K: float = float(os.getenv("BUILDING_UA_W_PER_K", "600"))
+    BUILDING_THERMAL_MASS_KWH_PER_K: float = float(os.getenv("BUILDING_THERMAL_MASS_KWH_PER_K", "12.0"))
     # INDOOR_SETPOINT_C is runtime-tunable via /api/v1/settings (#52) — see @property below.
     INDOOR_COMFORT_BAND_C: float = float(os.getenv("INDOOR_COMFORT_BAND_C", "1.5"))
     RADIATOR_MAX_KW: float = float(os.getenv("RADIATOR_MAX_KW", "6.0"))

--- a/src/db.py
+++ b/src/db.py
@@ -3806,6 +3806,19 @@ def get_nonzero_lwt_offset_windows(
     gate must observe the firmware's NATURAL behaviour, not HEM's own echo —
     the June-2026 incident showed offsets waking the compressor and the
     calibration then learning from the heating they caused.
+
+    Status filter covers the REAL lifecycle (pending → active →
+    completed/failed; review H1 on #541 — 'in_flight' is never stored):
+    'active' matters most, because a multi-hour window is live exactly when
+    overlapping re-plans evaluate the gate. 'failed' is included
+    conservatively (may have half-applied). 'pending' never fired → clean.
+
+    The plan ``date`` left edge is padded by one day (review H2): a rolling
+    plan written in the evening carries windows that SPILL past midnight
+    under the previous plan_date; filtering strictly by date made those
+    windows invisible to a lookback starting the next day, re-counting their
+    heating as natural demand (every-other-day gate oscillation). The pad
+    only over-fetches — actual exclusion is keyed off start/end timestamps.
     """
     with _lock:
         conn = get_connection()
@@ -3813,8 +3826,8 @@ def get_nonzero_lwt_offset_windows(
             cur = conn.execute(
                 """SELECT start_time, end_time, params FROM action_schedule
                    WHERE device = 'daikin' AND action_type = 'lwt_preheat'
-                     AND date >= ? AND date <= ?
-                     AND status IN ('completed', 'in_flight')""",
+                     AND date >= date(?, '-1 day') AND date <= ?
+                     AND status IN ('completed', 'active', 'failed')""",
                 (start_date, end_date),
             )
             out: list[tuple[str, str]] = []
@@ -3850,7 +3863,25 @@ def measured_space_heating_kwh_excluding_offset_windows(
 
     rows = get_daikin_consumption_2hourly_range(start_date, end_date)
     if not rows:
-        # No 2-hourly split cached — fall back to the daily totals.
+        # No 2-hourly split cached. The daily totals CANNOT be decontaminated
+        # (no intra-day resolution), so falling back to them while offset
+        # windows exist would count HEM-induced heating as natural demand and
+        # latch the gate open exactly when its primary signal is broken
+        # (review M1 on #541) — return 0 (gate-closed direction) instead.
+        # With no offsets in range, the daily totals are clean and usable.
+        if get_nonzero_lwt_offset_windows(start_date, end_date):
+            logger.warning(
+                "measured_space_heating: 2-hourly split missing %s..%s while "
+                "offset windows exist — cannot decontaminate daily totals; "
+                "returning 0 (demand-gate-closed direction)",
+                start_date, end_date,
+            )
+            return 0.0
+        logger.warning(
+            "measured_space_heating: 2-hourly split missing %s..%s — falling "
+            "back to whole-day daily totals (coarser than the %dh lookback)",
+            start_date, end_date, lookback_hours,
+        )
         daily = get_daikin_consumption_daily_range(start_date, end_date)
         return float(sum(r.get("kwh_heating") or 0.0 for r in daily))
 

--- a/src/db.py
+++ b/src/db.py
@@ -3795,6 +3795,94 @@ def upsert_daikin_consumption_2hourly(
             conn.close()
 
 
+def get_nonzero_lwt_offset_windows(
+    start_date: str, end_date: str
+) -> list[tuple[str, str]]:
+    """``(start_time, end_time)`` UTC-ISO pairs of every ``lwt_preheat`` action
+    with a non-zero offset whose plan ``date`` falls in the inclusive range.
+
+    Used to EXCLUDE HEM-commanded offset windows from measured-heating
+    signals (#540): both the k_per_degc regression and the pre-heat demand
+    gate must observe the firmware's NATURAL behaviour, not HEM's own echo —
+    the June-2026 incident showed offsets waking the compressor and the
+    calibration then learning from the heating they caused.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT start_time, end_time, params FROM action_schedule
+                   WHERE device = 'daikin' AND action_type = 'lwt_preheat'
+                     AND date >= ? AND date <= ?
+                     AND status IN ('completed', 'in_flight')""",
+                (start_date, end_date),
+            )
+            out: list[tuple[str, str]] = []
+            for r in cur.fetchall():
+                try:
+                    off = json.loads(r["params"] or "{}").get("lwt_offset", 0)
+                except (json.JSONDecodeError, TypeError):
+                    off = 1  # unparseable → treat as contaminated (conservative)
+                if off:
+                    out.append((str(r["start_time"]), str(r["end_time"])))
+            return out
+        finally:
+            conn.close()
+
+
+def measured_space_heating_kwh_excluding_offset_windows(
+    lookback_hours: int = 48,
+) -> float:
+    """Trailing measured space-heating kWh from ``daikin_consumption_2hourly``,
+    EXCLUDING 2-hour buckets overlapped by a HEM ``lwt_preheat`` window.
+
+    Powers the pre-heat demand gate (#540): without the exclusion the gate
+    would feed on offset-induced heating and hold itself open forever. With
+    it, June converges shut within a day or two of residual decay, while a
+    real winter day still shows natural heating in the non-offset buckets.
+    Bucket grid is local-date × 2 h (bucket_idx 0-11, hour//2).
+    """
+    tz = ZoneInfo(getattr(config, "BULLETPROOF_TIMEZONE", "Europe/London"))
+    now_local = datetime.now(tz)
+    start_local = now_local - timedelta(hours=lookback_hours)
+    start_date = start_local.date().isoformat()
+    end_date = now_local.date().isoformat()
+
+    rows = get_daikin_consumption_2hourly_range(start_date, end_date)
+    if not rows:
+        # No 2-hourly split cached — fall back to the daily totals.
+        daily = get_daikin_consumption_daily_range(start_date, end_date)
+        return float(sum(r.get("kwh_heating") or 0.0 for r in daily))
+
+    excluded: set[tuple[str, int]] = set()
+    for s_iso, e_iso in get_nonzero_lwt_offset_windows(start_date, end_date):
+        try:
+            s = datetime.fromisoformat(s_iso.replace("Z", "+00:00")).astimezone(tz)
+            e = datetime.fromisoformat(e_iso.replace("Z", "+00:00")).astimezone(tz)
+        except (ValueError, TypeError):
+            continue
+        cur = s.replace(minute=0, second=0, microsecond=0)
+        cur = cur.replace(hour=(cur.hour // 2) * 2)
+        while cur < e:
+            excluded.add((cur.date().isoformat(), cur.hour // 2))
+            cur += timedelta(hours=2)
+
+    total = 0.0
+    for r in rows:
+        # Only buckets inside the trailing window count.
+        bucket_start = datetime.combine(
+            date.fromisoformat(str(r["date"])),
+            datetime.min.time(),
+            tzinfo=tz,
+        ) + timedelta(hours=2 * int(r["bucket_idx"]))
+        if bucket_start < start_local or bucket_start >= now_local:
+            continue
+        if (str(r["date"]), int(r["bucket_idx"])) in excluded:
+            continue
+        total += float(r.get("kwh_heating") or 0.0)
+    return total
+
+
 def get_daikin_consumption_2hourly_range(
     start_date: str, end_date: str
 ) -> list[dict[str, Any]]:
@@ -6581,14 +6669,33 @@ def compute_daikin_lwt_kw_calibration(
     # of the day — earlier versions correlated on the day, which collapsed
     # to whichever single snapshot had the latest fetch with any slot in
     # that day, dropping coverage to a handful of hours for older days.
+    # Decontamination (#540): days where HEM itself commanded a non-zero LWT
+    # offset must not train k. X_day is computed from the NATURAL curve while
+    # y_day (measured heating) includes the offset-induced draw, so offset
+    # days bias k upward — observed June 2026: k drifted 0.033 → 0.067
+    # learning from the very heating the offsets caused.
+    contaminated_days: set[str] = set()
+    try:
+        for s_iso, e_iso in get_nonzero_lwt_offset_windows(
+            start_day.isoformat(), end_day.isoformat()
+        ):
+            contaminated_days.add(s_iso[:10])
+            contaminated_days.add(e_iso[:10])  # midnight-crossing windows
+    except Exception:  # pragma: no cover — decontamination is best-effort
+        logger.exception("lwt k-calibration: offset-window lookup failed")
+
     pairs: list[tuple[float, float, str]] = []  # (X_day, y_day, date)
     skipped_no_meteo: list[str] = []
     skipped_outlier: list[str] = []
+    skipped_hem_offset: list[str] = []
     with _lock:
         conn = get_connection()
         try:
             for row in obs_rows:
                 d = str(row["date"])
+                if d in contaminated_days:
+                    skipped_hem_offset.append(d)
+                    continue
                 kwh_heating = float(row["kwh_heating"])
                 cur = conn.execute(
                     """SELECT slot_time, temp_c FROM (
@@ -6693,6 +6800,7 @@ def compute_daikin_lwt_kw_calibration(
         "raw_pairs": len(pairs),
         "skipped_no_meteo": len(skipped_no_meteo),
         "skipped_outlier_pre": len(skipped_outlier),
+        "skipped_hem_offset": len(skipped_hem_offset),
         "outliers_filtered": len(pairs) - len(anchored),
     }
 

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -285,20 +285,14 @@ def _overnight_tank_idle_enabled() -> bool:
     return val not in ("false", "0", "no", "off")
 
 
-def _lwt_offset_from_plan(i: int, plan: LpPlan) -> float:
-    """Return the LP-derived LWT offset for slot *i*.
-
-    Uses the back-computed ``plan.lwt_offset_c`` list (filled by ``solve_lp`` via
-    ``lwt_offset_from_space_kw``).  This translates the solver's continuous ``e_space[i]``
-    decision — bounded by the physical climate curve — into the exact Daikin offset command
-    needed to deliver that energy draw.
-
-    PR Phase B: indoor-temp fallback removed (no plan.indoor_temp_c). When
-    ``plan.lwt_offset_c`` is empty (heuristic / legacy path), default to 0.
-    """
-    if plan.lwt_offset_c and i < len(plan.lwt_offset_c):
-        return float(plan.lwt_offset_c[i])
-    return 0.0
+# NOTE: the LP-derived per-slot LWT offset (`plan.lwt_offset_c`) is recorded in
+# lp_solution_snapshot for audit but is deliberately NOT dispatched from the
+# per-window loop below — Daikin window actions are TANK-ONLY (see the comment
+# block inside daikin_dispatch_preview). The only offset writer is
+# _write_lwt_preheat_actions, behind DAIKIN_LWT_PREHEAT_ENABLED and the
+# measured demand gate (#540). The old `_lwt_offset_from_plan` helper was dead
+# (computed, never written) and was removed in #541 review cleanup to keep the
+# tank-only invariant grep-provable.
 
 
 def _preheat_lwt_offset(
@@ -349,8 +343,10 @@ def _preheat_lwt_offset(
     if price_p < 0:
         # PAID to import — push space heating to the TOP of the operating range
         # (clamped below) to bank the most thermal mass while we're paid for it,
-        # not the modest cheap-slot nudge. Heating-cutoff gate above already
-        # ensures this only fires when the firmware is actually heating.
+        # not the modest cheap-slot nudge. The old outdoor-temp cutoff was
+        # removed; what keeps this from firing on a non-heating house is the
+        # measured DEMAND GATE in _write_lwt_preheat_actions (#540 — a
+        # positive offset can WAKE the compressor, June 2026).
         off = neg_boost
         # Comfort guard (sensor-ready): don't over-heat an already-warm room.
         if indoor_c is not None and indoor_c >= setpoint + band:
@@ -623,11 +619,6 @@ def daikin_dispatch_preview(
             "tank_idle_overnight": "tank_idle_overnight",
         }.get(kind, "normal")
 
-        mid = start_utc + timedelta(minutes=15)
-        fc = get_forecast_for_slot(mid, forecast)
-        outdoor = fc.temperature_c if fc else (plan.temp_outdoor_c[i0] if i0 < len(plan.temp_outdoor_c) else 0.0)
-        peak_frost = kind == "peak" and outdoor < float(config.WEATHER_FROST_THRESHOLD_C)
-
         # The merge in _merge_half_hour_slots_for_daikin groups slots by KIND
         # (battery state), not by heat-pump activity. For solar_charge, the LP
         # can plan e_dhw > 0 in just one slot inside a long merged window
@@ -662,12 +653,6 @@ def daikin_dispatch_preview(
         ed = ed_max
         es = es_max
         tt = tt_max
-        # LP-derived LWT offset: continuous value back-computed from e_space[j] via the
-        # inverse climate curve.  This replaces the old fixed-tier overrides so the solver's
-        # energy decision directly controls the radiator temperature rather than a lookup table.
-        lwt = _lwt_offset_from_plan(j, plan)
-        if peak_frost:
-            lwt = max(-2.0, float(config.OPTIMIZATION_LWT_OFFSET_MIN))
         tank_pow = ed > EPS
         tank_powful = ed >= max_b - 1e-3
         # Powerful boost is enabled on negative *and* solar_preheat slots —
@@ -996,9 +981,11 @@ def _write_lwt_preheat_actions(
     # the compressor the firmware would have left off (June 2026: heating went
     # 0 → 3-8 kWh/day within days of enabling pre-heat, with the LP budgeting
     # ~0.2). Pre-heating thermal mass the house isn't draining buys nothing;
-    # when a cold snap starts, firmware heats naturally within hours and the
-    # gate opens on the next plan. Negative (setback) offsets are gated too:
-    # with the compressor off they are pure quota churn.
+    # when a cold snap starts, the firmware heats naturally and the gate opens
+    # once that shows in the 2-hourly split — up to ~24 h (02:35 UTC rollup).
+    # Comfort-safe: the firmware heats regardless; only HEM's price-shaping is
+    # delayed. Negative (setback) offsets are gated too: with the compressor
+    # off they are pure quota churn.
     if not _space_heating_demand_present():
         logger.info(
             "LWT pre-heat: skipped — no measured space-heating demand in the "

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -950,6 +950,26 @@ def _apply_write_budget(
     return keep, dropped
 
 
+def _space_heating_demand_present() -> bool:
+    """True when the trailing window shows real measured space-heating demand.
+
+    Reads ``db.measured_space_heating_kwh_excluding_offset_windows`` — the
+    exclusion matters: counting offset-induced heating would let the gate
+    feed on its own output and never close (June 2026). Fail-open on errors:
+    a broken telemetry read must not silently disable winter pre-heat.
+    """
+    floor = float(getattr(config, "DAIKIN_LWT_PREHEAT_MIN_TRAILING_HEATING_KWH", 0.5))
+    if floor <= 0:
+        return True  # gate disabled
+    lookback = int(getattr(config, "DAIKIN_LWT_PREHEAT_DEMAND_LOOKBACK_HOURS", 48))
+    try:
+        measured = db.measured_space_heating_kwh_excluding_offset_windows(lookback)
+    except Exception:  # pragma: no cover — gate must never break dispatch
+        logger.exception("LWT pre-heat demand gate read failed — failing open")
+        return True
+    return measured >= floor
+
+
 def _write_lwt_preheat_actions(
     plan_date: str,
     plan: LpPlan,
@@ -969,6 +989,23 @@ def _write_lwt_preheat_actions(
     quota headroom here, dropping trailing pairs so we can never exceed budget.
     """
     if not config.DAIKIN_LWT_PREHEAT_ENABLED:
+        return 0
+
+    # Demand gate (#540 quick win): no pre-heat offsets without measured
+    # space-heating demand in the trailing window. A positive offset can WAKE
+    # the compressor the firmware would have left off (June 2026: heating went
+    # 0 → 3-8 kWh/day within days of enabling pre-heat, with the LP budgeting
+    # ~0.2). Pre-heating thermal mass the house isn't draining buys nothing;
+    # when a cold snap starts, firmware heats naturally within hours and the
+    # gate opens on the next plan. Negative (setback) offsets are gated too:
+    # with the compressor off they are pure quota churn.
+    if not _space_heating_demand_present():
+        logger.info(
+            "LWT pre-heat: skipped — no measured space-heating demand in the "
+            "trailing %dh window (floor %.1f kWh)",
+            int(getattr(config, "DAIKIN_LWT_PREHEAT_DEMAND_LOOKBACK_HOURS", 48)),
+            float(getattr(config, "DAIKIN_LWT_PREHEAT_MIN_TRAILING_HEATING_KWH", 0.5)),
+        )
         return 0
 
     # Sensor-ready hook: read the latest LIVE indoor temperature if any exists.

--- a/tests/test_lwt_demand_gate.py
+++ b/tests/test_lwt_demand_gate.py
@@ -152,3 +152,70 @@ def test_k_regression_skips_hem_offset_days(monkeypatch):
     assert result["status"] == "ok", result
     assert result["skipped_hem_offset"] == 3
     assert result["samples"] <= 7  # 10 seeded − 3 contaminated
+
+
+# ---------------------------------------------------------------------------
+# Review regressions (#541): H1 active-status windows, H2 plan-date spill,
+# M1 contaminated daily fallback
+# ---------------------------------------------------------------------------
+
+def test_active_window_is_excluded_h1():
+    """A window that is LIVE right now sits at status='active' — exactly when
+    overlapping re-plans evaluate the gate. It must be excluded ('in_flight'
+    is never a stored status; lifecycle is pending→active→completed/failed)."""
+    from src import db
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 4, 1.5)
+    start_utc = y.replace(hour=8).astimezone(UTC)
+    db.upsert_action(
+        plan_date=y.date().isoformat(),
+        start_time=start_utc.isoformat().replace("+00:00", "Z"),
+        end_time=(start_utc + timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
+        device="daikin", action_type="lwt_preheat",
+        params={"lwt_offset": 3}, status="active",
+    )
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == 0.0
+
+
+def test_midnight_spill_window_is_excluded_h2():
+    """A rolling plan written in the evening files midnight-spilling windows
+    under the PREVIOUS plan_date. A lookback whose start date is after that
+    plan_date must still see the window (left-edge pad), or its heating
+    re-counts as natural demand → every-other-day gate oscillation."""
+    from src import db
+    y = _yesterday_local()                       # lookback covers yesterday+today
+    plan_day = (y - timedelta(days=1)).date()    # filed under the day BEFORE lookback start
+    _seed_2h(y.date().isoformat(), 0, 2.0)       # 00-02 local yesterday
+    start_utc = y.replace(hour=0).astimezone(UTC)
+    db.upsert_action(
+        plan_date=plan_day.isoformat(),
+        start_time=start_utc.isoformat().replace("+00:00", "Z"),
+        end_time=(start_utc + timedelta(hours=2)).isoformat().replace("+00:00", "Z"),
+        device="daikin", action_type="lwt_preheat",
+        params={"lwt_offset": 3}, status="completed",
+    )
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == 0.0
+
+
+def test_daily_fallback_refuses_contaminated_data_m1():
+    """2-hourly split missing + offset windows present → daily totals cannot
+    be decontaminated; must return 0 (gate-closed direction), never the
+    offset-induced daily heating."""
+    from src import db
+    y = _yesterday_local()
+    db.upsert_daikin_consumption_daily(
+        date=y.date().isoformat(), kwh_total=6.0, kwh_heating=6.0, source="onecta",
+    )
+    _seed_offset_action(y.replace(hour=2), 2.0, 3)
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == 0.0
+
+
+def test_daily_fallback_clean_data_still_counts():
+    """2-hourly missing but NO offsets in range → daily totals are clean and
+    keep the gate responsive (winter cold-start case)."""
+    from src import db
+    y = _yesterday_local()
+    db.upsert_daikin_consumption_daily(
+        date=y.date().isoformat(), kwh_total=6.0, kwh_heating=6.0, source="onecta",
+    )
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == pytest.approx(6.0)

--- a/tests/test_lwt_demand_gate.py
+++ b/tests/test_lwt_demand_gate.py
@@ -1,0 +1,154 @@
+"""LWT pre-heat demand gate + k-calibration decontamination (#540 quick wins).
+
+June-2026 incident: positive LWT offsets WAKE the compressor the firmware
+would have left off (measured heating 0 → 3-8 kWh/day within days of
+enabling pre-heat), and the k_per_degc regression then learned from the
+heating the offsets caused (k 0.033 → 0.067). These tests pin:
+  - the gate closes when natural (non-offset-window) heating is absent,
+  - the gate cannot feed on offset-induced heating,
+  - contaminated days are excluded from the k regression.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.config import config as app_config
+
+TZ = ZoneInfo("Europe/London")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    from src import db as _db
+    _db.init_db()
+    yield
+
+
+def _seed_2h(date_str: str, bucket: int, kwh_heating: float) -> None:
+    from src import db
+    db.upsert_daikin_consumption_2hourly(
+        date=date_str, bucket_idx=bucket, kwh_total=kwh_heating,
+        kwh_heating=kwh_heating, kwh_dhw=0.0, source="onecta",
+    )
+
+
+def _seed_offset_action(start_local: datetime, hours: float, offset: int) -> None:
+    from src import db
+    start_utc = start_local.astimezone(UTC)
+    end_utc = start_utc + timedelta(hours=hours)
+    db.upsert_action(
+        plan_date=start_local.date().isoformat(),
+        start_time=start_utc.isoformat().replace("+00:00", "Z"),
+        end_time=end_utc.isoformat().replace("+00:00", "Z"),
+        device="daikin", action_type="lwt_preheat",
+        params={"lwt_offset": offset, "lp_optimizer": True},
+        status="completed",
+    )
+
+
+def _yesterday_local() -> datetime:
+    now = datetime.now(TZ)
+    return (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+# ---------------------------------------------------------------------------
+# measured_space_heating_kwh_excluding_offset_windows
+# ---------------------------------------------------------------------------
+
+def test_natural_heating_counts():
+    from src import db
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 4, 1.5)   # 08-10 local, no offsets anywhere
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == pytest.approx(1.5)
+
+
+def test_offset_window_heating_is_excluded():
+    """Heating inside a HEM offset window must NOT count as natural demand —
+    otherwise the gate feeds on its own output and never closes."""
+    from src import db
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 4, 1.5)          # 08-10 local
+    _seed_offset_action(y.replace(hour=8), 2.0, 3)  # offset covering that bucket
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == 0.0
+
+
+def test_mixed_day_keeps_non_offset_buckets():
+    """Winter shape: offsets in the cheap window, natural heating elsewhere —
+    the natural buckets keep the gate open."""
+    from src import db
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 1, 2.0)          # 02-04 local — offset window
+    _seed_2h(y.date().isoformat(), 9, 1.8)          # 18-20 local — natural
+    _seed_offset_action(y.replace(hour=2), 2.0, 3)
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == pytest.approx(1.8)
+
+
+def test_zero_offset_actions_do_not_exclude():
+    """Restore rows / offset=0 rows are not contamination."""
+    from src import db
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 4, 1.5)
+    _seed_offset_action(y.replace(hour=8), 2.0, 0)
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# _space_heating_demand_present (dispatch gate)
+# ---------------------------------------------------------------------------
+
+def test_gate_closed_without_demand(monkeypatch):
+    from src.scheduler import lp_dispatch
+    assert lp_dispatch._space_heating_demand_present() is False
+
+
+def test_gate_open_with_natural_demand():
+    from src.scheduler import lp_dispatch
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 4, 1.5)
+    assert lp_dispatch._space_heating_demand_present() is True
+
+
+def test_gate_disabled_by_zero_floor(monkeypatch):
+    from src.scheduler import lp_dispatch
+    monkeypatch.setattr(
+        app_config, "DAIKIN_LWT_PREHEAT_MIN_TRAILING_HEATING_KWH", 0.0, raising=False
+    )
+    assert lp_dispatch._space_heating_demand_present() is True
+
+
+# ---------------------------------------------------------------------------
+# k_per_degc decontamination
+# ---------------------------------------------------------------------------
+
+def test_k_regression_skips_hem_offset_days(monkeypatch):
+    """Days with non-zero lwt_preheat actions are excluded from the sample."""
+    from src import db
+
+    # Seed 10 days of heating + meteo coverage; mark 3 as offset days.
+    today = datetime.now(TZ).date()
+    for back in range(1, 11):
+        d = today - timedelta(days=back)
+        db.upsert_daikin_consumption_daily(
+            date=d.isoformat(), kwh_total=12.0, kwh_heating=10.0, source="onecta",
+        )
+        fetch = f"{(d - timedelta(days=1)).isoformat()}T12:00:00+00:00"
+        db.save_meteo_forecast_history(fetch, [
+            {"slot_time": f"{d.isoformat()}T{h:02d}:00:00+00:00",
+             "temp_c": 5.0, "solar_w_m2": 0.0, "cloud_cover_pct": 50.0}
+            for h in range(24)
+        ])
+        if back <= 3:
+            start_local = datetime.combine(d, datetime.min.time(), tzinfo=TZ).replace(hour=2)
+            _seed_offset_action(start_local, 2.0, 3)
+
+    result = db.compute_daikin_lwt_kw_calibration(window_days=12, min_samples=5)
+    assert result["status"] == "ok", result
+    assert result["skipped_hem_offset"] == 3
+    assert result["samples"] <= 7  # 10 seeded − 3 contaminated


### PR DESCRIPTION
Tracked by #540 (the three "quick wins" from `docs/WINTER_THERMAL_MODEL.md` §3.3).

## What

1. **Demand gate** — no LWT offset action rows unless the trailing 48 h shows ≥ 0.5 kWh of measured space heating, computed **excluding 2 h buckets overlapped by HEM's own offset windows** (`db.measured_space_heating_kwh_excluding_offset_windows`). Without the exclusion the gate would feed on offset-induced heating and hold itself open forever; with it, the June waste pattern (heating 0 → 3-8 kWh/day after pre-heat enablement, LP budgeting ~0.2) converges shut within a day of residual decay, while winter days keep it open via natural heating in non-offset buckets. Fail-open on telemetry errors; floor 0 disables.
2. **k_per_degc decontamination** — the daily regression excludes days with non-zero `lwt_preheat` actions (X_day uses the *natural* curve, y_day included offset-induced draw → upward bias; observed drift 0.033 → 0.067). New `skipped_hem_offset` audit field; midnight-crossing windows contaminate both days.
3. **Measured thermal constants** — `BUILDING_UA_W_PER_K` 180 → **600**, `BUILDING_THERMAL_MASS_KWH_PER_K` 8 → **12** (τ ≈ 20 h prior), from the 120-day HDD regression (R² 0.66). The estimator fallback stops being ~3.5× optimistic about heat retention. Both will be superseded by the W2 thermal learner once the indoor sensors land.

## Tests

8 new (natural-heating counts; offset-window exclusion; mixed winter day; offset=0 rows inert; gate closed/open/disabled; k regression skips contaminated days) + 240 related tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)