### PR TITLE
fix(quartz): disable numcodecs x86 SIMD flags for the aarch64 source build

### DIFF
--- a/quartz/Dockerfile
+++ b/quartz/Dockerfile
@@ -20,6 +20,15 @@ RUN apt-get update \
 RUN python -m venv /opt/venv
 ENV PATH=/opt/venv/bin:$PATH
 
+# numcodecs (pulled via pv-site-prediction → ocf-blosc2) has no aarch64
+# wheel for any version compatible with the pinned numpy 1.23.5, and its
+# sdist hardcodes -msse2/-mavx2 unless these flags are set (third build
+# failure: "gcc: error: unrecognized command-line option '-msse2'"). With
+# them, the C codecs compile as generic portable code — the documented
+# non-x86 build path in numcodecs' own setup.py.
+ENV DISABLE_NUMCODECS_SSE2=1 \
+    DISABLE_NUMCODECS_AVX2=1
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Tracked by #542. Build-fix iteration 3: `numcodecs` ships no aarch64 wheel for any version compatible with the pinned `numpy==1.23.5` (aarch64 wheels start at 0.16.5 which needs numpy>=1.24), and its sdist hardcodes `-msse2/-mavx2`. `DISABLE_NUMCODECS_SSE2=1`/`DISABLE_NUMCODECS_AVX2=1` is the documented non-x86 path in numcodecs' own setup.py — C codecs compile as generic portable code under the builder stage's gcc. Import-path audit: `ocf_blosc2` IS imported at module top in psp's inference path, so skipping the package was not an option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)