### PR TITLE
fix(foxess): map PV from PVEnergyTotal, not generation (AC output incl. discharge)

### DIFF
--- a/src/foxess/client.py
+++ b/src/foxess/client.py
@@ -509,7 +509,7 @@ class FoxESSClient:
             summary[key] = round(sum(v.get("value", 0) or 0 for v in values), 2)
         # Map possible response keys to get_energy_today-style keys (support various namings)
         return {
-            "pvEnergyToday": summary.get("pvEnergyToday") or summary.get("generation") or summary.get("todayYield") or 0,
+            "pvEnergyToday": summary.get("pvEnergyToday") or summary.get("PVEnergyTotal") or summary.get("generation") or summary.get("todayYield") or 0,
             "feedinEnergyToday": summary.get("feedinEnergyToday") or summary.get("feedin") or 0,
             "gridConsumptionEnergyToday": summary.get("gridConsumptionEnergyToday") or summary.get("gridConsumption") or 0,
             "chargeEnergyToday": summary.get("chargeEnergyToday") or summary.get("chargeEnergyToTal") or summary.get("chargeEnergyTotal") or 0,
@@ -538,9 +538,14 @@ class FoxESSClient:
         """Monthly totals via report/query. Uses exact parameter names from Open API doc."""
         # Doc example: dimension "day" with day; for "month" use year+month only (no day).
         # Variable names per doc: chargeEnergyToTal, dischargeEnergyToTal (capital T).
-        # Only variables accepted by report/query per Open API doc (40257 if unknown vars sent)
+        # Only variables accepted by report/query per Open API doc (40257 if unknown vars sent).
+        # ``PVEnergyTotal`` = true PV (panel side); ``generation`` = inverter AC
+        # output which INCLUDES battery discharge (verified empirically: Jan
+        # generation 256 kWh vs PVEnergyTotal 32 kWh ≈ PV + 247 kWh discharge).
+        # Both accepted by report/query; we request both and map PV from the
+        # former, keeping the latter as a fallback only.
         variables = [
-            "generation", "feedin", "gridConsumption",
+            "generation", "PVEnergyTotal", "feedin", "gridConsumption",
             "chargeEnergyToTal", "dischargeEnergyToTal",
         ]
         body = {
@@ -581,12 +586,18 @@ class FoxESSClient:
         # Map to same keys as get_energy_today (support alternate names if API returns them)
         charge = summary_raw.get("chargeEnergyToTal") or summary_raw.get("chargeEnergyTotal") or 0
         discharge = summary_raw.get("dischargeEnergyToTal") or summary_raw.get("dischargeEnergyTotal") or 0
-        pv_val = summary_raw.get("generation") or summary_raw.get("generationPower") or 0
+        # True PV (panel side). Explicit None check — a legitimate zero-PV winter
+        # day must NOT fall through to the discharge-inflated ``generation``.
+        pv_val = summary_raw.get("PVEnergyTotal")
+        if pv_val is None:
+            pv_val = summary_raw.get("generation") or summary_raw.get("generationPower") or 0
         loads_val = summary_raw.get("loads") or summary_raw.get("load") or 0
         feedin_val = summary_raw.get("feedin", 0)
         grid_val = summary_raw.get("gridConsumption", 0)
         if not loads_val and (pv_val or grid_val or discharge or feedin_val or charge):
-            # Estimate load from balance: consumption = import + solar + discharge - export - charge
+            # Balance: consumption = import + PV + discharge - export - charge.
+            # Now that pv_val is true PV (not generation, which already bundles
+            # discharge) this no longer double-counts battery discharge.
             loads_val = max(0.0, float(grid_val) + float(pv_val) + float(discharge) - float(feedin_val) - float(charge))
         return {
             "pvEnergyToday": pv_val,
@@ -599,8 +610,9 @@ class FoxESSClient:
 
     def get_energy_day(self, year: int, month: int, day: int) -> dict:
         """Get energy summary (kWh) for a single day via report/query dimension=day."""
+        # PVEnergyTotal = true PV; generation = inverter AC output (incl. discharge).
         variables = [
-            "generation", "feedin", "gridConsumption",
+            "generation", "PVEnergyTotal", "feedin", "gridConsumption",
             "chargeEnergyToTal", "dischargeEnergyToTal",
         ]
         body = {
@@ -634,7 +646,10 @@ class FoxESSClient:
             summary_raw[key] = round(total, 2)
         charge = summary_raw.get("chargeEnergyToTal") or summary_raw.get("chargeEnergyTotal") or 0
         discharge = summary_raw.get("dischargeEnergyToTal") or summary_raw.get("dischargeEnergyTotal") or 0
-        pv_val = summary_raw.get("generation") or summary_raw.get("generationPower") or 0
+        # True PV (panel side). Explicit None check so a zero-PV day stays zero.
+        pv_val = summary_raw.get("PVEnergyTotal")
+        if pv_val is None:
+            pv_val = summary_raw.get("generation") or summary_raw.get("generationPower") or 0
         loads_val = summary_raw.get("loads") or summary_raw.get("load") or 0
         feedin_val = summary_raw.get("feedin", 0)
         grid_val = summary_raw.get("gridConsumption", 0)
@@ -655,8 +670,12 @@ class FoxESSClient:
         """
         from calendar import monthrange
         _, ndays = monthrange(year, month)
+        # PVEnergyTotal = true PV (panel side); generation = inverter AC output
+        # which includes battery discharge. This per-day breakdown feeds
+        # fox_energy_daily.solar_kwh (and thus PV calibration), so PV must be the
+        # panel-side figure, not the discharge-inflated generation.
         variables = [
-            "generation", "feedin", "gridConsumption",
+            "generation", "PVEnergyTotal", "feedin", "gridConsumption",
             "chargeEnergyToTal", "dischargeEnergyToTal",
         ]
         body = {
@@ -686,19 +705,25 @@ class FoxESSClient:
                 by_var[key] = [float(v) if isinstance(v, (int, float)) else float(v.get("value", 0) or 0) if isinstance(v, dict) else 0 for v in vals]
             else:
                 by_var[key] = []
-        gen_arr = by_var.get("generation", [])
+        # True per-day PV (panel side); fall back to generation when the key is
+        # absent OR an empty array (older firmware / API anomaly). A real month
+        # always has some PV, so an empty PVEnergyTotal is an anomaly, not a
+        # genuine all-zero month — don't let it zero out the whole breakdown.
+        pv_arr = by_var.get("PVEnergyTotal")
+        if not pv_arr:
+            pv_arr = by_var.get("generation", [])
         feedin_arr = by_var.get("feedin", [])
         grid_arr = by_var.get("gridConsumption", [])
         loads_arr = by_var.get("loads", []) or by_var.get("load", [])
         charge_arr = by_var.get("chargeEnergyToTal", []) or by_var.get("chargeEnergyTotal", [])
         discharge_arr = by_var.get("dischargeEnergyToTal", []) or by_var.get("dischargeEnergyTotal", [])
-        max_len = max(len(gen_arr), len(feedin_arr), len(grid_arr), len(loads_arr), len(charge_arr), len(discharge_arr), ndays)
+        max_len = max(len(pv_arr), len(feedin_arr), len(grid_arr), len(loads_arr), len(charge_arr), len(discharge_arr), ndays)
         daily = []
         for idx in range(min(ndays, max_len)):
             d = idx + 1
             imp = round(grid_arr[idx], 2) if idx < len(grid_arr) else 0
             exp = round(feedin_arr[idx], 2) if idx < len(feedin_arr) else 0
-            sol = round(gen_arr[idx], 2) if idx < len(gen_arr) else 0
+            sol = round(pv_arr[idx], 2) if idx < len(pv_arr) else 0
             ch = round(charge_arr[idx], 2) if idx < len(charge_arr) else 0
             dis = round(discharge_arr[idx], 2) if idx < len(discharge_arr) else 0
             load_val = round(loads_arr[idx], 2) if idx < len(loads_arr) else 0

--- a/src/foxess/client.py
+++ b/src/foxess/client.py
@@ -26,6 +26,38 @@ from .models import ChargePeriod, DeviceInfo, RealTimeData, SchedulerGroup, Sche
 
 logger = logging.getLogger(__name__)
 
+
+def _warn_if_pv_tracks_generation(pv_val: object, summary_raw: dict) -> None:
+    """Runtime guard for the generation-vs-PVEnergyTotal class of regression.
+
+    Fox ``generation`` = inverter AC output (PV + battery discharge);
+    ``PVEnergyTotal`` = true panel-side PV. We map PV from PVEnergyTotal, so the
+    parsed ``pv_val`` must track PVEnergyTotal, NOT generation. If a future edit
+    reverts the mapping (or Fox renames a variable), ``pv_val`` will land closer
+    to generation than to PVEnergyTotal whenever the two diverge (i.e. whenever
+    the battery discharged). Log loudly so the regression screams in prod logs,
+    not just in CI. No-op when either variable is absent or they barely differ.
+    """
+    try:
+        gen = summary_raw.get("generation")
+        pvt = summary_raw.get("PVEnergyTotal")
+        if gen is None or pvt is None or pv_val is None:
+            return
+        gen_f, pvt_f, pv_f = float(gen), float(pvt), float(pv_val)
+        # Only meaningful when generation and true PV diverge (battery active).
+        if abs(gen_f - pvt_f) <= 1.0:
+            return
+        if abs(pv_f - gen_f) < abs(pv_f - pvt_f):
+            logger.warning(
+                "Fox PV sanity: parsed PV %.1f kWh tracks generation (%.1f, AC output incl. "
+                "discharge) instead of PVEnergyTotal (%.1f, panel side) — likely a "
+                "field-mapping regression",
+                pv_f, gen_f, pvt_f,
+            )
+    except (TypeError, ValueError):
+        pass
+
+
 # Known work mode strings (set_work_mode accepts these)
 WORK_MODE_VALID = frozenset({"Self Use", "Feed-in Priority", "Back Up", "Force charge", "Force discharge"})
 # Numeric code → label (Fox API may return code instead of string)
@@ -591,6 +623,7 @@ class FoxESSClient:
         pv_val = summary_raw.get("PVEnergyTotal")
         if pv_val is None:
             pv_val = summary_raw.get("generation") or summary_raw.get("generationPower") or 0
+        _warn_if_pv_tracks_generation(pv_val, summary_raw)
         loads_val = summary_raw.get("loads") or summary_raw.get("load") or 0
         feedin_val = summary_raw.get("feedin", 0)
         grid_val = summary_raw.get("gridConsumption", 0)
@@ -650,6 +683,7 @@ class FoxESSClient:
         pv_val = summary_raw.get("PVEnergyTotal")
         if pv_val is None:
             pv_val = summary_raw.get("generation") or summary_raw.get("generationPower") or 0
+        _warn_if_pv_tracks_generation(pv_val, summary_raw)
         loads_val = summary_raw.get("loads") or summary_raw.get("load") or 0
         feedin_val = summary_raw.get("feedin", 0)
         grid_val = summary_raw.get("gridConsumption", 0)
@@ -712,6 +746,12 @@ class FoxESSClient:
         pv_arr = by_var.get("PVEnergyTotal")
         if not pv_arr:
             pv_arr = by_var.get("generation", [])
+        # Same regression guard as the scalar paths, on the monthly sums.
+        _warn_if_pv_tracks_generation(
+            sum(pv_arr),
+            {"generation": sum(by_var.get("generation", [])),
+             "PVEnergyTotal": sum(by_var["PVEnergyTotal"]) if by_var.get("PVEnergyTotal") else None},
+        )
         feedin_arr = by_var.get("feedin", [])
         grid_arr = by_var.get("gridConsumption", [])
         loads_arr = by_var.get("loads", []) or by_var.get("load", [])

--- a/tests/test_daikin_daily_consumption_routing.py
+++ b/tests/test_daikin_daily_consumption_routing.py
@@ -1,0 +1,87 @@
+"""DaikinClient.get_daily_consumption_from_cache — management-point routing.
+
+Symmetry guard for the weekly ('w') array path, mirroring the routing test that
+already exists for the 2-hourly ('d') path. The 2026-06-15 telemetry audit
+found Daikin CLEAN of the Fox generation-vs-PVEnergyTotal class precisely
+because consumption is routed by management-point TYPE (domesticHotWaterTank →
+DHW bucket; everything else → space-heating bucket), not by the electrical mode
+field. These tests pin that contract so a future refactor can't silently swap
+the buckets (which would mis-attribute heat-pump energy in the brief / LP
+without changing any total).
+
+Daikin Onecta 'w' layout: 14 elements — indices 0–6 = last week (Mon→Sun),
+7–13 = this week (Mon→Sun); arr[7] = this Monday.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from src.daikin.client import DaikinClient
+
+
+class _FakeDevice:
+    def __init__(self, mp_payloads: list[dict]) -> None:
+        self.id = "test-device"
+        self.raw = {"managementPoints": mp_payloads}
+
+
+def _build_client(devices: list[_FakeDevice]) -> DaikinClient:
+    c = DaikinClient.__new__(DaikinClient)
+    c.get_devices = lambda **_: devices  # type: ignore[method-assign]
+    return c
+
+
+def _w_array(values_by_idx: dict[int, float]) -> list[float | None]:
+    arr: list[float | None] = [None] * 14
+    for idx, v in values_by_idx.items():
+        arr[idx] = v
+    return arr
+
+
+def _mp(*, w: list, mp_type: str, mode: str = "heating") -> dict:
+    return {
+        "managementPointType": mp_type,
+        "consumptionData": {"value": {"electrical": {mode: {"w": w}}}},
+    }
+
+
+def test_dhw_point_routes_to_dhw_bucket_heating_point_to_heating() -> None:
+    today = date(2026, 5, 6)  # a Wednesday → this Monday = 2026-05-04 (arr[7])
+    dhw = _mp(w=_w_array({7: 0.4}), mp_type="domesticHotWaterTank")
+    space = _mp(w=_w_array({7: 0.6}), mp_type="climateControl")
+    out = _build_client([_FakeDevice([dhw, space])]).get_daily_consumption_from_cache(today_utc=today)
+
+    monday = out["2026-05-04"]
+    assert monday["dhw_kwh"] == 0.4
+    assert monday["heating_kwh"] == 0.6
+    assert monday["total_kwh"] == 1.0
+
+
+def test_heatpump_point_counts_as_heating_not_dhw() -> None:
+    today = date(2026, 5, 6)
+    hp = _mp(w=_w_array({7: 1.1}), mp_type="heatPump")
+    out = _build_client([_FakeDevice([hp])]).get_daily_consumption_from_cache(today_utc=today)
+    assert out["2026-05-04"]["heating_kwh"] == 1.1
+    assert out["2026-05-04"]["dhw_kwh"] == 0.0
+
+
+def test_cooling_mode_sums_into_same_bucket_as_heating() -> None:
+    # Both electrical 'heating' and 'cooling' modes are electrical draw for the
+    # same point — they must accumulate together, not split or cancel.
+    today = date(2026, 5, 6)
+    mp = {
+        "managementPointType": "climateControl",
+        "consumptionData": {"value": {"electrical": {
+            "heating": {"w": _w_array({7: 0.5})},
+            "cooling": {"w": _w_array({7: 0.2})},
+        }}},
+    }
+    out = _build_client([_FakeDevice([mp])]).get_daily_consumption_from_cache(today_utc=today)
+    assert out["2026-05-04"]["heating_kwh"] == 0.7
+
+
+def test_last_week_indices_map_to_prior_week() -> None:
+    today = date(2026, 5, 6)  # this Monday = 2026-05-04; last Monday = 2026-04-27
+    mp = _mp(w=_w_array({0: 0.9}), mp_type="climateControl")  # arr[0] = last Monday
+    out = _build_client([_FakeDevice([mp])]).get_daily_consumption_from_cache(today_utc=today)
+    assert out["2026-04-27"]["heating_kwh"] == 0.9

--- a/tests/test_foxess.py
+++ b/tests/test_foxess.py
@@ -333,6 +333,74 @@ class TestFoxEnergyPvMapping(unittest.TestCase):
         self.assertAlmostEqual(daily[0]["solar_kwh"], 8.0)
         self.assertAlmostEqual(daily[1]["solar_kwh"], 9.0)
 
+    # ── Physical invariants — these fail if any field is re-mapped wrong ──────
+    # Each scenario: (generation, PVEnergyTotal, feedin, grid, charge, discharge).
+    # Realistic prod-shaped numbers incl. the winter battery-heavy case that
+    # exposed the original bug (generation 256 ≫ PV 32 because of 247 discharge).
+    SCENARIOS = {
+        "winter_battery_heavy": dict(generation=256.0, pv=32.1, feedin=0.5, grid=1751.2, charge=249.9, discharge=246.8),
+        "summer_pv_heavy": dict(generation=573.4, pv=467.6, feedin=84.0, grid=300.4, charge=327.8, discharge=324.1),
+        "zero_pv_winter_day": dict(generation=200.0, pv=0.0, feedin=0.0, grid=300.0, charge=210.0, discharge=200.0),
+        "no_battery": dict(generation=30.0, pv=30.0, feedin=5.0, grid=10.0, charge=0.0, discharge=0.0),
+    }
+
+    def _assert_invariants(self, out, sc):
+        pv, gen = out["pvEnergyToday"], sc["generation"]
+        # 1. PV must be the panel-side figure (PVEnergyTotal), never generation.
+        self.assertAlmostEqual(pv, sc["pv"], places=2)
+        # 2. PV (panel side) can NEVER exceed generation (AC output incl. discharge).
+        self.assertLessEqual(pv, gen + 1e-6, f"PV {pv} > generation {gen}")
+        # 3. When the battery discharged, PV must be STRICTLY below generation —
+        #    this is the assertion that fails if generation bleeds into solar.
+        if sc["discharge"] > 1.0:
+            self.assertLess(pv, gen, "PV == generation — discharge double-counted into solar")
+        # 4. No negative energy anywhere.
+        for k, v in out.items():
+            self.assertGreaterEqual(v, -1e-6, f"{k} negative ({v})")
+        # 5. Load balance closes with no discharge double-count.
+        expected = max(0.0, sc["grid"] + sc["pv"] + sc["discharge"] - sc["feedin"] - sc["charge"])
+        self.assertAlmostEqual(out["loadEnergyToday"], round(expected, 2), places=1)
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_month_report_invariants_all_scenarios(self, mock_post):
+        for name, sc in self.SCENARIOS.items():
+            with self.subTest(scenario=name):
+                mock_post.return_value = self._report(
+                    sc["generation"], sc["pv"], feedin=sc["feedin"],
+                    grid=sc["grid"], charge=sc["charge"], discharge=sc["discharge"],
+                )
+                self._assert_invariants(self.client._get_energy_month_report(2026, 1), sc)
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_day_report_invariants_all_scenarios(self, mock_post):
+        for name, sc in self.SCENARIOS.items():
+            with self.subTest(scenario=name):
+                mock_post.return_value = self._report(
+                    sc["generation"], sc["pv"], feedin=sc["feedin"],
+                    grid=sc["grid"], charge=sc["charge"], discharge=sc["discharge"],
+                )
+                self._assert_invariants(self.client.get_energy_day(2026, 1, 15), sc)
+
+    def test_guard_warns_when_pv_tracks_generation(self):
+        from src.foxess.client import _warn_if_pv_tracks_generation
+        raw = {"generation": 256.0, "PVEnergyTotal": 32.0}
+        with self.assertLogs("src.foxess.client", level="WARNING") as cm:
+            _warn_if_pv_tracks_generation(256.0, raw)  # pv tracks generation → regression
+        self.assertTrue(any("field-mapping regression" in m for m in cm.output))
+
+    def test_guard_silent_when_pv_is_panel_side(self):
+        from src.foxess.client import _warn_if_pv_tracks_generation
+        raw = {"generation": 256.0, "PVEnergyTotal": 32.0}
+        with self.assertNoLogs("src.foxess.client", level="WARNING"):
+            _warn_if_pv_tracks_generation(32.0, raw)  # correct mapping → no warning
+
+    def test_guard_silent_when_no_battery_activity(self):
+        from src.foxess.client import _warn_if_pv_tracks_generation
+        # generation ≈ PVEnergyTotal (no discharge) — ambiguous, must not warn.
+        raw = {"generation": 30.0, "PVEnergyTotal": 30.0}
+        with self.assertNoLogs("src.foxess.client", level="WARNING"):
+            _warn_if_pv_tracks_generation(30.0, raw)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_foxess.py
+++ b/tests/test_foxess.py
@@ -239,5 +239,100 @@ class TestFoxESSStatusEndpoint(unittest.TestCase):
         mock_get_cached.assert_called_once()
 
 
+class TestFoxEnergyPvMapping(unittest.TestCase):
+    """PV vs generation regression (Fox `generation` = AC output incl. battery
+    discharge; `PVEnergyTotal` = true panel-side PV). The energy report path
+    must map PV from PVEnergyTotal, not generation, or the "solar produced" /
+    self-sufficiency figures inflate (~8x in winter) and the load-balance
+    estimate double-counts discharge.
+    """
+
+    def setUp(self):
+        self.client = FoxESSClient(api_key="test_key", device_sn="TEST_SN")
+
+    @staticmethod
+    def _report(generation, pv, *, feedin=0.5, grid=100.0, charge=50.0, discharge=45.0):
+        items = [
+            {"variable": "feedin", "values": [feedin]},
+            {"variable": "gridConsumption", "values": [grid]},
+            {"variable": "chargeEnergyToTal", "values": [charge]},
+            {"variable": "dischargeEnergyToTal", "values": [discharge]},
+        ]
+        if generation is not None:
+            items.append({"variable": "generation", "values": [generation]})
+        if pv is not None:
+            items.append({"variable": "PVEnergyTotal", "values": [pv]})
+        return items
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_month_report_requests_pvenergytotal(self, mock_post):
+        mock_post.return_value = self._report(256.0, 32.1)
+        self.client._get_energy_month_report(2026, 1)
+        _, body = mock_post.call_args.args
+        self.assertIn("PVEnergyTotal", body["variables"])
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_month_report_pv_from_pvenergytotal_not_generation(self, mock_post):
+        mock_post.return_value = self._report(256.0, 32.1)
+        out = self.client._get_energy_month_report(2026, 1)
+        self.assertAlmostEqual(out["pvEnergyToday"], 32.1)
+        self.assertNotAlmostEqual(out["pvEnergyToday"], 256.0)
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_month_report_zero_pv_day_stays_zero(self, mock_post):
+        # A legitimate zero-PV winter day must NOT fall through to generation.
+        mock_post.return_value = self._report(200.0, 0.0)
+        out = self.client._get_energy_month_report(2026, 1)
+        self.assertEqual(out["pvEnergyToday"], 0.0)
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_month_report_falls_back_to_generation_when_pv_absent(self, mock_post):
+        # Older firmware / cloud variant that doesn't return PVEnergyTotal.
+        mock_post.return_value = self._report(180.0, None)
+        out = self.client._get_energy_month_report(2026, 1)
+        self.assertAlmostEqual(out["pvEnergyToday"], 180.0)
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_month_report_load_balance_no_discharge_double_count(self, mock_post):
+        # load = grid + PV + discharge - feedin - charge, with TRUE pv.
+        mock_post.return_value = self._report(
+            256.0, 32.1, feedin=0.5, grid=100.0, charge=50.0, discharge=45.0
+        )
+        out = self.client._get_energy_month_report(2026, 1)
+        expected = 100.0 + 32.1 + 45.0 - 0.5 - 50.0
+        self.assertAlmostEqual(out["loadEnergyToday"], round(expected, 2))
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_daily_breakdown_solar_from_pvenergytotal(self, mock_post):
+        mock_post.return_value = [
+            {"variable": "generation", "values": [8.0, 9.0]},
+            {"variable": "PVEnergyTotal", "values": [1.0, 1.2]},
+            {"variable": "feedin", "values": [0.0, 0.0]},
+            {"variable": "gridConsumption", "values": [5.0, 6.0]},
+            {"variable": "chargeEnergyToTal", "values": [3.0, 3.0]},
+            {"variable": "dischargeEnergyToTal", "values": [7.0, 7.5]},
+        ]
+        _, daily = self.client.get_energy_month_daily_breakdown(2026, 1)
+        self.assertAlmostEqual(daily[0]["solar_kwh"], 1.0)
+        self.assertAlmostEqual(daily[1]["solar_kwh"], 1.2)
+        self.assertIn("PVEnergyTotal", mock_post.call_args.args[1]["variables"])
+        # Per-row load balance uses true PV → no discharge double-count.
+        # load = import + PV + discharge - export - charge (loads absent).
+        self.assertAlmostEqual(daily[0]["load_kwh"], round(5.0 + 1.0 + 7.0 - 0.0 - 3.0, 2))
+        self.assertAlmostEqual(daily[1]["load_kwh"], round(6.0 + 1.2 + 7.5 - 0.0 - 3.0, 2))
+
+    @patch.object(FoxESSClient, "_open_post")
+    def test_daily_breakdown_empty_pv_array_falls_back_to_generation(self, mock_post):
+        # API anomaly: PVEnergyTotal present but empty → must not zero the month.
+        mock_post.return_value = [
+            {"variable": "generation", "values": [8.0, 9.0]},
+            {"variable": "PVEnergyTotal", "values": []},
+            {"variable": "gridConsumption", "values": [5.0, 6.0]},
+        ]
+        _, daily = self.client.get_energy_month_daily_breakdown(2026, 1)
+        self.assertAlmostEqual(daily[0]["solar_kwh"], 8.0)
+        self.assertAlmostEqual(daily[1]["solar_kwh"], 9.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
Fox `report/query` returns `generation` = "AC output from inverter side, affected by battery charging/discharging" (PV **+ battery discharge**). The client was mapping it to `pvEnergyToday`/`solar_kwh`, inflating "solar produced" and self-sufficiency **~8x in winter** and **double-counting discharge** in the load-balance estimate.

Confirmed on prod (Jan 2026, read-only probe): `generation`=256 kWh vs true `PVEnergyTotal`=32.1 kWh (matches Fox web report), `dischargeEnergyToTal`=246.8 kWh. 32 + 247 ≈ 256.

## Fix
All four energy-report call sites in `src/foxess/client.py` now request `PVEnergyTotal` (empirically verified accepted by report/query — no 40257) and map PV from it:
- scalar paths (`_get_energy_month_report`, `get_energy_day`): explicit `is None` fallback to generation, so a **legitimate zero-PV winter day stays zero** rather than reverting to the discharge-inflated figure.
- per-day breakdown (`get_energy_month_daily_breakdown`, which feeds `fox_energy_daily.solar_kwh` → PV calibration): falls back when the array is absent **or empty**.
- `get_energy_range` (history/query fallback): prefers PVEnergyTotal before generation.

The load-balance `grid + PV + discharge − feedin − charge` is now physically correct (PV is panel-side, so discharge is counted once).

## Blast radius
**Display/telemetry only — £/PnL unaffected.** Cost figures use Octopus metered import + `pv_realtime_history` pvPower (both already correct). This corrects monthly "solar produced", self-sufficiency, and the `fox_energy_daily` write-conflict where this report path could overwrite the correct realtime rollup. Historical monthly consumption will legitimately drop (was inflated); nothing is tuned against the old value (LP base load comes from Octopus ticks, not this path).

## Tests
New `TestFoxEnergyPvMapping` (8 cases): PV from PVEnergyTotal not generation, zero-PV day stays zero, fallback when absent, load-balance no discharge double-count, per-day breakdown solar + per-row balance, empty-array fallback. **44 passed** (foxess + cache-readthrough + monthly-proration).

## Verification
Independent Plan-agent review: fix sound; None-vs-truthy correct; no `gen_arr` stragglers; two writers now agree; calibration self-heals (ratio>1.5 outlier filter drops stale inflated rows). Two LOW findings addressed (empty-array guard) or accepted (history/query no-op term).

## Residual (follow-up, optional)
Pre-fix `fox_energy_daily` rows still hold inflated solar; a one-time `compute_fox_energy_daily_from_realtime` recompute over the calibration window would clean them immediately. They otherwise age out / are mostly dropped by the outlier filter.

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)