### PR TITLE
fix(fox): unwedge Fox V3 uploads — mode-aware drift comparators + bridge no-overlap

### DIFF
--- a/src/api/routers/dispatch.py
+++ b/src/api/routers/dispatch.py
@@ -283,7 +283,9 @@ async def get_foxess_schedule_diff() -> dict[str, Any]:
     # vendor default 100.
     def _fp(g: dict[str, Any]) -> tuple:
         mode = g.get("work_mode")
-        fd_relevant = mode == "ForceDischarge"
+        # fdSoc/fdPwr are used by ForceCharge AND ForceDischarge — #554 only
+        # kept ForceDischarge, which would miss a real ForceCharge target change.
+        fd_relevant = mode in ("ForceCharge", "ForceDischarge")
         max_soc = g.get("max_soc")
         return (
             g.get("start"), g.get("end"), mode,

--- a/src/foxess/models.py
+++ b/src/foxess/models.py
@@ -12,13 +12,17 @@ def _group_fingerprint(
     start_hour: int, start_minute: int, end_hour: int, end_minute: int,
     work_mode: str | None, min_soc_on_grid: Any,
     fd_soc: Any, fd_pwr: Any, max_soc: Any,
-    import_limit: Any = None, export_limit: Any = None,
 ) -> tuple:
     """Canonical, mode-aware fingerprint of one Scheduler V3 group.
 
     Shared by ``SchedulerGroup.fingerprint`` and the heartbeat drift check so
     both agree with the inverter's echo. See ``SchedulerGroup.fingerprint`` for
     the why (2026-06-14 ~41 h Fox-upload wedge; vendor-echo class of #554).
+
+    Deliberately EXCLUDES import/export limits: the LP/heuristic never sets them
+    (always None), so they'd only ever carry a vendor echo on read-back — the
+    exact phantom-drift class this fixes. The proven #554 comparator excludes
+    them too. If they ever become LP-driven, canonicalise them here first.
     """
     def _f(v: Any) -> float | None:
         return None if v is None else float(v)
@@ -31,8 +35,6 @@ def _group_fingerprint(
         _f(fd_pwr) if fd_relevant else None,
         # Absent maxSoc == the vendor default 100 (Fox fills it on read-back).
         100.0 if max_soc is None else _f(max_soc),
-        _f(import_limit),
-        _f(export_limit),
     )
 
 
@@ -126,7 +128,7 @@ class SchedulerGroup:
         return _group_fingerprint(
             self.start_hour, self.start_minute, self.end_hour, self.end_minute,
             self.work_mode, self.min_soc_on_grid, self.fd_soc, self.fd_pwr,
-            self.max_soc, self.import_limit, self.export_limit,
+            self.max_soc,
         )
 
 

--- a/src/foxess/models.py
+++ b/src/foxess/models.py
@@ -2,6 +2,39 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+# Modes that actually use fdSoc/fdPwr. On every other mode the inverter still
+# ECHOES whatever fd_* last occupied that clock window — stale leftovers that
+# must be ignored when comparing a live read against what we uploaded.
+_FD_MODES = ("ForceCharge", "ForceDischarge")
+
+
+def _group_fingerprint(
+    start_hour: int, start_minute: int, end_hour: int, end_minute: int,
+    work_mode: str | None, min_soc_on_grid: Any,
+    fd_soc: Any, fd_pwr: Any, max_soc: Any,
+    import_limit: Any = None, export_limit: Any = None,
+) -> tuple:
+    """Canonical, mode-aware fingerprint of one Scheduler V3 group.
+
+    Shared by ``SchedulerGroup.fingerprint`` and the heartbeat drift check so
+    both agree with the inverter's echo. See ``SchedulerGroup.fingerprint`` for
+    the why (2026-06-14 ~41 h Fox-upload wedge; vendor-echo class of #554).
+    """
+    def _f(v: Any) -> float | None:
+        return None if v is None else float(v)
+
+    fd_relevant = work_mode in _FD_MODES
+    return (
+        start_hour, start_minute, end_hour, end_minute, work_mode,
+        int(min_soc_on_grid) if min_soc_on_grid is not None else None,
+        _f(fd_soc) if fd_relevant else None,
+        _f(fd_pwr) if fd_relevant else None,
+        # Absent maxSoc == the vendor default 100 (Fox fills it on read-back).
+        100.0 if max_soc is None else _f(max_soc),
+        _f(import_limit),
+        _f(export_limit),
+    )
+
 
 @dataclass
 class RealTimeData:
@@ -73,20 +106,27 @@ class SchedulerGroup:
         }
 
     def fingerprint(self) -> tuple:
