### PR TITLE
feat(load-calibration): Phase 1 — per-slot load_error_log (measurement)

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -415,3 +415,53 @@ async def get_residual_load_profile(window_days: int | None = None) -> dict[str,
         "calibrated_days": prof.get("calibrated_days", 0),
         "physics_only_days": prof.get("physics_only_days", 0),
     }
+
+
+@router.get("/api/v1/load/error-log")
+async def get_load_error_log(window_days: int = 30) -> dict[str, Any]:
+    """Committed LOAD-forecast-vs-actual summary from the persisted load_error_log
+    (Phase-1 measurement). Overall MAE/bias + per-LOCAL-hour bias (load is
+    occupancy-driven, so local hour is the meaningful axis — and the axis a
+    future recent-bias corrector would act on). Read-only, viewer-safe.
+    """
+    window_days = max(1, min(int(window_days), 365))
+    now = datetime.now(UTC)
+    start = (now - timedelta(days=window_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    end = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    rows = await asyncio.to_thread(db.get_load_error_log_range, start, end)
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+
+    paired: list[tuple[float, float]] = []  # (forecast_total, actual)
+    per_hour: dict[int, list[tuple[float, float]]] = {}
+    for r in rows:
+        f = r.get("forecast_kwh")
+        a = r.get("actual_kwh")
+        if f is None or a is None:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(r["slot_time_utc"]).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+        lh = ts.astimezone(tz).hour
+        paired.append((float(f), float(a)))
+        per_hour.setdefault(lh, []).append((float(f), float(a)))
+
+    def _stats(pairs: list[tuple[float, float]]) -> dict[str, Any]:
+        n = len(pairs)
+        if n == 0:
+            return {"n": 0, "mae_kwh": 0.0, "bias_kwh": 0.0, "mean_forecast_kwh": 0.0, "mean_actual_kwh": 0.0}
+        errs = [a - f for f, a in pairs]
+        return {
+            "n": n,
+            "mae_kwh": round(sum(abs(e) for e in errs) / n, 4),
+            "bias_kwh": round(sum(errs) / n, 4),  # +ve = actual > forecast (under-forecast)
+            "mean_forecast_kwh": round(sum(f for f, _ in pairs) / n, 4),
+            "mean_actual_kwh": round(sum(a for _, a in pairs) / n, 4),
+        }
+
+    return {
+        "window_days": window_days,
+        "n_slots_logged": len(rows),
+        "overall": _stats(paired),
+        "per_hour_local": {str(h): _stats(per_hour[h]) for h in sorted(per_hour)},
+    }

--- a/src/db.py
+++ b/src/db.py
@@ -1066,6 +1066,29 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_pv_error_log_slot ON pv_error_log(slot_time_utc)"
     )
+
+    # load_error_log — per-slot committed LOAD forecast vs realised total load
+    # (the load analog of pv_error_log; Phase-1 measurement for load calibration).
+    # ``forecast_kwh`` = committed total (base_load + dhw + space); ``forecast_base_kwh``
+    # = the LP's exogenous residual-load input alone (what the load profile forecasts
+    # and a future recent-bias corrector would target). ``actual_kwh`` = measured
+    # total household load (pv_realtime_history.load_power_kw mean × 0.5 h). Per-slot
+    # we can only measure TOTAL (no per-slot Daikin meter); the Daikin daily check
+    # separates the heat-pump component. One row per slot; rebuilt nightly,
+    # idempotent on slot_time_utc.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS load_error_log (
+            slot_time_utc    TEXT PRIMARY KEY,
+            forecast_kwh     REAL,
+            forecast_base_kwh REAL,
+            actual_kwh       REAL,
+            error_kwh        REAL,
+            built_at_utc     TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_load_error_log_slot ON load_error_log(slot_time_utc)"
+    )
     # Daily export opportunity cost: what the day's export earned on the current
     # flat SEG tariff vs what it WOULD have earned on Outgoing Agile. The running
     # tally of money left on the table by not being on Agile export — ammunition
