### PR TITLE
feat(status): actuation-health alert — Fox upload + Daikin tank/LWT freshness

### DIFF
--- a/src/api/routers/status.py
+++ b/src/api/routers/status.py
@@ -247,12 +247,19 @@ def _actuation_block() -> dict[str, Any]:
 
     fox_stale_h = float(getattr(config, "FOX_UPLOAD_STALE_HOURS", 30) or 0)
     tank_stale_h = float(getattr(config, "DAIKIN_TANK_STALE_HOURS", 30) or 0)
-    fail_thr = int(getattr(config, "DAIKIN_FAILED_ALERT_THRESHOLD", 3))
+    fail_thr = max(1, int(getattr(config, "DAIKIN_FAILED_ALERT_THRESHOLD", 3) or 3))
 
     fox_age = _age_hours(raw.get("fox_upload_at"), now)
     tank_age = _age_hours(raw.get("tank_last_at"), now)
     tank_fail = int(raw.get("tank_failed_24h") or 0)
     lwt_fail = int(raw.get("lwt_failed_24h") or 0)
+
+    # In vacation mode dhw_policy writes ZERO tank rows by design, so the tank
+    # naturally goes "stale" with no fault — suppress the age alarm using the
+    # SAME source dhw_policy reads, so the two can never disagree. (Failures
+    # stay live: a rejected write is meaningful in any mode.)
+    dhw_mode = (getattr(config, "OPTIMIZATION_PRESET", "normal") or "normal").strip().lower()
+    tank_age_alarm = tank_stale_h > 0 and dhw_mode != "vacation"
 
     return {
         "fox": {
@@ -264,7 +271,7 @@ def _actuation_block() -> dict[str, Any]:
             "last_at": raw.get("tank_last_at"),
             "age_hours": None if tank_age is None else round(tank_age, 1),
             "failed_24h": tank_fail,
-            "stale": tank_stale_h > 0 and (tank_age is None or tank_age > tank_stale_h),
+            "stale": tank_age_alarm and (tank_age is None or tank_age > tank_stale_h),
             "failing": tank_fail >= fail_thr,
         },
         "daikin_lwt": {

--- a/src/api/routers/status.py
+++ b/src/api/routers/status.py
@@ -22,7 +22,7 @@ import asyncio
 import logging
 import time
 import urllib.request
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter
@@ -216,6 +216,65 @@ def _quota_block() -> dict[str, Any]:
     return out
 
 
+def _age_hours(ts: str | None, now: datetime) -> float | None:
+    if not ts:
+        return None
+    try:
+        t = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=UTC)
+        return max(0.0, (now - t).total_seconds() / 3600.0)
+    except (ValueError, TypeError):
+        return None
+
+
+def _actuation_block() -> dict[str, Any]:
+    """Is the plan actually reaching the hardware? The ~41h Fox-upload wedge of
+    2026-06-14 ran silently because nothing watched actuation freshness (drift
+    detection only compares live-vs-stored, both of which were stale-consistent).
+
+    Fox: stale when the last SUCCESSFUL upload is older than the daily cadence.
+    Daikin tank: stale when no tank action has fired in that window (~2×/day
+    normally) + a recent device-rejection count. Daikin LWT: rejection count
+    only (demand-gated, legitimately dormant in summer → no age alarm)."""
+    now = datetime.now(UTC)
+    since = (now - timedelta(hours=24)).isoformat()
+    try:
+        raw = db.get_actuation_health(since)
+    except Exception:  # pragma: no cover — strip must still render
+        logger.debug("status/alerts: actuation health read failed", exc_info=True)
+        return {"fox": None, "daikin_tank": None, "daikin_lwt": None}
+
+    fox_stale_h = float(getattr(config, "FOX_UPLOAD_STALE_HOURS", 30) or 0)
+    tank_stale_h = float(getattr(config, "DAIKIN_TANK_STALE_HOURS", 30) or 0)
+    fail_thr = int(getattr(config, "DAIKIN_FAILED_ALERT_THRESHOLD", 3))
+
+    fox_age = _age_hours(raw.get("fox_upload_at"), now)
+    tank_age = _age_hours(raw.get("tank_last_at"), now)
+    tank_fail = int(raw.get("tank_failed_24h") or 0)
+    lwt_fail = int(raw.get("lwt_failed_24h") or 0)
+
+    return {
+        "fox": {
+            "last_upload_at": raw.get("fox_upload_at"),
+            "age_hours": None if fox_age is None else round(fox_age, 1),
+            "stale": fox_stale_h > 0 and (fox_age is None or fox_age > fox_stale_h),
+        },
+        "daikin_tank": {
+            "last_at": raw.get("tank_last_at"),
+            "age_hours": None if tank_age is None else round(tank_age, 1),
+            "failed_24h": tank_fail,
+            "stale": tank_stale_h > 0 and (tank_age is None or tank_age > tank_stale_h),
+            "failing": tank_fail >= fail_thr,
+        },
+        "daikin_lwt": {
+            "failed_24h": lwt_fail,
+            # No age alarm — LWT is demand-gated and dormant in summer.
+            "failing": lwt_fail >= fail_thr,
+        },
+    }
+
+
 # ── endpoints ────────────────────────────────────────────────────────────────
 
 @router.get("/api/v1/status/alerts")
@@ -233,11 +292,12 @@ async def status_alerts() -> dict[str, Any]:
     # Every sqlite reader goes through to_thread — _forecast_block included:
     # it takes db._lock, and holding that on the event loop during a large
     # scheduler write would stall every in-flight request (review M on #553).
-    meter, lp, quota, forecast = await asyncio.gather(
+    meter, lp, quota, forecast, actuation = await asyncio.gather(
         asyncio.to_thread(_meter_block),
         asyncio.to_thread(_lp_block),
         asyncio.to_thread(_quota_block),
         asyncio.to_thread(_forecast_block, sidecar),
+        asyncio.to_thread(_actuation_block),
     )
     out = {
         "now_utc": datetime.now(UTC).isoformat(),
@@ -246,6 +306,7 @@ async def status_alerts() -> dict[str, Any]:
         "forecast": forecast,
         "fox_drift": await _fox_drift_block(),
         "quota": quota,
+        "actuation": actuation,
     }
     _cache["alerts"] = (now, out)
     return out

--- a/src/config.py
+++ b/src/config.py
@@ -401,11 +401,15 @@ class Config:
     CONSUMPTION_METER_STALE_DAYS: int = int(
         os.getenv("CONSUMPTION_METER_STALE_DAYS", "3")
     )
-    # Actuation-health alert (2026-06-14). A healthy system uploads the Fox V3
-    # schedule (00:05 plan push + price-driven re-solves) and fires tank rows
-    # (dhw_policy warmup+setback) at least daily, so >~30h without one means
-    # actuation is wedged. LWT is demand-gated (summer-dormant) → failure-count
-    # only. Set the *_STALE_HOURS to 0 to disable that age check.
+    # Actuation-health alert (2026-06-14). A healthy system refreshes the Fox V3
+    # upload timestamp at least daily — the 00:05 plan push always re-uploads
+    # (an unchanged schedule still saves state via skip_if_equal), plus the
+    # force-write triggers (drift / forecast_revision / octopus_fetch /
+    # tier_boundary) — and fires tank rows (dhw_policy warmup+setback) ~2×/day,
+    # so >~30h without one means actuation is wedged. Tank age is suppressed in
+    # vacation mode (no tank rows by design). LWT is demand-gated (summer-
+    # dormant) → failure-count only. Set *_STALE_HOURS to 0 to disable the age
+    # check; the failed-count threshold clamps to ≥1.
     FOX_UPLOAD_STALE_HOURS: float = float(os.getenv("FOX_UPLOAD_STALE_HOURS", "30"))
     DAIKIN_TANK_STALE_HOURS: float = float(os.getenv("DAIKIN_TANK_STALE_HOURS", "30"))
     DAIKIN_FAILED_ALERT_THRESHOLD: int = int(os.getenv("DAIKIN_FAILED_ALERT_THRESHOLD", "3"))

--- a/src/config.py
+++ b/src/config.py
@@ -401,6 +401,14 @@ class Config:
     CONSUMPTION_METER_STALE_DAYS: int = int(
         os.getenv("CONSUMPTION_METER_STALE_DAYS", "3")
     )
+    # Actuation-health alert (2026-06-14). A healthy system uploads the Fox V3
+    # schedule (00:05 plan push + price-driven re-solves) and fires tank rows
+    # (dhw_policy warmup+setback) at least daily, so >~30h without one means
+    # actuation is wedged. LWT is demand-gated (summer-dormant) → failure-count
+    # only. Set the *_STALE_HOURS to 0 to disable that age check.
+    FOX_UPLOAD_STALE_HOURS: float = float(os.getenv("FOX_UPLOAD_STALE_HOURS", "30"))
+    DAIKIN_TANK_STALE_HOURS: float = float(os.getenv("DAIKIN_TANK_STALE_HOURS", "30"))
+    DAIKIN_FAILED_ALERT_THRESHOLD: int = int(os.getenv("DAIKIN_FAILED_ALERT_THRESHOLD", "3"))
     BULLETPROOF_TIMEZONE: str = (os.getenv("BULLETPROOF_TIMEZONE") or "Europe/London").strip()
 
     # ── SmartThings smart-appliance scheduling — OAuth 2.0 (mirrors Daikin) ──

--- a/src/db.py
+++ b/src/db.py
@@ -5013,6 +5013,54 @@ def list_recent_lp_failures(limit: int = 10) -> list[dict[str, Any]]:
             conn.close()
 
 
+def get_actuation_health(failed_since_iso: str) -> dict[str, Any]:
+    """Raw signals for the actuation-health alert (2026-06-14, after the ~41h
+    Fox-upload wedge that nothing alerted on).
+
+    * ``fox_upload_at`` — last SUCCESSFUL Fox V3 upload (``save_fox_schedule_state``
+      only runs on success), so a stale value means uploads are failing/wedged.
+    * ``tank_last_at`` — last tank action that actually RAN (``completed``,
+      incl. the benign ``noop`` skip which still proves the reconciler is
+      firing, or ``active``). Tank fires ~2×/day under dhw_policy, so a stale
+      value is a robust "reconciler stopped actuating the tank" signal.
+    * ``{tank,lwt}_failed_24h`` — Daikin rows the device REJECTED (``failed``
+      status) since ``failed_since_iso``. LWT has no age signal — it's
+      demand-gated and legitimately dormant in summer — so failures are its
+      only meaningful actuation-health signal.
+
+    ISO timestamps compare lexicographically (all 'YYYY-MM-DDTHH:MM:SS...').
+    """
+    out: dict[str, Any] = {
+        "fox_upload_at": None, "tank_last_at": None,
+        "tank_failed_24h": 0, "lwt_failed_24h": 0,
+    }
+    with _lock:
+        conn = get_connection()
+        try:
+            r = conn.execute(
+                "SELECT uploaded_at FROM fox_schedule_state ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            if r:
+                out["fox_upload_at"] = r["uploaded_at"]
+            r = conn.execute(
+                "SELECT MAX(COALESCE(executed_at, created_at)) AS t FROM action_schedule "
+                "WHERE device='daikin' AND action_type LIKE 'tank%' "
+                "AND status IN ('completed', 'active')"
+            ).fetchone()
+            out["tank_last_at"] = r["t"] if r else None
+            for dom, like in (("tank", "tank%"), ("lwt", "lwt%")):
+                r = conn.execute(
+                    "SELECT COUNT(*) AS n FROM action_schedule "
+                    "WHERE device='daikin' AND action_type LIKE ? AND status='failed' "
+                    "AND COALESCE(executed_at, created_at) >= ?",
+                    (like, failed_since_iso),
+                ).fetchone()
+                out[f"{dom}_failed_24h"] = int(r["n"]) if r else 0
+            return out
+        finally:
+            conn.close()
+
+
 def find_run_for_time(when_utc: str) -> int | None:
     """Return the most recent optimizer_log.id whose run_at <= when_utc.
 

--- a/tests/api/test_actuation_health.py
+++ b/tests/api/test_actuation_health.py
@@ -62,6 +62,28 @@ def test_tank_stale_when_no_recent_actuation(monkeypatch):
     assert b["daikin_tank"]["stale"] is True
 
 
+def test_vacation_mode_suppresses_tank_stale_but_not_failures(monkeypatch):
+    """Vacation mode writes ZERO tank rows by design, so an old tank_last_at is
+    NOT a fault — the age alarm must stay quiet (the alert-noise the user hates).
+    A rejected write is still meaningful, so `failing` stays live."""
+    monkeypatch.setattr(st.config, "OPTIMIZATION_PRESET", "vacation", raising=False)
+    _patch_raw(monkeypatch, fox_upload_at=_iso(1), tank_last_at=_iso(99),
+               tank_failed_24h=3)
+    b = st._actuation_block()
+    assert b["daikin_tank"]["stale"] is False     # suppressed in vacation
+    assert b["daikin_tank"]["failing"] is True     # failures still surface
+
+
+def test_failed_threshold_zero_clamps_to_one(monkeypatch):
+    """A misconfigured threshold of 0 must NOT make everything 'failing'."""
+    monkeypatch.setattr(st.config, "DAIKIN_FAILED_ALERT_THRESHOLD", 0, raising=False)
+    _patch_raw(monkeypatch, fox_upload_at=_iso(1), tank_last_at=_iso(1),
+               tank_failed_24h=0, lwt_failed_24h=0)
+    b = st._actuation_block()
+    assert b["daikin_tank"]["failing"] is False
+    assert b["daikin_lwt"]["failing"] is False
+
+
 def test_failed_writes_flag_failing_at_threshold(monkeypatch):
     _patch_raw(monkeypatch, fox_upload_at=_iso(1), tank_last_at=_iso(1),
                tank_failed_24h=3, lwt_failed_24h=4)

--- a/tests/api/test_actuation_health.py
+++ b/tests/api/test_actuation_health.py
@@ -1,0 +1,125 @@
+"""Actuation-health alert (2026-06-14): is the plan reaching the hardware?
+
+The ~41h Fox-upload wedge ran silently because nothing watched actuation
+freshness — drift detection only compares live-vs-stored (both stale-consistent
+during the wedge). This block adds: Fox upload staleness, Daikin tank
+actuation staleness + failure count, Daikin LWT failure count (demand-gated,
+no age alarm).
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import src.api.routers.status as st
+from src import db
+
+
+def _iso(hours_ago: float) -> str:
+    return (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
+
+
+@pytest.fixture(autouse=True)
+def _knobs(monkeypatch):
+    monkeypatch.setattr(st.config, "FOX_UPLOAD_STALE_HOURS", 30.0, raising=False)
+    monkeypatch.setattr(st.config, "DAIKIN_TANK_STALE_HOURS", 30.0, raising=False)
+    monkeypatch.setattr(st.config, "DAIKIN_FAILED_ALERT_THRESHOLD", 3, raising=False)
+
+
+def _patch_raw(monkeypatch, **kw):
+    raw = {"fox_upload_at": None, "tank_last_at": None,
+           "tank_failed_24h": 0, "lwt_failed_24h": 0, **kw}
+    monkeypatch.setattr(db, "get_actuation_health", lambda since: raw)
+
+
+def test_healthy_all_quiet(monkeypatch):
+    _patch_raw(monkeypatch, fox_upload_at=_iso(0.7), tank_last_at=_iso(5.7))
+    b = st._actuation_block()
+    assert b["fox"]["stale"] is False
+    assert b["daikin_tank"]["stale"] is False
+    assert b["daikin_tank"]["failing"] is False
+    assert b["daikin_lwt"]["failing"] is False
+
+
+def test_fox_upload_wedge_flags_stale(monkeypatch):
+    """The exact incident: last successful upload 41h ago → stale (would have
+    surfaced the wedge in <30h instead of going unnoticed for 41h)."""
+    _patch_raw(monkeypatch, fox_upload_at=_iso(41), tank_last_at=_iso(5))
+    b = st._actuation_block()
+    assert b["fox"]["stale"] is True
+    assert b["fox"]["age_hours"] == pytest.approx(41, abs=0.5)
+
+
+def test_fox_never_uploaded_is_stale(monkeypatch):
+    _patch_raw(monkeypatch, fox_upload_at=None, tank_last_at=_iso(1))
+    assert st._actuation_block()["fox"]["stale"] is True
+
+
+def test_tank_stale_when_no_recent_actuation(monkeypatch):
+    _patch_raw(monkeypatch, fox_upload_at=_iso(1), tank_last_at=_iso(31))
+    b = st._actuation_block()
+    assert b["daikin_tank"]["stale"] is True
+
+
+def test_failed_writes_flag_failing_at_threshold(monkeypatch):
+    _patch_raw(monkeypatch, fox_upload_at=_iso(1), tank_last_at=_iso(1),
+               tank_failed_24h=3, lwt_failed_24h=4)
+    b = st._actuation_block()
+    assert b["daikin_tank"]["failing"] is True
+    assert b["daikin_lwt"]["failing"] is True
+
+
+def test_below_threshold_is_not_failing(monkeypatch):
+    _patch_raw(monkeypatch, fox_upload_at=_iso(1), tank_last_at=_iso(1),
+               tank_failed_24h=2, lwt_failed_24h=2)
+    b = st._actuation_block()
+    assert b["daikin_tank"]["failing"] is False
+    assert b["daikin_lwt"]["failing"] is False
+
+
+def test_stale_hours_zero_disables_age_alarm(monkeypatch):
+    monkeypatch.setattr(st.config, "FOX_UPLOAD_STALE_HOURS", 0.0, raising=False)
+    _patch_raw(monkeypatch, fox_upload_at=_iso(999), tank_last_at=None)
+    assert st._actuation_block()["fox"]["stale"] is False
+
+
+def test_block_never_raises_on_db_error(monkeypatch):
+    def boom(since):
+        raise RuntimeError("db down")
+    monkeypatch.setattr(db, "get_actuation_health", boom)
+    b = st._actuation_block()
+    assert b == {"fox": None, "daikin_tank": None, "daikin_lwt": None}
+
+
+# ── db helper against real rows ───────────────────────────────────────────────
+
+def test_get_actuation_health_counts_failed_by_domain(monkeypatch):
+    db.init_db()
+    now = datetime.now(UTC)
+    recent = (now - timedelta(hours=2)).isoformat()
+    old = (now - timedelta(hours=48)).isoformat()
+    with db._lock:
+        conn = db.get_connection()
+        try:
+            conn.execute("DELETE FROM action_schedule")
+            rows = [
+                ("daikin", "tank_warmup", "failed", recent),
+                ("daikin", "tank_setback", "failed", recent),
+                ("daikin", "tank_warmup", "failed", old),       # outside 24h window
+                ("daikin", "lwt_preheat", "failed", recent),
+                ("daikin", "tank_warmup", "completed", recent),  # a successful tank fire
+            ]
+            for dev, at, status, ts in rows:
+                conn.execute(
+                    "INSERT INTO action_schedule (date, start_time, end_time, device, "
+                    "action_type, status, executed_at, created_at) VALUES (?,?,?,?,?,?,?,?)",
+                    (ts[:10], ts, ts, dev, at, status, ts, ts),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+    raw = db.get_actuation_health((now - timedelta(hours=24)).isoformat())
+    assert raw["tank_failed_24h"] == 2          # old one excluded
+    assert raw["lwt_failed_24h"] == 1
+    assert raw["tank_last_at"] is not None        # the completed tank fire

--- a/ui/src/components/shell/AlertStrip.tsx
+++ b/ui/src/components/shell/AlertStrip.tsx
@@ -86,6 +86,47 @@ function buildChips(a: StatusAlertsResponse): Chip[] {
     }
   }
 
+  // Actuation freshness — the plan not reaching the hardware. This is the gap
+  // the 2026-06-14 ~41h Fox-upload wedge slipped through (drift was "in sync"
+  // because live and stored were both stale).
+  const act = a.actuation;
+  if (act) {
+    const hrs = (h: number | null | undefined) =>
+      h == null ? "" : h >= 1 ? ` (${Math.round(h)}h)` : "";
+    if (act.fox?.stale) {
+      chips.push({
+        key: "fox-stale",
+        tone: "bad",
+        label: `Fox plan not uploading${hrs(act.fox.age_hours)}`,
+        detail: `No successful Fox V3 upload since ${act.fox.last_upload_at ?? "?"}. The inverter may be running an obsolete schedule.`,
+      });
+    }
+    if (act.daikin_tank?.stale) {
+      chips.push({
+        key: "tank-stale",
+        tone: "bad",
+        label: `Tank not actuating${hrs(act.daikin_tank.age_hours)}`,
+        detail: `No tank action has fired since ${act.daikin_tank.last_at ?? "?"} (normally ~2×/day). The DHW schedule may not be reaching the heat pump.`,
+      });
+    }
+    if (act.daikin_tank?.failing) {
+      chips.push({
+        key: "tank-failing",
+        tone: "warn",
+        label: `Tank writes failing (${act.daikin_tank.failed_24h})`,
+        detail: "Daikin rejected this many tank writes in 24h (READ_ONLY / rate-limit / clamp).",
+      });
+    }
+    if (act.daikin_lwt?.failing) {
+      chips.push({
+        key: "lwt-failing",
+        tone: "warn",
+        label: `LWT writes failing (${act.daikin_lwt.failed_24h})`,
+        detail: "Daikin rejected this many leaving-water-temp writes in 24h.",
+      });
+    }
+  }
+
   return chips;
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -892,6 +892,17 @@ export interface StatusQuotaEntry {
   blocked: boolean;
 }
 
+// Is the plan actually reaching the hardware? (the ~41h Fox-upload wedge of
+// 2026-06-14 ran silently because nothing watched actuation freshness).
+export interface StatusActuationBlock {
+  fox: { last_upload_at: string | null; age_hours: number | null; stale: boolean } | null;
+  daikin_tank: {
+    last_at: string | null; age_hours: number | null;
+    failed_24h: number; stale: boolean; failing: boolean;
+  } | null;
+  daikin_lwt: { failed_24h: number; failing: boolean } | null;
+}
+
 export interface StatusAlertsResponse {
   now_utc: string;
   meter: StatusMeterBlock;
@@ -899,6 +910,7 @@ export interface StatusAlertsResponse {
   forecast: StatusForecastBlock;
   fox_drift: StatusFoxDriftBlock;
   quota: { fox: StatusQuotaEntry | null; daikin: StatusQuotaEntry | null };
+  actuation?: StatusActuationBlock;
 }
 
 export interface DhwBudgetState {


### PR DESCRIPTION
## Why

The 2026-06-14 ~41h Fox-upload wedge (#561) ran **silently** — nothing alerted. The existing `fox_drift` signal compares live-vs-stored, and both were stale-consistent during the wedge (it even read `in_sync: true`). The missing signal is **"is the plan actually reaching the hardware?"**. You asked for it for Fox and the same for Daikin (tank + LWT).

## What

New `actuation` block on `/status/alerts` → cockpit `AlertStrip` chips (invisible when healthy):

| signal | stale/failing when | robust because |
|---|---|---|
| **Fox upload** | last successful upload > `FOX_UPLOAD_STALE_HOURS` (30) | `save_fox_schedule_state` only runs on success → a stale value means uploads are failing. Daily push + price re-solves upload at least daily. **Would have caught the wedge in <30h.** |
| **Daikin tank** | last tank actuation > `DAIKIN_TANK_STALE_HOURS` (30), or `failed_24h ≥ 3` | tank fires ~2×/day under dhw_policy (warmup+setback); "completed" incl. the benign noop skip still proves the reconciler is alive |
| **Daikin LWT** | `failed_24h ≥ 3` | LWT is demand-gated → legitimately dormant in summer, so an **age alarm would false-positive**; device rejections are the only meaningful signal |

## Design (verified against prod data, low false-positive)

- **Rejected** "pending row past end_time" as a stale signal: prod has **23 orphaned superseded rows back to April** that would false-positive. Age-of-last-*success* + device-*rejection* counts are clean.
- Verified on live prod: Fox upload 0.7h, tank 5.7h, 0 failures → all quiet (strip renders nothing). During the wedge, Fox age ~41h → would have chipped.
- `*_STALE_HOURS=0` disables an age check; failure threshold is configurable.
- Block never raises (returns nulls on DB error); all reads via `asyncio.to_thread`.

## Tests
`tests/api/test_actuation_health.py` — 9 (healthy-quiet, the 41h-wedge case, never-uploaded, tank-stale, failure threshold both sides, TTL-zero disable, never-raises, db-helper domain counts). Full suite **1647 passed**. UI build clean.

## Verification plan (post-deploy)
- `/status/alerts` `actuation` block present, all `stale:false`/`failing:false` on the healthy system.
- Force `FOX_UPLOAD_STALE_HOURS=0.001` in a throwaway check → fox chip appears (or trust the unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)