### PR TITLE
fix(quartz): constrain cattrs<24 — requests-cache 1.2.0 forward-ref explodes on eager hint resolution

### DIFF
--- a/quartz/requirements.txt
+++ b/quartz/requirements.txt
@@ -4,3 +4,9 @@
 quartz-solar-forecast>=1.2,<2
 fastapi>=0.111,<1
 uvicorn>=0.30,<1
+# Upstream pins requests-cache==1.2.0, whose attrs models forward-reference
+# RequestsCookieJar under TYPE_CHECKING only; cattrs >=24 resolves type
+# hints eagerly and explodes with NameError at the first cached request
+# (prod boot 2026-06-12). Constrain cattrs to the era requests-cache 1.2.0
+# was built against.
+cattrs<24


### PR DESCRIPTION
Tracked by #542. Prod warm-up failed with `NameError: RequestsCookieJar`: upstream pins `requests-cache==1.2.0` whose attrs models forward-reference `RequestsCookieJar` under TYPE_CHECKING only, and `cattrs>=24` (resolver picked 26.1.0) eagerly resolves type hints in `gen_unstructure_attrs_fromdict`. `cattrs<24` matches the era the pin was built against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)