### PR TITLE
feat(ui): alert strip + self-check panel + system health; mode-aware schedule_diff fingerprint

### DIFF
--- a/src/api/routers/dispatch.py
+++ b/src/api/routers/dispatch.py
@@ -273,14 +273,24 @@ async def get_foxess_schedule_diff() -> dict[str, Any]:
 
     rec_norm = [_normalise_group(g) for g in recorded_groups]
 
-    # Compare on a fingerprint of (start, end, work_mode, min_soc_on_grid, fd_soc, fd_pwr, max_soc).
+    # Compare on a MODE-AWARE fingerprint. Naive field-by-field comparison
+    # produced permanent false drift on the very first consumer (the status
+    # alert strip, 2026-06-12): Fox echoes vendor DEFAULTS for fields the
+    # upload omitted — max_soc None comes back as 100, and Backup/SelfUse
+    # groups return whatever fd_soc/fd_pwr were last set even though those
+    # fields are meaningless outside ForceDischarge. Canonicalise both
+    # sides: fd_* compared only on ForceDischarge; absent max_soc == the
+    # vendor default 100.
     def _fp(g: dict[str, Any]) -> tuple:
+        mode = g.get("work_mode")
+        fd_relevant = mode == "ForceDischarge"
+        max_soc = g.get("max_soc")
         return (
-            g.get("start"), g.get("end"), g.get("work_mode"),
+            g.get("start"), g.get("end"), mode,
             g.get("min_soc_on_grid"),
-            None if g.get("fd_soc") is None else float(g["fd_soc"]),
-            None if g.get("fd_pwr") is None else float(g["fd_pwr"]),
-            None if g.get("max_soc") is None else float(g["max_soc"]),
+            float(g["fd_soc"]) if fd_relevant and g.get("fd_soc") is not None else None,
+            float(g["fd_pwr"]) if fd_relevant and g.get("fd_pwr") is not None else None,
+            100.0 if max_soc is None else float(max_soc),
         )
 
     live_fps = {_fp(g) for g in live_groups}

--- a/tests/test_dispatch_decisions_api.py
+++ b/tests/test_dispatch_decisions_api.py
@@ -247,8 +247,10 @@ def test_schedule_diff_fingerprint_ignores_vendor_default_echo(monkeypatch):
     monkeypatch.setattr(dispatch_mod, "FoxESSClient", _FakeFox)
     # foxess_client_kwargs() validates FOXESS_DEVICE_SN and raises in the test
     # env, which would short-circuit into the live_error path before the fake
-    # client is ever constructed.
-    monkeypatch.setattr(dispatch_mod.config, "foxess_client_kwargs", lambda: {})
+    # client is ever constructed. Patch the CLASS, not the instance — undoing
+    # an instance patch writes the bound method into the singleton's __dict__,
+    # permanently shadowing any later class-level patch.
+    monkeypatch.setattr(type(dispatch_mod.config), "foxess_client_kwargs", lambda self: {})
     monkeypatch.setattr(app_config, "HEM_UI_AUTH_REQUIRED", False, raising=False)
     from src.api.main import app
     client = TestClient(app)

--- a/tests/test_dispatch_decisions_api.py
+++ b/tests/test_dispatch_decisions_api.py
@@ -191,3 +191,77 @@ def test_scenarios_endpoint_returns_empty_when_no_scenarios_logged():
     body = resp.json()
     assert body["scenarios"] == []
     assert "note" in body
+
+
+def test_schedule_diff_fingerprint_ignores_vendor_default_echo(monkeypatch):
+    """Real prod shapes captured 2026-06-12: Fox echoes max_soc=100 where the
+    upload recorded None, and returns stale fd_* values on Backup groups —
+    the naive fingerprint reported 16 phantom diffs on identical schedules,
+    which would have made the alert strip's drift chip permanent noise."""
+    from src import db
+    from src.config import config as app_config
+    from fastapi.testclient import TestClient
+
+    db.init_db()
+
+    def rec(sh, sm, eh, em, mode, min_soc=10, fd_soc=None, fd_pwr=None, max_soc=None):
+        # fox_schedule_state.groups_json / to_api_dict shape
+        return {"startHour": sh, "startMinute": sm, "endHour": eh, "endMinute": em,
+                "workMode": mode,
+                "extraParam": {"minSocOnGrid": min_soc, "fdSoc": fd_soc,
+                               "fdPwr": fd_pwr, "maxSoc": max_soc}}
+
+    class LiveGroup:  # SchedulerGroup-like (attributes, NOT a dict)
+        def __init__(self, sh, sm, eh, em, mode, min_soc=10,
+                     fd_soc=None, fd_pwr=None, max_soc=None):
+            self.start_hour, self.start_minute = sh, sm
+            self.end_hour, self.end_minute = eh, em
+            self.work_mode = mode
+            self.min_soc_on_grid = min_soc
+            self.fd_soc, self.fd_pwr, self.max_soc = fd_soc, fd_pwr, max_soc
+
+    recorded = [
+        rec(21, 0, 22, 30, "ForceDischarge", fd_soc=15, fd_pwr=3680, max_soc=None),
+        rec(7, 0, 10, 59, "Backup", fd_soc=None, fd_pwr=None, max_soc=10),
+        rec(11, 0, 11, 30, "ForceCharge", fd_soc=31, fd_pwr=3500, max_soc=None),
+    ]
+    live = [
+        LiveGroup(21, 0, 22, 30, "ForceDischarge", fd_soc=15.0, fd_pwr=3680.0, max_soc=100.0),
+        # Backup echoes STALE fd_* values the upload never set:
+        LiveGroup(7, 0, 10, 59, "Backup", fd_soc=91.0, fd_pwr=2850.0, max_soc=10.0),
+        LiveGroup(11, 0, 11, 30, "ForceCharge", fd_soc=31.0, fd_pwr=3500.0, max_soc=100.0),
+    ]
+
+    import src.api.routers.dispatch as dispatch_mod
+    monkeypatch.setattr(db, "get_latest_fox_schedule_state",
+                        lambda: {"groups": recorded})
+
+    class _FakeState:
+        groups = live
+
+    class _FakeFox:
+        def __init__(self, **_kw): ...
+        def get_scheduler_v3(self):
+            return _FakeState()
+
+    monkeypatch.setattr(dispatch_mod, "FoxESSClient", _FakeFox)
+    # foxess_client_kwargs() validates FOXESS_DEVICE_SN and raises in the test
+    # env, which would short-circuit into the live_error path before the fake
+    # client is ever constructed.
+    monkeypatch.setattr(dispatch_mod.config, "foxess_client_kwargs", lambda: {})
+    monkeypatch.setattr(app_config, "HEM_UI_AUTH_REQUIRED", False, raising=False)
+    from src.api.main import app
+    client = TestClient(app)
+    body = client.get("/api/v1/foxess/schedule_diff").json()
+    assert body["ok"] is True, body.get("live_error")
+    assert body["any_drift"] is False, body["diffs"]
+    assert body["diffs"]["only_live"] == []
+    assert body["diffs"]["only_recorded"] == []
+
+    # Counter-case: a REAL fd_soc change on a ForceDischarge group must still
+    # register as drift — canonicalisation only forgives vendor default echo.
+    live[0].fd_soc = 50.0
+    body = client.get("/api/v1/foxess/schedule_diff").json()
+    assert body["any_drift"] is True
+    assert len(body["diffs"]["only_live"]) == 1
+    assert len(body["diffs"]["only_recorded"]) == 1

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense } from "preact/compat";
 import { useEffect } from "preact/hooks";
 import type { ComponentType } from "preact";
 import { TopNav } from "./components/shell/TopNav";
