### PR TITLE
perf(ui+api): nginx viewer micro-cache (Camada 3) + lifetime cache prime

### DIFF
--- a/docs/COCKPIT_PERF.md
+++ b/docs/COCKPIT_PERF.md
@@ -89,16 +89,32 @@ burst can still double-compute; the TTL is the cheap win. If a handler ever
 costs a *live vendor call*, use the single-flight `_cached_async` pattern in
 `src/api/routers/status.py` instead, so client count can't amplify into quota.
 
+## Camada 3 — nginx viewer micro-cache (PR #558, done)
+
+`hem-ui` nginx now `proxy_cache`s viewer GET `/api/v1/*` for 10 s
+(`ui/conf/api-cache.conf.template` http-context zone + the `/api/` location
+policy). N open tabs / aggressive polls collapse to **one hem hit per window**.
+Correctness guarantees worth remembering before you touch it:
+
+- **Admin never cached, either direction.** Admin requests carry
+  `Authorization: Bearer` → `proxy_cache_bypass` + `proxy_no_cache
+  $http_authorization` (never served from cache, never stored).
+- **Admin data can't leak to viewers.** A viewer (no token) hitting an
+  `admin_read_prefixes` path gets a **401** from `ApiV1RoleAuth`, and
+  `proxy_cache_valid 200 10s` caches **only 200s** — so a forbidden response
+  never enters the cache. (If you ever make a viewer-forbidden path return
+  200-with-error-body, this breaks — keep them 401.)
+- **GET/HEAD only** (writes are POST → never cached). `proxy_cache_lock on` =
+  single-flight so a cold-cache burst is one fill. Upstream `Cache-Control`
+  is ignored on this shared edge (uniform 10 s TTL governs the anonymous,
+  identical viewer responses). `X-Cache-Status` header exposes HIT/MISS/BYPASS.
+
+Also shipped with it: `_prime_lifetime_cache` warms `_lifetime_cache` ~5 s after
+boot (delayed, guarded, quota-neutral) so the first post-restart visitor skips
+the ~14 s cold rollup.
+
 ## What's left (ranked by leverage)
 
-- **Camada 3 — nginx micro-cache for viewer GETs.** `hem-ui` nginx currently
-  does gzip + static `expires` but does **not** `proxy_cache` the API. A short
-  (5–15 s) `proxy_cache` on `/api/v1/*`, **keyed to bypass when an
-  `Authorization` header is present** (admin never cached) and respecting the
-  per-endpoint `Cache-Control` (`_CACHE_CONTROL_MAX_AGE` in `main.py`), would
-  collapse N tabs/clients to one backend hit per window — the real protection
-  against "many open dashboards" on the small box. Costs a few MB in the 64 MB
-  nginx container.
 - **Camada 4 — reduce first-paint fan-out.** ~30 requests, ~12 hitting hem at
   t=0. Push more below-the-fold fetches behind `useAfterPaint` + idle, and/or
   add a single `/cockpit/bootstrap` aggregate the server assembles from warm

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -190,6 +190,11 @@ _mcp_instance = build_mcp()
 _mcp_http_app = _mcp_instance.streamable_http_app()
 
 
+# Strong refs to fire-and-forget background tasks so the loop doesn't GC them
+# mid-flight (asyncio only holds a weak ref).
+_background_tasks: set = set()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _bootstrap_openclaw_token()
@@ -224,6 +229,14 @@ async def lifespan(app: FastAPI):
         await asyncio.to_thread(appliance_dispatch.rehydrate_crons)
     except Exception:
         logger.warning("appliance rehydrate_crons failed at startup", exc_info=True)
+    # Warm the lifetime rollup in the background, OFF the boot-critical path —
+    # the strip is deferred + below the fold, but priming spares the first
+    # post-restart visitor the ~14 s cold compute. Fire-and-forget + fully
+    # guarded: a failure here can never affect startup. Quota-neutral (it does
+    # the same Fox month reads the first visitor would otherwise trigger).
+    _prime = asyncio.create_task(_prime_lifetime_cache())
+    _background_tasks.add(_prime)
+    _prime.add_done_callback(_background_tasks.discard)
     async with _mcp_instance.session_manager.run():
         yield
     try:
