### PR TITLE
fix(quartz): python 3.11 base — pv-site-prediction requires <3.12

### DIFF
--- a/quartz/Dockerfile
+++ b/quartz/Dockerfile
@@ -2,7 +2,12 @@
 # Self-hosts Open Climate Fix's open-source site-level PV model so HEM has no
 # external forecast-API dependency (the hosted token expired; open.quartz.solar
 # remains the drop-in fallback because this container mirrors its schema).
-FROM python:3.12-slim
+#
+# Python 3.11, NOT 3.12: quartz-solar-forecast → pv-site-prediction==0.1.19
+# declares requires-python <3.12 (first arm64 build failed ResolutionImpossible
+# on 3.12). Its pinned numpy 1.23.5 / scikit-learn 1.1.3 ship cp311 manylinux
+# aarch64 wheels, so 3.11 resolves cleanly.
+FROM python:3.11-slim
 
 # Model/weights caches live OUTSIDE the read-only rootfs — compose mounts a
 # named volume at /cache so the one-time Hugging Face download survives


### PR DESCRIPTION
Tracked by #542. First arm64 build of the sidecar failed `ResolutionImpossible`: `quartz-solar-forecast` → `pv-site-prediction==0.1.19` declares `requires-python <3.12` (verified on PyPI). Its pinned numpy 1.23.5 / scikit-learn 1.1.3 ship cp311 manylinux aarch64 wheels, so `python:3.11-slim` resolves cleanly. The real validation is the post-merge `quartz-publish` arm64 build (PR CI only smoke-compiles app.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)