### PR TITLE
fix(quartz): build on native arm64 runner — QEMU poisons numcodecs' SIMD probe

### DIFF
--- a/.github/workflows/quartz-publish.yml
+++ b/.github/workflows/quartz-publish.yml
@@ -43,13 +43,16 @@ jobs:
   build-and-push:
     needs: smoke
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    # NATIVE arm64 runner — not ubuntu-latest+QEMU like ui-publish.yml. The
+    # dependency tree compiles numcodecs from sdist, whose setup.py probes
+    # SIMD via py-cpuinfo; under QEMU that reads the x86 HOST's /proc/cpuinfo
+    # and emits -msse2 (or -mno-sse2) into an aarch64 gcc — unbuildable
+    # either way (build failures 3+4 on #542). Native ARM also drops the
+    # ~10× emulation tax on the scientific-stack install.
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/quartz/Dockerfile
+++ b/quartz/Dockerfile
@@ -20,15 +20,15 @@ RUN apt-get update \
 RUN python -m venv /opt/venv
 ENV PATH=/opt/venv/bin:$PATH
 
+# BUILD ON NATIVE ARM ONLY — do not build this image under QEMU emulation.
 # numcodecs (pulled via pv-site-prediction → ocf-blosc2) has no aarch64
-# wheel for any version compatible with the pinned numpy 1.23.5, and its
-# sdist hardcodes -msse2/-mavx2 unless these flags are set (third build
-# failure: "gcc: error: unrecognized command-line option '-msse2'"). With
-# them, the C codecs compile as generic portable code — the documented
-# non-x86 build path in numcodecs' own setup.py.
-ENV DISABLE_NUMCODECS_SSE2=1 \
-    DISABLE_NUMCODECS_AVX2=1
-
+# wheel compatible with the pinned numpy 1.23.5, so it compiles from sdist,
+# and its setup.py detects SIMD support via py-cpuinfo, which under QEMU
+# reads the HOST's /proc/cpuinfo: it sees the x86 runner's SSE2/AVX2 flags
+# and passes -msse2 to the aarch64 gcc (and with DISABLE_NUMCODECS_* set it
+# passes -mno-sse2 — equally x86-only). On a native arm64 builder
+# (ubuntu-24.04-arm runner, see quartz-publish.yml) cpuinfo sees the real
+# CPU and the build is clean and fast.
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Tracked by #542. Root cause of build attempts 3+4 failing: `numcodecs` builds from sdist and probes SIMD via `py-cpuinfo`, which under QEMU reads the **x86 host's** `/proc/cpuinfo` — emitting `-msse2` (or `-mno-sse2` with the DISABLE vars) into an aarch64 gcc. Unbuildable under emulation in either branch. Fix: `runs-on: ubuntu-24.04-arm` (free for public repos), QEMU step dropped, Dockerfile workaround reverted with a do-not-build-under-QEMU note. Bonus: native ARM removes the ~10× emulation tax on the scientific-stack install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)