@@ -4924,6 +4947,204 @@ def rebuild_pv_error_log_for_date(day: date) -> int:
     return written
 
 
+def committed_load_forecast_by_slot(day: date) -> dict[str, tuple[float, float]]:
+    """Per-slot committed (total, base) LOAD forecast for ``day``.
+
+    ``total`` = ``base_load_json[slot_index] + dhw_kwh + space_kwh`` (the full
+    household load the LP committed to). ``base`` = ``base_load_json[slot_index]``
+    alone — the LP's exogenous residual-load input, i.e. the quantity the load
+    profile forecasts and a future recent-bias corrector would target.
+
+    Stitched per slot the same way as :func:`committed_lp_field_by_slot` and the
+    PV path: for each slot, use the most recent solve whose ``run_at <= slot_start``
+    (the plan as known when the slot began); if none qualifies, the earliest solve
+    that covered it. Returns ``{slot_time_utc (stored form): (total, base)}``.
+    Empty on error.
+    """
+    day_start = datetime(day.year, day.month, day.day, tzinfo=UTC)
+    day_end = day_start + timedelta(days=1)
+    with _lock:
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                """SELECT s.slot_time_utc, s.slot_index, s.run_id,
+                          s.dhw_kwh, s.space_kwh, i.base_load_json, i.run_at_utc
+                   FROM lp_solution_snapshot s
+                   JOIN lp_inputs_snapshot i ON i.run_id = s.run_id
+                   WHERE s.slot_time_utc >= ? AND s.slot_time_utc < ?
+                     AND i.base_load_json IS NOT NULL""",
+                (day_start.isoformat(), day_end.isoformat()),
+            ).fetchall()
+        except sqlite3.Error as e:
+            logger.warning("committed_load_forecast_by_slot query failed: %s", e)
+            return {}
+        finally:
+            conn.close()
+
+    arr_cache: dict[int, list] = {}
+    # slot -> (run_dt, total, base, eligible)
+    best: dict[str, tuple[datetime, float, float, bool]] = {}
+    for slot_iso, slot_idx, run_id, dhw, space, base_json, run_at in rows:
+        slot_dt = _parse_iso_utc(slot_iso)
+        run_dt = _parse_iso_utc(run_at)
+        if slot_dt is None or run_dt is None:
+            continue
+        arr = arr_cache.get(run_id)
+        if arr is None:
+            try:
+                arr = json.loads(base_json or "[]")
+            except (TypeError, ValueError):
+                arr = []
+            arr_cache[run_id] = arr
+        try:
+            idx = int(slot_idx)
+        except (TypeError, ValueError):
+            continue
+        if idx < 0 or idx >= len(arr):
+            continue
+        try:
+            base = float(arr[idx])
+        except (TypeError, ValueError):
+            continue
+        total = base + float(dhw or 0.0) + float(space or 0.0)
+        eligible = run_dt <= slot_dt
+        cur = best.get(slot_iso)
+        if cur is None:
+            best[slot_iso] = (run_dt, total, base, eligible)
+            continue
+        c_run, _c_t, _c_b, c_elig = cur
+        if eligible and not c_elig:
+            best[slot_iso] = (run_dt, total, base, True)
+        elif eligible and c_elig:
+            if run_dt > c_run:
+                best[slot_iso] = (run_dt, total, base, True)
+        elif (not eligible) and (not c_elig):
+            if run_dt < c_run:
+                best[slot_iso] = (run_dt, total, base, False)
+    return {k: (v[1], v[2]) for k, v in best.items()}
+
+
+def _actual_load_kwh_by_slot(day: date) -> dict[str, float]:
+    """Realised total household load per half-hour slot for ``day``: mean
+    ``pv_realtime_history.load_power_kw`` in the slot × 0.5 h. Z-form slot keys."""
+    out: dict[str, list[float]] = {}
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT captured_at, load_power_kw
+                   FROM pv_realtime_history
+                   WHERE substr(captured_at, 1, 10) = ?
+                     AND load_power_kw IS NOT NULL""",
+                (day.isoformat(),),
+            )
+            samples = cur.fetchall()
+        finally:
+            conn.close()
+    for row in samples:
+        ts = _parse_iso_utc(row["captured_at"])
+        if ts is None:
+            continue
+        slot = ts.replace(minute=0 if ts.minute < 30 else 30, second=0, microsecond=0)
+        key = slot.strftime("%Y-%m-%dT%H:%M:%SZ")
+        out.setdefault(key, []).append(float(row["load_power_kw"]))
+    return {k: (sum(v) / len(v)) * 0.5 for k, v in out.items() if v}
+
+
+def rebuild_load_error_log_for_date(day: date) -> int:
+    """Persist per-slot committed-LOAD-forecast-vs-actual rows for ``day``.
+
+    Joins the stitched committed forecast (:func:`committed_load_forecast_by_slot`)
+    with the realised half-hour total-load roll-up. One row per slot that has a
+    forecast and/or an actual; idempotent on ``slot_time_utc``. Returns rows
+    written. Best-effort: the nightly cron swallows exceptions.
+    """
+    forecast = committed_load_forecast_by_slot(day)
+    try:
+        actual = _actual_load_kwh_by_slot(day)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("rebuild_load_error_log: actual roll-up failed for %s: %s", day, e)
+        actual = {}
+
+    def _z(s: str) -> str:
+        dt = _parse_iso_utc(s)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ") if dt else s
+
+    f_by_z = {_z(k): v for k, v in forecast.items()}
+    a_by_z = actual  # already Z-form
+    built_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    written = 0
+    with _lock:
+        conn = get_connection()
+        try:
+            for slot_z in sorted(set(f_by_z) | set(a_by_z)):
+                fv = f_by_z.get(slot_z)
+                total = fv[0] if fv else None
+                base = fv[1] if fv else None
+                a = a_by_z.get(slot_z)
+                err = (a - total) if (a is not None and total is not None) else None
+                conn.execute(
+                    """INSERT INTO load_error_log
+                         (slot_time_utc, forecast_kwh, forecast_base_kwh, actual_kwh, error_kwh, built_at_utc)
+                       VALUES (?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(slot_time_utc) DO UPDATE SET
+                         forecast_kwh=excluded.forecast_kwh,
+                         forecast_base_kwh=excluded.forecast_base_kwh,
+                         actual_kwh=excluded.actual_kwh,
+                         error_kwh=excluded.error_kwh,
+                         built_at_utc=excluded.built_at_utc""",
+                    (slot_z, total, base, a, err, built_at),
+                )
+                written += 1
+            conn.commit()
+        except sqlite3.Error as e:
+            logger.warning("rebuild_load_error_log write failed for %s: %s", day, e)
+        finally:
+            conn.close()
+    return written
+
+
+def backfill_load_error_log(start_day: date, end_day: date) -> dict[str, int]:
+    """Rebuild load_error_log for every day in [start_day, end_day] (inclusive).
+
+    Used for the one-time history backfill so the log is populated immediately
+    rather than accruing one day per nightly cron run. Returns
+    ``{"days": N, "rows": total_rows_written}``.
+    """
+    days = 0
+    rows = 0
+    d = start_day
+    while d <= end_day:
+        rows += rebuild_load_error_log_for_date(d)
+        days += 1
+        d += timedelta(days=1)
+    return {"days": days, "rows": rows}
+
+
+def get_load_error_log_range(start_utc_iso: str, end_utc_iso: str) -> list[dict[str, Any]]:
+    """Per-slot forecast/actual/error rows in ``[start, end)`` for load calibration."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT slot_time_utc, forecast_kwh, forecast_base_kwh, actual_kwh, error_kwh
+                   FROM load_error_log
+                   WHERE slot_time_utc >= ? AND slot_time_utc < ?
+                   ORDER BY slot_time_utc""",
+                (start_utc_iso, end_utc_iso),
+            )
+            return [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+
+
+def get_load_error_log_for_date(day: date) -> list[dict[str, Any]]:
+    """Persisted per-slot forecast/actual/error rows for ``day``."""
+    ds = datetime(day.year, day.month, day.day, tzinfo=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    de = (datetime(day.year, day.month, day.day, tzinfo=UTC) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return get_load_error_log_range(ds, de)
+
+
 def upsert_export_opportunity(
     day: date, export_kwh: float, seg_pence: float, agile_pence: float
 ) -> None:
@@ -5878,6 +6099,7 @@ def prune_history_tables() -> dict[str, int]:
         ("meteo_forecast_history", "forecast_fetch_at_utc", _config.METEO_FORECAST_HISTORY_RETENTION_DAYS, False),
         ("forecast_skill_log", "built_at_utc", _config.METEO_FORECAST_HISTORY_RETENTION_DAYS, False),
         ("pv_error_log", "slot_time_utc", _config.METEO_FORECAST_HISTORY_RETENTION_DAYS, False),
+        ("load_error_log", "slot_time_utc", _config.METEO_FORECAST_HISTORY_RETENTION_DAYS, False),
         ("lp_solution_snapshot", "slot_time_utc", _config.LP_SNAPSHOT_RETENTION_DAYS, False),
         ("lp_inputs_snapshot", "run_at_utc", _config.LP_SNAPSHOT_RETENTION_DAYS, False),
         ("config_audit", "changed_at_utc", _config.CONFIG_AUDIT_RETENTION_DAYS, False),

--- a/src/db.py
+++ b/src/db.py
@@ -3612,17 +3612,19 @@ def _half_hourly_grid_kwh_for_day(
 ) -> dict[str, float]:
     """Shared trapezoidal-integration over ``pv_realtime_history.<column>`` for
     ``day``, keyed by ISO half-hour slot start (UTC). ``column`` must be one of
-    ``grid_export_kw`` / ``grid_import_kw`` / ``solar_power_kw`` (caller-vetted).
+    ``grid_export_kw`` / ``grid_import_kw`` / ``solar_power_kw`` /
+    ``battery_discharge_kw`` / ``load_power_kw`` (caller-vetted).
 
     Each sample-pair's energy is assigned to the bucket containing the EARLIER
-    sample (matching :func:`compute_fox_energy_daily_from_realtime`). Slots with
-    no telemetry get no key — caller decides whether to treat missing as zero
-    or fall back to a daily total.
+    sample (matching :func:`compute_fox_energy_daily_from_realtime`). The
+    ``max_gap_seconds`` cap means a telemetry outage doesn't smear a stale value
+    across the gap. Slots with no telemetry get no key — caller decides whether
+    to treat missing as zero or fall back to a daily total.
     """
     from collections import defaultdict
     from datetime import datetime as _dt
 
-    if column not in ("grid_export_kw", "grid_import_kw", "solar_power_kw", "battery_discharge_kw"):
+    if column not in ("grid_export_kw", "grid_import_kw", "solar_power_kw", "battery_discharge_kw", "load_power_kw"):
         raise ValueError(f"unsupported column: {column}")
 
     day_iso = day.isoformat()
@@ -5024,33 +5026,6 @@ def committed_load_forecast_by_slot(day: date) -> dict[str, tuple[float, float]]
     return {k: (v[1], v[2]) for k, v in best.items()}
 
 
-def _actual_load_kwh_by_slot(day: date) -> dict[str, float]:
-    """Realised total household load per half-hour slot for ``day``: mean
-    ``pv_realtime_history.load_power_kw`` in the slot × 0.5 h. Z-form slot keys."""
-    out: dict[str, list[float]] = {}
-    with _lock:
-        conn = get_connection()
-        try:
-            cur = conn.execute(
-                """SELECT captured_at, load_power_kw
-                   FROM pv_realtime_history
-                   WHERE substr(captured_at, 1, 10) = ?
-                     AND load_power_kw IS NOT NULL""",
-                (day.isoformat(),),
-            )
-            samples = cur.fetchall()
-        finally:
-            conn.close()
-    for row in samples:
-        ts = _parse_iso_utc(row["captured_at"])
-        if ts is None:
-            continue
-        slot = ts.replace(minute=0 if ts.minute < 30 else 30, second=0, microsecond=0)
-        key = slot.strftime("%Y-%m-%dT%H:%M:%SZ")
-        out.setdefault(key, []).append(float(row["load_power_kw"]))
-    return {k: (sum(v) / len(v)) * 0.5 for k, v in out.items() if v}
-
-
 def rebuild_load_error_log_for_date(day: date) -> int:
     """Persist per-slot committed-LOAD-forecast-vs-actual rows for ``day``.
 
@@ -5061,7 +5036,9 @@ def rebuild_load_error_log_for_date(day: date) -> int:
     """
     forecast = committed_load_forecast_by_slot(day)
     try:
-        actual = _actual_load_kwh_by_slot(day)
+        # Trapezoidal integration with the shared gap-guarded helper (same actual
+        # path as PV/grid) — an outage can't smear a stale value across the gap.
+        actual = _half_hourly_grid_kwh_for_day(day, "load_power_kw")
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("rebuild_load_error_log: actual roll-up failed for %s: %s", day, e)
         actual = {}

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -735,6 +735,21 @@ def bulletproof_pv_error_log_job() -> None:
         logger.warning("pv_recent_bias refresh failed (non-fatal): %s", e)
 
 
+def bulletproof_load_error_log_job() -> None:
+    """Persist yesterday's per-slot committed-LOAD-forecast-vs-actual rows.
+
+    Phase-1 measurement for load calibration (load analog of the PV error log).
+    Runs nightly just after the PV error log so the prior UTC day has its fullest
+    load samples. Measurement only — does not touch the LP. Best-effort.
+    """
+    target_day = datetime.now(UTC).date() - timedelta(days=1)
+    try:
+        rows = db.rebuild_load_error_log_for_date(target_day)
+        logger.info("load_error_log rebuild: date_utc=%s rows=%d", target_day.isoformat(), rows)
+    except Exception as e:
+        logger.warning("load_error_log rebuild failed (non-fatal): %s", e)
+
+
 def bulletproof_export_opportunity_job() -> None:
     """Persist yesterday's export opportunity cost (Outgoing Agile − flat SEG).
 
@@ -1917,6 +1932,14 @@ def start_background_scheduler() -> None:
                 id="bulletproof_pv_error_log",
             )
             logger.info("PV error-log rebuild cron scheduled (04:20 UTC daily)")