-        """Stable hashable representation for skip-when-unchanged guard (#38).
+        """Stable, MODE-AWARE representation for the skip-when-unchanged guard
+        (#38) and live-vs-stored drift checks.
 
-        Built from ``to_api_dict()`` so it tracks exactly the fields we write.
-        Sorted tuple of ``extraParam`` items keeps dict-order out of equality.
+        Canonicalised so a re-read of the SAME schedule from the inverter
+        compares equal to what we uploaded. Fox echoes back STALE ``fdSoc`` /
+        ``fdPwr`` on SelfUse/Backup/Feedin groups (leftovers from whatever
+        ForceCharge/ForceDischarge once occupied that clock window) and fills an
+        absent ``maxSoc`` with the vendor default 100 — both of which made a raw
+        fingerprint perpetually disagree with the device, wedging Fox uploads
+        for ~41 h on 2026-06-14 (the same vendor-echo class fixed for the
+        ``schedule_diff`` endpoint in #554; this is the comparator that drives
+        ``set_scheduler_v3(skip_if_equal=...)`` and the heartbeat re-upload).
+
+        Rules: ``fdSoc``/``fdPwr`` count only for ForceCharge/ForceDischarge
+        (the only modes that use them); absent ``maxSoc`` == 100; numerics
+        coerced to float so ``31`` and ``31.0`` match.
         """
-        d = self.to_api_dict()
-        ep = tuple(sorted(d["extraParam"].items()))
-        return (
-            d["startHour"],
-            d["startMinute"],
-            d["endHour"],
-            d["endMinute"],
-            d["workMode"],
-            ep,
+        return _group_fingerprint(
+            self.start_hour, self.start_minute, self.end_hour, self.end_minute,
+            self.work_mode, self.min_soc_on_grid, self.fd_soc, self.fd_pwr,
+            self.max_soc, self.import_limit, self.export_limit,
         )
 
 

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -1639,10 +1639,20 @@ def _prepend_inflight_group(
     slot_start_min = (now_min // 30) * 30          # floor to half-hour
     slot_end_min = slot_start_min + 30             # exclusive end = next boundary
 
+    # Only bridge a genuine GAP: if ANY plan group already covers the current
+    # minute, the plan has explicitly decided this slot — re-asserting the old
+    # mode would both fight that decision and OVERLAP that group. Checking every
+    # group (not just groups[0]) is the fix for the 2026-06-14 wedge: a later
+    # group spanning the live slot let a stale ForceCharge bridge overlap it,
+    # the overlap guard refused the whole upload, and the inverter ran an
+    # obsolete (grid-force-charging) schedule for ~41 h.
+    for g in groups:
+        gs = g.start_hour * 60 + g.start_minute
+        ge = g.end_hour * 60 + g.end_minute
+        if gs <= now_min < ge:
+            return groups
     g0 = groups[0]
     first_start_min = g0.start_hour * 60 + g0.start_minute
-    if first_start_min <= now_min:
-        return groups                              # first group already covers now
     if first_start_min < slot_end_min:
         return groups                              # would overlap the current slot
     try:
@@ -1690,7 +1700,20 @@ def _prepend_inflight_group(
 def upload_fox_if_operational(fox: FoxESSClient | None, groups: list[SchedulerGroup]) -> bool:
     fox_ok = False
     if fox and fox.api_key and not config.OPENCLAW_READ_ONLY:
-        groups = _prepend_inflight_group(groups)
+        plan = groups                              # the LP/heuristic plan, no bridge
+        candidate = _prepend_inflight_group(plan)
+        if _detect_overlapping_groups(candidate) and candidate is not plan:
+            # The in-flight bridge collides with a plan group. DROP THE BRIDGE
+            # and upload the plan as-is rather than refuse the whole upload — a
+            # refusal leaves the STALE schedule live, which is exactly what
+            # wedged Fox dispatch (grid-force-charging on an obsolete plan) for
+            # ~41 h on 2026-06-14. The plan itself is still overlap-checked below.
+            logger.warning(
+                "Fox upload: in-flight bridge overlaps the plan — dropping the "
+                "bridge and uploading the plan as-is (avoids the stale-schedule wedge)",
+            )
+            candidate = plan
+        groups = candidate
         overlaps = _detect_overlapping_groups(groups)
         if overlaps:
             for i, j in overlaps:

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -117,7 +117,6 @@ def _schedule_signature(groups: list[Any]) -> str:
                     g.start_hour, g.start_minute, g.end_hour, g.end_minute,
                     g.work_mode, getattr(g, "min_soc_on_grid", None),
                     g.fd_soc, g.fd_pwr, getattr(g, "max_soc", None),
-                    getattr(g, "import_limit", None), getattr(g, "export_limit", None),
                 )
             )
         elif isinstance(g, dict):
@@ -127,7 +126,7 @@ def _schedule_signature(groups: list[Any]) -> str:
                     g.get("startHour"), g.get("startMinute"),
                     g.get("endHour"), g.get("endMinute"), g.get("workMode"),
                     ep.get("minSocOnGrid"), ep.get("fdSoc"), ep.get("fdPwr"),
-                    ep.get("maxSoc"), ep.get("importLimit"), ep.get("exportLimit"),
+                    ep.get("maxSoc"),
                 )
             )
     return json.dumps(payload, sort_keys=True, default=str)

--- a/src/state_machine.py
+++ b/src/state_machine.py
@@ -19,6 +19,7 @@ from .daikin_bulletproof import (
     user_gesture_still_in_effect,
 )
 from .foxess.client import FoxESSClient, FoxESSError, scheduler_groups_from_stored_json
+from .foxess.models import _group_fingerprint
 from .notifier import notify_critical, notify_risk, notify_user_override
 
 logger = logging.getLogger(__name__)
@@ -99,32 +100,34 @@ def _parse_utc(s: str) -> datetime:
 
 
 def _schedule_signature(groups: list[Any]) -> str:
-    """Comparable fingerprint for Fox V3 groups (hardware vs SQLite)."""
+    """Comparable, MODE-AWARE fingerprint for Fox V3 groups (hardware vs SQLite).
+
+    Uses the shared canonical fingerprint so a live device read compares equal
+    to what we uploaded. A raw field-by-field signature treated the inverter's
+    stale fdSoc/fdPwr echo on SelfUse/Backup groups (and its vendor-default
+    maxSoc fill) as drift, so the heartbeat re-uploaded forever and wedged Fox
+    dispatch for ~41 h on 2026-06-14 — the same vendor-echo class fixed for the
+    schedule_diff endpoint in #554.
+    """
     payload = []
     for g in groups:
         if hasattr(g, "start_hour"):
             payload.append(
-                (
-                    g.start_hour,
-                    g.start_minute,
-                    g.end_hour,
-                    g.end_minute,
-                    g.work_mode,
-                    g.fd_soc,
-                    g.fd_pwr,
+                _group_fingerprint(
+                    g.start_hour, g.start_minute, g.end_hour, g.end_minute,
+                    g.work_mode, getattr(g, "min_soc_on_grid", None),
+                    g.fd_soc, g.fd_pwr, getattr(g, "max_soc", None),
+                    getattr(g, "import_limit", None), getattr(g, "export_limit", None),
                 )
             )
         elif isinstance(g, dict):
             ep = g.get("extraParam") or g.get("extra_param") or {}
             payload.append(
-                (
-                    g.get("startHour"),
-                    g.get("startMinute"),
-                    g.get("endHour"),
-                    g.get("endMinute"),
-                    g.get("workMode"),
-                    ep.get("fdSoc"),
-                    ep.get("fdPwr"),
+                _group_fingerprint(
+                    g.get("startHour"), g.get("startMinute"),
+                    g.get("endHour"), g.get("endMinute"), g.get("workMode"),
+                    ep.get("minSocOnGrid"), ep.get("fdSoc"), ep.get("fdPwr"),
+                    ep.get("maxSoc"), ep.get("importLimit"), ep.get("exportLimit"),
                 )
             )
     return json.dumps(payload, sort_keys=True, default=str)

--- a/tests/test_fox_upload_deadlock.py
+++ b/tests/test_fox_upload_deadlock.py
@@ -1,0 +1,136 @@
+"""Regression tests for the 2026-06-14 Fox-upload wedge (~41h open-loop).
+
+Two defects combined to keep the inverter on an obsolete (grid-force-charging)
+schedule for ~41 h:
+
+  Defect 1 — the drift comparators (`SchedulerGroup.fingerprint`,
+  `state_machine._schedule_signature`) included fdSoc/fdPwr unconditionally, so
+  the inverter's STALE fd_* echo on SelfUse/Backup groups (and its vendor maxSoc
+  fill) read as perpetual drift → endless re-upload churn. Same vendor-echo
+  class fixed for the schedule_diff endpoint in #554, but those two comparators
+  were missed.
+
+  Defect 2 — `_prepend_inflight_group` only checked groups[0] for current-slot
+  coverage, so a later plan group spanning the live slot let a stale ForceCharge
+  bridge OVERLAP it; the overlap guard then refused the WHOLE upload, leaving
+  the stale schedule live.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.foxess.models import SchedulerGroup
+import src.state_machine as sm
+import src.scheduler.lp_dispatch as lpd
+
+
+# ── Defect 1: mode-aware fingerprints ─────────────────────────────────────────
+
+def test_fingerprint_ignores_stale_fd_echo_on_selfuse():
+    """A live SelfUse group with echoed fdSoc/fdPwr == the SelfUse we uploaded
+    (which carried no fd_*). This is the equality that was perpetually false."""
+    live = SchedulerGroup(9, 0, 9, 30, "SelfUse", min_soc_on_grid=100,
+                          fd_soc=31.0, fd_pwr=3800.0, max_soc=100.0)
+    uploaded = SchedulerGroup(9, 0, 9, 30, "SelfUse", min_soc_on_grid=100, max_soc=100)
+    assert live.fingerprint() == uploaded.fingerprint()
+
+
+def test_fingerprint_absent_maxsoc_equals_vendor_default_100():
+    live = SchedulerGroup(8, 0, 9, 0, "SelfUse", min_soc_on_grid=100, max_soc=100.0)
+    uploaded = SchedulerGroup(8, 0, 9, 0, "SelfUse", min_soc_on_grid=100, max_soc=None)
+    assert live.fingerprint() == uploaded.fingerprint()
+
+
+@pytest.mark.parametrize("mode", ["ForceCharge", "ForceDischarge"])
+def test_fingerprint_still_tracks_fd_change_on_active_modes(mode):
+    """fdSoc IS meaningful for ForceCharge and ForceDischarge — a real change
+    must still register (so a re-solve's new target gets uploaded)."""
+    a = SchedulerGroup(11, 0, 11, 30, mode, min_soc_on_grid=10, fd_soc=31, fd_pwr=3800)
+    b = SchedulerGroup(11, 0, 11, 30, mode, min_soc_on_grid=10, fd_soc=100, fd_pwr=3800)
+    assert a.fingerprint() != b.fingerprint()
+
+
+def test_fingerprint_int_float_equivalent():
+    assert (SchedulerGroup(0, 0, 1, 0, "ForceCharge", fd_soc=31, fd_pwr=3800).fingerprint()
+            == SchedulerGroup(0, 0, 1, 0, "ForceCharge", fd_soc=31.0, fd_pwr=3800.0).fingerprint())
+
+
+def test_schedule_signature_live_attr_equals_stored_dict():
+    """The heartbeat compares a live read (attribute objects, with fd_* echo)
+    against the stored plan (dicts, no fd_*). They must match for an unchanged
+    schedule — the comparison that drove the ~41h re-upload churn."""
+    live = [SchedulerGroup(9, 0, 9, 30, "SelfUse", min_soc_on_grid=100,
+                           fd_soc=31.0, fd_pwr=3800.0, max_soc=100.0)]
+    stored = [{"startHour": 9, "startMinute": 0, "endHour": 9, "endMinute": 30,
+               "workMode": "SelfUse", "extraParam": {"minSocOnGrid": 100, "maxSoc": 100}}]
+    assert sm._schedule_signature(live) == sm._schedule_signature(stored)
+
+
+def test_schedule_signature_still_detects_real_forcecharge_change():
+    a = [{"startHour": 11, "startMinute": 0, "endHour": 11, "endMinute": 30,
+          "workMode": "ForceCharge", "extraParam": {"minSocOnGrid": 10, "fdSoc": 31, "fdPwr": 3800}}]
+    b = [SchedulerGroup(11, 0, 11, 30, "ForceCharge", min_soc_on_grid=10, fd_soc=100, fd_pwr=3800)]
+    assert sm._schedule_signature(a) != sm._schedule_signature(b)
+
+
+# ── Defect 2: in-flight bridge must not wedge the upload ───────────────────────
+
+_NOW = datetime(2026, 6, 14, 12, 15, tzinfo=ZoneInfo("Europe/London"))
+
+
+def _stale_forcecharge_prev(monkeypatch):
+    """The inverter's live schedule has a ForceCharge active across 'now'."""
+    monkeypatch.setattr(lpd.db, "get_latest_fox_schedule_state", lambda: {
+        "groups": [{"startHour": 12, "startMinute": 0, "endHour": 13, "endMinute": 30,
+                    "workMode": "ForceCharge",
+                    "extraParam": {"minSocOnGrid": 10, "fdSoc": 100, "fdPwr": 3133}}],
+    })
+
+
+def test_no_bridge_when_a_later_plan_group_covers_now(monkeypatch):
+    """Plan's SelfUse spans the live slot → no bridge (the plan owns the slot),
+    so no overlap and the clean plan can upload. This is the wedge fix."""
+    _stale_forcecharge_prev(monkeypatch)
+    plan = [SchedulerGroup(11, 30, 15, 59, "SelfUse", min_soc_on_grid=100, max_soc=100)]
+    out = lpd._prepend_inflight_group(list(plan), now_local=_NOW)
+    assert len(out) == len(plan)               # no bridge added
+    assert lpd._detect_overlapping_groups(out) == []
+
+
+def test_bridge_still_added_for_a_genuine_gap(monkeypatch):
+    """When NO plan group covers the live slot (horizon starts at the next
+    boundary), the bridge is still added — its legitimate #458 purpose."""
+    _stale_forcecharge_prev(monkeypatch)
+    plan = [SchedulerGroup(13, 0, 15, 59, "SelfUse", min_soc_on_grid=100, max_soc=100)]
+    out = lpd._prepend_inflight_group(list(plan), now_local=_NOW)
+    assert len(out) == len(plan) + 1           # bridge prepended
+    assert out[0].work_mode == "ForceCharge"
+    assert lpd._detect_overlapping_groups(out) == []
+
+
+def test_upload_drops_bridge_on_overlap_instead_of_refusing(monkeypatch):
+    """If a bridge somehow still overlaps the plan, the upload drops the bridge
+    and pushes the plan — never refuses and leaves the stale schedule live."""
+    captured = {}
+
+    class _FakeFox:
+        api_key = "k"
+        def set_scheduler_v3(self, groups, is_default=False):
+            captured["groups"] = groups
+        def warn_if_scheduler_v3_mismatch(self, groups): ...
+        def set_scheduler_flag(self, on): ...
+
+    monkeypatch.setattr(lpd.config, "OPENCLAW_READ_ONLY", False, raising=False)
+    monkeypatch.setattr(lpd.db, "save_fox_schedule_state", lambda *a, **k: None)
+    # Force _prepend to return an overlapping (bridge, plan) pair.
+    plan = [SchedulerGroup(11, 30, 12, 30, "SelfUse", min_soc_on_grid=100, max_soc=100)]
+    bridge = SchedulerGroup(12, 0, 12, 29, "ForceCharge", min_soc_on_grid=10, fd_soc=100, fd_pwr=3133)
+    monkeypatch.setattr(lpd, "_prepend_inflight_group", lambda g: [bridge] + g)
+
+    ok = lpd.upload_fox_if_operational(_FakeFox(), plan)
+    assert ok is True
+    # The bridge was dropped; the plan (no overlap) was uploaded.
+    assert captured["groups"] == plan

