### PR TITLE
feat(quartz): self-hosted site-level forecast sidecar + open-schema provider

### DIFF
--- a/.github/workflows/quartz-publish.yml
+++ b/.github/workflows/quartz-publish.yml
@@ -1,0 +1,86 @@
+name: Publish Quartz sidecar image
+
+# Build + push the self-hosted Quartz solar-forecast sidecar (#542) to GHCR
+# on every push to main and on tags. Mirrors ui-publish.yml: paths-scoped so
+# only quartz/ changes trigger a rebuild; the image is consumed by
+# deploy/compose.yaml as the hem-quartz service and deploys independently of
+# the HEM API + UI images.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - "quartz/**"
+      - ".github/workflows/quartz-publish.yml"
+  pull_request:
+    paths:
+      - "quartz/**"
+      - ".github/workflows/quartz-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # Fast-fail on syntax/import errors before paying for the emulated arm64
+  # build (QEMU + xgboost/pyresample wheels take minutes).
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile check
+        run: python -m py_compile quartz/app.py
+
+  build-and-push:
+    needs: smoke
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/home-energy-manager-quartz
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=long
+
+      - name: Build + push (linux/arm64 to match prod Hetzner host)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./quartz
+          file: ./quartz/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=quartz
+          cache-to: type=gha,mode=max,scope=quartz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,6 +582,10 @@ ui/                        # Epic 13b — SPA container (nginx + static assets)
   src/{js,css}/            # vanilla JS + CSS, served by nginx; bearer injected by _api.js
   ui-entrypoint.sh         # writes /config.js with bearer + apiBase at container boot
 .github/workflows/ui-publish.yml  # builds + pushes ghcr.io/<owner>/home-energy-manager-ui on push to main (paths-scoped)
+quartz/                    # #542 — self-hosted Quartz solar-forecast sidecar (hem-quartz service)
+  Dockerfile               # python:3.12-slim + quartz-solar-forecast (xgboost site-level model, MIT)
+  app.py                   # FastAPI mirroring open.quartz.solar POST /forecast/ schema; lazy model warm-up
+.github/workflows/quartz-publish.yml  # builds + pushes ghcr.io/<owner>/home-energy-manager-quartz (paths-scoped)
 src/
   cli/__main__.py          # entrypoint: `python -m src.cli serve` (PID 1 in the container, behind tini)
   api/main.py              # FastAPI app + lifespan (token bootstrap, MCP session manager, scheduler) — JSON API only since B5

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -143,6 +143,56 @@ services:
     networks:
       - hem-net
 
+  # ── #542 — self-hosted Quartz solar-forecast sidecar ─────────────────────
+  # Open Climate Fix's open-source site-level PV model (xgboost), wrapped in
+  # a thin FastAPI that mirrors the hosted open.quartz.solar schema. HEM
+  # reaches it ONLY on the internal bridge (http://hem-quartz:8000 — no host
+  # ports). The model pulls its NWP from Open-Meteo itself: no API keys.
+  # Weights download once into the quartz-cache volume (~/cache survives
+  # redeploys). Rollback: set QUARTZ_OPEN_URL=https://open.quartz.solar in
+  # /srv/hem/.env (hosted twin, same schema) or QUARTZ_PROVIDER=hosted.
+  hem-quartz:
+    image: ghcr.io/albinati/home-energy-manager-quartz:${HEM_QUARTZ_IMAGE_TAG:-main}
+    container_name: hem-quartz
+    pull_policy: always
+    restart: unless-stopped
+
+    environment:
+      TZ: Europe/London
+
+    read_only: true
+    tmpfs:
+      - /tmp:rw,size=128m,mode=1777
+    volumes:
+      - quartz-cache:/cache
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 100
+    # xgboost + pandas + NWP frames; box has 4 GB with ~2.7 free (2026-06-12).
+    mem_limit: 1g
+    mem_reservation: 256m
+
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=3).status==200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+    logging:
+      driver: journald
+      options:
+        tag: hem-quartz
+
+    networks:
+      - hem-net
+
+volumes:
+  # One-time Hugging Face model-weights download for hem-quartz; keeping it
+  # off the read-only rootfs and out of tmpfs means no re-download per boot.
+  quartz-cache:
+
 # Pin a known subnet so the bridge gateway IP (172.30.0.1) is stable. The
 # container resolves openclaw.host -> 172.30.0.1 (extra_hosts above) and
 # reaches OpenClaw on the host. Without this, compose picks the next free

--- a/quartz/Dockerfile
+++ b/quartz/Dockerfile
@@ -1,0 +1,29 @@
+# HEM-local Quartz solar forecast sidecar (#542) — linux/arm64 (Hetzner CAX11).
+# Self-hosts Open Climate Fix's open-source site-level PV model so HEM has no
+# external forecast-API dependency (the hosted token expired; open.quartz.solar
+# remains the drop-in fallback because this container mirrors its schema).
+FROM python:3.12-slim
+
+# Model/weights caches live OUTSIDE the read-only rootfs — compose mounts a
+# named volume at /cache so the one-time Hugging Face download survives
+# restarts and redeploys.
+ENV HF_HOME=/cache/hf \
+    XDG_CACHE_HOME=/cache/xdg \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+ARG BUILD_SHA=unknown
+RUN echo "${BUILD_SHA}" > /app/.git-sha
+
+RUN useradd --uid 1001 --no-create-home quartz \
+    && mkdir -p /cache && chown -R 1001:1001 /cache
+USER 1001
+
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/quartz/app.py
+++ b/quartz/app.py
@@ -98,6 +98,10 @@ def forecast(req: ForecastRequest) -> dict:
     ts = req.timestamp or datetime.now(UTC)
     if ts.tzinfo is not None:
         ts = ts.astimezone(UTC).replace(tzinfo=None)  # package expects naive UTC