+            # Per-slot LOAD forecast-error log (Phase-1 load calibration). 04:22
+            # UTC — just after the PV error log; measurement only, no LP impact.
+            _background_scheduler.add_job(
+                bulletproof_load_error_log_job,
+                CronTrigger(hour=4, minute=22, timezone=ZoneInfo("UTC")),
+                id="bulletproof_load_error_log",
+            )
+            logger.info("Load error-log rebuild cron scheduled (04:22 UTC daily)")
             # Daily export opportunity cost (Agile vs SEG). 04:25 UTC — after the
             # Fox/PV roll-ups (02:30) so the prior day's export is complete.
             _background_scheduler.add_job(

--- a/tests/test_db_retention.py
+++ b/tests/test_db_retention.py
@@ -143,6 +143,8 @@ def test_prune_history_tables_returns_per_table_counts():
         "forecast_skill_log",
         # Per-slot PV forecast-error log (#462) rides on the meteo retention.
         "pv_error_log",
+        # Per-slot LOAD forecast-error log (Phase-1 load calibration) — same horizon.
+        "load_error_log",
         "lp_solution_snapshot",
         "lp_inputs_snapshot",
         "config_audit",

--- a/tests/test_load_error_log.py
+++ b/tests/test_load_error_log.py
@@ -1,0 +1,173 @@
+"""load_error_log — Phase-1 load forecast-vs-actual measurement (PV-error-log analog).
+
+committed_load_forecast_by_slot stitches the committed (total, base) load per slot;
+rebuild_load_error_log_for_date joins it with the realised total-load roll-up and
+persists per-slot forecast/actual/error rows (idempotent on slot_time_utc).
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = str(tmp_path / "t.db")
+    monkeypatch.setattr(app_config, "DB_PATH", db_path, raising=False)
+    db.init_db()
+
+
+def _seed_lp_run(*, run_at: datetime, slot_starts: list[datetime],
+                 base_loads: list[float], dhw_kwhs: list[float], space_kwhs: list[float]) -> int:
+    n = len(slot_starts)
+    run_id = db.log_optimizer_run({
+        "run_at": run_at.isoformat(), "rates_count": n,
+        "cheap_slots": 0, "peak_slots": 0, "standard_slots": n, "negative_slots": 0,
+        "target_vwap": 0.0, "actual_agile_mean": 0.0, "battery_warning": False,
+        "strategy_summary": "test", "fox_schedule_uploaded": False, "daikin_actions_count": 0,
+    })
+    inputs = {
+        "run_at_utc": run_at.isoformat(), "plan_date": run_at.date().isoformat(),
+        "horizon_hours": 24, "soc_initial_kwh": 5.0, "tank_initial_c": 45.0, "indoor_initial_c": 21.0,
+        "soc_source": "test", "tank_source": "test", "indoor_source": "test",
+        "base_load_json": json.dumps(base_loads), "micro_climate_offset_c": 0.0,
+        "config_snapshot_json": "{}", "price_quantize_p": 0.0,
+        "peak_threshold_p": 30.0, "cheap_threshold_p": 10.0,
+        "daikin_control_mode": "passive", "optimization_preset": "test",
+        "energy_strategy_mode": "savings_first",
+    }
+    solution = [{
+        "slot_index": i, "slot_time_utc": start.isoformat(), "price_p": 20.0,
+        "import_kwh": 0.0, "export_kwh": 0.0, "charge_kwh": 0.0, "discharge_kwh": 0.0,
+        "pv_use_kwh": 0.0, "pv_curtail_kwh": 0.0,
+        "dhw_kwh": dhw_kwhs[i], "space_kwh": space_kwhs[i],
+        "soc_kwh": 5.0, "tank_temp_c": 45.0, "indoor_temp_c": 21.0,
+        "outdoor_temp_c": 10.0, "lwt_offset_c": 0.0,
+    } for i, start in enumerate(slot_starts)]
+    db.save_lp_snapshots(run_id, inputs, solution)
+    return run_id
+
+
+def _seed_load_samples(slot_start: datetime, load_kw: float, n: int = 6) -> None:
+    for i in range(n):
+        ts = slot_start + timedelta(minutes=i * (30 // n))
+        db.save_pv_realtime_sample(
+            captured_at=ts.isoformat().replace("+00:00", "Z"),
+            solar_power_kw=0.0, soc_pct=50.0, load_power_kw=load_kw,
+            grid_import_kw=0.0, grid_export_kw=0.0,
+            battery_charge_kw=0.0, battery_discharge_kw=0.0, source="seed",
+        )
+
+
+def _slots(day: date, n: int = 4) -> list[datetime]:
+    base = datetime(day.year, day.month, day.day, 8, 0, tzinfo=UTC)
+    return [base + timedelta(minutes=30 * i) for i in range(n)]
+
+
+def test_committed_forecast_total_and_base() -> None:
+    day = date(2026, 6, 10)
+    slots = _slots(day)
+    _seed_lp_run(run_at=datetime(2026, 6, 10, 0, 0, tzinfo=UTC), slot_starts=slots,
+                 base_loads=[0.3, 0.4, 0.5, 0.6], dhw_kwhs=[0.1, 0.0, 0.2, 0.0],
+                 space_kwhs=[0.0, 0.2, 0.0, 0.1])
+    out = db.committed_load_forecast_by_slot(day)
+    # slot 0: base 0.3 + dhw 0.1 + space 0.0 = total 0.4
+    total0, base0 = out[slots[0].isoformat()]
+    assert base0 == pytest.approx(0.3)
+    assert total0 == pytest.approx(0.4)
+    # slot 1: base 0.4 + 0.0 + 0.2 = 0.6
+    total1, base1 = out[slots[1].isoformat()]
+    assert base1 == pytest.approx(0.4)
+    assert total1 == pytest.approx(0.6)
+
+
+def test_committed_forecast_stitches_latest_eligible_run() -> None:
+    """Two solves cover the same slot; the one whose run_at <= slot_start and is
+    most recent wins (the plan as known when the slot began)."""
+    day = date(2026, 6, 10)
+    slots = _slots(day, 2)  # 08:00, 08:30
+    # Early solve at 00:00 (eligible), base 1.0
+    _seed_lp_run(run_at=datetime(2026, 6, 10, 0, 0, tzinfo=UTC), slot_starts=slots,
+                 base_loads=[1.0, 1.0], dhw_kwhs=[0.0, 0.0], space_kwhs=[0.0, 0.0])
+    # Later solve at 07:00 (still <= 08:00), base 2.0 — should win
+    _seed_lp_run(run_at=datetime(2026, 6, 10, 7, 0, tzinfo=UTC), slot_starts=slots,
+                 base_loads=[2.0, 2.0], dhw_kwhs=[0.0, 0.0], space_kwhs=[0.0, 0.0])
+    out = db.committed_load_forecast_by_slot(day)
+    _t, base0 = out[slots[0].isoformat()]
+    assert base0 == pytest.approx(2.0)  # latest eligible solve
+
+
+def test_rebuild_writes_forecast_actual_error() -> None:
+    day = date(2026, 6, 10)
+    slots = _slots(day, 3)
+    _seed_lp_run(run_at=datetime(2026, 6, 10, 0, 0, tzinfo=UTC), slot_starts=slots,
+                 base_loads=[0.3, 0.4, 0.5], dhw_kwhs=[0.0, 0.0, 0.0],
+                 space_kwhs=[0.0, 0.0, 0.0])
+    # Actual load 1.0 kW → 0.5 kWh/slot for the first two slots
+    _seed_load_samples(slots[0], 1.0)
+    _seed_load_samples(slots[1], 1.0)
+    written = db.rebuild_load_error_log_for_date(day)
+    assert written >= 3
+    rows = {r["slot_time_utc"]: r for r in db.get_load_error_log_for_date(day)}
+    k0 = slots[0].strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert rows[k0]["forecast_kwh"] == pytest.approx(0.3)
+    assert rows[k0]["actual_kwh"] == pytest.approx(0.5)
+    assert rows[k0]["error_kwh"] == pytest.approx(0.2)  # actual - forecast
+    # Slot 2 had a forecast but no actual → actual/error NULL, row still present.
+    k2 = slots[2].strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert rows[k2]["forecast_kwh"] == pytest.approx(0.5)
+    assert rows[k2]["actual_kwh"] is None
+    assert rows[k2]["error_kwh"] is None
+
+
+def test_rebuild_idempotent() -> None:
+    day = date(2026, 6, 10)
+    slots = _slots(day, 2)
+    _seed_lp_run(run_at=datetime(2026, 6, 10, 0, 0, tzinfo=UTC), slot_starts=slots,
+                 base_loads=[0.3, 0.4], dhw_kwhs=[0.0, 0.0], space_kwhs=[0.0, 0.0])
+    _seed_load_samples(slots[0], 1.0)
+    db.rebuild_load_error_log_for_date(day)
+    n_first = len(db.get_load_error_log_for_date(day))
+    db.rebuild_load_error_log_for_date(day)
+    n_second = len(db.get_load_error_log_for_date(day))
+    assert n_first == n_second  # no duplication
+
+
+def test_backfill_range() -> None:
+    for d in (date(2026, 6, 8), date(2026, 6, 9), date(2026, 6, 10)):
+        slots = _slots(d, 2)
+        _seed_lp_run(run_at=datetime(d.year, d.month, d.day, 0, 0, tzinfo=UTC),
+                     slot_starts=slots, base_loads=[0.3, 0.4],
+                     dhw_kwhs=[0.0, 0.0], space_kwhs=[0.0, 0.0])
+        _seed_load_samples(slots[0], 1.0)
+    res = db.backfill_load_error_log(date(2026, 6, 8), date(2026, 6, 10))
+    assert res["days"] == 3
+    assert res["rows"] >= 6
+
+
+def test_error_log_endpoint_shape() -> None:
+    """GET /api/v1/load/error-log aggregates the persisted log per local hour."""
+    import asyncio
+    from src.api.routers import pv as pv_router
+
+    today = datetime.now(UTC).date()
+    slots = _slots(today, 3)
+    _seed_lp_run(run_at=datetime(today.year, today.month, today.day, 0, 0, tzinfo=UTC),
+                 slot_starts=slots, base_loads=[0.3, 0.4, 0.5],
+                 dhw_kwhs=[0.0, 0.0, 0.0], space_kwhs=[0.0, 0.0, 0.0])
+    for s in slots:
+        _seed_load_samples(s, 1.2)  # actual 0.6/slot → under-forecast (positive bias)
+    db.rebuild_load_error_log_for_date(today)
+
+    resp = asyncio.run(pv_router.get_load_error_log(window_days=7))
+    assert set(resp.keys()) == {"window_days", "n_slots_logged", "overall", "per_hour_local"}
+    assert resp["overall"]["n"] >= 3
+    assert resp["overall"]["bias_kwh"] > 0  # actual > forecast → under-forecast
+    import json as _json
+    _json.dumps(resp)  # JSON-serialisable


### PR DESCRIPTION
## What
Phase 1 of the load forecast-vs-actual calibration (load analog of the PV `pv_error_log` / #486 loop). **Measurement only — does not touch the LP.** Instruments the per-slot committed-forecast-vs-actual we lack for load, so Phase 2 (a recent-bias corrector) can be decided on real data instead of blind.

**Why load differs from PV:** the load forecast is the median of history (self-referential) → per-bucket bias & median-vs-mean already handled. The only systematic error worth correcting is **recent-regime shift** (the 120d median lagging seasonal/occupancy change). Phase 1 measures it first.

## Pieces
- `load_error_log` table (mirrors pv_error_log): `forecast_kwh` (committed total = base+dhw+space), `forecast_base_kwh` (exogenous residual-load input alone — what a corrector targets), `actual_kwh`, `error_kwh`. Meteo retention horizon.
- `committed_load_forecast_by_slot(day)` — same per-slot stitch as `committed_lp_field_by_slot`/PV (latest solve with run_at ≤ slot_start, else earliest), extracting `base_load_json[slot_index]` + committed dhw/space.
- `rebuild_load_error_log_for_date` + `backfill_load_error_log` (one-time history) + query helpers.
- Nightly cron at **04:22 UTC** (after the PV error log).
- `GET /api/v1/load/error-log` — overall MAE/bias + per-LOCAL-hour bias (+bias = under-forecast). Viewer-safe.

Per-slot we can only measure TOTAL load (no per-slot Daikin meter); the existing Daikin daily check separates the heat-pump part.

## Tests
stitch picks latest eligible solve; forecast/actual/error written; idempotent; backfill; endpoint shape + bias sign. 188 passed across error-log/retention/snapshot/pv subset.

## Next
After merge+deploy I'll run the **history backfill** on prod (`backfill_load_error_log`) so the log is populated immediately, then we read the per-local-hour bias to decide Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)