+import { AlertStrip } from "./components/shell/AlertStrip";
 import { Footer } from "./components/shell/Footer";
 import { ToastHost } from "./components/common/Toast";
 import { Spinner } from "./components/common/Spinner";
@@ -35,6 +36,7 @@ export function App() {
   return (
     <div class="shell">
       <TopNav />
+      <AlertStrip />
       <main class="shell-main">
         <Suspense fallback={<div class="page-padded"><Spinner label="Loading…" /></div>}>
           <Switch>

--- a/ui/src/components/home/FeedbackPanel.tsx
+++ b/ui/src/components/home/FeedbackPanel.tsx
@@ -1,0 +1,136 @@
+import type { ComponentChildren } from "preact";
+import { useFetch } from "../../lib/poll";
+import { getStatusFeedback } from "../../lib/endpoints";
+import { Icon } from "../common/Icon";
+import { Widget } from "../common/Widget";
+import { TriggersFeed } from "./TriggersFeed";
+import { role } from "../../lib/auth";
+import type { PvTodayResponse } from "../../lib/types";
+import "./feedback.css";
+
+// "Self-check" — answers "are the recent changes actually working?" without
+// a trip to the Journal or the DB: forecast provenance (Quartz sidecar vs
+// fallback), today's PV forecast accuracy, the DHW budget vs what the tank
+// really used (auto-scale, #534), and the LWT pre-heat demand gate (#540).
+// Degrades silently when /status/feedback doesn't exist yet (older image).
+//
+// PV accuracy comes in as a prop: landing already polls /pv/today for the
+// hero — no second fetch for the same payload.
+
+const fmtKwh = (v: number | null | undefined, dp = 1) =>
+  v == null ? "—" : `${v.toFixed(dp)} kWh`;
+
+function ageLabel(ageS: number | null | undefined): string {
+  if (ageS == null) return "?";
+  if (ageS < 90) return "now";
+  if (ageS < 5400) return `${Math.round(ageS / 60)}m ago`;
+  return `${Math.round(ageS / 3600)}h ago`;
+}
+
+export function FeedbackPanel({ pv }: { pv: PvTodayResponse | null }) {
+  const fb = useFetch(getStatusFeedback, []);
+  const d = fb.data;
+
+  // Older hem image (404), transient error, or still loading → render nothing
+  // (the panel owns its whole widget band, so no empty card is left behind).
+  if (!d) return null;
+
+  const f = d.forecast;
+  const forecastOk = !f.degraded;
+  const forecastName = f.model_name === "quartz-open-site" ? "Quartz (self-hosted)" : (f.model_name ?? "unknown");
+
+  const dhw = d.dhw;
+  const budget = dhw.effective_budget_kwh;
+  const measured = dhw.measured_today_kwh;
+  const dhwPct = budget && budget > 0 && measured != null
+    ? Math.min(100, (measured / budget) * 100)
+    : null;
+  const dhwTip = [
+    `nominal ${fmtKwh(dhw.nominal_kwh)} × auto-scale ${dhw.autoscale_factor != null ? dhw.autoscale_factor.toFixed(2) : "—"}${dhw.autoscale_enabled ? "" : " (disabled)"}`,
+    `7-day measured avg ${fmtKwh(dhw.measured_7d_avg_kwh)}`,
+    `mode: ${dhw.mode}`,
+  ].join(" · ");
+
+  const gate = d.lwt_gate;
+  let gateLabel: string;
+  let gateOk = true;
+  if (!gate.preheat_enabled) {
+    gateLabel = "Pre-heat off";
+  } else if (!gate.gate_enabled) {
+    gateLabel = "Pre-heat ungated";
+    gateOk = false; // gate disabled = offsets can fire with zero heating demand
+  } else if (gate.preheat_suppressed) {
+    gateLabel = "Pre-heat gated — no heating demand";
+  } else {
+    gateLabel = `Pre-heat active — ${fmtKwh(gate.measured_window_kwh)} heating in ${gate.lookback_hours}h`;
+  }
+  const gateTip = `measured space heating ${fmtKwh(gate.measured_window_kwh, 2)} over ${gate.lookback_hours}h vs ${fmtKwh(gate.threshold_kwh, 2)} threshold (HEM's own offset windows excluded)`;
+
+  const acc = pv?.accuracy ?? null;
+
+  return (
+    <div class="widget-grid widget-band">
+      <Widget title="Self-check" icon={<Icon name="check" size={14} />} tone="plan" size="wide">
+        <div class="selfcheck">
+          <div class="selfcheck-row">
+            <SelfCheckItem
+              ok={forecastOk}
+              label="PV forecast"
+              value={`${forecastName} · ${ageLabel(f.age_s)}`}
+              tip={`source=${f.source ?? "?"} · sidecar ${f.sidecar_ok == null ? "n/a" : f.sidecar_ok ? "healthy" : "DOWN"}`}
+            />
+            <SelfCheckItem
+              ok={acc ? acc.mae_kwh <= 0.5 : null}
+              label="PV accuracy today"
+              value={acc ? `MAE ${acc.mae_kwh.toFixed(2)} kWh · bias ${acc.bias_kwh >= 0 ? "+" : ""}${acc.bias_kwh.toFixed(2)}` : "no slots yet"}
+              tip={acc ? `${acc.slots_compared} half-hours compared · forecast ${acc.forecast_kwh.toFixed(1)} vs actual ${acc.actual_kwh.toFixed(1)} kWh` : undefined}
+            />
+            <SelfCheckItem
+              ok={dhwPct == null ? null : dhwPct <= 100}
+              label="Hot water budget"
+              value={`${fmtKwh(measured)} of ${fmtKwh(budget)}`}
+              tip={dhwTip}
+            >
+              {dhwPct != null && (
+                <span class="selfcheck-bar" aria-hidden="true">
+                  <span class="selfcheck-bar-fill" style={{ width: `${dhwPct}%` }} />
+                </span>
+              )}
+            </SelfCheckItem>
+            <SelfCheckItem ok={gateOk} label="Heating pre-heat" value={gateLabel} tip={gateTip} />
+          </div>
+          {role.value === "admin" && <TriggersFeed />}
+        </div>
+      </Widget>
+    </div>
+  );
+}
+
+function SelfCheckItem({
+  ok,
+  label,
+  value,
+  tip,
+  children,
+}: {
+  ok: boolean | null; // null = informational, no verdict
+  label: string;
+  value: string;
+  tip?: string;
+  children?: ComponentChildren;
+}) {
+  return (
+    <div class="selfcheck-item" title={tip}>
+      <span class="selfcheck-label">
+        {ok != null && (
+          <span class={`selfcheck-dot ${ok ? "is-ok" : "is-warn"}`} aria-hidden="true">
+            <Icon name={ok ? "check" : "warn"} size={11} />
+          </span>
+        )}
+        {label}
+      </span>
+      <span class="selfcheck-value">{value}</span>
+      {children}
+    </div>
+  );
+}

--- a/ui/src/components/home/TriggersFeed.tsx
+++ b/ui/src/components/home/TriggersFeed.tsx
@@ -1,0 +1,52 @@
+import { useFetch } from "../../lib/poll";
+import { getRecentTriggers } from "../../lib/endpoints";
+import { Icon } from "../common/Icon";
+import "./feedback.css";
+
+// Last few meaningful action_log events (manual writes, plan proposes,
+// scheduler crons — heartbeat/notification noise already filtered server-side).
+// ADMIN-ONLY: /recent-triggers is in the middleware's admin_read_prefixes, so
+// the parent must role-gate the mount — this component assumes it IS admin and
+// would just render its error-empty state otherwise.
+
+function timeLabel(ts: string): string {
+  try {
+    const d = new Date(ts.includes("T") ? ts : ts.replace(" ", "T") + "Z");
+    if (Number.isNaN(d.getTime())) return ts;
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
+  } catch {
+    return ts;
+  }
+}
+
+export function TriggersFeed() {
+  const triggers = useFetch(() => getRecentTriggers(6), []);
+  const rows = triggers.data?.rows ?? [];
+  if (triggers.error || rows.length === 0) return null;
+
+  return (
+    <div class="triggers-feed">
+      <div class="triggers-feed-head">Recent actions</div>
+      <ul class="triggers-feed-list">
+        {rows.map((r) => {
+          const failed = !!r.error_msg;
+          return (
+            <li key={r.id} class="triggers-feed-row" title={r.error_msg ?? r.result ?? undefined}>
+              <span class="triggers-feed-time">{timeLabel(r.timestamp)}</span>
+              <span class={`triggers-feed-status ${failed ? "is-warn" : "is-ok"}`} aria-hidden="true">
+                <Icon name={failed ? "warn" : "check"} size={11} />
+              </span>
+              <span class="triggers-feed-what">
+                {r.device ? `${r.device} · ` : ""}{r.action ?? "—"}
+              </span>
+              <span class="triggers-feed-meta">
+                {r.trigger ?? ""}
+                {r.duration_ms != null ? ` · ${r.duration_ms >= 1000 ? `${(r.duration_ms / 1000).toFixed(1)}s` : `${r.duration_ms}ms`}` : ""}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/ui/src/components/home/feedback.css
+++ b/ui/src/components/home/feedback.css
@@ -1,0 +1,108 @@
+/* Self-check panel — "are the changes working" facts + (admin) recent actions. */
+
+.selfcheck-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: var(--space-3);
+}
+
+.selfcheck-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.selfcheck-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+
+.selfcheck-dot { display: inline-flex; }
+.selfcheck-dot.is-ok { color: var(--ok); }
+.selfcheck-dot.is-warn { color: var(--warn); }
+
+.selfcheck-value {
+  font-size: 0.85rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selfcheck-bar {
+  display: block;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-card-3);
+  overflow: hidden;
+}
+
+.selfcheck-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+}
+
+/* ── Recent actions (admin) ─────────────────────────────────────────── */
+
+.triggers-feed {
+  margin-top: var(--space-4);
+}
+
+.triggers-feed-head {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: var(--space-2);
+}
+
+.triggers-feed-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.triggers-feed-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  font-size: 0.8rem;
+  min-width: 0;
+}
+
+.triggers-feed-time {
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+  flex: 0 0 auto;
+}
+
+.triggers-feed-status { flex: 0 0 auto; align-self: center; display: inline-flex; }
+.triggers-feed-status.is-ok { color: var(--ok); }
+.triggers-feed-status.is-warn { color: var(--warn); }
+
+.triggers-feed-what {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.triggers-feed-meta {
+  color: var(--text-mute);
+  flex: 0 0 auto;
+  font-size: 0.74rem;
+}

--- a/ui/src/components/insights/SystemHealthCard.tsx
+++ b/ui/src/components/insights/SystemHealthCard.tsx
@@ -1,0 +1,88 @@
+import { useFetch } from "../../lib/poll";
+import { getLpScorecard } from "../../lib/endpoints";
+import type { LpScorecard } from "../../lib/types";
+
+// "System health" — yesterday's LP scorecard (the last COMPLETE day, so the
+// plan-vs-realised comparison isn't half-empty). Three slices: did the plan
+// match reality (dispatch accuracy), did optimising pay (vs a naive self-use
+// shadow), and how good were the forecasts the LP planned on. Renders nothing
+// when the scorecard endpoint or its data isn't there — this card is a
+// diagnostic, not a load-bearing surface.
+
+function yesterdayIso(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+const pct = (v: number | null | undefined) => (v == null ? "—" : `${Math.round(v)}%`);
+const pence = (v: number | null | undefined) =>
+  v == null ? "—" : `${v >= 0 ? "" : "−"}£${Math.abs(v / 100).toFixed(2)}`;
+
+export function SystemHealthCard() {
+  const day = yesterdayIso();
+  const res = useFetch(() => getLpScorecard(day), [day]);
+  const sc: LpScorecard | undefined = res.data?.scorecard;
+  if (!sc) return null;
+
+  const disp = sc.dispatch_accuracy;
+  const econ = sc.economic_value;
+  const fc = sc.forecast_accuracy;
+  const hasAnything = !!(sc.grade || disp?.n_slots_with_plan || econ?.lp_realised_cost_p != null);
+  if (!hasAnything) return null;
+
+  const avoided = econ?.lp_avoided_cost_p;
+
+  return (
+    <section class="syshealth">
+      <header class="syshealth-head">
+        <h2>System health</h2>
+        <span class="muted">LP scorecard · {sc.day}</span>
+        {sc.grade && <span class={`syshealth-grade syshealth-grade--${sc.grade.toLowerCase()}`}>{sc.grade}</span>}
+      </header>
+
+      <div class="syshealth-grid">
+        {disp && (disp.n_slots_with_plan ?? 0) > 0 && (
+          <div class="syshealth-cell" title={`${disp.n_slots_with_plan} planned / ${disp.n_slots_with_real} realised slots`}>
+            <span class="syshealth-label">Plan followed</span>
+            <span class="syshealth-value">
+              import {pct(disp.import_accuracy_pct)} · export {pct(disp.export_accuracy_pct)} · charge {pct(disp.charge_accuracy_pct)}
+            </span>
+            <span class="syshealth-sub">
+              {disp.import_planned_kwh?.toFixed(1)} → {disp.import_real_kwh?.toFixed(1)} kWh imported
+            </span>
+          </div>
+        )}
+
+        {econ && econ.lp_realised_cost_p != null && (
+          <div class="syshealth-cell" title={econ.comparison_basis ?? undefined}>
+            <span class="syshealth-label">Optimising paid?</span>
+            <span class="syshealth-value">
+              {avoided != null
+                ? (avoided >= 0 ? `saved ${pence(avoided)}` : `cost ${pence(-avoided)} extra`)
+                : "no shadow baseline"}
+            </span>
+            <span class="syshealth-sub">
+              day cost {pence(econ.lp_realised_cost_p)}
+              {econ.naive_self_use_shadow_p != null ? ` · naive self-use ${pence(econ.naive_self_use_shadow_p)}` : ""}
+            </span>
+          </div>
+        )}
+
+        {fc?.available && (
+          <div class="syshealth-cell" title={`${fc.n_hours ?? 0} hours scored (positive bias = over-forecast)`}>
+            <span class="syshealth-label">Forecast skill</span>
+            <span class="syshealth-value">
+              PV MAE {fc.pv_kwh_mae != null ? `${fc.pv_kwh_mae.toFixed(2)} kWh` : "—"}
+              {fc.outdoor_temp_c_mae != null ? ` · temp ${fc.outdoor_temp_c_mae.toFixed(1)}°C` : ""}
+            </span>
+            <span class="syshealth-sub">
+              {fc.load_kwh_mae != null ? `load MAE ${fc.load_kwh_mae.toFixed(2)} kWh` : ""}
+              {fc.pv_kwh_bias != null ? ` · PV bias ${fc.pv_kwh_bias >= 0 ? "+" : ""}${fc.pv_kwh_bias.toFixed(2)}` : ""}
+            </span>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/insights/SystemHealthCard.tsx
+++ b/ui/src/components/insights/SystemHealthCard.tsx
@@ -28,7 +28,10 @@ export function SystemHealthCard() {
   const disp = sc.dispatch_accuracy;
   const econ = sc.economic_value;
   const fc = sc.forecast_accuracy;
-  const hasAnything = !!(sc.grade || disp?.n_slots_with_plan || econ?.lp_realised_cost_p != null);
+  // The backend grades a data-less day "N/A" (a string, never null) — treat
+  // it as no-grade so an empty day renders nothing instead of a hollow card.
+  const grade = sc.grade && sc.grade !== "N/A" ? sc.grade : null;
+  const hasAnything = !!(grade || disp?.n_slots_with_plan || econ?.lp_realised_cost_p != null);
   if (!hasAnything) return null;
 
   const avoided = econ?.lp_avoided_cost_p;
@@ -38,7 +41,7 @@ export function SystemHealthCard() {
       <header class="syshealth-head">
         <h2>System health</h2>
         <span class="muted">LP scorecard · {sc.day}</span>
-        {sc.grade && <span class={`syshealth-grade syshealth-grade--${sc.grade.toLowerCase()}`}>{sc.grade}</span>}
+        {grade && <span class={`syshealth-grade syshealth-grade--${grade.toLowerCase()}`}>{grade}</span>}
       </header>
 
       <div class="syshealth-grid">

--- a/ui/src/components/shell/AlertStrip.tsx
+++ b/ui/src/components/shell/AlertStrip.tsx
@@ -1,0 +1,142 @@
+import { usePoll } from "../../lib/poll";
+import { getStatusAlerts } from "../../lib/endpoints";
+import { cockpitFreshness, cockpitFreshnessAt } from "../../lib/freshness";
+import { Icon } from "../common/Icon";
+import type { StatusAlertsResponse } from "../../lib/types";
+import "./alert-strip.css";
+
+// Anomaly strip mounted between the TopNav and the page body on EVERY route.
+// Design contract: when the system is healthy it renders NOTHING — zero
+// pixels, zero layout shift. Chips only appear for conditions an operator
+// should react to. /status/alerts is TTL-cached server-side (60s, vendor
+// reads behind longer sub-caches), so the 60s client poll is cheap and can
+// never amplify into Fox/Daikin quota.
+//
+// Failure posture: any fetch error (404 on an older hem image, network blip,
+// auth misconfig) renders nothing. The strip is an enhancement — it must
+// never be the thing that breaks the page.
+
+interface Chip {
+  key: string;
+  tone: "bad" | "warn";
+  label: string;
+  detail?: string;
+}
+
+function buildChips(a: StatusAlertsResponse): Chip[] {
+  const chips: Chip[] = [];
+
+  if (a.meter?.stale) {
+    chips.push({
+      key: "meter",
+      tone: "bad",
+      label: a.meter.age_days != null ? `Meter data ${a.meter.age_days}d old` : "Meter data missing",
+      detail: a.meter.last_day
+        ? `Last metered day from Octopus: ${a.meter.last_day}. Bill figures beyond it are Fox-estimated.`
+        : "No Octopus consumption data recorded yet.",
+    });
+  }
+
+  if ((a.lp?.failures_24h ?? 0) > 0) {
+    const lf = a.lp.last_failure;
+    chips.push({
+      key: "lp",
+      tone: "bad",
+      label: `LP solve failed ×${a.lp.failures_24h}`,
+      detail: lf
+        ? `Last: ${lf.error_class ?? "unknown"} at ${lf.run_at_utc ?? "?"} (plan ${lf.plan_date ?? "?"})`
+        : undefined,
+    });
+  }
+
+  const f = a.forecast;
+  if (f?.degraded) {
+    let label = "PV forecast degraded";
+    if (f.sidecar_ok === false) label = "Quartz sidecar down";
+    else if (f.model_name !== "quartz-open-site") label = `PV forecast: ${f.model_name ?? "unknown"} fallback`;
+    else if (f.age_s != null && f.age_s > 7200) label = `PV forecast ${Math.round(f.age_s / 3600)}h old`;
+    chips.push({
+      key: "forecast",
+      tone: "warn",
+      label,
+      detail: `model=${f.model_name ?? "?"} · fetched ${f.fetched_at_utc ?? "?"} · sidecar ${f.sidecar_ok == null ? "n/a" : f.sidecar_ok ? "ok" : "down"}`,
+    });
+  }
+
+  if (a.fox_drift?.in_sync === false) {
+    chips.push({
+      key: "fox-drift",
+      tone: "warn",
+      label: `Fox schedule drift${a.fox_drift.diff_count != null ? ` (${a.fox_drift.diff_count})` : ""}`,
+      detail: "Live inverter schedule differs from the last LP upload — manual app edit or failed upload. Checked every 30 min.",
+    });
+  }
+
+  for (const [name, q] of [["Fox", a.quota?.fox], ["Daikin", a.quota?.daikin]] as const) {
+    if (!q) continue;
+    if (q.blocked) {
+      chips.push({ key: `quota-${name}`, tone: "bad", label: `${name} quota blocked` });
+    } else if (q.used != null && q.budget != null && q.budget > 0 && q.used / q.budget >= 0.9) {
+      chips.push({
+        key: `quota-${name}`,
+        tone: "warn",
+        label: `${name} quota ${q.used}/${q.budget}`,
+        detail: "Over 90% of the daily vendor API budget used.",
+      });
+    }
+  }
+
+  return chips;
+}
+
+/** Staleness chip from the cockpit's own /cockpit/now poll, via the shared
+ *  freshness signal — only meaningful while that poll is actually running
+ *  (i.e. the user is on the cockpit and the map was published recently). */
+function freshnessChip(): Chip | null {
+  const at = cockpitFreshnessAt.value;
+  const map = cockpitFreshness.value;
+  if (!map || at == null || Date.now() - at > 2 * 60_000) return null;
+  const stale = Object.entries(map).filter(([, v]) => v?.stale);
+  if (stale.length === 0) return null;
+  const names = stale.map(([k]) => k).join(", ");
+  return {
+    key: "freshness",
+    tone: "warn",
+    label: `Live data stale: ${names}`,
+    detail: stale
+      .map(([k, v]) => `${k}: ${v.age_s != null ? `${Math.round(v.age_s / 60)}m` : "?"} old`)
+      .join(" · "),
+  };
+}
+
+const DEBUG_CHIPS: Chip[] = [
+  { key: "meter", tone: "bad", label: "Meter data 5d old", detail: "debugAlerts sample" },
+  { key: "lp", tone: "bad", label: "LP solve failed ×2", detail: "debugAlerts sample" },
+  { key: "forecast", tone: "warn", label: "PV forecast: open-meteo fallback", detail: "debugAlerts sample" },
+  { key: "fox-drift", tone: "warn", label: "Fox schedule drift (3)", detail: "debugAlerts sample" },
+];
+
+export function AlertStrip() {
+  const alerts = usePoll(getStatusAlerts, 60_000);
+
+  const debug = typeof location !== "undefined" && location.search.includes("debugAlerts=1");
+  let chips: Chip[] = debug ? DEBUG_CHIPS : [];
+  if (!debug && alerts.data && !alerts.error) {
+    chips = buildChips(alerts.data);
+    const fc = freshnessChip();
+    if (fc) chips.push(fc);
+  }
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div class="alert-strip" role="alert" aria-live="polite">
+      {chips.map((c) => (
+        <span key={c.key} class={`alert-chip alert-chip--${c.tone}`} title={c.detail}>
+          <Icon name="warn" size={12} />
+          {c.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/shell/AlertStrip.tsx
+++ b/ui/src/components/shell/AlertStrip.tsx
@@ -130,7 +130,7 @@ export function AlertStrip() {
   if (chips.length === 0) return null;
 
   return (
-    <div class="alert-strip" role="alert" aria-live="polite">
+    <div class="alert-strip" role="status">
       {chips.map((c) => (
         <span key={c.key} class={`alert-chip alert-chip--${c.tone}`} title={c.detail}>
           <Icon name="warn" size={12} />

--- a/ui/src/components/shell/alert-strip.css
+++ b/ui/src/components/shell/alert-strip.css
@@ -1,0 +1,42 @@
+/* Anomaly strip — renders only when something needs attention, so it can
+ * afford to be loud. Sticky under the topnav on small screens so the alert
+ * survives scrolling on a phone glance. */
+
+.alert-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: var(--bg-card);
+}
+
+.alert-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.alert-chip--bad {
+  color: var(--bad);
+  background: color-mix(in srgb, var(--bad) 14%, transparent);
+}
+
+.alert-chip--warn {
+  color: var(--warn);
+  background: color-mix(in srgb, var(--warn) 14%, transparent);
+}
+
+@media (max-width: 640px) {
+  .alert-strip {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    padding: var(--space-2) var(--space-3);
+  }
+}

--- a/ui/src/components/shell/alert-strip.css
+++ b/ui/src/components/shell/alert-strip.css
@@ -35,8 +35,10 @@
 @media (max-width: 640px) {
   .alert-strip {
     position: sticky;
-    top: 0;
-    z-index: 40;
+    /* Below the sticky topnav, not over it: mobile nav = 40px tap targets +
+     * var(--space-2) padding top/bottom (see shell.css ≤640px block). */
+    top: 56px;
+    z-index: 39;
     padding: var(--space-2) var(--space-3);
   }
 }

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -38,6 +38,10 @@ import type {
   ApplianceSuggestionsResponse,
   ApplianceJobsResponse,
   AppliancesResponse,
+  StatusAlertsResponse,
+  StatusFeedbackResponse,
+  RecentTriggersResponse,
+  LpScorecardResponse,
 } from "./types";
 
 /* ----- Real-time / cockpit ----- */
@@ -69,6 +73,19 @@ export const getDhwSchedule = () => getJson<DhwScheduleResponse>("/daikin/dhw-sc
 // Per-slot heating-plan timeline (D-1/D/D+1): outdoor temp + LWT offset + tank
 // + heating-on, deterministically recomputed. Zero Daikin quota.
 export const getHeatingPlan = () => getJson<HeatingPlanResponse>("/daikin/heating-plan");
+
+/* ----- Ops status (alert strip + self-check, PR 3) -----
+   Both endpoints are server-side TTL-cached (60s / 300s) with sub-caches on
+   anything that costs vendor quota — polling them from every open tab can
+   never amplify into live Fox/Daikin calls. Viewer-readable. */
+
+export const getStatusAlerts = () => getJson<StatusAlertsResponse>("/status/alerts");
+export const getStatusFeedback = () => getJson<StatusFeedbackResponse>("/status/feedback");
+// Admin-only read (middleware admin_read_prefixes) — callers must role-gate.
+export const getRecentTriggers = (limit = 6) =>
+  getJson<RecentTriggersResponse>(`/recent-triggers?limit=${limit}`);
+export const getLpScorecard = (date: string) =>
+  getJson<LpScorecardResponse>(`/lp/scorecard/${encodeURIComponent(date)}`);
 
 /* ----- Daikin controls (writes — require DAIKIN_CONTROL_MODE=active) -----
    The UI shows its own confirm dialog, then sends skip_confirmation:true so

--- a/ui/src/lib/freshness.ts
+++ b/ui/src/lib/freshness.ts
@@ -1,0 +1,21 @@
+// Shared data-freshness signal.
+//
+// Landing already polls /cockpit/now every 20s and that payload carries a
+// per-source freshness map (fox/daikin/agile/...). The AlertStrip lives in
+// the app shell (all routes) and wants the same staleness info — publishing
+// the latest map through a signal lets it read freshness WITHOUT a duplicate
+// /cockpit/now poll. Off the cockpit route the signal simply goes stale/null
+// and the strip skips the staleness chip (no data ≠ alarm).
+import { signal } from "@preact/signals";
+import type { FreshnessEntry } from "./types";
+
+export const cockpitFreshness = signal<Record<string, FreshnessEntry> | null>(null);
+
+// Epoch ms of the last publish — lets readers ignore a map that itself is
+// old (e.g. user navigated away from the cockpit and the poll stopped).
+export const cockpitFreshnessAt = signal<number | null>(null);
+
+export function publishFreshness(map: Record<string, FreshnessEntry> | undefined | null): void {
+  cockpitFreshness.value = map ?? null;
+  cockpitFreshnessAt.value = map ? Date.now() : null;
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -826,3 +826,143 @@ export interface WorkbenchPromoteResult {
   promoted: Array<{ key: string; ok: boolean; value?: unknown; error?: string }>;
   profile_name?: string | null;
 }
+
+/* ----- /status/alerts + /status/feedback — ops health (PR 3, #553) ----- */
+
+export interface StatusMeterBlock {
+  last_day: string | null;
+  age_days: number | null;
+  stale: boolean;
+}
+
+export interface StatusLpBlock {
+  failures_24h: number;
+  last_failure: {
+    run_at_utc?: string | null;
+    error_class?: string | null;
+    plan_date?: string | null;
+  } | null;
+}
+
+export interface StatusForecastBlock {
+  model_name: string | null;
+  source: string | null;
+  fetched_at_utc: string | null;
+  age_s: number | null;
+  sidecar_ok: boolean | null;
+  degraded: boolean;
+}
+
+export interface StatusFoxDriftBlock {
+  checked_at_utc: string;
+  in_sync: boolean | null;   // null = live read failed (unknown, NOT drift)
+  diff_count: number | null;
+  error: string | null;
+}
+
+export interface StatusQuotaEntry {
+  used: number | null;
+  budget: number | null;
+  blocked: boolean;
+}
+
+export interface StatusAlertsResponse {
+  now_utc: string;
+  meter: StatusMeterBlock;
+  lp: StatusLpBlock;
+  forecast: StatusForecastBlock;
+  fox_drift: StatusFoxDriftBlock;
+  quota: { fox: StatusQuotaEntry | null; daikin: StatusQuotaEntry | null };
+}
+
+export interface DhwBudgetState {
+  mode: string;
+  nominal_kwh: number | null;
+  autoscale_factor: number | null;
+  autoscale_enabled: boolean;
+  effective_budget_kwh: number | null;
+  measured_today_kwh: number | null;
+  measured_7d_avg_kwh: number | null;
+}
+
+export interface LwtGateState {
+  preheat_enabled: boolean;
+  gate_enabled: boolean;
+  demand_present: boolean;
+  measured_window_kwh: number | null;
+  threshold_kwh: number;
+  lookback_hours: number;
+  preheat_suppressed: boolean;
+}
+
+export interface StatusFeedbackResponse {
+  now_utc: string;
+  dhw: DhwBudgetState;
+  lwt_gate: LwtGateState;
+  forecast: StatusForecastBlock;
+}
+
+/* ----- /recent-triggers (admin-only read) ----- */
+
+export interface TriggerRow {
+  id: number;
+  timestamp: string;
+  device: string | null;
+  action: string | null;
+  params: string | null;
+  result: string | null;
+  error_msg: string | null;
+  trigger: string | null;
+  slot_kind: string | null;
+  agile_price_at_time: number | null;
+  started_at: string | null;
+  completed_at: string | null;
+  duration_ms: number | null;
+  actor: string | null;
+}
+
+export interface RecentTriggersResponse {
+  rows: TriggerRow[];
+  count: number;
+}
+
+/* ----- /lp/scorecard/{date} ----- */
+
+export interface LpScorecard {
+  day: string;
+  forecast_accuracy: {
+    available?: boolean;
+    n_hours?: number;
+    pv_kwh_mae?: number;
+    pv_kwh_bias?: number;       // positive = over-forecast
+    outdoor_temp_c_mae?: number;
+    outdoor_temp_c_bias?: number;
+    load_kwh_mae?: number;
+    load_kwh_bias?: number;
+  } | null;
+  dispatch_accuracy: {
+    n_slots_with_plan?: number;
+    n_slots_with_real?: number;
+    import_planned_kwh?: number;
+    import_real_kwh?: number;
+    import_accuracy_pct?: number | null;
+    export_planned_kwh?: number;
+    export_real_kwh?: number;
+    export_accuracy_pct?: number | null;
+    charge_planned_kwh?: number;
+    charge_real_kwh?: number;
+    charge_accuracy_pct?: number | null;
+  } | null;
+  economic_value: {
+    lp_realised_cost_p?: number;
+    naive_self_use_shadow_p?: number;
+    lp_avoided_cost_p?: number;    // positive = LP saved money vs naive
+    comparison_basis?: string;
+  } | null;
+  grade: string | null;
+}
+
+export interface LpScorecardResponse {
+  ok: boolean;
+  scorecard: LpScorecard;
+}

--- a/ui/src/routes/insights.css
+++ b/ui/src/routes/insights.css
@@ -131,3 +131,51 @@
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+
+/* ── System health (LP scorecard, PR 3) ──────────────────────────────── */
+.syshealth {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+.syshealth-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.syshealth-head h2 {
+  font-size: var(--font-lg);
+  margin: 0;
+}
+.syshealth-grade {
+  margin-left: auto;
+  padding: 2px 10px;
+  border-radius: var(--radius-pill);
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+.syshealth-grade--a { color: var(--ok); background: color-mix(in srgb, var(--ok) 14%, transparent); }
+.syshealth-grade--b { color: var(--accent); background: color-mix(in srgb, var(--accent) 14%, transparent); }
+.syshealth-grade--c { color: var(--warn); background: color-mix(in srgb, var(--warn) 14%, transparent); }
+.syshealth-grade--d { color: var(--bad); background: color-mix(in srgb, var(--bad) 14%, transparent); }
+.syshealth-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+.syshealth-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.syshealth-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.syshealth-value { font-size: 0.88rem; color: var(--text); }
+.syshealth-sub { font-size: 0.74rem; color: var(--text-dim); }

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -8,6 +8,7 @@ import { gbp, gbpSigned, kwh } from "../lib/format";
 import { makeChart, baseOption, chartTheme, barGradient, withAlpha, type EChartsType } from "../lib/charts";
 import type { FairTariffRow } from "../lib/types";
 import { LoadPatternCard } from "../components/insights/LoadPatternCard";
+import { SystemHealthCard } from "../components/insights/SystemHealthCard";
 import "./insights.css";
 
 const p2 = (p: number) => gbp(p / 100);
@@ -164,6 +165,7 @@ export default function Insights() {
       )}
 
       <LoadPatternCard />
+      <SystemHealthCard />
     </div>
   );
 }

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -141,9 +141,12 @@ export default function Landing() {
 
   // Publish the cockpit's per-source freshness map so the shell-level
   // AlertStrip can flag stale live data WITHOUT its own /cockpit/now poll.
+  // Cleared on unmount — off this route the poll stops, and a frozen map
+  // would let a "stale data" chip linger past its 2-min relevance window.
   useEffect(() => {
     publishFreshness(now.data?.freshness);
   }, [now.data]);
+  useEffect(() => () => publishFreshness(null), []);
 
   if (now.loading && !now.data) {
     return <div class="home"><Spinner label="Loading dashboard…" /></div>;

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -32,6 +32,8 @@ import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
 import { Hero } from "../components/home/Hero";
 import { HeatingWidget } from "../components/home/HeatingWidget";
 import { PlanMini } from "../components/home/PlanMini";
+import { FeedbackPanel } from "../components/home/FeedbackPanel";
+import { publishFreshness } from "../lib/freshness";
 import type { MonthlyEnergy } from "../lib/types";
 import "../components/home/home.css";
 
@@ -136,6 +138,12 @@ export default function Landing() {
     () => getEnergyPeriod(period.gran, periodFetchOpts(period)),
     [period.gran, period.anchor],
   );
+
+  // Publish the cockpit's per-source freshness map so the shell-level
+  // AlertStrip can flag stale live data WITHOUT its own /cockpit/now poll.
+  useEffect(() => {
+    publishFreshness(now.data?.freshness);
+  }, [now.data]);
 
   if (now.loading && !now.data) {
     return <div class="home"><Spinner label="Loading dashboard…" /></div>;
@@ -245,6 +253,12 @@ export default function Landing() {
           </Suspense>
         </Widget>
       </div>
+
+      {/* ── SELF-CHECK — is the system doing what we shipped it to do?
+          Forecast provenance, PV accuracy, DHW budget vs measured, LWT gate;
+          admins also get the recent-actions feed. The panel renders its own
+          widget band — and nothing at all against an older API image. */}
+      <FeedbackPanel pv={pvToday.data} />
     </div>
   );
 }


### PR DESCRIPTION
PR 3/5 of the cockpit ops-console plan (PRs 1-2: #552 #553). Touches BOTH images: UI consumers + the hem-side schedule_diff normalization fix the strip depends on.

## UI

**AlertStrip** (`components/shell/AlertStrip.tsx`, mounted in the app shell on every route)
- Polls `/status/alerts` every 60s (server-side TTL-cached; vendor reads behind longer sub-caches — client count can never amplify into quota).
- **Renders nothing when healthy** — zero pixels, zero layout shift.
- Chips: meter stale (#533), LP solve failures (error_class only), forecast degraded / Quartz sidecar down (#542), Fox schedule drift, Fox/Daikin quota blocked or ≥90%, stale live data.
- Live-data staleness reuses the cockpit's existing `/cockpit/now` poll via a shared signal (`lib/freshness.ts`) — no duplicate poll; off-cockpit the signal ages out and the chip is skipped.
- `?debugAlerts=1` renders sample chips for styling verification.
- Failure posture: any fetch error (404 on an older hem image included) → invisible.

**FeedbackPanel "Self-check"** (cockpit, below the energy band)
- Forecast provenance chip (`Quartz (self-hosted) · 12m ago`), PV accuracy today (MAE/bias from the existing `/pv/today` poll — no second fetch), DHW budget vs measured mini-bar with the auto-scale factor in the tooltip (#534), LWT pre-heat demand-gate chip (#540).
- Owns its whole widget band → older API = no empty card.
- **TriggersFeed** (admin-only mount — `/recent-triggers` is an admin read): last 6 action_log events with ok/error + duration.

**Insights → System health**
- Yesterday's LP scorecard via `GET /lp/scorecard/{date}`: composite grade, plan-followed accuracy (import/export/charge), LP-vs-naive-self-use economics, forecast MAEs. Renders nothing when sparse.

## hem

**Mode-aware `schedule_diff` fingerprint** (`src/api/routers/dispatch.py`)
- First real consumer of the diff (the strip, via `/status/alerts` fox_drift) immediately exposed 16 phantom diffs on identical schedules: Fox echoes vendor defaults for fields the upload omitted (`max_soc` None → 100, stale `fd_*` on Backup/SelfUse groups).
- Fingerprint now compares `fd_soc`/`fd_pwr` **only on ForceDischarge** and canonicalises absent `max_soc` to the vendor default 100 on both sides.
- Regression test uses the real prod shapes captured 2026-06-12 (recorded `to_api_dict` dicts vs live `SchedulerGroup`-style objects) + a counter-case proving a real `fd_soc` change still registers as drift.

## Tests
- `pytest -q`: **1621 passed, 3 skipped, 1 xfailed** (new: `test_schedule_diff_fingerprint_ignores_vendor_default_echo`).
- `ui`: `tsc -b && vite build` clean.

## Verification plan (post-deploy, headless vs the funnel)
- Healthy state → strip absent; `?debugAlerts=1` → chips render.
- Self-check shows quartz-open-site provenance + DHW ~2.0 kWh budget; viewer network log contains NO `/recent-triggers` call.
- `/status/alerts` fox_drift returns `in_sync: true` after the hem image deploy (was 16 phantom diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)