### PR TITLE
fix(ui): stabilize — mobile chrome, chart registration/resize, i18n, build SHA

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -38,6 +38,13 @@ RUN npm run build
 # --- Stage 2: runtime nginx -------------------------------------------------
 FROM nginx:1.27-alpine
 
+# ARG scope is per-stage: without re-declaring here the runtime stage has no
+# BUILD_SHA env, so ui-entrypoint.sh wrote buildSha:"unknown" into config.js —
+# and "unknown" being truthy also masked the baked __BUILD_SHA__ fallback.
+# (The footer showed "HEM build unknown" in prod because of this.)
+ARG BUILD_SHA=unknown
+ENV BUILD_SHA=$BUILD_SHA
+
 # gettext provides `envsubst` for the entrypoint
 RUN apk add --no-cache gettext
 

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,4 +1,5 @@
-import { Route, Switch } from "wouter-preact";
+import { Link, Route, Switch } from "wouter-preact";
+import { Icon } from "./components/common/Icon";
 import { lazy, Suspense } from "preact/compat";
 import { useEffect } from "preact/hooks";
 import type { ComponentType } from "preact";
@@ -20,7 +21,7 @@ function AdminOnlyRoute({ component: C }: { component: ComponentType }) {
   if (role.value === "admin") return <C />;
   return (
     <div class="page-padded admin-locked">
-      <h1>🔒 Admin required</h1>
+      <h1><Icon name="lock" size={20} /> Admin required</h1>
       <p>This page is only available to admins. Use the <strong>Admin</strong> button
         in the top bar to unlock with your secret.</p>
     </div>
@@ -42,9 +43,15 @@ export function App() {
             <Route path="/report">{() => <AdminOnlyRoute component={Report} />}</Route>
             <Route path="/settings">{() => <AdminOnlyRoute component={Settings} />}</Route>
             <Route>
-              <div class="page-padded">
+              <div class="page-padded not-found">
                 <h1>Not found</h1>
-                <p>The page you're looking for doesn't exist in this app.</p>
+                <p>The page you're looking for doesn't exist in this app. The
+                  old per-section routes (heating, history, forecast) merged
+                  into the cockpit.</p>
+                <p class="not-found-links">
+                  <Link href="/" class="nav-link"><Icon name="house" size={15} />Cockpit</Link>
+                  <Link href="/insights" class="nav-link"><Icon name="trend" size={15} />Insights</Link>
+                </p>
               </div>
             </Route>
           </Switch>

--- a/ui/src/components/common/Icon.tsx
+++ b/ui/src/components/common/Icon.tsx
@@ -27,6 +27,10 @@ export type IconName =
   | "appliance"
   | "chevron"
   | "check"
+  | "cross"
+  | "lock"
+  | "unlock"
+  | "warn"
   | "revert"
   | "moon";
 
@@ -146,6 +150,26 @@ const PATHS: Record<IconName, JSX.Element> = {
   ),
   chevron: <path d="M9 6 L15 12 L9 18" />,
   check: <path d="M5 12.5 L10 17 L19 7" />,
+  cross: <path d="M6 6 L18 18 M18 6 L6 18" />,
+  lock: (
+    <>
+      <rect x="5.5" y="11" width="13" height="9" rx="2" />
+      <path d="M8.5 11 V8 A3.5 3.5 0 0 1 15.5 8 V11" />
+    </>
+  ),
+  unlock: (
+    <>
+      <rect x="5.5" y="11" width="13" height="9" rx="2" />
+      <path d="M8.5 11 V8 A3.5 3.5 0 0 1 15.2 7.2" />
+    </>
+  ),
+  warn: (
+    <>
+      <path d="M12 4 L21 19.5 H3 Z" stroke-linejoin="round" />
+      <path d="M12 10 V14.5" />
+      <circle cx="12" cy="17" r="0.9" fill="currentColor" stroke="none" />
+    </>
+  ),
   revert: (
     <>
       <path d="M5 12 A7 7 0 1 1 8 17.5" />

--- a/ui/src/components/common/WidgetBoundary.tsx
+++ b/ui/src/components/common/WidgetBoundary.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren } from "preact";
+import { Icon } from "./Icon";
 import { useErrorBoundary } from "preact/hooks";
 import "./widget-boundary.css";
 
@@ -16,7 +17,7 @@ export function WidgetBoundary({ label, children }: WidgetBoundaryProps) {
   if (error) {
     return (
       <div class="widget-boundary-error" role="alert">
-        <div class="widget-boundary-error-icon" aria-hidden="true">⚠</div>
+        <div class="widget-boundary-error-icon" aria-hidden="true"><Icon name="warn" size={18} /></div>
         <div class="widget-boundary-error-body">
           <div class="widget-boundary-error-title">
             {label ? `${label} couldn't render` : "This widget couldn't render"}

--- a/ui/src/components/home/ApplianceWidget.tsx
+++ b/ui/src/components/home/ApplianceWidget.tsx
@@ -1,4 +1,5 @@
 import type { ApplianceSuggestion, ApplianceJob, Appliance } from "../../lib/types";
+import { Icon } from "../common/Icon";
 import "./appliance.css";
 
 interface ApplianceWidgetProps {
@@ -27,8 +28,8 @@ export function ApplianceWidget({ suggestions, jobs, appliances }: ApplianceWidg
   if (enabled.length === 0) {
     return (
       <div class="appliance appliance--empty">
-        <p class="muted">Nenhum eletrodoméstico registrado.</p>
-        <p class="appliance-hint">Registre a máquina (SmartThings) para agendar lavagens nas janelas baratas.</p>
+        <p class="muted">No appliance registered.</p>
+        <p class="appliance-hint">Register the machine (SmartThings) to schedule runs into cheap windows.</p>
       </div>
     );
   }
@@ -44,14 +45,14 @@ export function ApplianceWidget({ suggestions, jobs, appliances }: ApplianceWidg
         const sug = sugByApp.get(a.id);
         return (
           <div class="appliance-row" key={a.id}>
-            <div class="appliance-name">🧺 {a.name}</div>
+            <div class="appliance-name"><Icon name="appliance" size={14} /> {a.name}</div>
 
             {job ? (
               job.status === "running" ? (
-                <div class="appliance-state appliance-state--run">Rodando agora</div>
+                <div class="appliance-state appliance-state--run">Running now</div>
               ) : (
                 <div class="appliance-state appliance-state--sched">
-                  Programado <strong>{fmtLocal(job.planned_start_utc)}–{fmtLocal(job.planned_end_utc)}</strong>
+                  Scheduled <strong>{fmtLocal(job.planned_start_utc)}–{fmtLocal(job.planned_end_utc)}</strong>
                   {job.avg_price_pence != null && (
                     <span class="appliance-price"> · {job.avg_price_pence.toFixed(1)}p/kWh</span>
                   )}
@@ -62,24 +63,24 @@ export function ApplianceWidget({ suggestions, jobs, appliances }: ApplianceWidg
                 {sug.meets_threshold === false ? (
                   // No cheap window ahead → still show the NEXT/cheapest available.
                   <>
-                    <span class="appliance-tag appliance-tag--next">próxima</span>
+                    <span class="appliance-tag appliance-tag--next">next</span>
                     <strong>{fmtLocal(sug.recommended_start_utc)}–{fmtLocal(sug.recommended_end_utc)}</strong>
-                    <span class="appliance-price"> · {sug.avg_price_pence.toFixed(1)}p (sem janela barata)</span>
-                    <div class="appliance-cta">Carregue + Smart Control até {sug.deadline_local}</div>
+                    <span class="appliance-price"> · {sug.avg_price_pence.toFixed(1)}p (no cheap window)</span>
+                    <div class="appliance-cta">Load + Smart Control by {sug.deadline_local}</div>
                   </>
                 ) : (
                   <>
                     <span class={sug.is_negative ? "appliance-tag appliance-tag--paid" : "appliance-tag appliance-tag--cheap"}>
-                      {sug.is_negative ? "janela paga" : "janela barata"}
+                      {sug.is_negative ? "paid window" : "cheap window"}
                     </span>
                     <strong>{fmtLocal(sug.recommended_start_utc)}–{fmtLocal(sug.recommended_end_utc)}</strong>
                     <span class="appliance-price"> · {sug.avg_price_pence.toFixed(1)}p</span>
-                    <div class="appliance-cta">Carregue + Smart Control até {sug.deadline_local}</div>
+                    <div class="appliance-cta">Load + Smart Control by {sug.deadline_local}</div>
                   </>
                 )}
               </div>
             ) : (
-              <div class="appliance-state appliance-state--none muted">Sem janela disponível antes do prazo</div>
+              <div class="appliance-state appliance-state--none muted">No window available before the deadline</div>
             )}
           </div>
         );

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -100,9 +100,9 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
       ? optionForDay(execution, pv ?? null, grid)
       : optionForPeriod(period, daikin, granularity);
     chart.setOption(option, true);
-    const ro = new ResizeObserver(() => chart.resize());
-    ro.observe(elRef.current);
-    return () => ro.disconnect();
+    // Resize handling now lives centrally in makeChart (rAF-debounced
+    // ResizeObserver) — the per-effect observer this widget carried would
+    // double every resize() call.
   }, [granularity, period, daikin, grid, execution, pv, isToday]);
 
   useEffect(() => () => {

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -95,7 +95,7 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, opp
         <div class="tlw-summary">
           <span class="tlw-summary-value">{genTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh solar</span></span>
           <span class="tlw-summary-value tlw-pos">{exportedTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh export</span></span>
-          <span class="tlw-summary-label">esperado hoje{segRate != null ? ` · export pago a ${segRate.toFixed(1)}p/kWh (SEG flat)` : ""}</span>
+          <span class="tlw-summary-label">expected today{segRate != null ? ` · export paid at ${segRate.toFixed(1)}p/kWh (SEG flat)` : ""}</span>
         </div>
         <OppyLine o={opportunity} />
         {/* Export price line (green, right axis) mirrors Consumption's import

--- a/ui/src/components/home/HeatingControls.tsx
+++ b/ui/src/components/home/HeatingControls.tsx
@@ -39,7 +39,7 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
             class="heating-controls-passive"
             title="Heat-pump controls are admin-only. Use the Admin button in the top bar to unlock."
           >
-            🔒 admin
+            <Icon name="lock" size={12} /> admin
           </span>
         </div>
         <p class="muted heating-controls-hint">
@@ -101,7 +101,7 @@ export function HeatingControls({ dev, controlMode, onChanged }: HeatingControls
 
       {active && (
         <div class={`hc-lockbar${unlocked ? " hc-lockbar--open" : ""}`}>
-          <span class="hc-lockbar-icon" aria-hidden="true">{unlocked ? "🔓" : "🔒"}</span>
+          <span class="hc-lockbar-icon" aria-hidden="true"><Icon name={unlocked ? "unlock" : "lock"} size={14} /></span>
           <span class="hc-lockbar-text">
             {unlocked
               ? "Manual control on — what you apply is written to the heat pump."

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -33,7 +33,12 @@ export function Hero({ metrics, monthly, period, periodState, periodLoading, tod
   const fixedLabel = todayCum?.fixed_tariff_label || metrics?.fixed_tariff?.label || "British Gas Fixed";
 
   // --- Money story for the SELECTED period (period-aware; today == todayCum). ---
-  const bill = period?.cost?.net_cost_pounds ?? null;
+  // On the CURRENT period, fall back to todayCum's running net bill while the
+  // (slower) period aggregate is still loading or failed — the £ headline is
+  // the first thing the eye looks for and must never sit on a skeleton when a
+  // 60s-polled number already knows the answer (mobile showed exactly that).
+  const bill = period?.cost?.net_cost_pounds
+    ?? (isNow ? todayCum?.realised_net_cost_gbp ?? null : null);
   const savedVsBG = period?.cost?.delta_vs_fixed_real_pounds
     ?? (isNow ? todayCum?.delta_vs_fixed_tariff_real_gbp : null) ?? null;
   const grid = period?.energy?.import_kwh ?? (isNow ? todayCum?.import_kwh : null) ?? null;
@@ -125,8 +130,14 @@ export function Hero({ metrics, monthly, period, periodState, periodLoading, tod
           {/* today-only quiet notes (kept from earlier asks) */}
           {breakevenP != null && (
             <div class="hero-note" title={`To beat ${fixedLabel}, keep the average import price ≤ ${breakevenP.toFixed(1)}p/kWh — Agile's higher standing must be won back on the unit rate.`}>
-              Target: import avg ≤ <strong>{breakevenP.toFixed(1)}p</strong>
-              {realisedAvgP != null && <> · now <strong class={beatingTarget ? "pos" : "neg"}>{realisedAvgP.toFixed(1)}p {beatingTarget ? "✓" : "✗"}</strong></>}
+              <span class="hero-note-pair">Target: import avg ≤ <strong>{breakevenP.toFixed(1)}p</strong></span>
+              {realisedAvgP != null && (
+                <span class="hero-note-pair"> · now{" "}
+                  <strong class={beatingTarget ? "pos" : "neg"}>
+                    {realisedAvgP.toFixed(1)}p <Icon name={beatingTarget ? "check" : "cross"} size={11} />
+                  </strong>
+                </span>
+              )}
             </div>
           )}
           {showEarnings && earnings != null && (

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -37,8 +37,12 @@ export function Hero({ metrics, monthly, period, periodState, periodLoading, tod
   // (slower) period aggregate is still loading or failed — the £ headline is
   // the first thing the eye looks for and must never sit on a skeleton when a
   // 60s-polled number already knows the answer (mobile showed exactly that).
+  // Day-granularity ONLY: todayCum is a single day's figure — labelling it
+  // as the current week/month/year while the aggregate loads (or after it
+  // fails) would put a mislabelled £ on a money display (review M on #552).
+  const isTodayView = periodState.gran === "day" && isNow;
   const bill = period?.cost?.net_cost_pounds
-    ?? (isNow ? todayCum?.realised_net_cost_gbp ?? null : null);
+    ?? (isTodayView ? todayCum?.realised_net_cost_gbp ?? null : null);
   const savedVsBG = period?.cost?.delta_vs_fixed_real_pounds
     ?? (isNow ? todayCum?.delta_vs_fixed_tariff_real_gbp : null) ?? null;
   const grid = period?.energy?.import_kwh ?? (isNow ? todayCum?.import_kwh : null) ?? null;

--- a/ui/src/components/home/appliance.css
+++ b/ui/src/components/home/appliance.css
@@ -62,3 +62,6 @@
   color: var(--text-mute, #8a8f98);
   background: color-mix(in srgb, var(--text-mute, #8a8f98) 16%, transparent);
 }
+
+/* Inline name icon rides the text baseline (matches hero-note-pair). */
+.appliance-name svg { display: inline-block; vertical-align: -2px; }

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -62,6 +62,10 @@
 .standing-note { margin-top: var(--space-3); font-size: var(--font-xs); color: var(--text-mute); display: flex; align-items: center; gap: var(--space-2); }
 .hero-note { margin-top: var(--space-2); font-size: var(--font-xs); color: var(--text-dim); font-variant-numeric: tabular-nums; }
 .hero-note strong { font-variant-numeric: tabular-nums; }
+/* Value+verdict pairs never split across lines (the "now 5.9p ✓" orphan on
+ * 375px); the inline check/cross icon rides the text baseline. */
+.hero-note-pair { white-space: nowrap; }
+.hero-note-pair svg { display: inline-block; vertical-align: -1px; }
 
 /* ── lifetime strip ─────────────────────────────────────────────────── */
 .lifetime { display: flex; gap: var(--space-5); flex-wrap: wrap; padding-top: var(--space-4); margin-top: var(--space-4); border-top: 1px dashed var(--border); position: relative; }

--- a/ui/src/components/shell/AdminButton.tsx
+++ b/ui/src/components/shell/AdminButton.tsx
@@ -1,8 +1,9 @@
 import { useState } from "preact/hooks";
+import { Icon } from "../common/Icon";
 import { role, adminConfigured, unlock, lock } from "../../lib/auth";
 
 /** Lock/unlock control in the top nav.
- *  Viewer → a 🔒 button that reveals an inline password field to enter the
+ *  Viewer → a lock button that reveals an inline password field to enter the
  *  admin secret. Admin → an "Admin" badge + Unlock(lock) button. */
 export function AdminButton() {
   const [open, setOpen] = useState(false);
@@ -56,7 +57,7 @@ export function AdminButton() {
         title="Unlock admin to change settings"
         onClick={() => setOpen(true)}
       >
-        <span class="admin-lock" aria-hidden="true">🔒</span> Admin
+        <span class="admin-lock" aria-hidden="true"><Icon name="lock" size={13} /></span> Admin
       </button>
     );
   }

--- a/ui/src/components/shell/QuotaChips.tsx
+++ b/ui/src/components/shell/QuotaChips.tsx
@@ -1,4 +1,5 @@
 import { useFetch } from "../../lib/poll";
+import { Icon } from "../common/Icon";
 import { getDaikinQuota, getFoxQuota } from "../../lib/endpoints";
 import type { ApiQuotaResponse } from "../../lib/types";
 import "./quota-chips.css";
@@ -46,7 +47,7 @@ function QuotaChip({ label, data }: { label: string; data: ApiQuotaResponse | nu
     <span class={`quota-chip quota-chip--${tone}`} title={tooltipParts.join(" · ")}>
       <span class="quota-chip-label">{label}</span>
       <span class="quota-chip-value">{used}/{budget}</span>
-      {failed > 0 && <span class="quota-chip-fail" title={`${failed} failed calls in last 24h`}>⚠{failed}</span>}
+      {failed > 0 && <span class="quota-chip-fail" title={`${failed} failed calls in last 24h`}><Icon name="warn" size={11} />{failed}</span>}
     </span>
   );
 }

--- a/ui/src/components/shell/TopNav.tsx
+++ b/ui/src/components/shell/TopNav.tsx
@@ -29,11 +29,11 @@ export function TopNav() {
         {periodRoutes.includes(path) && <PeriodNavigator variant="chrome" />}
         <span class="topnav-spacer" />
         <nav class="topnav-tabs" aria-label="Primary">
-          <Link href="/insights" class={`nav-link${path === "/insights" ? " active" : ""}`}>
+          <Link href="/insights" title="Insights" class={`nav-link${path === "/insights" ? " active" : ""}`}>
             <Icon name="trend" size={15} />Insights
           </Link>
           {isAdmin && (
-            <Link href="/report" class={`nav-link${path === "/report" ? " active" : ""}`}>
+            <Link href="/report" title="Journal" class={`nav-link${path === "/report" ? " active" : ""}`}>
               <Icon name="schedule" size={15} />Journal
             </Link>
           )}

--- a/ui/src/components/shell/period-nav.css
+++ b/ui/src/components/shell/period-nav.css
@@ -106,3 +106,16 @@
 
 @media (max-width: 960px) { .pnav--chrome { display: none; } }
 @media (min-width: 961px) { .pnav--page { display: none; } }
+
+/* Phone: the page variant must cost ONE compact row, not two — together
+ * with the single-row topnav this keeps total chrome under ~96px so the
+ * hero £ is inside the first fold. */
+@media (max-width: 640px) {
+  .pnav--page {
+    flex-wrap: nowrap;
+    margin-bottom: var(--space-2);
+  }
+  .pnav--page .pnav-label { min-width: 7ch; font-size: var(--font-sm); }
+  .pnav--page .pnav-gran { padding: 5px 9px; font-size: var(--font-xs); }
+  .pnav--page .pnav-arrow { width: 28px; height: 28px; font-size: 16px; }
+}

--- a/ui/src/lib/charts.ts
+++ b/ui/src/lib/charts.ts
@@ -10,6 +10,11 @@ import {
   BarChart,
   PieChart,
   EffectScatterChart,
+  // HeatmapChart powers the Insights load-pattern card. It MUST be
+  // registered here: the tree-shaken echarts/core build silently renders
+  // nothing for unregistered series types (the heatmap shipped empty in
+  // prod for weeks because this import was missing — no console error).
+  HeatmapChart,
 } from "echarts/charts";
 import {
   GridComponent,
@@ -20,6 +25,8 @@ import {
   MarkLineComponent,
   TitleComponent,
   DataZoomComponent,
+  // Required by HeatmapChart (colour scale). Same silent-failure trap.
+  VisualMapComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsType } from "echarts/core";
@@ -29,6 +36,7 @@ echarts.use([
   BarChart,
   PieChart,
   EffectScatterChart,
+  HeatmapChart,
   GridComponent,
   TooltipComponent,
   LegendComponent,
@@ -37,6 +45,7 @@ echarts.use([
   MarkLineComponent,
   TitleComponent,
   DataZoomComponent,
+  VisualMapComponent,
   CanvasRenderer,
 ]);
 
@@ -162,6 +171,27 @@ export function baseOption(): Record<string, unknown> {
 
 export function makeChart(el: HTMLDivElement): EChartsType {
   const chart = echarts.init(el, undefined, { renderer: "canvas" });
+  // Central resize handling: ECharts snapshots the container size at init
+  // and never re-measures. A container that is 0-width at init (mobile
+  // stacked layout, lazy/Suspense mount, display:none tab) stays BLANK
+  // forever — the exact prod bug on the Live-heating card at 375px.
+  // Observe the container (not the canvas), debounce via rAF so layout
+  // thrash can't loop, and tear down with the chart.
+  let raf = 0;
+  const ro = new ResizeObserver(() => {
+    cancelAnimationFrame(raf);
+    raf = requestAnimationFrame(() => {
+      if (!chart.isDisposed()) chart.resize();
+    });
+  });
+  ro.observe(el);
+  const origDispose = chart.dispose.bind(chart);
+  // Wrap dispose so every existing call site cleans the observer for free.
+  (chart as unknown as { dispose: () => void }).dispose = () => {
+    ro.disconnect();
+    cancelAnimationFrame(raf);
+    origDispose();
+  };
   return chart;
 }
 

--- a/ui/src/routes/insights.css
+++ b/ui/src/routes/insights.css
@@ -112,3 +112,22 @@
   font-size: var(--font-2xs);
   margin-top: var(--space-2);
 }
+
+/* ── fair-compare loading skeleton ─────────────────────────────────────
+ * Self-contained (insights doesn't import home.css where .skel-text lives).
+ * Ghost rows mirror the real table's rhythm so the eventual swap is calm. */
+.skel-table { display: flex; flex-direction: column; gap: 10px; padding: var(--space-3) 0; }
+.skel-table-head { display: flex; gap: var(--space-4); margin-bottom: 2px; }
+.skel-table-row { display: flex; gap: var(--space-4); align-items: center; }
+.skel-table .skel-text {
+  display: inline-block;
+  height: 0.85em;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--bg-card-2), var(--bg-card-3), var(--bg-card-2));
+  background-size: 200% 100%;
+  animation: insights-skel 1.3s ease-in-out infinite;
+}
+@keyframes insights-skel {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -3,7 +3,6 @@ import { useFetch } from "../lib/poll";
 import { getFairCompare } from "../lib/endpoints";
 import { usePeriod, periodLabel } from "../lib/period";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
-import { Spinner } from "../components/common/Spinner";
 import { Pill } from "../components/common/Pill";
 import { gbp, gbpSigned, kwh } from "../lib/format";
 import { makeChart, baseOption, chartTheme, barGradient, withAlpha, type EChartsType } from "../lib/charts";
@@ -40,7 +39,26 @@ export default function Insights() {
 
       <PeriodNavigator variant="page" />
 
-      {cmp.loading && !data && <Spinner label="Comparing tariffs…" />}
+      {/* The first compare for a period is a heavy server-side replay (can
+          take seconds before the TTL cache warms). A ghost table reads as
+          progress; a lone spinner reads as "stuck". */}
+      {cmp.loading && !data && (
+        <div class="skel-table" aria-label="Comparing tariffs" role="status">
+          <div class="skel-table-head">
+            <span class="skel-text" style={{ width: "9rem" }} />
+            <span class="skel-text" style={{ width: "5rem" }} />
+          </div>
+          {Array.from({ length: 8 }, (_, i) => (
+            <div class="skel-table-row" key={i}>
+              <span class="skel-text" style={{ width: `${11 - (i % 3)}rem` }} />
+              <span class="skel-text" style={{ width: "3.5rem" }} />
+              <span class="skel-text" style={{ width: "3rem" }} />
+              <span class="skel-text" style={{ width: "4rem" }} />
+            </div>
+          ))}
+          <p class="muted small">Comparing tariffs on your metered usage…</p>
+        </div>
+      )}
       {cmp.error && <p class="insights-error">Couldn't load the comparison: {cmp.error.message}</p>}
 
       {data && rows.length === 0 && (

--- a/ui/src/styles/shell.css
+++ b/ui/src/styles/shell.css
@@ -204,12 +204,29 @@
     margin-right: 0;
     gap: 2px;
   }
-  .nav-link {
+  /* Scoped to the TOPNAV — bare .nav-link is reused by the 404 page links,
+   * which must keep their labels (review L on #552). */
+  .topnav .nav-link {
     font-size: 0;
     gap: 0;
     padding: 10px;
     min-width: 40px;
     min-height: 40px;
     justify-content: center;
+  }
+  /* Wrong-secret message must not widen the single row — float it under
+   * the bar instead (the unlock form already crowds 375px). */
+  .admin-unlock { position: relative; }
+  .admin-unlock-input { width: 100px; }
+  .admin-unlock-msg {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    white-space: nowrap;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 2px 8px;
+    z-index: 41;
   }
 }

--- a/ui/src/styles/shell.css
+++ b/ui/src/styles/shell.css
@@ -186,21 +186,30 @@
   .topnav .brand-name { display: none; }
 }
 
-/* Mobile-ish */
+/* Mobile-ish — ONE compact row, never a stack. The previous column layout
+ * burned ~170px of a 375px-wide phone's first fold on chrome alone (brand
+ * row + tabs row + admin row + theme row) before any data was visible; on
+ * the PWA that's the whole reaction-time budget. Brand keeps only the mark;
+ * nav links keep only their icons (label collapsed via font-size:0 — the
+ * svg has its own size, padding preserves the ≥40px touch target, and
+ * aria-label/title still announce the route). */
 @media (max-width: 640px) {
   .topnav-inner {
-    flex-direction: column;
-    align-items: flex-start;
+    padding: var(--space-2) var(--space-3);
     gap: var(--space-2);
   }
-  .topnav-spacer { display: none; }
+  .topnav .brand-name { display: none; }
+  .topnav-spacer { flex: 1; }
   .topnav-tabs {
-    margin-left: 0;
-    width: 100%;
-    overflow-x: auto;
-    flex-wrap: nowrap;
+    margin-right: 0;
+    gap: 2px;
   }
   .nav-link {
-    white-space: nowrap;
+    font-size: 0;
+    gap: 0;
+    padding: 10px;
+    min-width: 40px;
+    min-height: 40px;
+    justify-content: center;
   }
 }

--- a/ui/ui-entrypoint.sh
+++ b/ui/ui-entrypoint.sh
@@ -38,13 +38,22 @@ else
   BEARER_LITERAL="null"
 fi
 
+# Write null (not "unknown") when the env is absent/placeholder so the SPA's
+# buildSha() falls through to the Vite-baked __BUILD_SHA__ — a truthy
+# "unknown" here used to mask the perfectly good baked value.
+if [ -n "${BUILD_SHA:-}" ] && [ "${BUILD_SHA}" != "unknown" ]; then
+  SHA_LITERAL="\"$BUILD_SHA\""
+else
+  SHA_LITERAL="null"
+fi
+
 cat > "$CONFIG_PATH" <<EOF
 // Generated at container start by ui-entrypoint.sh — DO NOT EDIT.
 // Cached:no-store via nginx config.
 window.__HEM_CONFIG__ = {
   apiBase: "/api/v1",
   bearer:  $BEARER_LITERAL,
-  buildSha: "${BUILD_SHA:-unknown}"
+  buildSha: $SHA_LITERAL
 };
 EOF
 


### PR DESCRIPTION
PR 1/5 of the cockpit ops-console plan (browser-verified against prod).

## Root causes fixed

| symptom (prod, browser-verified) | root cause |
|---|---|
| Insights heatmap renders empty, no console error | `HeatmapChart`/`VisualMapComponent` never registered in the tree-shaken ECharts build |
| Live-heating chart blank at 375px | `makeChart` had no resize handling — 0-width container at init stays blank forever |
| ~300px of chrome before any data on mobile | ≤640px topnav stacked into 4 rows + 2-row period bar |
| Hero £ shows a skeleton on mobile | headline waits on the slow period aggregate even when `todayCum` (60s poll) already knows the answer |
| Footer "HEM build unknown" | `ARG BUILD_SHA` not re-declared in the nginx stage + truthy `"unknown"` masking the baked fallback |
| "esperado hoje", "janela barata", 🔒/🔓/⚠/🧺 | pt-BR leaks + no-emoji handoff violations |

Also: real 404 page with navigation; ghost-table loading state for the fair-compare (server-side TTL cache lands in PR 2).

## Verification
- `npm run typecheck` + `vite build` green.
- Post-deploy browser pass planned (375×812 + 1280×800): hero £ ≤3s, non-blank heating canvas, heatmap paints, zero pt-BR/emoji in DOM, footer shows 7-char SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)