+    # Defense-in-depth (#544 review): the model anchors its 15-min prediction
+    # grid at this ts. Floor it so multi-plane callers always get identical,
+    # quarter-aligned grids even if they forget to send a shared timestamp.
+    ts = ts.replace(minute=(ts.minute // 15) * 15, second=0, microsecond=0)
 
     site = PVSite(
         latitude=req.site.latitude,

--- a/quartz/app.py
+++ b/quartz/app.py
@@ -1,0 +1,129 @@
+"""HEM-local Quartz solar forecast sidecar (#542).
+
+Thin FastAPI wrapper around Open Climate Fix's open-source
+``quartz-solar-forecast`` model (MIT, xgboost ``gb`` model trained on ~25k UK
+sites; pulls its NWP input from Open-Meteo itself — no API keys anywhere).
+
+The endpoint schema deliberately MIRRORS the hosted ``open.quartz.solar``
+``POST /forecast/`` contract, so HEM's client can point at either this
+container (``http://hem-quartz:8000``) or the hosted service with nothing but
+a URL change. See ``src/weather.py:_fetch_quartz_open_forecast``.
+
+Model weights are fetched once into ``$HF_HOME`` (a named docker volume in
+deploy/compose.yaml) and lazily loaded on the first request — /health stays
+fast at boot so the compose healthcheck doesn't gate on the download.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import UTC, datetime
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("hem-quartz")
+
+app = FastAPI(title="HEM local Quartz solar forecast", version="1.0.0")
+
+_model_lock = threading.Lock()
+_model_loaded = False
+
+
+class PVSiteIn(BaseModel):
+    latitude: float = Field(ge=-90, le=90)
+    longitude: float = Field(ge=-180, le=180)
+    capacity_kwp: float = Field(gt=0)
+    tilt: float = Field(default=35, ge=0, le=90)
+    orientation: float = Field(default=180, ge=0, le=360)
+
+
+class GenerationValue(BaseModel):
+    timestamp: datetime
+    generation: float
+
+
+class ForecastRequest(BaseModel):
+    site: PVSiteIn
+    timestamp: datetime | None = None
+    # Accepted for hosted-API compatibility. The local ``run_forecast`` entry
+    # point does not take recent-generation input (that path needs the
+    # package's inverter integrations), so it is ignored here — HEM's
+    # calibration/bias stack covers the nowcast correction instead.
+    live_generation: list[GenerationValue] | None = None
+
+
+def _warm_model() -> None:
+    """Background warm-up: the first ``run_forecast`` downloads model weights
+    (Hugging Face → /cache volume) and the NWP frame — can take minutes on a
+    cold volume. Doing it off-thread at boot means HEM's first real fetch
+    (typically < 60 s timeout) hits a warm model instead of timing out once.
+    """
+    global _model_loaded
+    try:
+        from quartz_solar_forecast.forecast import run_forecast
+        from quartz_solar_forecast.pydantic_models import PVSite
+        with _model_lock:
+            run_forecast(
+                site=PVSite(latitude=51.5, longitude=-0.2, capacity_kwp=1.0),
+                ts=datetime.now(UTC).replace(tzinfo=None),
+            )
+            _model_loaded = True
+        logger.info("model warm-up complete")
+    except Exception:  # pragma: no cover — warm-up is best-effort
+        logger.exception("model warm-up failed (first request will retry)")
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    threading.Thread(target=_warm_model, name="model-warmup", daemon=True).start()
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok", "model_loaded": _model_loaded}
+
+
+@app.post("/forecast/")
+def forecast(req: ForecastRequest) -> dict:
+    global _model_loaded
+    try:
+        from quartz_solar_forecast.forecast import run_forecast
+        from quartz_solar_forecast.pydantic_models import PVSite
+    except Exception as exc:  # pragma: no cover — import failure = broken image
+        logger.exception("quartz-solar-forecast import failed")
+        raise HTTPException(status_code=500, detail=f"model import failed: {exc}") from exc
+
+    ts = req.timestamp or datetime.now(UTC)
+    if ts.tzinfo is not None:
+        ts = ts.astimezone(UTC).replace(tzinfo=None)  # package expects naive UTC
+
+    site = PVSite(
+        latitude=req.site.latitude,
+        longitude=req.site.longitude,
+        capacity_kwp=req.site.capacity_kwp,
+        tilt=req.site.tilt,
+        orientation=req.site.orientation,
+    )
+
+    # xgboost predict is not re-entrancy-hazardous, but the first call also
+    # downloads + loads weights; serialize so concurrent first requests don't
+    # double-download into the cache volume.
+    with _model_lock:
+        try:
+            df = run_forecast(site=site, ts=ts)
+        except Exception as exc:
+            logger.exception("run_forecast failed")
+            raise HTTPException(status_code=502, detail=f"forecast failed: {exc}") from exc
+        _model_loaded = True
+
+    col = "power_kw" if "power_kw" in df.columns else df.columns[0]
+    preds = {
+        idx.isoformat(): max(0.0, float(v))
+        for idx, v in df[col].items()
+    }
+    return {
+        "timestamp": ts.isoformat(),
+        "predictions": {"power_kw": preds},
+    }

--- a/quartz/requirements.txt
+++ b/quartz/requirements.txt
@@ -1,0 +1,6 @@
+# Pinned loosely on purpose: the model API (run_forecast/PVSite) is stable
+# across 1.x; security/bug fixes flow in on image rebuilds. xgboost +
+# pyresample publish manylinux aarch64 wheels (prod host is ARM64/CAX11).
+quartz-solar-forecast>=1.2,<2
+fastapi>=0.111,<1
+uvicorn>=0.30,<1

--- a/src/config.py
+++ b/src/config.py
@@ -648,6 +648,33 @@ class Config:
     QUARTZ_INSTALLED_CAPACITY_MW: float = float(
         os.getenv("QUARTZ_INSTALLED_CAPACITY_MW", "0") or "0"
     )
+    # --- #542 — site-level open Quartz provider --------------------------
+    # The hosted api.quartz.solar token is the COMMERCIAL national/GSP
+    # product (access expiring); the open-source SITE-level model is free in
+    # two interchangeable forms behind the same schema:
+    #   * the hem-quartz sidecar container (deploy/compose.yaml) at
+    #     http://hem-quartz:8000 — self-hosted, no external dependency;
+    #   * the hosted twin https://open.quartz.solar — unauthenticated.
+    # QUARTZ_PROVIDER selects the client: "open" (new default) talks the
+    # open schema at QUARTZ_OPEN_URL; "hosted" preserves the legacy
+    # token-based national/GSP client for rollback while the token lives.
+    QUARTZ_PROVIDER: str = (os.getenv("QUARTZ_PROVIDER") or "open").strip().lower()
+    QUARTZ_OPEN_URL: str = (
+        os.getenv("QUARTZ_OPEN_URL") or "https://open.quartz.solar"
+    ).strip().rstrip("/")
+    # JSON list of panel planes, e.g. (this house: 6 SW-pitched + 6 flat-rack
+    # south — see project_quartz_site_level_killed for the sweep evidence):
+    #   [{"tilt": 35, "orientation": 225, "capacity_kwp": 2.25},
+    #    {"tilt": 10, "orientation": 180, "capacity_kwp": 2.25}]
+    # Empty → single aggregate plane (tilt 30, orientation 200,
+    # capacity PV_CAPACITY_KWP); the L3 calibration absorbs the residual.
+    QUARTZ_OPEN_PLANES: str = (os.getenv("QUARTZ_OPEN_PLANES") or "").strip()
+    QUARTZ_OPEN_TIMEOUT_SECONDS: int = int(os.getenv("QUARTZ_OPEN_TIMEOUT_SECONDS", "60"))
+    # Send recent measured generation with the request (the hosted twin uses
+    # it for nowcast anchoring; the sidecar accepts-and-ignores it today).
+    QUARTZ_OPEN_SEND_LIVE: bool = os.getenv(
+        "QUARTZ_OPEN_SEND_LIVE", "true"
+    ).lower() in ("true", "1", "yes")
     # PR L1 (2026-05-24) — apply the per-hour + per-(hour, cloud) calibration
     # tables on top of Quartz's direct PV output. Previously SKIPPED (PR #279)
     # under the assumption "Quartz self-calibrates", but observed AM 0.65 /

--- a/src/config.py
+++ b/src/config.py
@@ -670,8 +670,10 @@ class Config:
     # capacity PV_CAPACITY_KWP); the L3 calibration absorbs the residual.
     QUARTZ_OPEN_PLANES: str = (os.getenv("QUARTZ_OPEN_PLANES") or "").strip()
     QUARTZ_OPEN_TIMEOUT_SECONDS: int = int(os.getenv("QUARTZ_OPEN_TIMEOUT_SECONDS", "60"))
-    # Send recent measured generation with the request (the hosted twin uses
-    # it for nowcast anchoring; the sidecar accepts-and-ignores it today).
+    # Send recent measured generation with the request. NOTE (#544 review):
+    # today BOTH the sidecar and the hosted twin accept-and-ignore it (the
+    # upstream model only anchors on live data via its inverter
+    # integrations) — kept on as future-proof plumbing, harmless either way.
     QUARTZ_OPEN_SEND_LIVE: bool = os.getenv(
         "QUARTZ_OPEN_SEND_LIVE", "true"
     ).lower() in ("true", "1", "yes")

--- a/src/weather.py
+++ b/src/weather.py
@@ -766,10 +766,15 @@ def _fetch_quartz_open_forecast(
                 ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
             except (TypeError, ValueError):
                 continue
-            # Model timestamps are naive UTC (sometimes with stray microseconds).
+            # Model timestamps are naive UTC with per-REQUEST sub-minute
+            # offsets (live probe: '09:45:00.533720', different on every
+            # call). Floor to the 15-min grid so the planes' keys COLLIDE —
+            # without this, plane A and plane B land on disjoint keys and the
+            # half-hour bucket averages the planes instead of summing them
+            # (half the real forecast for a 2-plane site).
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=UTC)
-            ts = ts.replace(microsecond=0)
+            ts = ts.replace(minute=(ts.minute // 15) * 15, second=0, microsecond=0)
             try:
                 kw_by_ts[ts] = kw_by_ts.get(ts, 0.0) + max(0.0, float(kw))
             except (TypeError, ValueError):

--- a/src/weather.py
+++ b/src/weather.py
@@ -730,6 +730,15 @@ def _fetch_quartz_open_forecast(
     timeout = int(getattr(config, "QUARTZ_OPEN_TIMEOUT_SECONDS", 60))
     live = _quartz_open_live_generation()
 
+    # One SHARED, quarter-floored timestamp for every plane request: the
+    # server anchors its 15-min prediction grid at the request ts (review
+    # #544 finding 1 — per-request now() gave each plane a drifted grid, and
+    # the merge averaged planes instead of summing). Floored client-side so
+    # plane calls can't straddle a quarter boundary either.
+    now_q = datetime.now(UTC).replace(second=0, microsecond=0)
+    shared_ts = now_q.replace(minute=(now_q.minute // 15) * 15)
+    shared_ts_iso = shared_ts.replace(tzinfo=None).isoformat()
+
     # kW summed across planes per raw model timestamp.
     kw_by_ts: dict[datetime, float] = {}
     planes = _quartz_open_planes()
@@ -742,6 +751,7 @@ def _fetch_quartz_open_forecast(
                 "tilt": plane["tilt"],
                 "orientation": plane["orientation"],
             },
+            "timestamp": shared_ts_iso,
         }
         if live:
             body["live_generation"] = live

--- a/src/weather.py
+++ b/src/weather.py
@@ -453,7 +453,13 @@ def fetch_forecast_snapshot(
     source = (getattr(config, "FORECAST_SOURCE", "open_meteo") or "open_meteo").strip().lower()
     if source in ("quartz", "quartz_solar"):
         base = _fetch_open_meteo_forecast(lat=lat, lon=lon, hours=hours)
-        quartz = _fetch_quartz_forecast(hours=hours, base_weather=base)
+        provider = (getattr(config, "QUARTZ_PROVIDER", "open") or "open").strip().lower()
+        if provider == "open":
+            quartz = _fetch_quartz_open_forecast(
+                hours=hours, base_weather=base, lat=lat, lon=lon
+            )
+        else:
+            quartz = _fetch_quartz_forecast(hours=hours, base_weather=base)
         if quartz.forecast:
             return quartz
         logger.warning("Quartz forecast unavailable; falling back to Open-Meteo")
@@ -629,6 +635,202 @@ def _quartz_site_kw(
         return None
     frac = mw / capacity_mw
     return max(0.0, frac * float(config.PV_CAPACITY_KWP))
+
+
+def _quartz_open_planes() -> list[dict[str, float]]:
+    """Panel planes for the site-level open Quartz model (#542).
+
+    ``QUARTZ_OPEN_PLANES`` JSON when set; otherwise a single aggregate plane
+    (tilt 30, orientation 200 = the measured SSW aggregate of this split
+    array, capacity ``PV_CAPACITY_KWP``). Bad JSON → aggregate fallback with
+    a warning, never a crash (forecast fetch must degrade gracefully).
+    """
+    raw = (getattr(config, "QUARTZ_OPEN_PLANES", "") or "").strip()
+    fallback = [{
+        "tilt": 30.0,
+        "orientation": 200.0,
+        "capacity_kwp": float(getattr(config, "PV_CAPACITY_KWP", 4.5)),
+    }]
+    if not raw:
+        return fallback
+    try:
+        planes = json.loads(raw)
+        ok = [
+            {
+                "tilt": float(p.get("tilt", 30)),
+                "orientation": float(p.get("orientation", 200)),
+                "capacity_kwp": float(p["capacity_kwp"]),
+            }
+            for p in planes
+            if isinstance(p, dict) and p.get("capacity_kwp")
+        ]
+        if ok:
+            return ok
+    except (json.JSONDecodeError, TypeError, ValueError, KeyError) as e:
+        logger.warning("QUARTZ_OPEN_PLANES unparseable (%s) — using aggregate plane", e)
+    return fallback
+
+
+def _quartz_open_live_generation() -> list[dict[str, Any]]:
+    """Recent measured generation samples for nowcast anchoring (#542).
+
+    The hosted open.quartz.solar twin uses these to anchor the first forecast
+    hours to reality; the local sidecar accepts-and-ignores. Best-effort —
+    any DB trouble returns [] and the request goes out without them.
+    """
+    if not bool(getattr(config, "QUARTZ_OPEN_SEND_LIVE", True)):
+        return []
+    try:
+        from . import db as _db
+        conn = _db.get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT captured_at, solar_power_kw FROM pv_realtime_history
+                   WHERE solar_power_kw IS NOT NULL
+                     AND captured_at >= datetime('now', '-2 hours')
+                   ORDER BY captured_at DESC LIMIT 8"""
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+        out = []
+        for r in rows:
+            ts = str(r["captured_at"])
+            if not ts.endswith("Z") and "+" not in ts:
+                ts = ts + "Z"
+            out.append({"timestamp": ts, "generation": float(r["solar_power_kw"])})
+        return out
+    except Exception:  # pragma: no cover — live anchor is optional sugar
+        logger.debug("quartz-open: live-generation read failed", exc_info=True)
+        return []
+
+
+def _fetch_quartz_open_forecast(
+    *,
+    hours: int,
+    base_weather: list[HourlyForecast],
+    lat: str | None = None,
+    lon: str | None = None,
+) -> ForecastFetchResult:
+    """Site-level PV forecast via the open Quartz schema (#542).
+
+    Talks ``POST {QUARTZ_OPEN_URL}/forecast/`` — served either by the
+    hem-quartz sidecar container or by the hosted open.quartz.solar twin
+    (identical schema, no auth). One call per configured panel plane; the
+    per-timestamp kW are summed, the 15-min cadence is averaged into
+    half-hour slot starts, and the result is merged with Open-Meteo weather
+    context exactly like the legacy hosted client so everything downstream
+    (calibration chain, snapshots, pv_error_log) is provider-agnostic.
+    """
+    lat_s = (lat or config.WEATHER_LAT or "").strip()
+    lon_s = (lon or config.WEATHER_LON or "").strip()
+    if not lat_s or not lon_s:
+        return ForecastFetchResult(forecast=[], source="quartz-open")
+    base_url = (getattr(config, "QUARTZ_OPEN_URL", "https://open.quartz.solar") or "").rstrip("/")
+    timeout = int(getattr(config, "QUARTZ_OPEN_TIMEOUT_SECONDS", 60))
+    live = _quartz_open_live_generation()
+
+    # kW summed across planes per raw model timestamp.
+    kw_by_ts: dict[datetime, float] = {}
+    planes = _quartz_open_planes()
+    for plane in planes:
+        body = {
+            "site": {
+                "latitude": float(lat_s),
+                "longitude": float(lon_s),
+                "capacity_kwp": plane["capacity_kwp"],
+                "tilt": plane["tilt"],
+                "orientation": plane["orientation"],
+            },
+        }
+        if live:
+            body["live_generation"] = live
+        req = urllib.request.Request(
+            f"{base_url}/forecast/",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                payload = json.loads(resp.read().decode())
+            preds = (payload.get("predictions") or {}).get("power_kw") or {}
+        except (urllib.error.URLError, json.JSONDecodeError, AttributeError, TypeError) as e:
+            logger.warning(
+                "quartz-open fetch failed for plane %s@%s°: %s",
+                plane["orientation"], plane["tilt"], e,
+            )
+            return ForecastFetchResult(forecast=[], source="quartz-open")
+        for ts_raw, kw in preds.items():
+            try:
+                ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+            except (TypeError, ValueError):
+                continue
+            # Model timestamps are naive UTC (sometimes with stray microseconds).
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            ts = ts.replace(microsecond=0)
+            try:
+                kw_by_ts[ts] = kw_by_ts.get(ts, 0.0) + max(0.0, float(kw))
+            except (TypeError, ValueError):
+                continue
+
+    if not kw_by_ts:
+        return ForecastFetchResult(forecast=[], source="quartz-open")
+
+    # 15-min cadence → half-hour slot starts (mean kW inside each bucket).
+    bucket_sum: dict[datetime, float] = {}
+    bucket_n: dict[datetime, int] = {}
+    for ts, kw in kw_by_ts.items():
+        slot = ts.replace(minute=(ts.minute // 30) * 30, second=0)
+        bucket_sum[slot] = bucket_sum.get(slot, 0.0) + kw
+        bucket_n[slot] = bucket_n.get(slot, 0) + 1
+
+    quartz_rows: list[HourlyForecast] = []
+    horizon_end = datetime.now(UTC) + timedelta(hours=max(1, hours))
+    for slot in sorted(bucket_sum):
+        if slot > horizon_end:
+            continue
+        site_kw = bucket_sum[slot] / max(1, bucket_n[slot])
+        if base_weather:
+            temp_c = _interp_hourly_scalar(base_weather, slot, "temperature_c", 10.0)
+            cloud_pct = _interp_hourly_scalar(base_weather, slot, "cloud_cover_pct", 50.0)
+        else:
+            temp_c = 10.0
+            cloud_pct = 50.0
+        equivalent_rad = site_kw / max(0.001, float(config.PV_CAPACITY_KWP) * float(config.PV_SYSTEM_EFFICIENCY)) * 1000.0
+        quartz_rows.append(
+            HourlyForecast(
+                time_utc=slot,
+                temperature_c=temp_c,
+                cloud_cover_pct=cloud_pct,
+                shortwave_radiation_wm2=max(0.0, equivalent_rad),
+                estimated_pv_kw=site_kw,
+                heating_demand_factor=compute_heating_demand_factor(temp_c),
+                pv_direct=True,
+            )
+        )
+
+    quartz_by_time = {f.time_utc for f in quartz_rows}
+    first_q = min(quartz_by_time)
+    last_q = max(quartz_by_time)
+    merged = list(quartz_rows)
+    for f in base_weather:
+        if first_q <= f.time_utc <= last_q:
+            continue
+        merged.append(f)
+    merged.sort(key=lambda f: f.time_utc)
+    compact = json.dumps(
+        {"planes": planes, "n_points": len(kw_by_ts), "url": base_url},
+        separators=(",", ":"),
+    )
+    return ForecastFetchResult(
+        forecast=merged[: max(hours, len(quartz_rows))],
+        source="quartz",
+        model_name="quartz-open-site",
+        model_version=None,
+        raw_payload_json=compact,
+    )
 
 
 def _fetch_quartz_forecast(

--- a/tests/test_quartz_forecast.py
+++ b/tests/test_quartz_forecast.py
@@ -64,6 +64,9 @@ def test_quartz_fetch_merges_direct_pv_with_open_meteo_weather(monkeypatch: pyte
         raise AssertionError(f"unexpected url {url}")
 
     monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
+    # These tests exercise the LEGACY hosted national/GSP client, kept for
+    # rollback while the commercial token lives (#542) — pin the provider.
+    monkeypatch.setattr(app_config, "QUARTZ_PROVIDER", "hosted", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_CLIENT_ID", "test-client-id", raising=False)
@@ -166,6 +169,9 @@ def test_quartz_national_metadata_capacity_can_downscale_site_kw(monkeypatch: py
         raise AssertionError(f"unexpected url {url}")
 
     monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
+    # These tests exercise the LEGACY hosted national/GSP client, kept for
+    # rollback while the commercial token lives (#542) — pin the provider.
+    monkeypatch.setattr(app_config, "QUARTZ_PROVIDER", "hosted", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_CLIENT_ID", "test-client-id", raising=False)
@@ -289,6 +295,9 @@ def test_quartz_half_hour_slot_interpolates_open_meteo_temp(monkeypatch: pytest.
         raise AssertionError(f"unexpected url {url}")
 
     monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
+    # These tests exercise the LEGACY hosted national/GSP client, kept for
+    # rollback while the commercial token lives (#542) — pin the provider.
+    monkeypatch.setattr(app_config, "QUARTZ_PROVIDER", "hosted", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_USERNAME", "user", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_PASSWORD", "pass", raising=False)
     monkeypatch.setattr(app_config, "QUARTZ_CLIENT_ID", "test-client-id", raising=False)

--- a/tests/test_quartz_open_provider.py
+++ b/tests/test_quartz_open_provider.py
@@ -173,3 +173,35 @@ def test_bad_planes_json_falls_back_to_aggregate(monkeypatch):
     planes = weather._quartz_open_planes()
     assert len(planes) == 1
     assert planes[0]["orientation"] == pytest.approx(200.0)
+
+
+def test_planes_sum_despite_per_request_microsecond_offsets(monkeypatch):
+    """The live API stamps timestamps with per-REQUEST microsecond offsets
+    ('09:45:00.533720', different on every call). Plane keys must be floored
+    to the 15-min grid so they collide and SUM — otherwise a 2-plane site
+    forecasts at half its real output (caught during #544 self-review)."""
+    from src import weather
+
+    monkeypatch.setattr(
+        app_config, "QUARTZ_OPEN_PLANES",
+        '[{"tilt": 35, "orientation": 225, "capacity_kwp": 2.25},'
+        ' {"tilt": 10, "orientation": 180, "capacity_kwp": 2.25}]',
+        raising=False,
+    )
+    start = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    call_n = {"n": 0}
+
+    def fake_urlopen(req, timeout=0):  # noqa: ANN001
+        call_n["n"] += 1
+        jitter = timedelta(microseconds=123456 * call_n["n"])  # differs per call
+        jittered = start + jitter
+        return _Resp(_open_payload(jittered, [1.0, 1.0, 1.0, 1.0]))
+
+    monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
+    res = weather._fetch_quartz_open_forecast(
+        hours=48, base_weather=_base_weather(start), lat="51.4927", lon="-0.2628"
+    )
+    by_time = {f.time_utc: f for f in res.forecast if f.pv_direct}
+    # Each plane contributes 1.0 kW per quarter → the SUM is 2.0 kW, not the
+    # 1.0 kW a non-colliding average would produce.
+    assert by_time[start].estimated_pv_kw == pytest.approx(2.0)

--- a/tests/test_quartz_open_provider.py
+++ b/tests/test_quartz_open_provider.py
@@ -1,0 +1,175 @@
+"""Site-level open Quartz provider (#542) — sidecar/open.quartz.solar client.
+
+The provider must be a drop-in for the legacy hosted client: same
+HourlyForecast shape (pv_direct=True, half-hour slot starts, weather context
+interpolated from Open-Meteo), so the calibration chain and snapshots stay
+provider-agnostic.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+class _Resp:
+    def __init__(self, payload: dict[str, Any]):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode()
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+    monkeypatch.setattr(app_config, "WEATHER_LAT", "51.4927", raising=False)
+    monkeypatch.setattr(app_config, "WEATHER_LON", "-0.2628", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_OPEN_SEND_LIVE", False, raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_OPEN_PLANES", "", raising=False)
+
+
+def _base_weather(start: datetime, n: int = 6):
+    from src.weather import HourlyForecast, compute_heating_demand_factor
+    return [
+        HourlyForecast(
+            time_utc=start + timedelta(hours=i),
+            temperature_c=12.0 + i,
+            cloud_cover_pct=40.0,
+            shortwave_radiation_wm2=300.0,
+            estimated_pv_kw=1.0,
+            heating_demand_factor=compute_heating_demand_factor(12.0 + i),
+        )
+        for i in range(n)
+    ]
+
+
+def _open_payload(start: datetime, quarter_kw: list[float]) -> dict[str, Any]:
+    """Build an open-schema response: naive-UTC 15-min timestamps → kW."""
+    return {
+        "timestamp": start.replace(tzinfo=None).isoformat(),
+        "predictions": {
+            "power_kw": {
+                (start + timedelta(minutes=15 * i)).replace(tzinfo=None).isoformat(): kw
+                for i, kw in enumerate(quarter_kw)
+            }
+        },
+    }
+
+
+def test_open_provider_buckets_quarters_into_half_hours(monkeypatch):
+    from src import weather
+
+    start = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    calls: list[dict] = []
+
+    def fake_urlopen(req, timeout=0):  # noqa: ANN001
+        calls.append(json.loads(req.data.decode()))
+        return _Resp(_open_payload(start, [1.0, 2.0, 3.0, 5.0]))
+
+    monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
+    res = weather._fetch_quartz_open_forecast(
+        hours=48, base_weather=_base_weather(start), lat="51.4927", lon="-0.2628"
+    )
+    assert res.forecast, "expected merged forecast rows"
+    assert res.model_name == "quartz-open-site"
+    by_time = {f.time_utc: f for f in res.forecast if f.pv_direct}
+    # :00+:15 → mean 1.5 kW at slot :00; :30+:45 → mean 4.0 kW at slot :30
+    assert by_time[start].estimated_pv_kw == pytest.approx(1.5)
+    assert by_time[start + timedelta(minutes=30)].estimated_pv_kw == pytest.approx(4.0)
+    # Weather context interpolated from base, not placeholder
+    assert by_time[start].temperature_c == pytest.approx(12.0)
+    # Single aggregate plane by default
+    assert len(calls) == 1
+    assert calls[0]["site"]["capacity_kwp"] == pytest.approx(
+        float(app_config.PV_CAPACITY_KWP)
+    )
+
+
+def test_open_provider_sums_planes(monkeypatch):
+    from src import weather
+
+    monkeypatch.setattr(
+        app_config, "QUARTZ_OPEN_PLANES",
+        '[{"tilt": 35, "orientation": 225, "capacity_kwp": 2.25},'
+        ' {"tilt": 10, "orientation": 180, "capacity_kwp": 2.25}]',
+        raising=False,
+    )
+    start = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+    calls: list[dict] = []
+
+    def fake_urlopen(req, timeout=0):  # noqa: ANN001
+        body = json.loads(req.data.decode())
+        calls.append(body)
+        kw = 1.0 if body["site"]["orientation"] == 225 else 0.5
+        return _Resp(_open_payload(start, [kw, kw]))
+
+    monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
+    res = weather._fetch_quartz_open_forecast(
+        hours=48, base_weather=_base_weather(start), lat="51.4927", lon="-0.2628"
+    )
+    assert len(calls) == 2
+    by_time = {f.time_utc: f for f in res.forecast if f.pv_direct}
+    assert by_time[start].estimated_pv_kw == pytest.approx(1.5)  # 1.0 + 0.5
+
+
+def test_open_provider_failure_falls_back_to_open_meteo(monkeypatch):
+    from src import weather
+
+    start = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+
+    def fake_urlopen(req, timeout=0):  # noqa: ANN001
+        raise weather.urllib.error.URLError("sidecar down")
+
+    monkeypatch.setattr(weather.urllib.request, "urlopen", fake_urlopen)
+    res = weather._fetch_quartz_open_forecast(
+        hours=48, base_weather=_base_weather(start), lat="51.4927", lon="-0.2628"
+    )
+    assert res.forecast == []  # caller (fetch_forecast_snapshot) falls back to OM
+
+
+def test_fetch_snapshot_provider_switch(monkeypatch):
+    """FORECAST_SOURCE=quartz + QUARTZ_PROVIDER=open routes to the open client
+    and falls back to Open-Meteo rows when it returns empty."""
+    from src import weather
+
+    start = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    monkeypatch.setattr(app_config, "FORECAST_SOURCE", "quartz", raising=False)
+    monkeypatch.setattr(app_config, "QUARTZ_PROVIDER", "open", raising=False)
+    monkeypatch.setattr(
+        weather, "_fetch_open_meteo_forecast", lambda **_kw: _base_weather(start)
+    )
+    seen = {}
+
+    def fake_open_fetch(**kwargs):
+        seen.update(kwargs)
+        return weather.ForecastFetchResult(forecast=[], source="quartz-open")
+
+    monkeypatch.setattr(weather, "_fetch_quartz_open_forecast", fake_open_fetch)
+    res = weather.fetch_forecast_snapshot(hours=12)
+    assert "base_weather" in seen, "open provider was not invoked"
+    assert res.source == "open-meteo"  # graceful fallback
+    assert len(res.forecast) == 6
+
+
+def test_bad_planes_json_falls_back_to_aggregate(monkeypatch):
+    from src import weather
+
+    monkeypatch.setattr(app_config, "QUARTZ_OPEN_PLANES", "not json", raising=False)
+    planes = weather._quartz_open_planes()
+    assert len(planes) == 1
+    assert planes[0]["orientation"] == pytest.approx(200.0)

--- a/tests/test_quartz_open_provider.py
+++ b/tests/test_quartz_open_provider.py
@@ -190,10 +190,14 @@ def test_planes_sum_despite_per_request_microsecond_offsets(monkeypatch):
     )
     start = datetime.now(UTC).replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
     call_n = {"n": 0}
+    bodies: list[dict] = []
 
     def fake_urlopen(req, timeout=0):  # noqa: ANN001
         call_n["n"] += 1
-        jitter = timedelta(microseconds=123456 * call_n["n"])  # differs per call
+        bodies.append(json.loads(req.data.decode()))
+        # Real grids anchor at per-request now(): SECONDS and microseconds
+        # both differ between the two plane calls (review #544 finding 1).
+        jitter = timedelta(seconds=3 * call_n["n"], microseconds=123456 * call_n["n"])
         jittered = start + jitter
         return _Resp(_open_payload(jittered, [1.0, 1.0, 1.0, 1.0]))
 
@@ -205,3 +209,8 @@ def test_planes_sum_despite_per_request_microsecond_offsets(monkeypatch):
     # Each plane contributes 1.0 kW per quarter → the SUM is 2.0 kW, not the
     # 1.0 kW a non-colliding average would produce.
     assert by_time[start].estimated_pv_kw == pytest.approx(2.0)
+    # And both plane requests carry the SAME quarter-floored timestamp so the
+    # server-side grids can't drift in the first place.
+    assert bodies[0]["timestamp"] == bodies[1]["timestamp"]
+    ts0 = datetime.fromisoformat(bodies[0]["timestamp"])
+    assert ts0.minute % 15 == 0 and ts0.second == 0 and ts0.microsecond == 0


### PR DESCRIPTION
Closes #542.

## What

The expiring `api.quartz.solar` token is the **commercial national/GSP** product. This PR replaces it with the free open-source **site-level** model, in the separate-container architecture:

1. **`quartz/` sidecar** — FastAPI wrapper around OCF's `quartz-solar-forecast` (MIT; xgboost `gb` model trained on ~25k UK sites; pulls its own NWP from Open-Meteo → zero API keys anywhere). The endpoint mirrors the hosted `open.quartz.solar` `POST /forecast/` schema, so the HEM client swaps between local container and hosted twin with a URL change. Lazy warm-up thread at boot (first run downloads weights into the `quartz-cache` volume); `/health` stays instant.
2. **Compose** — `hem-quartz` service: internal bridge only (no host ports), read-only rootfs, `mem_limit: 1g` (capacity audit: CAX11, load 0.02, 2.7 GB free). Rollback knobs in the service comment.
3. **CI** — `quartz-publish.yml` (paths-scoped, arm64, GHA-cached).
4. **HEM client** — `QUARTZ_PROVIDER=open` (new default) → `_fetch_quartz_open_forecast`: one POST per panel plane (`QUARTZ_OPEN_PLANES` JSON; this house: 225°/35° pitched + 180°/10° flat, default = single 200° aggregate), kW summed per timestamp, 15-min → half-hour bucketing, weather context merged exactly like the legacy client — **calibration chain, snapshots and pv_error_log stay provider-agnostic** (they key on `pv_direct`, not the provider). Optional live-generation anchoring from `pv_realtime_history`. Legacy hosted client kept behind `QUARTZ_PROVIDER=hosted` for rollback while the token lives.

## Why keep a Quartz-class source at all

Empirical A/B on prod data (#542): slot-level tie with Open-Meteo after our calibration stack, but **~18% better daily-total MAE** (2.15 vs 2.61 kWh/day) — the day-shape signal battery planning feels. OM fallback remains automatic when the provider returns empty.

## Deploy plan (after merge + image builds)

`HEM_QUARTZ_IMAGE_TAG` pin in `.compose.env`, sync compose.yaml to the host, `.env`: `QUARTZ_PROVIDER=open`, `QUARTZ_OPEN_URL=http://hem-quartz:8000`, `QUARTZ_OPEN_PLANES` for the split array; restart. First forecast fetch after warm-up validates end-to-end; `meteo_forecast_snapshot.model_name='quartz-open-site'` is the audit marker.

## Tests

5 new (quarter→half-hour bucketing + weather interpolation; multi-plane summing; failure → OM fallback; provider switch routing; bad planes JSON fallback). Legacy hosted tests now pin `QUARTZ_PROVIDER=hosted` (they test the rollback path). 234 weather/PV tests green; the one failure under `-k` selection is the known pre-existing order-dependent flake (fails on main too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)