@@ -2950,6 +2963,28 @@ async def energy_lifetime(months: int = 6):
     if ttl > 0:
         _lifetime_cache[key] = (now, out)
     return out
+
+
+async def _prime_lifetime_cache() -> None:
+    """Background warm of ``_lifetime_cache`` for the default 6-month window.
+
+    Best-effort and delayed so it can't contend with the boot-critical Fox/
+    Daikin recovery. Skips silently when Fox isn't configured; per-month errors
+    are swallowed inside ``_compute_lifetime``."""
+    try:
+        await asyncio.sleep(float(getattr(config, "LIFETIME_PRIME_DELAY_SECONDS", 5)))
+        if not _foxess_configured():
+            return
+        import time as _t
+        from zoneinfo import ZoneInfo
+
+        today = datetime.now(ZoneInfo(config.BULLETPROOF_TIMEZONE)).date()
+        n = 6
+        out = await asyncio.to_thread(_compute_lifetime, n, today)
+        _lifetime_cache[(n, today.isoformat())] = (_t.monotonic(), out)
+        logger.info("lifetime cache primed: %s", out)
+    except Exception:  # pragma: no cover - best-effort warm; never fatal
+        logger.debug("lifetime cache prime skipped", exc_info=True)
 
 
 # In-process TTL cache for day/week period insights (Fox ESS HTTP). Month already

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -51,8 +51,11 @@ RUN apk add --no-cache gettext
 # Built SPA → nginx html root
 COPY --from=build /app/dist/  /usr/share/nginx/html/
 
-# nginx config — single template; entrypoint envsubsts HEM_API_URL into it
-COPY conf/nginx.conf.template  /etc/nginx/templates/default.conf.template
+# nginx config — entrypoint envsubsts ${HEM_API_URL} into the server template.
+# api-cache.conf.template carries the http-context proxy_cache_path (no vars);
+# both land in /etc/nginx/conf.d/ via the official envsubst-on-templates step.
+COPY conf/nginx.conf.template     /etc/nginx/templates/default.conf.template
+COPY conf/api-cache.conf.template /etc/nginx/templates/api-cache.conf.template
 
 # Runtime config — entrypoint writes /usr/share/nginx/html/config.js with
 # the bearer token + API base so the SPA can read window.__HEM_CONFIG__.

--- a/ui/conf/api-cache.conf.template
+++ b/ui/conf/api-cache.conf.template
@@ -1,0 +1,21 @@
+# HTTP-context directive for the API micro-cache (Camada 3, 2026-06-13 perf).
+#
+# Lives in its own template because proxy_cache_path is only valid in the
+# http{} context — conf.d/*.conf files are included there, so this loads as a
+# bare http-level directive (envsubst leaves it untouched: no ${VARS} here).
+#
+# Purpose: collapse repeated VIEWER GET /api/v1/* requests (no Authorization
+# header) to ONE hem hit per short window. The single hem process serialises
+# synchronous compute, so N open tabs / aggressive polls otherwise multiply
+# into N backend hits; this caps that at the edge regardless of client count.
+# The actual caching policy (auth bypass, 10s TTL, single-flight) lives in the
+# /api/ location block in default.conf.template.
+#
+# /var/cache/nginx is writable (hem-ui runs read_only:false). 4 MB keys_zone
+# holds ~32k entries — far more than the handful of distinct viewer GETs.
+proxy_cache_path /var/cache/nginx/api
+    levels=1:2
+    keys_zone=api_cache:4m
+    max_size=24m
+    inactive=30s
+    use_temp_path=off;

