### PR TITLE
feat(api): ops-status endpoints + fair-compare TTL cache

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -115,6 +115,7 @@ from .routers import appliances as appliances_router
 from .routers import dispatch as dispatch_router
 from .routers import energy_providers as energy_providers_router
 from .routers import pv as pv_router
+from .routers import status as status_router
 from .routers import workbench as workbench_router
 
 
@@ -300,6 +301,8 @@ _CACHE_CONTROL_MAX_AGE: dict[str, int] = {
     "/api/v1/daikin/status": 120,
     "/api/v1/daikin/heating-plan": 120,
     "/api/v1/scheduler/timeline": 120,
+    "/api/v1/status/alerts": 30,
+    "/api/v1/status/feedback": 120,
 }
 
 
@@ -321,6 +324,7 @@ app.include_router(workbench_router.router)
 app.include_router(dispatch_router.router)
 app.include_router(appliances_router.router)
 app.include_router(pv_router.router)
+app.include_router(status_router.router)
 
 # Mount the FastMCP streamable-HTTP transport at /mcp, guarded by a bearer
 # token. Replaces the legacy stdio subprocess (`bin/mcp`) for OpenClaw in
@@ -3823,6 +3827,14 @@ def _resolve_period_range(period: str, anchor: str):
     return start, end
 
 
