### PR TITLE
fix(insights): consistent tariff framing + live standing charge

### DIFF
--- a/src/analytics/fair_compare.py
+++ b/src/analytics/fair_compare.py
@@ -178,6 +178,25 @@ def _empty(requested_start: date, end_day: date, agile_start: date) -> dict[str,
     }
 
 
+def _current_standing_per_day(candidates: list, current_code: str) -> float:
+    """Standing charge (pence/day) to price the household's CURRENT tariff with.
+
+    Prefer the LIVE Octopus catalogue value for the actual product — it
+    auto-corrects and never drifts. The hand-set ``MANUAL_STANDING_CHARGE``
+    config silently goes stale (it sat at 59.26p while the live AGILE-24-10-01
+    standing was 62.22p, so every comparison flattered Agile by ~3p/day). Fall
+    back to MANUAL only when the catalogue is offline or the current product
+    isn't in it (standing must be > 0 to count as a real catalogue value).
+    """
+    for t in candidates:
+        if getattr(t, "product_code", None) == current_code:
+            sc = float(getattr(t.rates, "standing_charge_pence_per_day", 0) or 0)
+            if sc > 0:
+                return sc
+            break
+    return float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0)
+
+
 def compute_fair_comparison(
     start_day: date, end_day: date, *, max_tariffs: int = 14
 ) -> dict[str, Any]:
