### PR TITLE
feat(insights): heat-pump load heatmap breakdown

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -391,6 +391,12 @@ async def get_residual_load_profile(window_days: int | None = None) -> dict[str,
                 })
         return out
 
+    def _hp_series(dow: int) -> list[dict[str, Any]]:
+        return [
+            {"h": h, "m": m, "median": round(db.lookup_hp_kwh(prof, dow, h, m), 4)}
+            for h in range(24) for m in (0, 30)
+        ]
+
     p = prof.get("profile", {})
     all_series = [
         {"h": h, "m": m,
@@ -400,6 +406,8 @@ async def get_residual_load_profile(window_days: int | None = None) -> dict[str,
     ]
     return {
         "by_dow": {str(d): _series(d) for d in range(7)},
+        # Heat-pump (Daikin) split — the load the residual profile subtracts.
+        "hp_by_dow": {str(d): _hp_series(d) for d in range(7)},
         "all": all_series,
         "flat": round(float(prof.get("flat", 0.0)), 4),
         "away_days": prof.get("away_days", []),

--- a/src/db.py
+++ b/src/db.py
@@ -2094,7 +2094,7 @@ def residual_load_profile_v2(
             flat = mean_consumption_kwh_from_execution_logs(limit=2016)
         return _finish({
             "profile": {(h, m): flat for h in range(24) for m in (0, 30)},
-            "spread": {}, "flat": flat, "away_days": [],
+            "hp_profile": {}, "spread": {}, "flat": flat, "away_days": [],
             "day_counts": {"weekday": 0, "weekend": 0, "away_excluded": 0,
                            "negative_excluded": dropped_negative, "total": 0},
             "calibrated_days": 0, "physics_only_days": 0,
@@ -2137,12 +2137,15 @@ def residual_load_profile_v2(
         return 1.0
 
     # Pass 2 — calibrated residual per sample, grouped by date for away detection.
+    # ``hp`` is the calibrated heat-pump (Daikin) slot energy we subtracted — kept
+    # so we can publish its own per-(dow,hour) profile for the heat-pump heatmap.
     by_date_daytime: dict[str, list[float]] = {}
-    residual_samples: list[tuple[datetime, str, float]] = []  # (local, date_iso, residual)
+    residual_samples: list[tuple[datetime, str, float, float]] = []  # (local, date_iso, residual, hp)
     for local, date_iso, b, load_slot, physics_slot in samples:
         k = _calib(date_iso, b)
-        residual = max(0.0, load_slot - physics_slot * k)
-        residual_samples.append((local, date_iso, residual))
+        hp = physics_slot * k
+        residual = max(0.0, load_slot - hp)
+        residual_samples.append((local, date_iso, residual, hp))
         if 9 <= local.hour < 21:
             by_date_daytime.setdefault(date_iso, []).append(residual)
 
@@ -2157,11 +2160,13 @@ def residual_load_profile_v2(
         threshold = away_fraction * pop_median
         away_days = {d for d, sig in day_signatures.items() if sig < threshold}
 
-    # Aggregation (away days removed) into the three tiers.
+    # Aggregation (away days removed) into the three tiers. ``hp_tiers`` mirrors
+    # ``tiers`` for the heat-pump split so both heatmaps share the same buckets.
     tiers: dict[Any, list[float]] = {}
+    hp_tiers: dict[Any, list[float]] = {}
     weekday_days: set[str] = set()
     weekend_days: set[str] = set()
-    for local, date_iso, residual in residual_samples:
+    for local, date_iso, residual, hp in residual_samples:
         if date_iso in away_days:
             continue
         dow = local.weekday()
@@ -2172,14 +2177,17 @@ def residual_load_profile_v2(
         if _v2:  # day-of-week + weekday/weekend tiers (kill-switch off → (h,m) only)
             tiers.setdefault((dow, h, m), []).append(residual)
             tiers.setdefault((group, h, m), []).append(residual)
+            hp_tiers.setdefault((dow, h, m), []).append(hp)
+            hp_tiers.setdefault((group, h, m), []).append(hp)
         tiers.setdefault((h, m), []).append(residual)
+        hp_tiers.setdefault((h, m), []).append(hp)
 
     def _p75(vs: list[float]) -> float:
         if len(vs) < 2:
             return vs[0] if vs else 0.0
         return _quantiles(vs, n=4)[2]
 
-    retained = [r for (_l, d, r) in residual_samples if d not in away_days]
+    retained = [r for (_l, d, r, _hp) in residual_samples if d not in away_days]
     flat = _median(retained) if retained else (
         mean_fox_load_kwh_per_slot(limit=60) or mean_consumption_kwh_from_execution_logs(limit=2016)
     )
@@ -2190,6 +2198,14 @@ def residual_load_profile_v2(
         if len(vs) >= min_samples_per_bucket:
             profile[key] = _median(vs)
             spread[key] = _p75(vs)
+
+    # Heat-pump profile — same tier structure, median per bucket. Unfilled buckets
+    # mean "no heat-pump signal learned there" → the lookup falls back to 0, which
+    # is the honest reading (the heat pump genuinely idles in many slots).
+    hp_profile: dict[Any, float] = {}
+    for key, vs in hp_tiers.items():
+        if len(vs) >= min_samples_per_bucket:
+            hp_profile[key] = _median(vs)
 
     # Always fill all 48 (h, m) buckets (hour-aware fallback) so the lookup chain
     # has a guaranteed leaf below the dow/group tiers.
@@ -2225,6 +2241,7 @@ def residual_load_profile_v2(
     )
     return _finish({
         "profile": profile,
+        "hp_profile": hp_profile,
         "spread": spread,
         "flat": float(flat),
         "away_days": sorted(away_days),
@@ -2251,6 +2268,20 @@ def lookup_residual_kwh(profile_obj: dict[str, Any], dow: int, h: int, m: int) -
         if v is not None:
             return float(v)
     return float(profile_obj.get("flat", 0.0))
+
+
+def lookup_hp_kwh(profile_obj: dict[str, Any], dow: int, h: int, m: int) -> float:
+    """Resolve the heat-pump (Daikin) kWh for a slot from a
+    :func:`residual_load_profile_v2` object, same fallback hierarchy as
+    :func:`lookup_residual_kwh` but over ``hp_profile``. Returns 0.0 when no
+    heat-pump signal was learned for the slot (honest — the pump idles often)."""
+    hp = profile_obj.get("hp_profile", {})
+    group = "weekend" if dow >= 5 else "weekday"
+    for key in ((dow, h, m), (group, h, m), (h, m)):
+        v = hp.get(key)
+        if v is not None:
+            return float(v)
+    return 0.0
 
 
 def lookup_residual_spread_kwh(profile_obj: dict[str, Any], dow: int, h: int, m: int) -> float:

--- a/tests/test_db_residual_profile_v2.py
+++ b/tests/test_db_residual_profile_v2.py
@@ -243,12 +243,42 @@ def test_residual_profile_endpoint_shape() -> None:
         _seed_local(d, 19, 0, load_kw=2.0)
         _seed_local(d, 19, 10, load_kw=2.0)
     resp = asyncio.run(pv_router.get_residual_load_profile(window_days=120))
-    assert set(resp.keys()) >= {"by_dow", "all", "flat", "away_days", "day_counts",
-                                "calibrated_days", "physics_only_days"}
+    assert set(resp.keys()) >= {"by_dow", "hp_by_dow", "all", "flat", "away_days",
+                                "day_counts", "calibrated_days", "physics_only_days"}
     assert len(resp["by_dow"]) == 7
+    assert len(resp["hp_by_dow"]) == 7
     assert len(resp["all"]) == 48
+    assert len(resp["hp_by_dow"]["5"]) == 48
     sat19 = next(s for s in resp["by_dow"]["5"] if s["h"] == 19 and s["m"] == 0)
     assert sat19["median"] == pytest.approx(1.0, abs=0.1)
     # JSON-serialisable (no tuple keys leaked).
     import json
     json.dumps(resp)
+
+
+def test_heat_pump_profile_present_on_cold_days() -> None:
+    """hp_profile carries the heat-pump (Daikin) split; cold slots → non-zero."""
+    days = _recent_days_of_weekday(3, 6)   # Thursdays, cold so physics > 0
+    for d in days:
+        _seed_local(d, 8, 0, load_kw=1.5, temp_c=2.0)
+        _seed_local(d, 8, 10, load_kw=1.5, temp_c=2.0)
+    prof = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    assert (3, 8, 0) in prof["hp_profile"]
+    assert db.lookup_hp_kwh(prof, 3, 8, 0) > 0.0
+
+
+def test_heat_pump_profile_zero_when_warm() -> None:
+    """Warm slots → physics heat-pump estimate ≈ 0, so the hp profile is ~0."""
+    for d in _recent_days_of_weekday(2, 6):   # Wednesdays, warm
+        _seed_local(d, 14, 0, load_kw=0.6, temp_c=25.0)
+        _seed_local(d, 14, 10, load_kw=0.6, temp_c=25.0)
+    prof = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    assert db.lookup_hp_kwh(prof, 2, 14, 0) == pytest.approx(0.0, abs=0.05)
+
+
+def test_lookup_hp_kwh_falls_back_to_zero_for_unknown_slot() -> None:
+    for d in _recent_days_of_weekday(0, 6):   # Mondays only
+        _seed_local(d, 8, 0, load_kw=1.0, temp_c=2.0)
+    prof = db.residual_load_profile_v2(window_days=120)
+    # Sunday 03:00 was never observed → honest 0.0 (heat pump idles).
+    assert db.lookup_hp_kwh(prof, 6, 3, 0) == 0.0

--- a/ui/src/components/insights/LoadPatternCard.tsx
+++ b/ui/src/components/insights/LoadPatternCard.tsx
@@ -1,16 +1,21 @@
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { useFetch } from "../../lib/poll";
-import { getResidualProfile, type ResidualProfile } from "../../lib/endpoints";
+import { getResidualProfile, type ResidualProfile, type ResidualProfileSlot } from "../../lib/endpoints";
 import { makeChart, chartTheme, type EChartsType } from "../../lib/charts";
 import { Spinner } from "../common/Spinner";
 
 const DOW = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-/** Per-(day-of-week × hour) median residual household load — "when we spend the
- *  most while at home". The same profile the LP plans against (#477). */
+type View = "home" | "hp";
+
+/** Per-(day-of-week × hour) median load heatmap. Two views: the residual
+ *  household load (heat pump excluded — the profile the LP plans against, #477)
+ *  and the heat-pump (Daikin) split it subtracts. */
 export function LoadPatternCard() {
   const res = useFetch<ResidualProfile>(getResidualProfile, []);
   const data = res.data;
+  const hasHp = !!data?.hp_by_dow;
+  const [view, setView] = useState<View>("home");
   const elRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
 
@@ -19,11 +24,14 @@ export function LoadPatternCard() {
     if (!chartRef.current) chartRef.current = makeChart(elRef.current);
     const t = chartTheme();
 
+    const source: Record<string, ResidualProfileSlot[]> =
+      (view === "hp" && data.hp_by_dow) ? data.hp_by_dow : data.by_dow;
+
     // 7 dow × 24 hours; value = mean of the two half-hour medians in the hour.
     const cells: [number, number, number][] = [];
     let max = 0;
     for (let d = 0; d < 7; d++) {
-      const slots = data.by_dow[String(d)] || [];
+      const slots = source[String(d)] || [];
       for (let h = 0; h < 24; h++) {
         const a = slots[h * 2]?.median ?? 0;
         const b = slots[h * 2 + 1]?.median ?? 0;
@@ -32,6 +40,12 @@ export function LoadPatternCard() {
         cells.push([h, d, Number(v.toFixed(3))]);
       }
     }
+
+    // Heat-pump view gets a distinct (cool→warm) ramp so the two reads don't
+    // get confused; residual keeps the established amber→red.
+    const ramp = view === "hp"
+      ? [t.bg ?? "#1b1f27", "#38bdf8", "#ef4444"]
+      : [t.bg ?? "#1b1f27", t.pv ?? "#fbbf24", t.importColor ?? "#ef4444"];
 
     chartRef.current.setOption({
       backgroundColor: "transparent",
@@ -57,7 +71,7 @@ export function LoadPatternCard() {
       },
       visualMap: {
         min: 0, max: Math.max(0.4, max), calculable: false, show: false,
-        inRange: { color: [t.bg ?? "#1b1f27", t.pv ?? "#fbbf24", t.importColor ?? "#ef4444"] },
+        inRange: { color: ramp },
       },
       series: [{
         type: "heatmap", data: cells,
@@ -67,7 +81,7 @@ export function LoadPatternCard() {
       }],
     });
     chartRef.current.resize();
-  }, [data]);
+  }, [data, view]);
 
   useEffect(() => () => { chartRef.current?.dispose(); chartRef.current = null; }, []);
 
@@ -75,10 +89,27 @@ export function LoadPatternCard() {
   return (
     <section class="insights-card load-pattern">
       <header class="load-pattern-head">
-        <h2>When you spend the most</h2>
+        <div class="load-pattern-titlerow">
+          <h2>When you spend the most</h2>
+          {hasHp && (
+            <div class="load-pattern-toggle" role="group" aria-label="Load view">
+              <button
+                class={view === "home" ? "is-active" : ""}
+                onClick={() => setView("home")}
+                type="button"
+              >Home</button>
+              <button
+                class={view === "hp" ? "is-active" : ""}
+                onClick={() => setView("hp")}
+                type="button"
+              >Heat pump</button>
+            </div>
+          )}
+        </div>
         <p class="muted">
-          Median household load (heat pump excluded) by day-of-week and hour — the typical
-          at-home pattern the optimizer plans against.
+          {view === "hp"
+            ? "Median heat-pump (Daikin) load by day-of-week and hour — the split subtracted from the household total."
+            : "Median household load (heat pump excluded) by day-of-week and hour — the typical at-home pattern the optimizer plans against."}
         </p>
       </header>
       {res.loading && !data && <Spinner label="Loading load pattern…" />}
@@ -90,6 +121,7 @@ export function LoadPatternCard() {
             {(dc.weekday ?? 0) + (dc.weekend ?? 0)} days learned
             ({dc.weekday ?? 0} weekday / {dc.weekend ?? 0} weekend)
             {(dc.away_excluded ?? 0) > 0 && <> · {dc.away_excluded} away day(s) excluded</>}
+            {(dc.negative_excluded ?? 0) > 0 && <> · {dc.negative_excluded} negative-price slot(s) excluded</>}
             {" · "}
             {data.calibrated_days}/{data.calibrated_days + data.physics_only_days} days calibrated
             to the measured heat-pump split

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -280,13 +280,14 @@ export async function promoteWorkbench(
 
 // --- Residual load profile (#477) — the learned household demand the LP plans
 //     against (day-of-week median + p75 spread, measured-split calibrated).
-export interface ResidualProfileSlot { h: number; m: number; median: number; p75: number; }
+export interface ResidualProfileSlot { h: number; m: number; median: number; p75?: number; }
 export interface ResidualProfile {
   by_dow: Record<string, ResidualProfileSlot[]>;
+  hp_by_dow?: Record<string, ResidualProfileSlot[]>;
   all: ResidualProfileSlot[];
   flat: number;
   away_days: string[];
-  day_counts: { weekday?: number; weekend?: number; away_excluded?: number; total?: number };
+  day_counts: { weekday?: number; weekend?: number; away_excluded?: number; negative_excluded?: number; total?: number };
   calibrated_days: number;
   physics_only_days: number;
 }

--- a/ui/src/routes/insights.css
+++ b/ui/src/routes/insights.css
@@ -103,6 +103,20 @@
   font-size: var(--font-lg);
   margin: 0 0 var(--space-1);
 }
+.load-pattern-titlerow {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-2); flex-wrap: wrap;
+}
+.load-pattern-toggle { display: inline-flex; gap: 2px; }
+.load-pattern-toggle button {
+  font-size: var(--font-2xs); padding: 3px 10px; cursor: pointer;
+  background: transparent; color: var(--text-mute);
+  border: 1px solid var(--border); border-radius: var(--radius-pill, 999px);
+}
+.load-pattern-toggle button.is-active {
+  color: var(--text); border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
 .load-pattern-chart {
   width: 100%;
   height: 220px;


### PR DESCRIPTION
## What
The load heatmap only showed residual household load (heat pump excluded), so the heat-pump (Daikin) usage pattern — a large share of the winter bill — was invisible. This adds it as a toggleable view.

`residual_load_profile_v2` already computes the calibrated Daikin estimate it subtracts per sample; this publishes it as its own per-(dow,hour) profile.

- **db.py**: parallel `hp_profile` (same tier structure); new `lookup_hp_kwh` mirrors `lookup_residual_kwh`, falling back to **0.0** (the pump genuinely idles in many slots — honest, not a gap).
- **pv.py**: `hp_by_dow` alongside `by_dow`.
- **LoadPatternCard**: **Home / Heat pump** toggle; heat-pump view gets a distinct cool→warm ramp. Also surfaces the `negative_excluded` count from PR B.

## Tests
hp_profile non-zero on cold days, ~0 when warm, lookup falls back to 0 for unknown slots; endpoint shape includes `hp_by_dow` (7×48). 226 passed across consumers; UI tsc + build clean.

## Notes
- **Stacked on #566** (PR B — base branch `feat/load-profile-exclude-negative`). Merge #566 first; this retargets to main automatically after.
- Images: **hem** (db/pv) + **ui** (card). PR C of 3 from the Insights review (A #565, B #566).

🤖 Generated with [Claude Code](https://claude.com/claude-code)