+# Fair-compare replays the whole period's half-hourly usage against every
+# tariff's rate card — measured 9.6s for a month×14 tariffs in prod, which
+# the Insights page paid on EVERY visit. Same in-process TTL pattern as
+# _period_insights_cache; the anchor key keeps a stale "today" view bounded
+# by the TTL while past periods are effectively immutable anyway.
+_fair_compare_cache: dict[tuple, tuple[float, dict]] = {}
+
+
 @app.get("/api/v1/tariffs/fair-compare", response_model=FairCompareResponse)
 async def tariffs_fair_compare(period: str = "month", anchor: str = "", max_tariffs: int = 14):
     """Fair per-slot tariff comparison for the selected navigator period.
@@ -3834,11 +3846,22 @@ async def tariffs_fair_compare(period: str = "month", anchor: str = "", max_tari
     if period not in ("day", "week", "month", "year"):
         raise HTTPException(status_code=400, detail="period must be day|week|month|year")
     start, end = _resolve_period_range(period, anchor)
+
+    import time as _t
+    ttl = int(getattr(config, "FAIR_COMPARE_CACHE_TTL_SECONDS", 900))
+    key = (period, str(start), str(end), int(max_tariffs))
+    if ttl > 0:
+        hit = _fair_compare_cache.get(key)
+        if hit and (_t.monotonic() - hit[0]) < ttl:
+            return FairCompareResponse(**hit[1])
+
     from ..analytics.fair_compare import compute_fair_comparison
 
     data = await asyncio.to_thread(
         compute_fair_comparison, start, end, max_tariffs=max_tariffs
     )
+    if ttl > 0 and data is not None:
+        _fair_compare_cache[key] = (_t.monotonic(), data)
     return FairCompareResponse(**data)
 
 

--- a/src/api/routers/dispatch.py
+++ b/src/api/routers/dispatch.py
@@ -13,6 +13,7 @@ the matching MCP tool (see :mod:`src.mcp_server`).
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
@@ -260,7 +261,11 @@ async def get_foxess_schedule_diff() -> dict[str, Any]:
     live_error: str | None = None
     try:
         fox = FoxESSClient(**config.foxess_client_kwargs())
-        live_state = fox.get_scheduler_v3()
+        # Off the event loop: this is a synchronous vendor HTTP call that can
+        # hang for seconds on a Fox timeout — and since the status alert
+        # strip started polling this on a 30-min cadence (#553), a blocking
+        # call here would stall EVERY in-flight request, not one page view.
+        live_state = await asyncio.to_thread(fox.get_scheduler_v3)
         live_groups = [_normalise_group(g) for g in live_state.groups]
     except Exception as e:
         live_error = str(e)

--- a/src/api/routers/status.py
+++ b/src/api/routers/status.py
@@ -43,14 +43,11 @@ SIDECAR_TTL_S = 300
 FOX_DRIFT_TTL_S = 1800  # live Fox read costs quota — 48/day worst case, ~4% of budget
 
 
-def _cached(key: str, ttl: float, compute):
-    hit = _cache.get(key)
-    now = time.time()
-    if hit and now - hit[0] < ttl:
-        return hit[1]
-    out = compute()
-    _cache[key] = (now, out)
-    return out
+# Single-flight guard for the quota-costing computes: without it, N requests
+# arriving on a cold cache would EACH fire a live vendor read before the
+# first writes the cache (review L on #553) — the lock makes the "client
+# count can never amplify into vendor calls" guarantee real.
+_compute_locks: dict[str, asyncio.Lock] = {}
 
 
 async def _cached_async(key: str, ttl: float, compute):
@@ -58,9 +55,16 @@ async def _cached_async(key: str, ttl: float, compute):
     now = time.time()
     if hit and now - hit[0] < ttl:
         return hit[1]
-    out = await compute()
-    _cache[key] = (now, out)
-    return out
+    lock = _compute_locks.setdefault(key, asyncio.Lock())
+    async with lock:
+        # Re-check under the lock — a concurrent waiter may have filled it.
+        hit = _cache.get(key)
+        now = time.time()
+        if hit and now - hit[0] < ttl:
+            return hit[1]
+        out = await compute()
+        _cache[key] = (now, out)
+        return out
 
 
 # ── building blocks ──────────────────────────────────────────────────────────
@@ -165,11 +169,20 @@ async def _fox_drift_block() -> dict[str, Any]:
         try:
             from .dispatch import get_foxess_schedule_diff
             diff = await get_foxess_schedule_diff()
+            # Contract: schedule_diff returns {"diffs": {"only_live": [...],
+            # "only_recorded": [...]}} — review HIGH on #553 caught this
+            # reading a nonexistent "differences" key (count was always 0).
+            diffs = diff.get("diffs") or {}
+            n_diff = len(diffs.get("only_live") or []) + len(diffs.get("only_recorded") or [])
+            live_error = diff.get("live_error")
+            # A failed live read makes the structural comparison meaningless
+            # (empty live vs recorded reads as "drift") — report UNKNOWN
+            # rather than caching a false alarm for 30 minutes.
             return {
                 "checked_at_utc": datetime.now(UTC).isoformat(),
-                "in_sync": not bool(diff.get("any_drift")),
-                "diff_count": len(diff.get("differences") or []),
-                "error": diff.get("live_error"),
+                "in_sync": None if live_error else not bool(diff.get("any_drift")),
+                "diff_count": None if live_error else n_diff,
+                "error": live_error,
             }
         except Exception as e:  # pragma: no cover — defensive: strip must render
             logger.warning("status/alerts: fox drift check failed: %s", e)
@@ -217,16 +230,20 @@ async def status_alerts() -> dict[str, Any]:
         return hit[1]
 
     sidecar = await _sidecar_ok()
-    meter, lp, quota = await asyncio.gather(
+    # Every sqlite reader goes through to_thread — _forecast_block included:
+    # it takes db._lock, and holding that on the event loop during a large
+    # scheduler write would stall every in-flight request (review M on #553).
+    meter, lp, quota, forecast = await asyncio.gather(
         asyncio.to_thread(_meter_block),
         asyncio.to_thread(_lp_block),
         asyncio.to_thread(_quota_block),
+        asyncio.to_thread(_forecast_block, sidecar),
     )
     out = {
         "now_utc": datetime.now(UTC).isoformat(),
         "meter": meter,
         "lp": lp,
-        "forecast": _forecast_block(sidecar),
+        "forecast": forecast,
         "fox_drift": await _fox_drift_block(),
         "quota": quota,
     }
@@ -256,7 +273,8 @@ async def status_feedback() -> dict[str, Any]:
             "lwt_gate": space_heating_gate_state(),
         }
 
+    sidecar = await _sidecar_ok()
     out = await asyncio.to_thread(compute)
-    out["forecast"] = _forecast_block(await _sidecar_ok())
+    out["forecast"] = await asyncio.to_thread(_forecast_block, sidecar)
     _cache["feedback"] = (now, out)
     return out

--- a/src/api/routers/status.py
+++ b/src/api/routers/status.py
@@ -1,0 +1,262 @@
+"""Operations-status endpoints for the cockpit alert strip + self-check panel.
+
+Two read-only, viewer-accessible aggregates designed for the UI's
+reaction-time loop (see the ops-cockpit plan):
+
+* ``GET /api/v1/status/alerts`` — binary health signals: meter freshness,
+  LP failures, forecast provenance/degradation, Fox schedule drift, API
+  quotas. One 60s-TTL poll powers the whole alert strip; every upstream
+  read that could cost vendor quota sits behind its own LONGER sub-cache so
+  client count can never amplify into live vendor calls.
+* ``GET /api/v1/status/feedback`` — "are the changes working": DHW budget
+  vs measured (auto-scale state), the LWT pre-heat demand gate, forecast
+  provenance. 300s TTL.
+
+Caching follows the in-process pattern of ``_period_insights_cache`` in
+``main.py`` (#507): module-level dict, monotonic-free wall-clock TTL —
+single-process app, cheap and sufficient.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import urllib.request
+from datetime import UTC, date, datetime
+from typing import Any
+
+from fastapi import APIRouter
+
+from ... import db
+from ...config import config
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["status"])
+
+# ── tiny TTL caches ──────────────────────────────────────────────────────────
+_cache: dict[str, tuple[float, Any]] = {}
+
+ALERTS_TTL_S = 60
+FEEDBACK_TTL_S = 300
+SIDECAR_TTL_S = 300
+FOX_DRIFT_TTL_S = 1800  # live Fox read costs quota — 48/day worst case, ~4% of budget
+
+
+def _cached(key: str, ttl: float, compute):
+    hit = _cache.get(key)
+    now = time.time()
+    if hit and now - hit[0] < ttl:
+        return hit[1]
+    out = compute()
+    _cache[key] = (now, out)
+    return out
+
+
+async def _cached_async(key: str, ttl: float, compute):
+    hit = _cache.get(key)
+    now = time.time()
+    if hit and now - hit[0] < ttl:
+        return hit[1]
+    out = await compute()
+    _cache[key] = (now, out)
+    return out
+
+
+# ── building blocks ──────────────────────────────────────────────────────────
+
+def _meter_block() -> dict[str, Any]:
+    """Octopus meter freshness — the #533 alarm, on a UI surface at last."""
+    last = db.get_octopus_meter_last_day()
+    if last is None:
+        return {"last_day": None, "age_days": None, "stale": True}
+    try:
+        age = (date.today() - date.fromisoformat(last)).days
+    except ValueError:
+        return {"last_day": last, "age_days": None, "stale": True}
+    threshold = int(getattr(config, "CONSUMPTION_METER_STALE_DAYS", 3))
+    return {"last_day": last, "age_days": age, "stale": threshold > 0 and age > threshold}
+
+
+def _lp_block() -> dict[str, Any]:
+    """Recent LP failures. error_class ONLY — never the stacktrace (this is a
+    viewer-readable surface; stacktraces stay in the admin Journal/DB)."""
+    rows = db.list_recent_lp_failures(20)
+    now = datetime.now(UTC)
+    recent = []
+    for r in rows:
+        try:
+            ts = datetime.fromisoformat(str(r["run_at_utc"]).replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+        except (KeyError, ValueError, TypeError):
+            continue
+        if (now - ts).total_seconds() <= 24 * 3600:
+            recent.append(r)
+    last = recent[0] if recent else None
+    return {
+        "failures_24h": len(recent),
+        "last_failure": None if last is None else {
+            "run_at_utc": last.get("run_at_utc"),
+            "error_class": last.get("error_class"),
+            "plan_date": last.get("plan_date"),
+        },
+    }
+
+
+def _forecast_block(sidecar_ok: bool | None) -> dict[str, Any]:
+    """Provenance of the forecast the LP is planning on (#542 migration):
+    healthy = quartz-open-site and fresh; anything else is degraded-visible."""
+    meta = db.get_latest_forecast_snapshot_meta()
+    model_name = (meta or {}).get("model_name")
+    fetched = (meta or {}).get("forecast_fetch_at_utc")
+    age_s: float | None = None
+    if fetched:
+        try:
+            ts = datetime.fromisoformat(str(fetched).replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            age_s = max(0.0, (datetime.now(UTC) - ts).total_seconds())
+        except (ValueError, TypeError):
+            age_s = None
+    degraded = (
+        model_name != "quartz-open-site"
+        or age_s is None
+        or age_s > 7200
+        or sidecar_ok is False
+    )
+    return {
+        "model_name": model_name,
+        "source": (meta or {}).get("source"),
+        "fetched_at_utc": fetched,
+        "age_s": None if age_s is None else round(age_s),
+        "sidecar_ok": sidecar_ok,
+        "degraded": degraded,
+    }
+
+
+def _probe_sidecar_blocking() -> bool | None:
+    """GET {QUARTZ_OPEN_URL}/health with a hard 1.5s timeout. ``None`` when
+    the open provider isn't configured (nothing to probe)."""
+    if (getattr(config, "QUARTZ_PROVIDER", "open") or "").lower() != "open":
+        return None
+    base = (getattr(config, "QUARTZ_OPEN_URL", "") or "").rstrip("/")
+    if not base:
+        return None
+    try:
+        with urllib.request.urlopen(f"{base}/health", timeout=1.5) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+async def _sidecar_ok() -> bool | None:
+    return await _cached_async(
+        "sidecar", SIDECAR_TTL_S,
+        lambda: asyncio.to_thread(_probe_sidecar_blocking),
+    )
+
+
+async def _fox_drift_block() -> dict[str, Any]:
+    """Schedule-drift summary behind a 30-min sub-cache. The underlying
+    endpoint performs a LIVE Fox read — the sub-cache (not client courtesy)
+    is what guarantees the alert strip can't burn quota."""
+    async def compute() -> dict[str, Any]:
+        try:
+            from .dispatch import get_foxess_schedule_diff
+            diff = await get_foxess_schedule_diff()
+            return {
+                "checked_at_utc": datetime.now(UTC).isoformat(),
+                "in_sync": not bool(diff.get("any_drift")),
+                "diff_count": len(diff.get("differences") or []),
+                "error": diff.get("live_error"),
+            }
+        except Exception as e:  # pragma: no cover — defensive: strip must render
+            logger.warning("status/alerts: fox drift check failed: %s", e)
+            return {"checked_at_utc": datetime.now(UTC).isoformat(),
+                    "in_sync": None, "diff_count": None, "error": str(e)}
+    return await _cached_async("fox_drift", FOX_DRIFT_TTL_S, compute)
+
+
+def _quota_block() -> dict[str, Any]:
+    out: dict[str, Any] = {"fox": None, "daikin": None}
+    try:
+        from ...foxess.service import get_refresh_stats_extended
+        fx = get_refresh_stats_extended()
+        out["fox"] = {
+            "used": fx.get("quota_used_today_utc") or fx.get("quota_used_24h"),
+            "budget": fx.get("daily_budget"),
+            "blocked": bool(fx.get("blocked")),
+        }
+    except Exception:  # pragma: no cover
+        logger.debug("status/alerts: fox quota read failed", exc_info=True)
+    try:
+        from ...daikin import service as daikin_service
+        dq = daikin_service.get_quota_status_daikin()
+        out["daikin"] = {
+            "used": dq.get("quota_used_today_utc") or dq.get("quota_used_24h"),
+            "budget": dq.get("daily_budget"),
+            "blocked": bool(dq.get("blocked")),
+        }
+    except Exception:  # pragma: no cover
+        logger.debug("status/alerts: daikin quota read failed", exc_info=True)
+    return out
+
+
+# ── endpoints ────────────────────────────────────────────────────────────────
+
+@router.get("/api/v1/status/alerts")
+async def status_alerts() -> dict[str, Any]:
+    """Binary health signals for the cockpit alert strip (viewer-readable).
+
+    Healthy systems return all-quiet values and the strip renders nothing.
+    """
+    hit = _cache.get("alerts")
+    now = time.time()
+    if hit and now - hit[0] < ALERTS_TTL_S:
+        return hit[1]
+
+    sidecar = await _sidecar_ok()
+    meter, lp, quota = await asyncio.gather(
+        asyncio.to_thread(_meter_block),
+        asyncio.to_thread(_lp_block),
+        asyncio.to_thread(_quota_block),
+    )
+    out = {
+        "now_utc": datetime.now(UTC).isoformat(),
+        "meter": meter,
+        "lp": lp,
+        "forecast": _forecast_block(sidecar),
+        "fox_drift": await _fox_drift_block(),
+        "quota": quota,
+    }
+    _cache["alerts"] = (now, out)
+    return out
+
+
+@router.get("/api/v1/status/feedback")
+async def status_feedback() -> dict[str, Any]:
+    """The "are the changes working" panel (viewer-readable):
+    DHW budget vs measured + auto-scale factor (#534), the LWT pre-heat
+    demand gate (#540 quick win), and forecast provenance (#542).
+    PV accuracy is NOT duplicated here — ``/api/v1/pv/today`` already
+    serves MAE/bias and the UI polls it.
+    """
+    hit = _cache.get("feedback")
+    now = time.time()
+    if hit and now - hit[0] < FEEDBACK_TTL_S:
+        return hit[1]
+
+    def compute() -> dict[str, Any]:
+        from ...dhw_policy import dhw_budget_state
+        from ...scheduler.lp_dispatch import space_heating_gate_state
+        return {
+            "now_utc": datetime.now(UTC).isoformat(),
+            "dhw": dhw_budget_state(),
+            "lwt_gate": space_heating_gate_state(),
+        }
+
+    out = await asyncio.to_thread(compute)
+    out["forecast"] = _forecast_block(await _sidecar_ok())
+    _cache["feedback"] = (now, out)
+    return out

--- a/src/config.py
+++ b/src/config.py
@@ -1905,6 +1905,13 @@ class Config:
     ENERGY_PERIOD_CACHE_TTL_SECONDS: int = int(
         os.getenv("ENERGY_PERIOD_CACHE_TTL_SECONDS", "1200")
     )
+    # In-process TTL cache for /tariffs/fair-compare — the per-slot replay of
+    # the whole period against every tariff card took ~9.6 s uncached in prod
+    # (month × 14 tariffs) and the Insights page paid it on every visit.
+    # 0 disables (always recompute).
+    FAIR_COMPARE_CACHE_TTL_SECONDS: int = int(
+        os.getenv("FAIR_COMPARE_CACHE_TTL_SECONDS", "900")
+    )
     # Minimum interval between user-initiated "force refresh" calls
     FOX_FORCE_REFRESH_MIN_INTERVAL_SECONDS: int = int(
         os.getenv("FOX_FORCE_REFRESH_MIN_INTERVAL_SECONDS", "60")

--- a/src/db.py
+++ b/src/db.py
@@ -5152,6 +5152,32 @@ def upsert_pv_recent_bias(
     return n
 
 
+def get_latest_forecast_snapshot_meta() -> dict[str, Any] | None:
+    """Metadata of the most recent canonical forecast fetch, or None.
+
+    Returns ``{forecast_fetch_at_utc, source, model_name, model_version}``
+    from the snapshot pointed at by ``meteo_forecast_latest_state``. Powers
+    the cockpit's forecast-provenance chip (#542): after the Quartz sidecar
+    migration the healthy value is ``model_name='quartz-open-site'``;
+    anything else means the fetch degraded to a fallback.
+    """
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT s.forecast_fetch_at_utc, s.source, s.model_name,
+                          s.model_version
+                   FROM meteo_forecast_snapshot s
+                   JOIN meteo_forecast_latest_state ls
+                     ON ls.forecast_fetch_at_utc = s.forecast_fetch_at_utc
+                   WHERE ls.id = 1"""
+            )
+            r = cur.fetchone()
+            return dict(r) if r else None
+        finally:
+            conn.close()
+
+
 def get_pv_recent_bias() -> dict[int, float]:
     """Return cached per-hour adaptive PV bias factors, or ``{}`` when empty."""
     with _lock:

--- a/src/dhw_policy.py
+++ b/src/dhw_policy.py
@@ -480,6 +480,49 @@ def _dhw_autoscale_factor(mode: str) -> float:
     return factor
 
 
+def dhw_budget_state(mode: str | None = None) -> dict[str, Any]:
+    """Public snapshot of the DHW budget feedback loop (#534) for the API.
+
+    The status endpoints must not import underscore-private internals, so
+    this composes them here: nominal mode total × trailing measured/nominal
+    auto-scale = the daily electric budget the LP actually pins, plus the
+    measured Onecta dhw figures it is being compared against.
+    """
+    if mode is None:
+        mode = (config.OPTIMIZATION_PRESET or "normal").strip().lower()
+    nominal = _nominal_daily_total_kwh(mode)
+    factor = _dhw_autoscale_factor(mode)
+
+    measured_today: float | None = None
+    measured_7d_avg: float | None = None
+    try:
+        tz = _tz_local()
+        today = datetime.now(tz).date()
+        start = today - timedelta(days=7)
+        rows = db.get_daikin_consumption_daily_range(start.isoformat(), today.isoformat())
+        vals = [
+            float(r["kwh_dhw"]) for r in rows
+            if r.get("kwh_dhw") is not None and str(r["date"]) != today.isoformat()
+        ]
+        if vals:
+            measured_7d_avg = round(sum(vals) / len(vals), 2)
+        for r in rows:
+            if str(r["date"]) == today.isoformat() and r.get("kwh_dhw") is not None:
+                measured_today = float(r["kwh_dhw"])
+    except Exception:  # pragma: no cover - defensive: status read must not fail
+        logger.debug("dhw_budget_state: measured read failed", exc_info=True)
+
+    return {
+        "mode": mode,
+        "nominal_kwh": round(nominal, 2),
+        "autoscale_factor": round(factor, 3),
+        "autoscale_enabled": bool(getattr(config, "DHW_FORECAST_AUTOSCALE_ENABLED", True)),
+        "effective_budget_kwh": round(nominal * factor, 2),
+        "measured_today_kwh": measured_today,
+        "measured_7d_avg_kwh": measured_7d_avg,
+    }
+
+
 def forecast_dhw_load_per_slot(
     slot_starts_utc: list[datetime],
     *,

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -973,7 +973,7 @@ def space_heating_gate_state() -> dict[str, Any]:
         "preheat_enabled": preheat_enabled,
         "gate_enabled": floor > 0,
         "demand_present": demand_present,
-        "measured_kwh_48h": measured,
+        "measured_window_kwh": measured,
         "threshold_kwh": floor,
         "lookback_hours": lookback,
         # The one-line story the chip renders:

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -955,6 +955,32 @@ def _space_heating_demand_present() -> bool:
     return measured >= floor
 
 
+def space_heating_gate_state() -> dict[str, Any]:
+    """Public snapshot of the LWT pre-heat demand gate (#540 quick win) for
+    the status API: the INPUTS, not just the verdict, so the cockpit can
+    explain WHY pre-heat is suppressed or allowed right now.
+    """
+    floor = float(getattr(config, "DAIKIN_LWT_PREHEAT_MIN_TRAILING_HEATING_KWH", 0.5))
+    lookback = int(getattr(config, "DAIKIN_LWT_PREHEAT_DEMAND_LOOKBACK_HOURS", 48))
+    measured: float | None = None
+    try:
+        measured = round(db.measured_space_heating_kwh_excluding_offset_windows(lookback), 2)
+    except Exception:  # pragma: no cover - defensive: status read must not fail
+        logger.debug("space_heating_gate_state: measured read failed", exc_info=True)
+    demand_present = _space_heating_demand_present()
+    preheat_enabled = bool(getattr(config, "DAIKIN_LWT_PREHEAT_ENABLED", False))
+    return {
+        "preheat_enabled": preheat_enabled,
+        "gate_enabled": floor > 0,
+        "demand_present": demand_present,
+        "measured_kwh_48h": measured,
+        "threshold_kwh": floor,
+        "lookback_hours": lookback,
+        # The one-line story the chip renders:
+        "preheat_suppressed": preheat_enabled and floor > 0 and not demand_present,
+    }
+
+
 def _write_lwt_preheat_actions(
     plan_date: str,
     plan: LpPlan,

--- a/tests/test_status_endpoints.py
+++ b/tests/test_status_endpoints.py
@@ -128,14 +128,21 @@ def test_fox_drift_subcache_blocks_repeat_live_reads(monkeypatch):
 
     async def fake_diff():
         calls["n"] += 1
-        return {"any_drift": False, "differences": [], "live_error": None}
+        # The REAL endpoint contract (review HIGH on #553: a fake with a
+        # nonexistent "differences" key masked the wrong-key bug).
+        return {"any_drift": True,
+                "diffs": {"only_live": [{"g": 1}], "only_recorded": []},
+                "live_error": None}
 
     import src.api.routers.dispatch as dispatch_router
     monkeypatch.setattr(dispatch_router, "get_foxess_schedule_diff", fake_diff)
     import asyncio
-    asyncio.run(status_router._fox_drift_block())
+    first = asyncio.run(status_router._fox_drift_block())
     asyncio.run(status_router._fox_drift_block())
     assert calls["n"] == 1, "second call within TTL must hit the sub-cache"
+    # And the real-contract keys flow through: drift visible with a count.
+    assert first["in_sync"] is False
+    assert first["diff_count"] == 1
 
 
 # ── /status/feedback ─────────────────────────────────────────────────────────

--- a/tests/test_status_endpoints.py
+++ b/tests/test_status_endpoints.py
@@ -1,0 +1,193 @@
+"""Ops-status endpoints (/status/alerts + /status/feedback) — cockpit plan PR 2.
+
+These power the alert strip and the self-check panel. Contract under test:
+viewer-readable without a token, never leak stacktraces, sub-cache the
+quota-costing upstream reads, and reflect the recently-shipped feedback
+loops (DHW auto-scale #534, LWT demand gate #540, forecast provenance #542,
+meter staleness #533).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import db
+from src.config import config
+
+
+@pytest.fixture(autouse=True)
+def _fresh_state(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setenv("DB_PATH", db_path)
+    monkeypatch.setattr(config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+    from src.api.routers import status as status_router
+    status_router._cache.clear()
+    yield
+    status_router._cache.clear()
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr(config, "HEM_UI_AUTH_REQUIRED", False, raising=False)
+    from src.api.main import app
+    return TestClient(app)
+
+
+def _quiet_upstreams(monkeypatch):
+    """Neutralise the vendor-touching blocks so unit tests stay offline."""
+    from src.api.routers import status as status_router
+    monkeypatch.setattr(status_router, "_probe_sidecar_blocking", lambda: True)
+
+    async def fake_drift():
+        return {"checked_at_utc": "t", "in_sync": True, "diff_count": 0, "error": None}
+    monkeypatch.setattr(status_router, "_fox_drift_block", fake_drift)
+    monkeypatch.setattr(status_router, "_quota_block", lambda: {"fox": None, "daikin": None})
+
+
+# ── /status/alerts ───────────────────────────────────────────────────────────
+
+def test_alerts_viewer_readable_and_shaped(monkeypatch):
+    _quiet_upstreams(monkeypatch)
+    client = _client(monkeypatch)
+    r = client.get("/api/v1/status/alerts")
+    assert r.status_code == 200
+    body = r.json()
+    for k in ("now_utc", "meter", "lp", "forecast", "fox_drift", "quota"):
+        assert k in body, k
+    # Empty DB: no metered day yet → stale, no failures, no forecast snapshot.
+    assert body["meter"]["stale"] is True
+    assert body["lp"]["failures_24h"] == 0
+    assert body["forecast"]["degraded"] is True
+
+
+def test_alerts_meter_freshness_math(monkeypatch):
+    _quiet_upstreams(monkeypatch)
+    fresh = (datetime.now(UTC) - timedelta(days=1)).date().isoformat()
+    db.upsert_octopus_daily_meter(fresh, import_kwh=9.0, export_kwh=1.0)
+    client = _client(monkeypatch)
+    body = client.get("/api/v1/status/alerts").json()
+    assert body["meter"]["last_day"] == fresh
+    assert body["meter"]["stale"] is False
+
+
+def test_alerts_lp_failures_never_leak_stacktrace(monkeypatch):
+    _quiet_upstreams(monkeypatch)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """INSERT INTO lp_failure_log (run_at_utc, plan_date, error_class,
+                                           error_msg, stacktrace)
+               VALUES (?, ?, ?, ?, ?)""",
+            (datetime.now(UTC).isoformat(), "2026-06-12", "Infeasible",
+             "secret detail", "Traceback (most recent call last): SECRET"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    client = _client(monkeypatch)
+    body = client.get("/api/v1/status/alerts").json()
+    assert body["lp"]["failures_24h"] == 1
+    assert body["lp"]["last_failure"]["error_class"] == "Infeasible"
+    blob = client.get("/api/v1/status/alerts").text
+    assert "SECRET" not in blob and "secret detail" not in blob
+
+
+def test_alerts_forecast_provenance_healthy(monkeypatch):
+    _quiet_upstreams(monkeypatch)
+    now_iso = datetime.now(UTC).isoformat()
+    # NB: save_meteo_forecast_snapshot no-ops on an empty rows list.
+    db.save_meteo_forecast_snapshot(
+        now_iso,
+        [{"slot_time": now_iso, "temp_c": 15.0, "solar_w_m2": 100.0,
+          "cloud_cover_pct": 40.0, "direct_pv_kw": 0.5}],
+        source="quartz", model_name="quartz-open-site", mark_latest=True,
+    )
+    client = _client(monkeypatch)
+    body = client.get("/api/v1/status/alerts").json()
+    assert body["forecast"]["model_name"] == "quartz-open-site"
+    assert body["forecast"]["degraded"] is False
+
+
+def test_alerts_ttl_serves_cached(monkeypatch):
+    _quiet_upstreams(monkeypatch)
+    client = _client(monkeypatch)
+    first = client.get("/api/v1/status/alerts").json()
+    # A meter row landing AFTER the first call must not appear within the TTL.
+    db.upsert_octopus_daily_meter(
+        datetime.now(UTC).date().isoformat(), import_kwh=9.0, export_kwh=1.0
+    )
+    second = client.get("/api/v1/status/alerts").json()
+    assert second == first
+
+
+def test_fox_drift_subcache_blocks_repeat_live_reads(monkeypatch):
+    from src.api.routers import status as status_router
+    calls = {"n": 0}
+
+    async def fake_diff():
+        calls["n"] += 1
+        return {"any_drift": False, "differences": [], "live_error": None}
+
+    import src.api.routers.dispatch as dispatch_router
+    monkeypatch.setattr(dispatch_router, "get_foxess_schedule_diff", fake_diff)
+    import asyncio
+    asyncio.run(status_router._fox_drift_block())
+    asyncio.run(status_router._fox_drift_block())
+    assert calls["n"] == 1, "second call within TTL must hit the sub-cache"
+
+
+# ── /status/feedback ─────────────────────────────────────────────────────────
+
+def test_feedback_shape_and_gate_story(monkeypatch):
+    _quiet_upstreams(monkeypatch)
+    monkeypatch.setattr(config, "OPTIMIZATION_PRESET", "normal", raising=False)
+    monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_ENABLED", True, raising=False)
+    client = _client(monkeypatch)
+    r = client.get("/api/v1/status/feedback")
+    assert r.status_code == 200
+    body = r.json()
+    dhw = body["dhw"]
+    assert dhw["mode"] == "normal"
+    assert dhw["nominal_kwh"] == pytest.approx(3.0, abs=0.05)
+    assert dhw["effective_budget_kwh"] == pytest.approx(
+        dhw["nominal_kwh"] * dhw["autoscale_factor"], abs=0.02
+    )
+    gate = body["lwt_gate"]
+    # Empty DB → no measured heating → gate suppresses pre-heat.
+    assert gate["demand_present"] is False
+    assert gate["preheat_suppressed"] is True
+    assert gate["threshold_kwh"] == pytest.approx(0.5)
+    assert "forecast" in body
+
+
+# ── fair-compare TTL cache ───────────────────────────────────────────────────
+
+def test_fair_compare_cached_within_ttl(monkeypatch):
+    import src.api.main as api_main
+    api_main._fair_compare_cache.clear()
+    calls = {"n": 0}
+
+    def fake_compute(start, end, max_tariffs=14):
+        calls["n"] += 1
+        return {
+            "period_start": str(start), "period_end": str(end),
+            "n_days": 1, "days_with_data": 1, "clamped": False,
+            "catalogue_unavailable": False, "winner_product_code": "x",
+            "current_product_code": "x",
+            "savings_vs_current_pounds": 0.0,
+            "basis": {"import_kwh": 1.0, "export_kwh": 0.0},
+            "tariffs": [], "export": None,
+        }
+
+    import src.analytics.fair_compare as fc
+    monkeypatch.setattr(fc, "compute_fair_comparison", fake_compute)
+    client = _client(monkeypatch)
+    r1 = client.get("/api/v1/tariffs/fair-compare?period=day&anchor=2026-06-10")
+    r2 = client.get("/api/v1/tariffs/fair-compare?period=day&anchor=2026-06-10")
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert calls["n"] == 1, "second hit must come from the TTL cache"
+    r3 = client.get("/api/v1/tariffs/fair-compare?period=day&anchor=2026-06-09")
+    assert r3.status_code == 200
+    assert calls["n"] == 2, "different anchor = different key"


### PR DESCRIPTION
PR 2/5 of the cockpit ops-console plan (hem image; UI consumers land in PR 3).

## New endpoints (viewer-readable, in-process TTL like #507)

**`GET /api/v1/status/alerts`** (60s) — one poll powers the whole alert strip:
- `meter` — #533 staleness on a UI surface at last (`get_octopus_meter_last_day`, threshold = `CONSUMPTION_METER_STALE_DAYS`)
- `lp` — failures last-24h; `error_class` only, **stacktraces never leave the DB** (test-pinned)
- `forecast` — provenance (`model_name`, age) + quartz **sidecar reachability** (1.5s probe, 300s sub-cache); `degraded` when not `quartz-open-site`/fresh/sidecar-down
- `fox_drift` — schedule drift behind a **30-min server-side sub-cache**: the underlying check is a live Fox read; the sub-cache (not client discipline) guarantees the strip can't burn quota (test-pinned single-flight)
- `quota` — fox/daikin summaries

**`GET /api/v1/status/feedback`** (300s) — the "are the changes working" panel: DHW nominal × auto-scale = effective budget vs measured today/7d (#534); LWT demand-gate verdict **with its inputs** (#540); forecast provenance. PV accuracy intentionally not duplicated (`/pv/today` already serves it).

Public wrappers added (`dhw_policy.dhw_budget_state`, `lp_dispatch.space_heating_gate_state`) so the API never imports underscore-privates.

## Fair-compare cache

`/tariffs/fair-compare` measured **9.6s** in prod (month × 14 tariffs) and Insights paid it on every visit. Same TTL-dict pattern as `_period_insights_cache`, keyed `(period, start, end, max_tariffs)`, `FAIR_COMPARE_CACHE_TTL_SECONDS=900` (0 disables).

## Tests

8 new (see commit). 211 related tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)