@@ -303,7 +322,7 @@ def compute_fair_comparison(
     rows: list[dict[str, Any]] = []
 
     # Current Agile (realised) — its own standing + realised Outgoing export.
-    cur_standing = float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0) * n_days
+    cur_standing = _current_standing_per_day(candidates, current_code) * n_days
     cur_net = cur["import_cost"] + cur_standing - cur["export_credit"]
     rows.append({
         "product_code": current_code,

--- a/tests/test_fair_compare_standing.py
+++ b/tests/test_fair_compare_standing.py
@@ -1,0 +1,47 @@
+"""fair_compare: current-tariff standing charge prefers the live Octopus
+catalogue over the stale MANUAL_STANDING_CHARGE config.
+
+The configured MANUAL value drifted (59.26p) below the household's real live
+AGILE-24-10-01 standing (62.22p), flattering Agile in every comparison by
+~3p/day. The fair-compare current row must price with the live value when the
+catalogue carries the household's product, and fall back to MANUAL only when it
+doesn't (or the catalogue is offline).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.analytics.fair_compare import _current_standing_per_day
+from src.config import config
+
+
+def _product(code: str, standing: float):
+    return SimpleNamespace(
+        product_code=code,
+        rates=SimpleNamespace(standing_charge_pence_per_day=standing),
+    )
+
+
+def test_prefers_live_catalogue_standing_for_current_product():
+    cands = [_product("VAR-22-11-01", 44.35), _product("AGILE-24-10-01", 62.22)]
+    assert _current_standing_per_day(cands, "AGILE-24-10-01") == pytest.approx(62.22)
+
+
+def test_falls_back_to_manual_when_product_absent(monkeypatch):
+    monkeypatch.setattr(config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 59.26, raising=False)
+    cands = [_product("VAR-22-11-01", 44.35)]
+    assert _current_standing_per_day(cands, "AGILE-24-10-01") == pytest.approx(59.26)
+
+
+def test_falls_back_to_manual_when_catalogue_empty(monkeypatch):
+    monkeypatch.setattr(config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 59.26, raising=False)
+    assert _current_standing_per_day([], "AGILE-24-10-01") == pytest.approx(59.26)
+
+
+def test_zero_or_missing_catalogue_standing_falls_back_to_manual(monkeypatch):
+    # A catalogue row that exists but reports 0 standing isn't a real value.
+    monkeypatch.setattr(config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 59.26, raising=False)
+    cands = [_product("AGILE-24-10-01", 0.0)]
+    assert _current_standing_per_day(cands, "AGILE-24-10-01") == pytest.approx(59.26)

--- a/ui/src/routes/insights.css
+++ b/ui/src/routes/insights.css
@@ -46,6 +46,8 @@
 .insights-export { color: var(--ok); }
 .insights-cheaper { color: var(--ok); font-weight: 600; }
 .insights-dearer { color: var(--bad); }
+/* A dearer alternative is reassuring, not a loss — muted "+£X", never red. */
+.insights-costlier { color: var(--text-mute); }
 
 .insights-note { margin-top: var(--space-3); font-size: var(--font-2xs); max-width: 70ch; }
 .insights-legend-approx { color: var(--warn); font-weight: 700; }

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -27,6 +27,9 @@ export default function Insights() {
   const current = rows.find((r) => r.is_current) ?? null;
   const winner = rows.find((r) => r.product_code === data?.winner_product_code) ?? null;
   const winnerIsCurrent = winner?.is_current ?? false;
+  // The household's previous fixed tariff (synthetic "FIXED" row), for the
+  // "saving £X vs <old tariff>" line — mirrors the cockpit header framing.
+  const fixedRow = rows.find((r) => r.product_code === "FIXED") ?? null;
 
   return (
     <div class="page-padded insights">
@@ -82,7 +85,12 @@ export default function Insights() {
           ) : (
             <div class={`insights-winner${winnerIsCurrent ? " is-current-best" : ""}`}>
               {winnerIsCurrent ? (
-                <span>You're on the cheapest tariff for {periodLabel(period)} — <strong>{winner?.display_name}</strong>.</span>
+                <span>
+                  You're on the cheapest tariff for {periodLabel(period)} — <strong>{winner?.display_name}</strong>.
+                  {fixedRow && current && fixedRow.net_pence > current.net_pence && (
+                    <> Saving <strong>{gbp((fixedRow.net_pence - current.net_pence) / 100)}</strong> vs {fixedRow.display_name}.</>
+                  )}
+                </span>
               ) : (
                 <span>
                   Cheapest for {periodLabel(period)}: <strong>{winner?.display_name}</strong> —
@@ -145,7 +153,7 @@ export default function Insights() {
                   <th class="num">Standing</th>
                   <th class="num">Export</th>
                   <th class="num">Net</th>
-                  <th class="num">vs yours</th>
+                  <th class="num">If you switch</th>
                 </tr>
               </thead>
               <tbody>
@@ -171,7 +179,13 @@ export default function Insights() {
 }
 
 function Row({ r, curNet }: { r: FairTariffRow; curNet: number }) {
-  const delta = (curNet - r.net_pence) / 100; // >0 → cheaper than yours
+  // How YOUR bill would change if you switched TO this tariff.
+  //   + (costs more) → staying on yours is right → muted, not alarming.
+  //   − (cheaper)    → a genuine opportunity → highlighted green.
+  // (Earlier this showed every dearer alternative as a red negative — a table of
+  //  red "−£38" next to the "you're cheapest" banner read as if we were losing.)
+  const billChange = (r.net_pence - curNet) / 100;
+  const cheaper = billChange < -0.005;
   return (
     <tr class={r.is_current ? "is-current" : ""}>
       <td class="insights-name">
@@ -189,7 +203,12 @@ function Row({ r, curNet }: { r: FairTariffRow; curNet: number }) {
       <td class="num insights-net">{p2(r.net_pence)}</td>
       <td class="num">
         {r.is_current ? "—" : (
-          <span class={delta >= 0 ? "insights-cheaper" : "insights-dearer"}>{gbpSigned(delta)}</span>
+          <span
+            class={cheaper ? "insights-cheaper" : "insights-costlier"}
+            title={cheaper ? "Cheaper than your tariff on this usage" : "You'd pay this much more on this tariff"}
+          >
+            {gbpSigned(billChange)}
+          </span>
         )}
       </td>
     </tr>


### PR DESCRIPTION
## Problem
The Insights page contradicted itself (user-reported "ganhando no header, perdendo no detalhe"):
- **Banner**: "You're on the cheapest tariff" → winning.
- **Table "vs yours" column**: every dearer alternative rendered as a **red negative** (BG Fixed −£38.46). A column of red negatives next to the banner reads as losing — the opposite of the truth.

Verified on prod (read-only) that the maths is consistent: `realised_net £111.05 + delta_vs_fixed_real £38.46 = fair-compare BG Fixed £149.51`. So this is a **presentation + standing-accuracy** issue, not a calculation bug.

## Fixes
1. **Consistent framing (UI).** The column now answers "what happens to YOUR bill if you switch": `+£X` **muted** for dearer tariffs (reassuring, not alarming), `−£X` **green** for genuinely cheaper ones (the only actionable case). Header → "If you switch". When Agile wins, the banner also shows "Saving £X vs <old fixed tariff>", mirroring the cockpit header.
2. **Accurate current-tariff standing (backend).** fair_compare priced current Agile with the hand-set `MANUAL_STANDING_CHARGE` (59.26p), which had drifted below the household's real live `AGILE-24-10-01` standing (**62.22p**, confirmed via the Octopus catalogue) — flattering Agile by ~3p/day. New `_current_standing_per_day` prefers the live catalogue value, falling back to MANUAL only when the catalogue is offline or the product is absent.

## Tests
`tests/test_fair_compare_standing.py` — live preferred; fallback on absent/empty/zero. 88 passed across fair/pnl/tariff/insights subset; UI tsc + build clean.

## Notes
- Image: both **hem** (fair_compare) and **ui** (insights route).
- This is PR A of 3 from the Insights review. PR B (exclude negative-price slots from the load profile — LP + heatmap) and PR C (heat-pump heatmap breakdown) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)