### PR TITLE
feat(ui): visual polish — full-width power flow, today-first hero, plain cache chip, legend scroll, chip grid

### DIFF
--- a/ui/src/components/cockpit/cockpit.css
+++ b/ui/src/components/cockpit/cockpit.css
@@ -6,9 +6,13 @@
   justify-content: center;
   align-items: center;
   padding: var(--space-2) 0;
+  /* Fill the card: as a width-less flex item the svg's circular 100%-of-
+   * shrink-to-fit sizing collapsed it to its replaced-element default
+   * (~300px) — a small chart floating in blank card space on desktop. */
+  width: 100%;
 }
 .powerflow-svg {
   width: 100%;
-  max-width: 560px;
+  max-width: 720px;
   height: auto;
 }

--- a/ui/src/components/cockpit/live-power.css
+++ b/ui/src/components/cockpit/live-power.css
@@ -14,6 +14,9 @@
   min-height: 200px;
   display: flex;
   justify-content: center;
+  /* The flow is the card's centerpiece — let it take the full card width
+   * (the svg scales by its viewBox aspect, so width drives height too). */
+  width: 100%;
 }
 
 /* ── rate read-outs row: Import · Export · (spacer) · battery ─────────── */

--- a/ui/src/components/home/HeatingWidget.tsx
+++ b/ui/src/components/home/HeatingWidget.tsx
@@ -137,14 +137,15 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
     <div class="heating">
       <div class="heating-header">
         {freshLabel && (
-          <span class="heating-freshness" title={`Daikin cache last refreshed ${freshLabel}`}>
-            Cache · {freshLabel}
+          <span class="heating-freshness"
+                title={`These readings come from the heat pump's last automatic refresh (${freshLabel}); the planner re-reads it about every 30 minutes.`}>
+            Data from {freshLabel}
           </span>
         )}
         {quotaBudget != null && (
           <Pill tone={quotaTone === "ok" ? "ok" : quotaTone === "warn" ? "warn" : quotaTone === "bad" ? "bad" : "dim"}
-                title={`Daikin API — ${quotaUsed}/${quotaBudget} calls in the last 24h (Daikin enforces ~200/day, resets midnight UTC)`}>
-            {quotaUsed}/{quotaBudget} · 24h
+                title={`Daikin API — ${quotaUsed} of ${quotaBudget} calls used in the last 24h (Daikin enforces ~200/day, resets midnight UTC). A manual refresh costs 1 call.`}>
+            {quotaUsed}/{quotaBudget} calls
           </Pill>
         )}
         <RefreshCountdown