--- a/tests/test_fox_upload_deadlock.py
+++ b/tests/test_fox_upload_deadlock.py
@@ -58,6 +58,16 @@ def test_fingerprint_int_float_equivalent():
             == SchedulerGroup(0, 0, 1, 0, "ForceCharge", fd_soc=31.0, fd_pwr=3800.0).fingerprint())
 
 
+def test_fingerprint_ignores_echoed_import_export_limits():
+    """import/export limits are never LP-set, so an echoed value on read-back
+    must not register as drift (review HIGH on #561 — they were initially
+    included in the fingerprint and would re-open the churn)."""
+    live = SchedulerGroup(9, 0, 9, 30, "SelfUse", min_soc_on_grid=100, max_soc=100,
+                          import_limit=8000, export_limit=3680)
+    uploaded = SchedulerGroup(9, 0, 9, 30, "SelfUse", min_soc_on_grid=100, max_soc=100)
+    assert live.fingerprint() == uploaded.fingerprint()
+
+
 def test_schedule_signature_live_attr_equals_stored_dict():
     """The heartbeat compares a live read (attribute objects, with fd_* echo)
     against the stored plan (dicts, no fd_*). They must match for an unchanged
@@ -97,6 +107,22 @@ def test_no_bridge_when_a_later_plan_group_covers_now(monkeypatch):
     plan = [SchedulerGroup(11, 30, 15, 59, "SelfUse", min_soc_on_grid=100, max_soc=100)]
     out = lpd._prepend_inflight_group(list(plan), now_local=_NOW)
     assert len(out) == len(plan)               # no bridge added
+    assert lpd._detect_overlapping_groups(out) == []
+
+
+def test_no_bridge_when_a_LATER_indexed_group_covers_now(monkeypatch):
+    """The real incident shape: groups[0] starts AFTER now (so the old
+    groups[0]-only guard would add a bridge), but a LATER group in the list
+    covers the live slot. The all-groups guard must still suppress the bridge.
+    (This is the case that FAILS against main — the single-group test above
+    passes on main and doesn't actually guard the fix.)"""
+    _stale_forcecharge_prev(monkeypatch)
+    plan = [
+        SchedulerGroup(13, 0, 15, 59, "Backup", min_soc_on_grid=10, max_soc=10),   # groups[0] — after now
+        SchedulerGroup(11, 30, 12, 59, "SelfUse", min_soc_on_grid=100, max_soc=100),  # covers now (12:15)
+    ]
+    out = lpd._prepend_inflight_group(list(plan), now_local=_NOW)
+    assert len(out) == len(plan)               # no bridge despite groups[0] being after now
     assert lpd._detect_overlapping_groups(out) == []
 
 


### PR DESCRIPTION
## Incident (2026-06-14)

The inverter ran an **obsolete, grid-force-charging** Fox V3 schedule for **~41h** while the LP solved `Optimal` every few minutes. Every upload silently failed (`fox_schedule_uploaded: 0` on every run). The stale schedule was yesterday's negative-price plan, whose daily-cyclic `ForceCharge 11:00-13:30` fired today at **+13-15p**, force-charging the battery from grid with solar available.

Diagnosed live against the inverter echo. Two defects combined:

### Defect 1 — drift comparators not mode-aware
The inverter **echoes stale `fdSoc`/`fdPwr`** on SelfUse/Backup groups (leftovers from whatever ForceCharge once held that clock window) and fills an absent `maxSoc` with the vendor default 100. Proven live: stored SelfUse groups had no fd_*, but the device reported `fd_soc=31, fd_pwr=3800` on the same groups. `SchedulerGroup.fingerprint` (drives `set_scheduler_v3(skip_if_equal)`) and `_schedule_signature` (drives the heartbeat re-upload) included `fd_*` unconditionally → a live read **never** matched what we uploaded → **perpetual false drift → endless re-upload churn** (and Fox `40257` rejections on the bridge payloads). Same vendor-echo class fixed for the `schedule_diff` endpoint in #554 — these two comparators were missed, and #554's own `_fp` only forgave ForceDischarge (missing ForceCharge).

**Fix:** a shared `_group_fingerprint` (`foxess/models.py`): `fdSoc`/`fdPwr` count only for ForceCharge/ForceDischarge; absent `maxSoc` == 100; numerics → float. `fingerprint()`, `_schedule_signature`, and `_fp` all use the same rule.

### Defect 2 — in-flight bridge wedged the upload
`_prepend_inflight_group` (#458) re-asserts the live slot's mode so a mid-slot re-upload can't drop a force-charge. But it only checked `groups[0]` for current-slot coverage, so a **later** plan group spanning the live slot let a stale ForceCharge bridge **overlap** it; `_detect_overlapping_groups` then **refused the whole upload**, leaving the stale schedule live — self-perpetuating, since the daily-cyclic ForceCharge recurs every day.

**Fix:** `_prepend_inflight_group` checks **all** groups — no bridge when the plan already covers the live slot (only a genuine gap is bridged). `upload_fox_if_operational` **drops the bridge and uploads the plan** if the bridge overlaps, instead of refusing and leaving the stale schedule.

## Impact
Self-healed in prod at 15:05 UTC when a re-solve happened to dodge the overlap; these fixes make recovery **deterministic** and stop the perpetual churn (which also burns Fox quota). The inverter is currently on a clean SelfUse schedule.

## Tests
`tests/test_fox_upload_deadlock.py` — 10 regression tests (echo equality both comparators, real ForceCharge/ForceDischarge changes still detected, bridge-coverage guard, drop-bridge-on-overlap). Full suite **1636 passed**.

## Verification plan (post-deploy)
- Heartbeat stops logging "Fox V3 differs from SQLite plan" every 30 min (drift churn gone).
- `fox_schedule_uploaded` flips to 1 on the next re-solve; `/foxess/schedule_diff` `in_sync: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)