### PR TITLE
feat(load-calibration): Phase 2 — recent-bias corrector (gated, default OFF)

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -465,3 +465,17 @@ async def get_load_error_log(window_days: int = 30) -> dict[str, Any]:
         "overall": _stats(paired),
         "per_hour_local": {str(h): _stats(per_hour[h]) for h in sorted(per_hour)},
     }
+
+
+@router.get("/api/v1/load/error-log/backtest")
+async def get_load_bias_backtest(window_days: int | None = None) -> dict[str, Any]:
+    """Offline what-if for the Phase-2 load-bias corrector: would the additive
+    per-local-hour correction have reduced the error over the persisted
+    load_error_log? Returns MAE/bias before vs after + per-hour corrections.
+    Read-only — never writes, never touches the LP. The gate for enabling.
+    """
+    from ... import load_bias
+
+    if window_days is not None:
+        window_days = max(1, min(int(window_days), 365))
+    return await asyncio.to_thread(load_bias.backtest_load_recent_bias, window_days)

--- a/src/config.py
+++ b/src/config.py
@@ -753,7 +753,16 @@ class Config:
     LOAD_RECENT_BIAS_MAX_KWH: float = float(os.getenv("LOAD_RECENT_BIAS_MAX_KWH", "0.3"))
     # A slot needs at least this forecast+actual kWh to contribute (drop noise).
     LOAD_RECENT_BIAS_MIN_KWH: float = float(os.getenv("LOAD_RECENT_BIAS_MIN_KWH", "0.05"))
+    # Min DISTINCT DAYS of evidence for a local hour before it gets a correction.
     LOAD_RECENT_BIAS_MIN_SAMPLES: int = int(os.getenv("LOAD_RECENT_BIAS_MIN_SAMPLES", "3"))
+    # Per-slot we can only measure TOTAL load (no per-slot Daikin meter). To
+    # isolate the BASE (residual) bias — the only thing this corrector should
+    # touch — we only LEARN from slots where the committed heat-pump load
+    # (forecast_kwh − forecast_base_kwh) is below this, so on the learning slots
+    # total ≈ base and the heat-pump timing error doesn't pollute the base
+    # correction. Hours that are always heat-pump-heavy (e.g. the 13–14h warmup)
+    # get no clean sample → no correction, which is the honest outcome.
+    LOAD_RECENT_BIAS_MAX_DAIKIN_KWH: float = float(os.getenv("LOAD_RECENT_BIAS_MAX_DAIKIN_KWH", "0.1"))
 
     # Agile scheduler (Daikin ASHP by price)
     SCHEDULER_ENABLED: bool = os.getenv("SCHEDULER_ENABLED", "false").lower() in ("true", "1", "yes")

--- a/src/config.py
+++ b/src/config.py
@@ -731,6 +731,30 @@ class Config:
     # A slot needs at least this forecast+actual kWh to contribute (drop noise).
     PV_RECENT_BIAS_MIN_KWH: float = float(os.getenv("PV_RECENT_BIAS_MIN_KWH", "0.05"))
 
+    # --- Load recent-bias corrector (Phase 2; analog of the PV one) -----------
+    # ADDITIVE per-LOCAL-hour correction on the residual base-load forecast.
+    # Load is occupancy-driven (local hour) and the bias is a level offset from
+    # seasonal/occupancy regime shift (the 120d median lags), so it's ADDITIVE,
+    # not multiplicative like PV. Closed loop: ``new = old + damping·raw_bias``
+    # where raw_bias is the recency-weighted mean (actual − committed_forecast)
+    # — i.e. the RESIDUAL error of the already-corrected forecast — so it ramps
+    # to full correction and settles at raw_bias≈0. DEFAULT OFF — the table is
+    # still refreshed nightly (cheap, observable) but never touches the LP until
+    # this is flipped on after the backtest confirms it helps.
+    LOAD_RECENT_BIAS_ENABLED: bool = (
+        os.getenv("LOAD_RECENT_BIAS_ENABLED", "false").strip().lower() in ("1", "true", "yes", "on")
+    )
+    LOAD_RECENT_BIAS_WINDOW_DAYS: int = int(os.getenv("LOAD_RECENT_BIAS_WINDOW_DAYS", "21"))
+    LOAD_RECENT_BIAS_HALFLIFE_DAYS: float = float(os.getenv("LOAD_RECENT_BIAS_HALFLIFE_DAYS", "7"))
+    LOAD_RECENT_BIAS_DAMPING: float = float(os.getenv("LOAD_RECENT_BIAS_DAMPING", "0.5"))
+    # Hard safety rail on the |additive correction| (kWh/slot). The observed
+    # diurnal swing is ~0.35 kWh/slot; 0.3 covers it without letting a noisy
+    # hour run away.
+    LOAD_RECENT_BIAS_MAX_KWH: float = float(os.getenv("LOAD_RECENT_BIAS_MAX_KWH", "0.3"))
+    # A slot needs at least this forecast+actual kWh to contribute (drop noise).
+    LOAD_RECENT_BIAS_MIN_KWH: float = float(os.getenv("LOAD_RECENT_BIAS_MIN_KWH", "0.05"))
+    LOAD_RECENT_BIAS_MIN_SAMPLES: int = int(os.getenv("LOAD_RECENT_BIAS_MIN_SAMPLES", "3"))
+
     # Agile scheduler (Daikin ASHP by price)
     SCHEDULER_ENABLED: bool = os.getenv("SCHEDULER_ENABLED", "false").lower() in ("true", "1", "yes")
     OCTOPUS_TARIFF_CODE: str = (os.getenv("OCTOPUS_TARIFF_CODE") or "").strip()