@@ -153,7 +154,7 @@ export function HeatingWidget({ state, daikin, daikinQuota, report, weather, exe
           loading={refreshing}
           disabled={onCooldown}
           onRefresh={() => setConfirmingRefresh(true)}
-          label={onCooldown ? undefined : "Live"} />
+          label={onCooldown ? undefined : "Refresh · 1 call"} />
       </div>
 
       {/* Heating-plan timeline — the hero of this card (redesign). */}

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -1,5 +1,5 @@
 import type {
-  MetricsResponse, CockpitNow, AgileTodayResponse, MonthlyEnergy,
+  MetricsResponse, CockpitNow, AgileTodayResponse,
   PeriodInsightsResponse, TodayCumulativeResponse, WeatherResponse, PvTodayResponse,
 } from "../../lib/types";
 import { gbp, kwh } from "../../lib/format";
@@ -14,7 +14,6 @@ interface HeroProps {
   metricsLoading: boolean;
   cockpit: CockpitNow | null;
   agile: AgileTodayResponse | null;
-  monthly: MonthlyEnergy[];
   period: PeriodInsightsResponse | null;
   periodState: PeriodState;
   periodLoading: boolean;
@@ -24,10 +23,11 @@ interface HeroProps {
 }
 
 // The redesign hero (Claude Design handoff): the period's net bill + an
-// Agile-vs-fixed verdict + cost bars on the LEFT, the live weather panel on the
-// RIGHT, a lifetime strip below. Money figures follow the period navigator; the
-// today-only extras (break-even target, money paid in) show only on "today".
-export function Hero({ metrics, monthly, period, periodState, periodLoading, todayCum, weather, pv }: HeroProps) {
+// Agile-vs-fixed verdict + cost bars on the LEFT, the live weather panel on
+// the RIGHT. Money figures follow the period navigator; the today-only extras
+// (break-even target, money paid in) show only on "today". The lifetime strip
+// moved to the foot of the cockpit (LifetimeStrip) — the hero is today-first.
+export function Hero({ metrics, period, periodState, periodLoading, todayCum, weather, pv }: HeroProps) {
   const isNow = isCurrentPeriod(periodState);
   const label = periodLabel(periodState);
   const fixedLabel = todayCum?.fixed_tariff_label || metrics?.fixed_tariff?.label || "British Gas Fixed";
@@ -60,15 +60,6 @@ export function Hero({ metrics, monthly, period, periodState, periodLoading, tod
   const negCredit = isNow ? todayCum?.negative_import_credit_gbp ?? null : null;
   const exportRev = isNow ? todayCum?.export_revenue_gbp ?? null : null;
   const showEarnings = (earnings ?? 0) > 0.005;
-
-  // --- Lifetime totals on Agile. ---
-  const active = monthly.filter((m) => (m.cost?.net_cost_pounds ?? 0) !== 0 || (m.energy?.export_kwh ?? 0) > 0);
-  const lifetime = active.length > 0 ? {
-    months: active.length,
-    solar_kwh: active.reduce((s, m) => s + (m.energy?.solar_kwh ?? 0), 0),
-    export_kwh: active.reduce((s, m) => s + (m.energy?.export_kwh ?? 0), 0),
-    saved_vs_fixed: active.reduce((s, m) => s + (m.cost?.delta_vs_fixed_real_pounds ?? 0), 0),
-  } : null;
 
   const billA = useAnimatedNumber(bill);
   const max = Math.max(bill ?? 0, fixedShadow ?? 0) * 1.12 || 1;
@@ -157,18 +148,6 @@ export function Hero({ metrics, monthly, period, periodState, periodLoading, tod
         {/* ── RIGHT: live weather ───────────────────────────────────── */}
         <div class="hero-right"><HeroWeather weather={weather} pv={pv} /></div>
       </div>
-
-      {/* ── lifetime strip ──────────────────────────────────────────── */}
-      {lifetime && (
-        <div class="lifetime" title={`Sums across ${lifetime.months} active months on Agile`}>
-          <div class="stat"><div class="stat-v">{kwh(lifetime.solar_kwh, 0)}</div><div class="stat-l">Solar produced · {lifetime.months} mo</div></div>
-          <div class="stat"><div class="stat-v">{kwh(lifetime.export_kwh, 0)}</div><div class="stat-l">Exported</div></div>
-          <div class="stat">
-            <div class={`stat-v ${lifetime.saved_vs_fixed >= 0 ? "pos" : "neg"}`}>{gbp(Math.abs(lifetime.saved_vs_fixed))}</div>
-            <div class="stat-l">{lifetime.saved_vs_fixed >= 0 ? "Saved vs fixed" : "Extra vs fixed"}</div>
-          </div>
-        </div>
-      )}
     </section>
   );
 }
@@ -203,23 +182,6 @@ function HeroWeather({ weather, pv }: { weather?: WeatherResponse | null; pv?: P
   const lo = temps.length ? Math.min(...temps) : null;
   const markPct = hi != null && lo != null && hi > lo
     ? Math.max(6, Math.min(94, ((outdoor - lo) / (hi - lo)) * 100)) : 50;
-
-  // Daily forecast (up to 4 days) from the hourly slots.
-  const byDay = new Map<string, { temps: number[]; clouds: number[]; date: Date }>();
-  for (const s of fc) {
-    const d = new Date(s.time);
-    const k = d.toDateString();
-    if (!byDay.has(k)) byDay.set(k, { temps: [], clouds: [], date: d });
-    const e = byDay.get(k)!;
-    e.temps.push(s.temp_c);
-    if (s.cloud_cover_pct != null) e.clouds.push(s.cloud_cover_pct);
-  }
-  const days = [...byDay.values()].slice(0, 4).map((e, i) => ({
-    label: i === 0 ? "Today" : e.date.toLocaleDateString([], { weekday: "short" }),
-    hi: Math.round(Math.max(...e.temps)),
-    lo: Math.round(Math.min(...e.temps)),
-    cond: condOf(e.clouds.length ? e.clouds.reduce((a, b) => a + b, 0) / e.clouds.length : null),
-  }));
 
   // Solar today: generated so far (actual) toward the DAY total (locked actuals
   // for elapsed slots + forecast for the rest). Using the day total — not the
@@ -262,18 +224,6 @@ function HeroWeather({ weather, pv }: { weather?: WeatherResponse | null; pv?: P
             <span class="dim small">today's range</span>
             <span class="t-hi">H {Math.round(hi)}°</span>
           </div>
-        </div>
-      )}
-
-      {days.length > 1 && (
-        <div class="forecast" style={{ gridTemplateColumns: `repeat(${days.length}, 1fr)` }}>
-          {days.map((f) => (
-            <div class="fc-day" key={f.label}>
-              <span class="fc-d">{f.label}</span>
-              <WxIcon cond={f.cond} size={22} />
-              <div class="fc-hl"><span class="fc-hi">{f.hi}°</span><span class="fc-lo">{f.lo}°</span></div>
-            </div>
-          ))}
         </div>
       )}
 

--- a/ui/src/components/home/LifetimeStrip.tsx
+++ b/ui/src/components/home/LifetimeStrip.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "preact/hooks";
+import { useAfterPaint } from "../../lib/poll";
+import { getEnergyMonthly } from "../../lib/endpoints";
+import { gbp, kwh } from "../../lib/format";
+import type { MonthlyEnergy } from "../../lib/types";
+import "./hero.css";
+
+// Lifetime-on-Agile totals (solar produced, exported, saved vs fixed).
+// Lived in the Hero until the today-first pass — as a closing line at the
+// foot of the cockpit it keeps the story without competing with today's
+// bill, and its 6 /energy/monthly fetches stay off the critical path
+// (self-deferred until the browser is idle after first paint).
+
+function lastMonths(n: number): string[] {
+  const now = new Date();
+  const out: string[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    out.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
+  }
+  return out;
+}
+
+export function LifetimeStrip() {
+  const deferred = useAfterPaint();
+  const [monthly, setMonthly] = useState<MonthlyEnergy[]>([]);
+  useEffect(() => {
+    if (!deferred) return;
+    let alive = true;
+    Promise.all(lastMonths(6).map((m) => getEnergyMonthly(m).catch(() => null))).then((r) => {
+      if (alive) setMonthly(r.filter((x): x is MonthlyEnergy => !!x));
+    });
+    return () => { alive = false; };
+  }, [deferred]);
+
+  const active = monthly.filter((m) => (m.cost?.net_cost_pounds ?? 0) !== 0 || (m.energy?.export_kwh ?? 0) > 0);
+  if (active.length === 0) return null;
+  const lifetime = {
+    months: active.length,
+    solar_kwh: active.reduce((s, m) => s + (m.energy?.solar_kwh ?? 0), 0),
+    export_kwh: active.reduce((s, m) => s + (m.energy?.export_kwh ?? 0), 0),
+    saved_vs_fixed: active.reduce((s, m) => s + (m.cost?.delta_vs_fixed_real_pounds ?? 0), 0),
+  };
+
+  return (
+    <div class="lifetime" title={`Sums across ${lifetime.months} active months on Agile`}>
+      <div class="stat"><div class="stat-v">{kwh(lifetime.solar_kwh, 0)}</div><div class="stat-l">Solar produced · {lifetime.months} mo</div></div>
+      <div class="stat"><div class="stat-v">{kwh(lifetime.export_kwh, 0)}</div><div class="stat-l">Exported</div></div>
+      <div class="stat">
+        <div class={`stat-v ${lifetime.saved_vs_fixed >= 0 ? "pos" : "neg"}`}>{gbp(Math.abs(lifetime.saved_vs_fixed))}</div>
+        <div class="stat-l">{lifetime.saved_vs_fixed >= 0 ? "Saved vs fixed" : "Extra vs fixed"}</div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/home/heating-plan.css
+++ b/ui/src/components/home/heating-plan.css
@@ -34,6 +34,18 @@
   color: var(--text-dim);
   padding: 2px 4px 0;
 }
+@media (max-width: 640px) {
+  /* One scrollable row instead of a 3-line wrap that pushes the gauges down. */
+  .hpl-legend {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 4px;
+  }
+  .hpl-legend::-webkit-scrollbar { display: none; }
+  .hpl-legend .hpl-tok, .hpl-legend .hpl-hint { flex: none; white-space: nowrap; }
+}
 .hpl-tok {
   display: inline-flex;
   align-items: center;

--- a/ui/src/components/home/hero.css
+++ b/ui/src/components/home/hero.css
@@ -1,6 +1,6 @@
 /* Hero — redesign (Claude Design handoff): the period's net bill + Agile-vs-fixed
- * verdict + cost bars on the left, the live weather panel on the right, a
- * lifetime strip below. Surface tokens come from tokens.css; this is layout. */
+ * verdict + cost bars on the left, the live weather panel on the right.
+ * Surface tokens come from tokens.css; this is layout. */
 
 .hero {
   position: relative;
@@ -67,7 +67,7 @@
 .hero-note-pair { white-space: nowrap; }
 .hero-note-pair svg { display: inline-block; vertical-align: -1px; }
 
-/* ── lifetime strip ─────────────────────────────────────────────────── */
+/* ── lifetime strip (LifetimeStrip.tsx — cockpit foot, today-first pass) ── */
 .lifetime { display: flex; gap: var(--space-5); flex-wrap: wrap; padding-top: var(--space-4); margin-top: var(--space-4); border-top: 1px dashed var(--border); position: relative; }
 .lifetime .stat-v { font-size: var(--font-md); }
 
@@ -84,13 +84,6 @@
 .thermo-row { display: flex; justify-content: space-between; align-items: baseline; margin-top: 6px; font-size: var(--font-xs); }
 .t-lo { color: var(--grid); font-weight: 700; font-variant-numeric: tabular-nums; }
 .t-hi { color: var(--import); font-weight: 700; font-variant-numeric: tabular-nums; }
-
-.forecast { display: grid; gap: var(--space-2); }
-.fc-day { display: flex; flex-direction: column; align-items: center; gap: 5px; padding: var(--space-2) 0; border-radius: var(--radius-sm); background: var(--bg-card-2); }
-.fc-d { font-size: var(--font-2xs); text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; color: var(--text-mute); }
-.fc-hl { font-size: var(--font-xs); font-variant-numeric: tabular-nums; display: flex; gap: 6px; }
-.fc-hi { color: var(--import); font-weight: 700; }
-.fc-lo { color: var(--grid); }
 
 .solar-prog { margin-top: auto; }
 .solar-prog-head { margin-bottom: 6px; }

--- a/ui/src/components/home/plan-mini.css
+++ b/ui/src/components/home/plan-mini.css
@@ -47,10 +47,11 @@
   grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
   gap: var(--space-2);
 }
+/* block, not flex: text-overflow only ellipsizes the inline content of a
+ * block container — on a flex container it's a no-op and long chips would
+ * hard-clip mid-glyph. All chip children are inline, so block works. */
 .chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  display: block;
   font-size: var(--font-xs);
   padding: 4px 9px;
   border-radius: var(--radius-sm);
@@ -64,4 +65,11 @@
 .chip .when { color: var(--text-mute); font-variant-numeric: tabular-nums; }
 .chip .note { color: var(--text-mute); font-variant-numeric: tabular-nums; }
 .chip--faded { opacity: 0.72; }
-.cdot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.cdot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: 1px;
+}

--- a/ui/src/components/home/plan-mini.css
+++ b/ui/src/components/home/plan-mini.css
@@ -39,7 +39,14 @@
   font-style: italic;
 }
 
-.chips { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+/* Equal-width chip grid: ragged flex rows made the dispatch plan read as
+ * noise — a grid ranks the chips into tidy columns and truncates long labels
+ * (full text stays in the title tooltip). */
+.chips {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: var(--space-2);
+}
 .chip {
   display: inline-flex;
   align-items: center;
@@ -49,6 +56,9 @@
   border-radius: var(--radius-sm);
   background: var(--bg-card-2);
   white-space: nowrap;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .chip b { font-variant-numeric: tabular-nums; }
 .chip .when { color: var(--text-mute); font-variant-numeric: tabular-nums; }

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect } from "preact/hooks";
 import { lazy, Suspense } from "preact/compat";
 import { usePoll, useFetch, useAfterPaint } from "../lib/poll";
 import {
@@ -9,7 +9,6 @@ import {
   getSchedulerTimeline,
   getExecutionToday,
   getEnergyReport,
-  getEnergyMonthly,
   getEnergyPeriod,
   getDaikinStatus,
   getDaikinQuota,
@@ -34,9 +33,9 @@ import { HeatingWidget } from "../components/home/HeatingWidget";
 import { PlanMini } from "../components/home/PlanMini";
 import { FeedbackPanel } from "../components/home/FeedbackPanel";
 import { OperateCard } from "../components/home/OperateCard";
+import { LifetimeStrip } from "../components/home/LifetimeStrip";
 import { publishFreshness } from "../lib/freshness";
 import { role } from "../lib/auth";
-import type { MonthlyEnergy } from "../lib/types";
 import "../components/home/home.css";
 
 // The four timeline widgets (Solar / Grid / Load / Heating) each own echarts
@@ -58,33 +57,6 @@ const EnergyChartWidget = lazy(() =>
 const HeatingPlanWidget = lazy(() =>
   import("../components/home/HeatingPlanWidget").then((m) => ({ default: m.HeatingPlanWidget })),
 );
-
-function lastMonths(n: number): string[] {
-  const now = new Date();
-  const out: string[] = [];
-  for (let i = n - 1; i >= 0; i--) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    out.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
-  }
-  return out;
-}
-
-function useMonthlyHistory(n: number, enabled = true) {
-  const [data, setData] = useState<MonthlyEnergy[]>([]);
-  const [loading, setLoading] = useState(true);
-  useEffect(() => {
-    if (!enabled) return;
-    let alive = true;
-    setLoading(true);
-    Promise.all(lastMonths(n).map((m) => getEnergyMonthly(m).catch(() => null))).then((r) => {
-      if (!alive) return;
-      setData(r.filter((x): x is MonthlyEnergy => !!x));
-      setLoading(false);
-    });
-    return () => { alive = false; };
-  }, [n, enabled]);
-  return { data, loading };
-}
 
 // Home dashboard, grouped into three semantic bands so the eye can skim:
 //   1. LIVE   — what's happening right now (Live power, Heating)
@@ -112,9 +84,6 @@ export default function Landing() {
   const weather = useFetch(getWeather, []);
   const execution = useFetch(getExecutionToday, []);
   const report = useFetch(() => getEnergyReport(new Date().toISOString().slice(0, 10)), []);
-  // Lifetime rollup = 6 sequential /energy/monthly calls — deferred (it's a
-  // small stats strip low in the hero, not the headline).
-  const monthly = useMonthlyHistory(6, deferred);
   // Export opportunity (SEG-vs-Agile money left on the table) — deferred, slow.
   const exportOppy = useFetch(() => (deferred ? getExportOpportunity(60) : Promise.resolve(null)), [deferred]);
   // Daikin cached read — no refresh=true, so no live cloud call (30-min cache TTL).
@@ -187,7 +156,7 @@ export default function Landing() {
         {scope.date && <span class="scope-when">{scope.date}</span>}
       </div>
 
-      <Hero metrics={metrics.data} metricsLoading={metrics.loading} cockpit={data} agile={agile.data} monthly={monthly.data}
+      <Hero metrics={metrics.data} metricsLoading={metrics.loading} cockpit={data} agile={agile.data}
             period={periodInsights.data} periodState={period}
             periodLoading={periodInsights.loading} todayCum={todayCum.data}
             weather={weather.data} pv={pvToday.data} />
@@ -279,6 +248,10 @@ export default function Landing() {
           admins also get the recent-actions feed. The panel renders its own
           widget band — and nothing at all against an older API image. */}
       <FeedbackPanel pv={pvToday.data} />
+
+      {/* Lifetime-on-Agile closing line (moved out of the hero — today-first).
+          Self-defers its 6 monthly fetches until the browser is idle. */}
+      <LifetimeStrip />
     </div>
   );
 }


### PR DESCRIPTION
PR 5/5 of the cockpit ops-console plan (stacked on #555 → #554; will retarget as the stack merges). UI image only.

## Live power widget (user-reported)
The motion chart (solar/grid/battery/house) rendered small with a large blank area on desktop: `.powerflow` was a width-less flex item, so the svg's `width:100%` resolved against shrink-to-fit and collapsed to the replaced-element default (~300px). It now fills the card (`width:100%`, svg max 720px) — the flow scales with the half-width card and the blank space is gone.

## Today-first hero
- Lifetime strip moved out of the hero to a `LifetimeStrip` at the cockpit foot; it self-defers its 6 `/energy/monthly` fetches until the browser is idle.
- `HeroWeather` drops the 4-day forecast row (duplicated the Outdoor gauge): now + condition + today's range + solar progress.

## Plain-language cache chip (Live heating)
`Cache · 53m ago` → `Data from 53m ago`; quota pill reads `12/180 calls`; the refresh action is labelled `Refresh · 1 call`. Detail stays in tooltips.

## Smaller fixes
- Live-heating legend: one scrollable row on ≤640px (was a 3-line wrap pushing the gauges down).
- Dispatch chips (`PlanMini`): equal-width grid `minmax(112px,1fr)` with truncation + tooltip.

## Tests
`tsc -b && vite build` clean. No backend changes.

## Verification plan (post-deploy, headless)
- 1280×800: PowerFlow fills the Live power card (node field ≥ ~550px wide), no blank band.
- 375×812: legend is one row; hero has no lifetime strip; LifetimeStrip renders at the foot.
- gstack-design-review pass before/after at both widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)