--- a/ui/conf/nginx.conf.template
+++ b/ui/conf/nginx.conf.template
@@ -56,6 +56,31 @@ server {
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
         proxy_read_timeout 60s;
+
+        # ── Viewer micro-cache (Camada 3) ──────────────────────────────────
+        # Collapse repeated no-auth GETs to one hem hit per 10s window so open
+        # tabs / polls can't multiply load on the single-process backend. Only
+        # GET/HEAD are cacheable (writes are POST → never cached). ADMIN
+        # requests carry an Authorization header → fully bypassed (never served
+        # from cache, never stored), so writes and per-admin reads stay live.
+        proxy_cache            api_cache;
+        proxy_cache_methods    GET HEAD;
+        proxy_cache_key        "$request_method$request_uri";
+        proxy_cache_valid      200 10s;
+        proxy_cache_bypass     $http_authorization;
+        proxy_no_cache         $http_authorization;
+        # The backend marks cockpit reads `Cache-Control: private` (a per-user
+        # browser hint) with varying max-ages; for this shared edge we want a
+        # uniform short TTL on the public viewer responses, so ignore the
+        # upstream caching hints and let proxy_cache_valid govern. Mutating
+        # routes are POST and excluded above, so this can't cache a write.
+        proxy_ignore_headers   Cache-Control Expires Set-Cookie Vary;
+        # Single-flight: on a cold/expired key ONE request fills the cache and
+        # concurrent identical ones wait for it — a first-load burst becomes one
+        # backend hit, not N. Backend is now <150ms so holders never stall.
+        proxy_cache_lock       on;
+        proxy_cache_use_stale  updating error timeout;
+        add_header             X-Cache-Status $upstream_cache_status always;
     }
 
     # Static assets — long cache since SPA filenames are versioned by the CI


### PR DESCRIPTION
Follow-ups to #557 (Camada 1+2). Both protect the single-process `hem` on the small CAX11 from request multiplication, per the cockpit-perf plan. Two images.

## Camada 3 — nginx viewer micro-cache (ui)

`hem-ui`'s nginx did gzip + static `expires` but **never cached the API**. Now `/api/v1/*` viewer GETs are `proxy_cache`d for 10s, so N open tabs / aggressive polls collapse to **one hem hit per window** instead of multiplying load on the serialising backend.

- New `conf/api-cache.conf.template` → http-context `proxy_cache_path` (4 MB keys zone, 24 MB on the writable rootfs; `read_only:false` on hem-ui).
- `/api/` location: `proxy_cache_valid 200 10s`, **`proxy_cache_bypass`/`proxy_no_cache` on `$http_authorization`** so ADMIN (token) requests are fully bypassed — never served from cache, never stored → writes and per-admin reads stay live. GET/HEAD only (writes are POST → never cached).
- `proxy_cache_lock on` = single-flight: even a cold-cache first-load burst is one backend fill, the rest wait/serve-stale.
- Ignores upstream `Cache-Control` on this shared edge (the backend marks reads `private` with varying max-ages; we want a uniform short shared TTL on public viewer responses). Mutating routes are POST and excluded, so this can't cache a write.
- `add_header X-Cache-Status` for verification. Validated with `nginx -t` (envsubst renders both templates into `conf.d/`).

## Lifetime cache prime (hem)

Background, delayed, fully-guarded warm of `_lifetime_cache` on startup so the first post-restart visitor doesn't eat the ~14s cold rollup (PR #557 left it cold-on-restart).

- `_prime_lifetime_cache` via a tracked `create_task`, **off the boot-critical path** (5s delay, `LIFETIME_PRIME_DELAY_SECONDS`), skips if Fox unconfigured, swallows per-month errors.
- **Quota-neutral**: it does the same Fox month reads the first visitor would otherwise trigger — just eagerly.
- A failure can never affect startup; `_background_tasks` holds a strong ref so the loop can't GC the task mid-flight.

## Safety (small-box concern)

Both **reduce** backend hits. The micro-cache only ever serves no-auth GETs; admin and all writes bypass it entirely. The prime is fire-and-forget and quota-neutral. Nothing touches the dispatch loop, scheduler, or other containers.

## Tests
- Full suite **1626 passed**; `nginx -t` syntax OK; UI `tsc -b && vite build` clean.

## Verification plan (post-deploy)
- `curl -sI .../api/v1/cockpit/now` twice → `X-Cache-Status: MISS` then `HIT`.
- With an admin token → always `BYPASS`.
- `docker stats hem` during a multi-tab refresh: backend hit-rate flat regardless of tab count.
- hem logs show `lifetime cache primed` ~5s after restart; first cockpit visit gets the strip instantly.

Camada 4 (fan-out / `/cockpit/bootstrap`) + 5 (bundle) remain — `docs/COCKPIT_PERF.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)