--- a/src/db.py
+++ b/src/db.py
@@ -874,6 +874,20 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         )"""
     )
 
+    # Phase-2 load corrector — ADDITIVE per-LOCAL-hour correction (kWh/slot) on
+    # the residual base-load forecast, from the damped recency-weighted mean
+    # (actual − committed_forecast) in load_error_log. Refreshed nightly; only
+    # APPLIED to the LP when LOAD_RECENT_BIAS_ENABLED.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS load_recent_bias (
+            hour_local      INTEGER PRIMARY KEY CHECK(hour_local >= 0 AND hour_local < 24),
+            bias_kwh        REAL NOT NULL,
+            raw_bias_kwh    REAL,
+            samples         INTEGER NOT NULL,
+            computed_at     TEXT NOT NULL
+        )"""
+    )
+
     # V14: presence_periods — manually-flagged periods of household presence
     # (home / travel / guests) so future load-pattern analyses + LP calibration
     # can de-bias the rolling load profile by occupancy. Read by analytics
@@ -5498,6 +5512,45 @@ def get_pv_recent_bias() -> dict[int, float]:
         conn = get_connection()
         try:
             cur = conn.execute("SELECT hour_utc, factor FROM pv_recent_bias")
+            return {int(r[0]): float(r[1]) for r in cur.fetchall()}
+        finally:
+            conn.close()
+
+
+def upsert_load_recent_bias(
+    biases: dict[int, float],
+    raw_biases: dict[int, float],
+    samples: dict[int, int],
+    computed_at: str,
+) -> int:
+    """Replace the ``load_recent_bias`` table with freshly-computed per-local-hour
+    additive corrections (Phase 2)."""
+    n = 0
+    with _lock:
+        conn = get_connection()
+        try:
+            conn.execute("DELETE FROM load_recent_bias")
+            for h, b in biases.items():
+                conn.execute(
+                    """INSERT OR REPLACE INTO load_recent_bias
+                       (hour_local, bias_kwh, raw_bias_kwh, samples, computed_at)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (int(h), float(b), float(raw_biases.get(h, b)), int(samples.get(h, 0)), computed_at),
+                )
+                n += 1
+            conn.commit()
+        finally:
+            conn.close()
+    return n
+
+
+def get_load_recent_bias() -> dict[int, float]:
+    """Return cached per-LOCAL-hour additive load-bias corrections (kWh/slot), or
+    ``{}`` when empty. The optimizer reads this only when LOAD_RECENT_BIAS_ENABLED."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute("SELECT hour_local, bias_kwh FROM load_recent_bias")
             return {int(r[0]): float(r[1]) for r in cur.fetchall()}
         finally:
             conn.close()

--- a/src/load_bias.py
+++ b/src/load_bias.py
@@ -1,0 +1,181 @@
+"""Adaptive closed-loop LOAD bias corrector (Phase 2 — analog of the PV one).
+
+The residual base-load forecast is the median of 120 days of history, so it's
+unbiased at the LEVEL (overall) but carries a per-LOCAL-hour bias from seasonal /
+occupancy regime shift (the median lags a trend). This module measures that bias
+from ``load_error_log`` and produces an ADDITIVE per-local-hour correction
+(kWh/slot) — additive, not multiplicative like PV, because the load bias is a
+level offset, not a magnitude scaling.
+
+Closed loop (the #488 lesson — accumulate, don't decay toward the raw input when
+the input is your own output): each refresh nudges the previous correction by the
+RESIDUAL error of the already-corrected committed forecast::
+
+    new_bias = old_bias + damping · raw_bias        (raw_bias = mean(actual − committed_forecast))
+
+so it ramps to full correction while the corrected forecast still mis-predicts,
+and settles when raw_bias ≈ 0. Warm-starts from the measured bias (we already
+have history). Hard-clamped to ±LOAD_RECENT_BIAS_MAX_KWH.
+
+DEFAULT OFF: the table is refreshed nightly (cheap, observable) but the optimizer
+only APPLIES it when ``LOAD_RECENT_BIAS_ENABLED``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from .config import config
+
+logger = logging.getLogger(__name__)
+
+
+def _local_hour_bias(window_days: int) -> tuple[dict[int, list[float]], ZoneInfo]:
+    """Recency-weighted accumulator per local hour: {hour: [sum_w_err, sum_w, n]}."""
+    from . import db as _db
+
+    half_life = float(getattr(config, "LOAD_RECENT_BIAS_HALFLIFE_DAYS", 7))
+    min_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MIN_KWH", 0.05))
+    tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+
+    now = datetime.now(UTC)
+    start = now - timedelta(days=window_days)
+    rows = _db.get_load_error_log_range(
+        start.strftime("%Y-%m-%dT%H:%M:%SZ"), now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    acc: dict[int, list[float]] = {}
+    for r in rows:
+        f = r.get("forecast_kwh")
+        a = r.get("actual_kwh")
+        if f is None or a is None or f < min_kwh or a < min_kwh:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(r["slot_time_utc"]).replace("Z", "+00:00"))
+        except (ValueError, TypeError, KeyError):
+            continue
+        lh = ts.astimezone(tz).hour
+        age_days = max(0.0, (now - ts).total_seconds() / 86400.0)
+        w = 0.5 ** (age_days / half_life) if half_life > 0 else 1.0
+        d = acc.setdefault(lh, [0.0, 0.0, 0.0])
+        d[0] += w * (float(a) - float(f))  # additive error (actual − forecast)
+        d[1] += w
+        d[2] += 1
+    return acc, tz
+
+
+def compute_load_recent_bias_by_hour_local() -> tuple[dict[int, float], dict[int, float], dict[int, int], dict[str, Any]]:
+    """Return ``(applied_bias, raw_bias, samples, diag)`` — additive kWh/slot per
+    local hour. ``applied_bias`` accumulates on the previous correction; ``raw_bias``
+    is the measured recency-weighted residual error this refresh."""
+    from . import db as _db
+
+    window = int(getattr(config, "LOAD_RECENT_BIAS_WINDOW_DAYS", 21))
+    damping = float(getattr(config, "LOAD_RECENT_BIAS_DAMPING", 0.5))
+    max_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MAX_KWH", 0.3))
+    min_samples = int(getattr(config, "LOAD_RECENT_BIAS_MIN_SAMPLES", 3))
+
+    try:
+        prev = _db.get_load_recent_bias()
+    except Exception:  # pragma: no cover — cold start / missing table
+        prev = {}
+
+    acc, _tz = _local_hour_bias(window)
+    applied: dict[int, float] = {}
+    raw: dict[int, float] = {}
+    samples: dict[int, int] = {}
+    for h, (sw, w, n) in acc.items():
+        if w <= 0 or n < min_samples:
+            continue
+        raw_bias = sw / w
+        if h in prev:
+            # Accumulate on the previous correction by the RESIDUAL error of the
+            # already-corrected forecast → ramps to full, settles at raw_bias≈0.
+            new_bias = float(prev[h]) + damping * raw_bias
+        else:
+            new_bias = raw_bias  # warm start — we already have the historical error
+        new_bias = max(-max_kwh, min(max_kwh, new_bias))
+        raw[h] = round(raw_bias, 4)
+        applied[h] = round(new_bias, 4)
+        samples[h] = int(n)
+    diag = {"window_days": window, "damping": damping, "clamp_kwh": max_kwh,
+            "min_samples": min_samples, "n_hours": len(applied)}
+    return applied, raw, samples, diag
+
+
+def refresh_load_recent_bias() -> int:
+    """Recompute + persist the additive load-bias table (nightly cron, after the
+    error-log rebuild). Refreshing is cheap and has NO LP effect unless enabled."""
+    from . import db as _db
+
+    applied, raw, samples, diag = compute_load_recent_bias_by_hour_local()
+    if not applied:
+        logger.info("load_recent_bias: nothing to compute (%s)", diag)
+        return 0
+    ca = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    n = _db.upsert_load_recent_bias(applied, raw, samples, ca)
+    logger.info(
+        "load_recent_bias refreshed: %d hours; applied=%s raw=%s",
+        n, {h: applied[h] for h in sorted(applied)}, {h: raw[h] for h in sorted(raw)},
+    )
+    return n
+
+
+def backtest_load_recent_bias(window_days: int | None = None) -> dict[str, Any]:
+    """Offline what-if: would the additive corrector have reduced the error over
+    the persisted load_error_log? Computes the per-local-hour correction from the
+    window, replays ``corrected = max(0, forecast + bias[hour])`` per slot, and
+    reports MAE/bias BEFORE vs AFTER. Read-only — never writes, never touches the
+    LP. This is the gate for deciding whether to enable the corrector.
+    """
+    from . import db as _db
+
+    window = int(window_days or getattr(config, "LOAD_RECENT_BIAS_WINDOW_DAYS", 21))
+    min_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MIN_KWH", 0.05))
+    # Compute the correction map from a clean (no-prev) run so the backtest reflects
+    # the warm-start correction the loop converges to, not a half-ramped state.
+    acc, tz = _local_hour_bias(window)
+    max_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MAX_KWH", 0.3))
+    min_samples = int(getattr(config, "LOAD_RECENT_BIAS_MIN_SAMPLES", 3))
+    bias = {}
+    for h, (sw, w, n) in acc.items():
+        if w > 0 and n >= min_samples:
+            bias[h] = max(-max_kwh, min(max_kwh, sw / w))
+
+    now = datetime.now(UTC)
+    start = now - timedelta(days=window)
+    rows = _db.get_load_error_log_range(
+        start.strftime("%Y-%m-%dT%H:%M:%SZ"), now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    before_abs = before_sum = after_abs = after_sum = 0.0
+    n = 0
+    for r in rows:
+        f = r.get("forecast_kwh")
+        a = r.get("actual_kwh")
+        if f is None or a is None or f < min_kwh:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(r["slot_time_utc"]).replace("Z", "+00:00"))
+        except (ValueError, TypeError, KeyError):
+            continue
+        lh = ts.astimezone(tz).hour
+        corrected = max(0.0, float(f) + bias.get(lh, 0.0))
+        e0 = float(a) - float(f)
+        e1 = float(a) - corrected
+        before_abs += abs(e0); before_sum += e0
+        after_abs += abs(e1); after_sum += e1
+        n += 1
+    if n == 0:
+        return {"n": 0, "note": "no paired slots in window"}
+    mae0, mae1 = before_abs / n, after_abs / n
+    return {
+        "window_days": window,
+        "n_slots": n,
+        "n_hours_corrected": len(bias),
+        "before": {"mae_kwh": round(mae0, 4), "bias_kwh": round(before_sum / n, 4)},
+        "after": {"mae_kwh": round(mae1, 4), "bias_kwh": round(after_sum / n, 4)},
+        "mae_reduction_kwh": round(mae0 - mae1, 4),
+        "mae_reduction_pct": round((mae0 - mae1) / mae0 * 100, 2) if mae0 > 0 else 0.0,
+        "correction_by_hour_local": {str(h): round(bias[h], 4) for h in sorted(bias)},
+    }

--- a/src/load_bias.py
+++ b/src/load_bias.py
@@ -32,37 +32,65 @@ from .config import config
 logger = logging.getLogger(__name__)
 
 
-def _local_hour_bias(window_days: int) -> tuple[dict[int, list[float]], ZoneInfo]:
-    """Recency-weighted accumulator per local hour: {hour: [sum_w_err, sum_w, n]}."""
+def _is_low_daikin(forecast_total: float | None, forecast_base: float | None, max_daikin: float) -> bool:
+    """True when the committed heat-pump load (total − base) is below ``max_daikin``,
+    so on this slot total ≈ base and the measured error isolates the base bias.
+    Requires both columns present (can't confirm low-Daikin otherwise → exclude)."""
+    if forecast_total is None or forecast_base is None:
+        return False
+    return (float(forecast_total) - float(forecast_base)) <= max_daikin
+
+
+def _local_hour_bias(window_days: int, rows: list | None = None) -> tuple[dict[int, dict], ZoneInfo]:
+    """Recency-weighted accumulator per local hour, LEARNED ONLY from low-Daikin
+    slots so it isolates the base-load bias. Returns
+    ``{hour: {"sw":.., "w":.., "n":.., "days": set()}}``. ``rows`` overridable for
+    the backtest holdout."""
     from . import db as _db
 
     half_life = float(getattr(config, "LOAD_RECENT_BIAS_HALFLIFE_DAYS", 7))
     min_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MIN_KWH", 0.05))
+    max_daikin = float(getattr(config, "LOAD_RECENT_BIAS_MAX_DAIKIN_KWH", 0.1))
     tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
 
     now = datetime.now(UTC)
-    start = now - timedelta(days=window_days)
-    rows = _db.get_load_error_log_range(
-        start.strftime("%Y-%m-%dT%H:%M:%SZ"), now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    )
-    acc: dict[int, list[float]] = {}
+    if rows is None:
+        start = now - timedelta(days=window_days)
+        rows = _db.get_load_error_log_range(
+            start.strftime("%Y-%m-%dT%H:%M:%SZ"), now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+    acc: dict[int, dict] = {}
     for r in rows:
         f = r.get("forecast_kwh")
         a = r.get("actual_kwh")
         if f is None or a is None or f < min_kwh or a < min_kwh:
             continue
+        if not _is_low_daikin(f, r.get("forecast_base_kwh"), max_daikin):
+            continue  # heat-pump-heavy slot — its error isn't the base's, skip
         try:
             ts = datetime.fromisoformat(str(r["slot_time_utc"]).replace("Z", "+00:00"))
         except (ValueError, TypeError, KeyError):
             continue
-        lh = ts.astimezone(tz).hour
+        local = ts.astimezone(tz)
+        lh = local.hour
         age_days = max(0.0, (now - ts).total_seconds() / 86400.0)
         w = 0.5 ** (age_days / half_life) if half_life > 0 else 1.0
-        d = acc.setdefault(lh, [0.0, 0.0, 0.0])
-        d[0] += w * (float(a) - float(f))  # additive error (actual − forecast)
-        d[1] += w
-        d[2] += 1
+        d = acc.setdefault(lh, {"sw": 0.0, "w": 0.0, "n": 0, "days": set()})
+        d["sw"] += w * (float(a) - float(f))  # additive base error (low-Daikin → total≈base)
+        d["w"] += w
+        d["n"] += 1
+        d["days"].add(local.date())
     return acc, tz
+
+
+def _bias_from_acc(acc: dict[int, dict], *, max_kwh: float, min_days: int) -> dict[int, float]:
+    """Clamp + min-DISTINCT-DAYS gate over a low-Daikin accumulator → {hour: bias}."""
+    out: dict[int, float] = {}
+    for h, d in acc.items():
+        if d["w"] <= 0 or len(d["days"]) < min_days:
+            continue
+        out[h] = max(-max_kwh, min(max_kwh, d["sw"] / d["w"]))
+    return out
 
 
 def compute_load_recent_bias_by_hour_local() -> tuple[dict[int, float], dict[int, float], dict[int, int], dict[str, Any]]:
@@ -74,7 +102,7 @@ def compute_load_recent_bias_by_hour_local() -> tuple[dict[int, float], dict[int
     window = int(getattr(config, "LOAD_RECENT_BIAS_WINDOW_DAYS", 21))
     damping = float(getattr(config, "LOAD_RECENT_BIAS_DAMPING", 0.5))
     max_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MAX_KWH", 0.3))
-    min_samples = int(getattr(config, "LOAD_RECENT_BIAS_MIN_SAMPLES", 3))
+    min_days = int(getattr(config, "LOAD_RECENT_BIAS_MIN_SAMPLES", 3))
 
     try:
         prev = _db.get_load_recent_bias()
@@ -82,13 +110,11 @@ def compute_load_recent_bias_by_hour_local() -> tuple[dict[int, float], dict[int
         prev = {}
 
     acc, _tz = _local_hour_bias(window)
+    raw_map = _bias_from_acc(acc, max_kwh=max_kwh, min_days=min_days)
     applied: dict[int, float] = {}
     raw: dict[int, float] = {}
     samples: dict[int, int] = {}
-    for h, (sw, w, n) in acc.items():
-        if w <= 0 or n < min_samples:
-            continue
-        raw_bias = sw / w
+    for h, raw_bias in raw_map.items():
         if h in prev:
             # Accumulate on the previous correction by the RESIDUAL error of the
             # already-corrected forecast → ramps to full, settles at raw_bias≈0.
@@ -98,9 +124,10 @@ def compute_load_recent_bias_by_hour_local() -> tuple[dict[int, float], dict[int
         new_bias = max(-max_kwh, min(max_kwh, new_bias))
         raw[h] = round(raw_bias, 4)
         applied[h] = round(new_bias, 4)
-        samples[h] = int(n)
+        samples[h] = int(acc[h]["n"])
     diag = {"window_days": window, "damping": damping, "clamp_kwh": max_kwh,
-            "min_samples": min_samples, "n_hours": len(applied)}
+            "min_days": min_days, "n_hours": len(applied),
+            "learned_from": "low_Daikin_slots"}
     return applied, raw, samples, diag
 
 
@@ -122,32 +149,9 @@ def refresh_load_recent_bias() -> int:
     return n
 
 
-def backtest_load_recent_bias(window_days: int | None = None) -> dict[str, Any]:
-    """Offline what-if: would the additive corrector have reduced the error over
-    the persisted load_error_log? Computes the per-local-hour correction from the
-    window, replays ``corrected = max(0, forecast + bias[hour])`` per slot, and
-    reports MAE/bias BEFORE vs AFTER. Read-only — never writes, never touches the
-    LP. This is the gate for deciding whether to enable the corrector.
-    """
-    from . import db as _db
-
-    window = int(window_days or getattr(config, "LOAD_RECENT_BIAS_WINDOW_DAYS", 21))
-    min_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MIN_KWH", 0.05))
-    # Compute the correction map from a clean (no-prev) run so the backtest reflects
-    # the warm-start correction the loop converges to, not a half-ramped state.
-    acc, tz = _local_hour_bias(window)
-    max_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MAX_KWH", 0.3))
-    min_samples = int(getattr(config, "LOAD_RECENT_BIAS_MIN_SAMPLES", 3))
-    bias = {}
-    for h, (sw, w, n) in acc.items():
-        if w > 0 and n >= min_samples:
-            bias[h] = max(-max_kwh, min(max_kwh, sw / w))
-
-    now = datetime.now(UTC)
-    start = now - timedelta(days=window)
-    rows = _db.get_load_error_log_range(
-        start.strftime("%Y-%m-%dT%H:%M:%SZ"), now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    )
+def _evaluate(rows: list, bias: dict[int, float], tz: ZoneInfo, min_kwh: float) -> dict[str, Any] | None:
+    """Replay ``corrected = max(0, forecast + bias[local_hour])`` over ``rows``;
+    MAE/bias before vs after. Evaluated on TOTAL forecast (what the LP provisions)."""
     before_abs = before_sum = after_abs = after_sum = 0.0
     n = 0
     for r in rows:
@@ -161,21 +165,70 @@ def backtest_load_recent_bias(window_days: int | None = None) -> dict[str, Any]:
             continue
         lh = ts.astimezone(tz).hour
         corrected = max(0.0, float(f) + bias.get(lh, 0.0))
-        e0 = float(a) - float(f)
-        e1 = float(a) - corrected
+        e0, e1 = float(a) - float(f), float(a) - corrected
         before_abs += abs(e0); before_sum += e0
         after_abs += abs(e1); after_sum += e1
         n += 1
     if n == 0:
-        return {"n": 0, "note": "no paired slots in window"}
+        return None
     mae0, mae1 = before_abs / n, after_abs / n
     return {
-        "window_days": window,
         "n_slots": n,
-        "n_hours_corrected": len(bias),
         "before": {"mae_kwh": round(mae0, 4), "bias_kwh": round(before_sum / n, 4)},
         "after": {"mae_kwh": round(mae1, 4), "bias_kwh": round(after_sum / n, 4)},
         "mae_reduction_kwh": round(mae0 - mae1, 4),
         "mae_reduction_pct": round((mae0 - mae1) / mae0 * 100, 2) if mae0 > 0 else 0.0,
-        "correction_by_hour_local": {str(h): round(bias[h], 4) for h in sorted(bias)},
+    }
+
+
+def backtest_load_recent_bias(window_days: int | None = None) -> dict[str, Any]:
+    """Offline what-if for the corrector — the gate for enabling it. Reports BOTH:
+
+    * ``in_sample`` — correction fit on the whole window, evaluated on the same
+      slots (optimistic; structured bias always looks good).
+    * ``out_of_sample`` — correction fit on the OLDER half, evaluated on the
+      RECENT half (honest; this is the number to decide on).
+
+    Read-only — never writes, never touches the LP. The correction is learned only
+    from low-Daikin slots (isolates base bias) but EVALUATED on the total forecast
+    (what the LP must provision).
+    """
+    from . import db as _db
+
+    window = int(window_days or getattr(config, "LOAD_RECENT_BIAS_WINDOW_DAYS", 21))
+    min_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MIN_KWH", 0.05))
+    max_kwh = float(getattr(config, "LOAD_RECENT_BIAS_MAX_KWH", 0.3))
+    min_days = int(getattr(config, "LOAD_RECENT_BIAS_MIN_SAMPLES", 3))
+
+    now = datetime.now(UTC)
+    start = now - timedelta(days=window)
+    rows = _db.get_load_error_log_range(
+        start.strftime("%Y-%m-%dT%H:%M:%SZ"), now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    if not rows:
+        return {"n_slots": 0, "note": "no paired slots in window"}
+
+    # In-sample: fit on all, evaluate on all.
+    acc_all, tz = _local_hour_bias(window, rows=rows)
+    bias_all = _bias_from_acc(acc_all, max_kwh=max_kwh, min_days=min_days)
+    in_sample = _evaluate(rows, bias_all, tz, min_kwh)
+
+    # Out-of-sample: split by time at the window midpoint; fit older, eval recent.
+    mid = (now - timedelta(days=window / 2.0)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    older = [r for r in rows if str(r["slot_time_utc"]) < mid]
+    recent = [r for r in rows if str(r["slot_time_utc"]) >= mid]
+    out_of_sample = None
+    if older and recent:
+        acc_old, _tz = _local_hour_bias(window, rows=older)
+        bias_old = _bias_from_acc(acc_old, max_kwh=max_kwh, min_days=max(1, min_days // 2))
+        out_of_sample = _evaluate(recent, bias_old, tz, min_kwh)
+
+    return {
+        "window_days": window,
+        "learned_from": "low_Daikin_slots",
+        "evaluated_on": "total_forecast",
+        "n_hours_corrected": len(bias_all),
+        "in_sample": in_sample,
+        "out_of_sample": out_of_sample,
+        "correction_by_hour_local": {str(h): round(bias_all[h], 4) for h in sorted(bias_all)},
     }

--- a/src/scheduler/lp_simulation.py
+++ b/src/scheduler/lp_simulation.py
@@ -58,11 +58,22 @@ def _build_load_profile(slot_starts_utc: list[datetime]) -> list[float]:
     prof = db.residual_load_profile_v2()
     load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
     tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+    # Mirror the optimizer's Phase-2 bias correction so Simulate can't diverge
+    # from the real LP. Gated — empty (no-op) unless LOAD_RECENT_BIAS_ENABLED.
+    load_bias: dict[int, float] = {}
+    if getattr(config, "LOAD_RECENT_BIAS_ENABLED", False):
+        try:
+            load_bias = db.get_load_recent_bias()
+        except Exception:
+            load_bias = {}
     out: list[float] = []
     for s in slot_starts_utc:
         local = s.astimezone(tz)
         m = 30 if local.minute >= 30 else 0
-        out.append(db.lookup_residual_kwh(prof, local.weekday(), local.hour, m) * load_scale)
+        v = db.lookup_residual_kwh(prof, local.weekday(), local.hour, m) * load_scale
+        if load_bias:
+            v = max(0.0, v + load_bias.get(local.hour, 0.0))
+        out.append(v)
     return out
 
 

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1381,6 +1381,15 @@ def _run_optimizer_lp(
     # dispatch loads (below) are added at their true kWh. ``base_load_spread`` is
     # the per-slot p75 spread used by the scenario LP (#477 Stage 2).
     _load_scale = float(getattr(config, "LP_LOAD_SCALE_FACTOR", 1.0))
+    # Phase-2 additive per-local-hour bias correction — applied to the residual
+    # base load (so the committed base_load_json the error log measures includes
+    # it → the loop closes). OFF unless LOAD_RECENT_BIAS_ENABLED; empty otherwise.
+    _load_bias: dict[int, float] = {}
+    if getattr(config, "LOAD_RECENT_BIAS_ENABLED", False):
+        try:
+            _load_bias = db.get_load_recent_bias()
+        except Exception:
+            _load_bias = {}
     base_load = []
     base_load_spread = []
     for s in slots:
@@ -1388,10 +1397,15 @@ def _run_optimizer_lp(
         _dow = _local.weekday()
         _h = _local.hour
         _m = 30 if _local.minute >= 30 else 0
-        base_load.append(db.lookup_residual_kwh(_prof, _dow, _h, _m) * _load_scale)
+        _b = db.lookup_residual_kwh(_prof, _dow, _h, _m) * _load_scale
+        if _load_bias:
+            _b = max(0.0, _b + _load_bias.get(_h, 0.0))
+        base_load.append(_b)
         base_load_spread.append(db.lookup_residual_spread_kwh(_prof, _dow, _h, _m) * _load_scale)
     if _load_scale != 1.0:
         logger.info("LP base_load: operator load scale %.2f applied to residual profile", _load_scale)
+    if _load_bias:
+        logger.info("LP base_load: recent-bias correction applied to %d local hour(s)", len(_load_bias))
     residual_base_load = list(base_load)
     appliance_profile_kwh = [0.0] * len(base_load)
 

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -740,7 +740,7 @@ def bulletproof_load_error_log_job() -> None:
 
     Phase-1 measurement for load calibration (load analog of the PV error log).
     Runs nightly just after the PV error log so the prior UTC day has its fullest
-    load samples. Measurement only — does not touch the LP. Best-effort.
+    load samples. Measurement only — the Phase-2 refresh below is gated. Best-effort.
     """
     target_day = datetime.now(UTC).date() - timedelta(days=1)
     try:
@@ -748,6 +748,13 @@ def bulletproof_load_error_log_job() -> None:
         logger.info("load_error_log rebuild: date_utc=%s rows=%d", target_day.isoformat(), rows)
     except Exception as e:
         logger.warning("load_error_log rebuild failed (non-fatal): %s", e)
+    # Phase 2 — refresh the adaptive load-bias table from the just-rebuilt error
+    # log. Cheap + observable; NO LP effect unless LOAD_RECENT_BIAS_ENABLED.
+    try:
+        from ..load_bias import refresh_load_recent_bias
+        refresh_load_recent_bias()
+    except Exception as e:
+        logger.warning("load_recent_bias refresh failed (non-fatal): %s", e)
 
 
 def bulletproof_export_opportunity_job() -> None:

--- a/tests/test_load_recent_bias.py
+++ b/tests/test_load_recent_bias.py
@@ -24,8 +24,9 @@ def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     db.init_db()
 
 
-def _seed_error_row(slot_utc: datetime, forecast: float, actual: float) -> None:
+def _seed_error_row(slot_utc: datetime, forecast: float, actual: float, base: float | None = None) -> None:
     key = slot_utc.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    base = forecast if base is None else base  # default: base==total → low Daikin
     with db._lock:
         conn = db.get_connection()
         try:
@@ -33,21 +34,23 @@ def _seed_error_row(slot_utc: datetime, forecast: float, actual: float) -> None:
                 """INSERT OR REPLACE INTO load_error_log
                    (slot_time_utc, forecast_kwh, forecast_base_kwh, actual_kwh, error_kwh, built_at_utc)
                    VALUES (?, ?, ?, ?, ?, ?)""",
-                (key, forecast, forecast, actual, actual - forecast, "2026-06-15T00:00:00Z"),
+                (key, forecast, base, actual, actual - forecast, "2026-06-15T00:00:00Z"),
             )
             conn.commit()
         finally:
             conn.close()
 
 
-def _seed_constant_bias(*, utc_hour: int, forecast: float, bias: float, n_days: int = 10) -> int:
+def _seed_constant_bias(*, utc_hour: int, forecast: float, bias: float, n_days: int = 10,
+                        base: float | None = None) -> int:
     """Seed n_days of one slot at a fixed UTC hour with actual = forecast + bias.
+    ``base`` controls committed Daikin (total−base); default base==forecast → low.
     Returns the LOCAL hour those slots fall in."""
     now = datetime.now(UTC)
     local_hour = None
     for d in range(1, n_days + 1):
         slot = (now - timedelta(days=d)).replace(hour=utc_hour, minute=0, second=0, microsecond=0)
-        _seed_error_row(slot, forecast, forecast + bias)
+        _seed_error_row(slot, forecast, forecast + bias, base=base)
         local_hour = slot.astimezone(LON).hour
     return local_hour
 
@@ -75,10 +78,19 @@ def test_clamped_to_max() -> None:
     assert applied[lh] == pytest.approx(app_config.LOAD_RECENT_BIAS_MAX_KWH)
 
 
-def test_below_min_samples_dropped() -> None:
-    _seed_constant_bias(utc_hour=12, forecast=0.5, bias=0.2, n_days=2)  # < MIN_SAMPLES (3)
+def test_below_min_days_dropped() -> None:
+    _seed_constant_bias(utc_hour=12, forecast=0.5, bias=0.2, n_days=2)  # 2 days < MIN (3)
     applied, _r, _s, _d = load_bias.compute_load_recent_bias_by_hour_local()
     assert applied == {}
+
+
+def test_high_daikin_slots_excluded() -> None:
+    """A slot whose committed heat-pump load (total−base) is large must NOT teach
+    the base corrector — its error isn't the base's."""
+    # forecast 1.0, base 0.3 → committed Daikin 0.7 (>> 0.1 threshold).
+    lh = _seed_constant_bias(utc_hour=12, forecast=1.0, bias=0.3, n_days=10, base=0.3)
+    applied, _r, _s, _d = load_bias.compute_load_recent_bias_by_hour_local()
+    assert lh not in applied  # excluded → no correction learned for that hour
 
 
 def test_refresh_persists_round_trip() -> None:
@@ -91,13 +103,18 @@ def test_refresh_persists_round_trip() -> None:
 
 def test_backtest_reduces_mae_on_structured_bias() -> None:
     # Two hours with opposite bias (nets to ~0 overall, like the real diurnal pattern).
-    _seed_constant_bias(utc_hour=2, forecast=0.4, bias=-0.15)   # overnight over-forecast
-    _seed_constant_bias(utc_hour=13, forecast=0.5, bias=+0.18)  # midday under-forecast
+    _seed_constant_bias(utc_hour=2, forecast=0.4, bias=-0.15, n_days=20)   # overnight over
+    _seed_constant_bias(utc_hour=13, forecast=0.5, bias=+0.18, n_days=20)  # midday under
     res = load_bias.backtest_load_recent_bias()
-    assert res["n_slots"] >= 10
-    # The corrector removes the per-hour bias → MAE drops materially.
-    assert res["after"]["mae_kwh"] < res["before"]["mae_kwh"]
-    assert res["mae_reduction_kwh"] > 0.1
+    ins = res["in_sample"]
+    assert ins["n_slots"] >= 20
+    # In-sample: corrector removes the per-hour bias → MAE drops materially.
+    assert ins["after"]["mae_kwh"] < ins["before"]["mae_kwh"]
+    assert ins["mae_reduction_kwh"] > 0.1
+    # Out-of-sample present (older→recent holdout) and also improves on stable bias.
+    oos = res["out_of_sample"]
+    assert oos is not None
+    assert oos["after"]["mae_kwh"] < oos["before"]["mae_kwh"]
 
 
 def test_corrector_off_by_default() -> None:

--- a/tests/test_load_recent_bias.py
+++ b/tests/test_load_recent_bias.py
@@ -1,0 +1,104 @@
+"""Phase-2 load recent-bias corrector (additive, per-local-hour, closed-loop).
+
+Seeds load_error_log rows directly with a known per-local-hour additive bias and
+checks: warm-start jumps to the measured bias; accumulation nudges the previous
+value; the clamp bounds it; the backtest reduces MAE on structured bias.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src import db, load_bias
+from src.config import config as app_config
+
+LON = ZoneInfo("Europe/London")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(app_config, "DB_PATH", str(tmp_path / "t.db"), raising=False)
+    db.init_db()
+
+
+def _seed_error_row(slot_utc: datetime, forecast: float, actual: float) -> None:
+    key = slot_utc.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    with db._lock:
+        conn = db.get_connection()
+        try:
+            conn.execute(
+                """INSERT OR REPLACE INTO load_error_log
+                   (slot_time_utc, forecast_kwh, forecast_base_kwh, actual_kwh, error_kwh, built_at_utc)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (key, forecast, forecast, actual, actual - forecast, "2026-06-15T00:00:00Z"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def _seed_constant_bias(*, utc_hour: int, forecast: float, bias: float, n_days: int = 10) -> int:
+    """Seed n_days of one slot at a fixed UTC hour with actual = forecast + bias.
+    Returns the LOCAL hour those slots fall in."""
+    now = datetime.now(UTC)
+    local_hour = None
+    for d in range(1, n_days + 1):
+        slot = (now - timedelta(days=d)).replace(hour=utc_hour, minute=0, second=0, microsecond=0)
+        _seed_error_row(slot, forecast, forecast + bias)
+        local_hour = slot.astimezone(LON).hour
+    return local_hour
+
+
+def test_warm_start_jumps_to_measured_bias() -> None:
+    lh = _seed_constant_bias(utc_hour=12, forecast=0.5, bias=0.2)
+    applied, raw, samples, diag = load_bias.compute_load_recent_bias_by_hour_local()
+    assert lh in applied
+    assert raw[lh] == pytest.approx(0.2, abs=0.01)
+    assert applied[lh] == pytest.approx(0.2, abs=0.01)  # warm start = raw
+
+
+def test_accumulates_on_previous() -> None:
+    lh = _seed_constant_bias(utc_hour=12, forecast=0.5, bias=0.2)
+    # Pretend a previous correction of 0.1 already exists.
+    db.upsert_load_recent_bias({lh: 0.1}, {lh: 0.1}, {lh: 5}, "2026-06-15T00:00:00Z")
+    applied, raw, _s, _d = load_bias.compute_load_recent_bias_by_hour_local()
+    # new = prev(0.1) + damping(0.5) * raw(0.2) = 0.2
+    assert applied[lh] == pytest.approx(0.1 + 0.5 * 0.2, abs=0.01)
+
+
+def test_clamped_to_max() -> None:
+    lh = _seed_constant_bias(utc_hour=12, forecast=1.0, bias=5.0)  # absurd bias
+    applied, _r, _s, _d = load_bias.compute_load_recent_bias_by_hour_local()
+    assert applied[lh] == pytest.approx(app_config.LOAD_RECENT_BIAS_MAX_KWH)
+
+
+def test_below_min_samples_dropped() -> None:
+    _seed_constant_bias(utc_hour=12, forecast=0.5, bias=0.2, n_days=2)  # < MIN_SAMPLES (3)
+    applied, _r, _s, _d = load_bias.compute_load_recent_bias_by_hour_local()
+    assert applied == {}
+
+
+def test_refresh_persists_round_trip() -> None:
+    lh = _seed_constant_bias(utc_hour=12, forecast=0.5, bias=0.2)
+    n = load_bias.refresh_load_recent_bias()
+    assert n >= 1
+    got = db.get_load_recent_bias()
+    assert got[lh] == pytest.approx(0.2, abs=0.01)
+
+
+def test_backtest_reduces_mae_on_structured_bias() -> None:
+    # Two hours with opposite bias (nets to ~0 overall, like the real diurnal pattern).
+    _seed_constant_bias(utc_hour=2, forecast=0.4, bias=-0.15)   # overnight over-forecast
+    _seed_constant_bias(utc_hour=13, forecast=0.5, bias=+0.18)  # midday under-forecast
+    res = load_bias.backtest_load_recent_bias()
+    assert res["n_slots"] >= 10
+    # The corrector removes the per-hour bias → MAE drops materially.
+    assert res["after"]["mae_kwh"] < res["before"]["mae_kwh"]
+    assert res["mae_reduction_kwh"] > 0.1
+
+
+def test_corrector_off_by_default() -> None:
+    assert app_config.LOAD_RECENT_BIAS_ENABLED is False


### PR DESCRIPTION
## What
The corrector for the diurnal load-forecast bias Phase 1 (#569) revealed: over-forecast overnight (00-06h, −0.08..−0.16 kWh/slot), under-forecast midday/evening (07-19h, up to +0.19), over-forecast late (21-23h) — the seasonal-regime-shift signature of a 120d median lagging Apr-cold→Jun-warm. Zero overall bias hid it.

**DEFAULT OFF — zero dispatch impact until the backtest confirms it helps and the flag is flipped.**

## Design (mirrors the PV recent-bias loop, with the right differences for load)
- **ADDITIVE** per-**LOCAL**-hour correction (kWh/slot), not multiplicative — load bias is a level offset, not magnitude scaling; load is occupancy-driven → local hour.
- **Closed loop** (#488 lesson): `new_bias = old_bias + damping·raw_bias`, `raw_bias = recency-weighted mean(actual − committed_forecast)` from load_error_log → ramps to full, settles at raw≈0. Warm-starts from measured bias. Hard-clamped ±0.3 kWh/slot.

## Pieces
- `src/load_bias.py`: compute / refresh / **backtest** (offline what-if: MAE/bias before vs after over the persisted log — the decision gate).
- `load_recent_bias` table + upsert/get.
- Applied in **optimizer.py AND lp_simulation.py** to the residual base load (so committed base_load_json includes it → loop closes), both **gated by LOAD_RECENT_BIAS_ENABLED**.
- Refreshed nightly in the load-error-log cron (cheap; no LP effect unless enabled).
- `GET /api/v1/load/error-log/backtest` (read-only).

## Tests
warm-start = measured bias; accumulation; clamp; min-samples drop; refresh round-trip; backtest reduces MAE on structured diurnal bias; off by default. 231 passed across load/optimizer/sim/runner/pv subset.

## Next
After merge+deploy: run the **backtest on prod** (`/load/error-log/backtest`) over the 52 backfilled days → if MAE drops materially, enable `LOAD_RECENT_BIAS_ENABLED` and observe; if the bias is mostly heat-pump timing (no MAE gain), leave OFF and it's a #540 lever instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)