### PR TITLE
feat(load-profile): exclude negative-price slots from the residual sample

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -805,6 +805,15 @@ class Config:
     LP_RESIDUAL_PROFILE_V2: bool = os.getenv(
         "LP_RESIDUAL_PROFILE_V2", "true"
     ).lower() in ("true", "1", "yes")
+    # Drop negative-price half-hour slots from the residual load-profile sample.
+    # During plunges the system DELIBERATELY boosts consumption (battery charge,
+    # appliance dispatch, tank to 65 °C), so those slots aren't the organic
+    # at-home pattern — keeping them biases the LP base-load forecast upward for
+    # whichever (dow,hour) the plunge landed on. Set false to roll back to the
+    # old behaviour (include them).
+    LP_LOAD_EXCLUDE_NEGATIVE_SLOTS: bool = os.getenv(
+        "LP_LOAD_EXCLUDE_NEGATIVE_SLOTS", "true"
+    ).lower() in ("true", "1", "yes")
     LP_PEAK_EXPORT_PESSIMISTIC_FLOOR_KWH: float = float(
         os.getenv("LP_PEAK_EXPORT_PESSIMISTIC_FLOOR_KWH", "0.30")
     )

--- a/src/db.py
+++ b/src/db.py
@@ -1977,6 +1977,13 @@ def residual_load_profile_v2(
     # physics, no away exclusion) so the LP plan can be rolled back live (#477).
     _v2 = bool(getattr(config, "LP_RESIDUAL_PROFILE_V2", True))
     away_fraction = float(getattr(config, "LP_AWAY_DAY_FRACTION", 0.4) or 0.0) if _v2 else 0.0
+    # During negative-price windows the system DELIBERATELY boosts consumption
+    # (battery charge, appliance dispatch, tank to 65 °C). Those slots aren't the
+    # household's organic at-home pattern — including them biases the load profile
+    # (and thus the LP base-load forecast) upward for whichever (dow,hour) the
+    # plunge happened to land on. Drop them from the sample. Kill-switch via
+    # LP_LOAD_EXCLUDE_NEGATIVE_SLOTS=false.
+    exclude_neg = bool(getattr(config, "LP_LOAD_EXCLUDE_NEGATIVE_SLOTS", True))
 
     # Short-TTL cache — this 120-day rebuild runs the physics estimator over
     # ~thousands of pv samples and is called multiple times per optimizer solve
@@ -1984,7 +1991,7 @@ def residual_load_profile_v2(
     # as new telemetry / the nightly Daikin sync land, so a 4-min TTL is safe and
     # collapses the per-solve cost to one rebuild. Keyed by DB_PATH so isolated
     # test DBs never share an entry.
-    cache_key = (config.DB_PATH, window_days, min_samples_per_bucket, _v2)
+    cache_key = (config.DB_PATH, window_days, min_samples_per_bucket, _v2, exclude_neg)
     if use_cache:
         ent = _RESIDUAL_V2_CACHE.get(cache_key)
         if ent is not None and ent[0] > time.monotonic():
@@ -2023,6 +2030,26 @@ def residual_load_profile_v2(
                 (cutoff_iso,),
             )
             rows = cur.fetchall()
+            # Negative-price slots over the window (same source the LP priced
+            # against: execution_log.agile_price_pence), keyed by half-hour UTC
+            # slot start so Pass 1 can drop the deliberately-boosted samples.
+            neg_slots: set[str] = set()
+            if exclude_neg:
+                ncur = conn.execute(
+                    """SELECT DISTINCT timestamp FROM execution_log
+                       WHERE timestamp > ? AND agile_price_pence < 0""",
+                    (cutoff_iso,),
+                )
+                for nr in ncur.fetchall():
+                    try:
+                        nt = datetime.fromisoformat(str(nr["timestamp"]).replace("Z", "+00:00"))
+                    except (ValueError, TypeError):
+                        continue
+                    nsm = (nt.minute // 30) * 30
+                    neg_slots.add(
+                        nt.replace(minute=nsm, second=0, microsecond=0)
+                        .astimezone(UTC).isoformat().replace("+00:00", "Z")
+                    )
         finally:
             conn.close()
 
@@ -2033,6 +2060,7 @@ def residual_load_profile_v2(
     physics_bucket: dict[tuple[str, int], float] = {}
     physics_day: dict[str, float] = {}
     dropped_no_meteo = 0
+    dropped_negative = 0
     for row in rows:
         outdoor = row["outdoor_history_c"]
         if outdoor is None:
@@ -2045,6 +2073,13 @@ def residual_load_profile_v2(
             local = ts.astimezone(tz)
         except (ValueError, TypeError):
             continue
+        if exclude_neg and neg_slots:
+            sm = (ts.minute // 30) * 30
+            skey = (ts.replace(minute=sm, second=0, microsecond=0)
+                    .astimezone(UTC).isoformat().replace("+00:00", "Z"))
+            if skey in neg_slots:
+                dropped_negative += 1
+                continue
         load_slot = float(row["load_power_kw"]) * 0.5
         physics_slot = _physics_daikin_slot_kwh(float(outdoor), cop_curve)
         date_iso = local.date().isoformat()
@@ -2060,7 +2095,8 @@ def residual_load_profile_v2(
         return _finish({
             "profile": {(h, m): flat for h in range(24) for m in (0, 30)},
             "spread": {}, "flat": flat, "away_days": [],
-            "day_counts": {"weekday": 0, "weekend": 0, "away_excluded": 0, "total": 0},
+            "day_counts": {"weekday": 0, "weekend": 0, "away_excluded": 0,
+                           "negative_excluded": dropped_negative, "total": 0},
             "calibrated_days": 0, "physics_only_days": 0,
         })
 
@@ -2180,10 +2216,10 @@ def residual_load_profile_v2(
     calibrated_days = len(calibrated_dates - away_days)
     physics_only_days = len(set(dates) - calibrated_dates - away_days)
     logger.info(
-        "residual_profile_v2: %d samples (%d no-meteo), window=%dd; "
+        "residual_profile_v2: %d samples (%d no-meteo, %d negative-price), window=%dd; "
         "%d weekday / %d weekend days, %d away excluded; "
         "%d calibrated / %d physics-only days",
-        len(samples), dropped_no_meteo, window_days,
+        len(samples), dropped_no_meteo, dropped_negative, window_days,
         len(weekday_days), len(weekend_days), len(away_days),
         calibrated_days, physics_only_days,
     )
@@ -2196,6 +2232,7 @@ def residual_load_profile_v2(
             "weekday": len(weekday_days),
             "weekend": len(weekend_days),
             "away_excluded": len(away_days),
+            "negative_excluded": dropped_negative,
             "total": len(set(dates)),
         },
         "calibrated_days": calibrated_days,

--- a/tests/test_db_residual_profile_v2.py
+++ b/tests/test_db_residual_profile_v2.py
@@ -132,6 +132,52 @@ def test_calibration_fallback_equals_pure_physics() -> None:
     assert db.lookup_residual_kwh(prof, 4, 8, 0) == pytest.approx(legacy[(8, 0)], abs=0.05)
 
 
+def _seed_negative_exec(d: date, hour: int, minute: int = 0) -> None:
+    """Mark the half-hour slot at LOCAL (hour:minute) on date d as negative-price
+    in execution_log (the same source residual_load_profile_v2 reads)."""
+    t_utc = datetime(d.year, d.month, d.day, hour, minute, tzinfo=LON).astimezone(UTC)
+    db.log_execution({
+        "timestamp": t_utc.isoformat().replace("+00:00", "Z"),
+        "agile_price_pence": -4.0,
+        "consumption_kwh": 1.0,
+    })
+
+
+def test_negative_price_slots_excluded_by_default() -> None:
+    """Plunge slots carry deliberately-boosted load — they must be dropped so the
+    profile reflects the organic at-home pattern, not price-driven consumption."""
+    tues = _recent_days_of_weekday(1, 6)
+    for d in tues:
+        # 02:00 plunge — boosted high load AND negative price → must be excluded.
+        _seed_local(d, 2, 0, load_kw=3.0)
+        _seed_negative_exec(d, 2, 0)
+        # 19:00 organic evening — normal load, positive price → retained.
+        _seed_local(d, 19, 0, load_kw=0.6)
+
+    prof = db.residual_load_profile_v2(window_days=120)
+    assert prof["day_counts"]["negative_excluded"] >= 6
+    # The boosted plunge bucket is gone → lookup falls back well below 1.5 kWh.
+    assert db.lookup_residual_kwh(prof, 1, 2, 0) < 1.0
+    # The organic bucket survives untouched.
+    assert prof["profile"][(1, 19, 0)] == pytest.approx(0.3, abs=0.1)
+
+
+def test_negative_price_slots_kept_when_killswitch_off(monkeypatch) -> None:
+    """LP_LOAD_EXCLUDE_NEGATIVE_SLOTS=false → legacy behaviour (slots retained)."""
+    from src.config import config as cfg
+    monkeypatch.setattr(cfg, "LP_LOAD_EXCLUDE_NEGATIVE_SLOTS", False, raising=False)
+
+    tues = _recent_days_of_weekday(1, 6)
+    for d in tues:
+        _seed_local(d, 2, 0, load_kw=3.0)
+        _seed_negative_exec(d, 2, 0)
+
+    prof = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    assert prof["day_counts"]["negative_excluded"] == 0
+    # Boosted slots retained → bucket median = 3.0 kW × 0.5 h = 1.5 kWh.
+    assert prof["profile"][(1, 2, 0)] == pytest.approx(1.5, abs=0.1)
+
+
 def test_fallback_hierarchy_and_min_samples() -> None:
     """A (dow,h,m) bucket below min_samples is dropped; lookup falls to (h,m).
     Every (h,m) leaf is always present."""


### PR DESCRIPTION
## Problem
During negative-price plunges the system **deliberately boosts consumption** (battery charge from grid, appliance dispatch timed to the cheap window, tank to 65 °C). Those half-hours are price-driven, not the household's organic at-home pattern — leaving them in the residual load sample biases the per-(dow,hour) median (and the LP base-load forecast) upward for whichever slot the plunge landed on.

## Fix
`residual_load_profile_v2` (src/db.py) drops samples whose half-hour slot was negative-priced — source `execution_log.agile_price_pence < 0`, the same rate the LP priced against, keyed by half-hour UTC slot. The dropped count surfaces as `day_counts.negative_excluded` and in the log line.

- Gated by **`LP_LOAD_EXCLUDE_NEGATIVE_SLOTS`** (default true; false = legacy/rollback).
- Flag is part of the TTL cache key, so toggling never returns a stale profile.
- De-biases **both** the LP base-load forecast and the Insights load heatmap (they share the profile) — per the user decision "LP + heatmap".

## Tests
`tests/test_db_residual_profile_v2.py` — negative slots excluded by default (boosted bucket dropped, organic bucket retained, count surfaced); kill-switch off retains them at the boosted median. 223 passed across residual/optimizer/appliance/scenario consumers.

## Notes
- Image: **hem**. PR B of 3 from the Insights review (PR A #565 = tariff framing/standing; PR C = heat-pump heatmap breakdown, will also surface `negative_excluded` in the card meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)