### PR TITLE
feat(ui): Insights — Load forecast accuracy card

### DIFF
--- a/ui/src/components/insights/LoadForecastAccuracyCard.tsx
+++ b/ui/src/components/insights/LoadForecastAccuracyCard.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef } from "preact/hooks";
+import { useFetch } from "../../lib/poll";
+import { getLoadErrorLog, type LoadErrorLog } from "../../lib/endpoints";
+import { makeChart, chartTheme, type EChartsType } from "../../lib/charts";
+import { Spinner } from "../common/Spinner";
+
+/** How well the household LOAD forecast the LP plans against matched reality,
+ *  by local hour. Complements LoadPatternCard (when we spend) with how well we
+ *  predict it. Surfaces the load_error_log measurement (Phase 1). Read-only. */
+export function LoadForecastAccuracyCard() {
+  const res = useFetch<LoadErrorLog>(() => getLoadErrorLog(30), []);
+  const data = res.data;
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsType | null>(null);
+
+  useEffect(() => {
+    if (!elRef.current || !data) return;
+    if (!chartRef.current) chartRef.current = makeChart(elRef.current);
+    const t = chartTheme();
+
+    // 24 bars: bias (actual − forecast) per local hour. + = under-forecast
+    // (planned too little), − = over-forecast (planned too much).
+    const bars: { value: number; itemStyle: { color: string } }[] = [];
+    for (let h = 0; h < 24; h++) {
+      const s = data.per_hour_local[String(h)];
+      const b = s ? s.bias_kwh : 0;
+      bars.push({
+        value: Number(b.toFixed(3)),
+        itemStyle: { color: b >= 0 ? (t.importColor ?? "#ef4444") : (t.pv ?? "#38bdf8") },
+      });
+    }
+
+    chartRef.current.setOption({
+      backgroundColor: "transparent",
+      tooltip: {
+        trigger: "axis",
+        formatter: (ps: { dataIndex: number; value: number }[]) => {
+          const h = ps[0].dataIndex;
+          const s = data.per_hour_local[String(h)];
+          if (!s) return `${String(h).padStart(2, "0")}:00 — no data`;
+          const dir = s.bias_kwh >= 0 ? "under-forecast" : "over-forecast";
+          return `${String(h).padStart(2, "0")}:00 — <b>${s.bias_kwh >= 0 ? "+" : ""}${s.bias_kwh.toFixed(2)} kWh</b> (${dir})<br/>MAE ${s.mae_kwh.toFixed(2)} · n=${s.n}`;
+        },
+      },
+      grid: { left: 40, right: 12, top: 10, bottom: 24 },
+      xAxis: {
+        type: "category",
+        data: Array.from({ length: 24 }, (_, h) => (h % 3 === 0 ? String(h) : "")),
+        axisLine: { lineStyle: { color: t.border } },
+        axisTick: { show: false },
+        axisLabel: { color: t.textMute, fontSize: 10 },
+      },
+      yAxis: {
+        type: "value",
+        axisLabel: { color: t.textMute, fontSize: 10, formatter: "{value}" },
+        splitLine: { lineStyle: { color: t.border, opacity: 0.3 } },
+      },
+      series: [{
+        type: "bar",
+        data: bars,
+        barWidth: "65%",
+        markLine: {
+          silent: true, symbol: "none",
+          lineStyle: { color: t.textMute, type: "solid", opacity: 0.5 },
+          data: [{ yAxis: 0 }],
+          label: { show: false },
+        },
+      }],
+    });
+    chartRef.current.resize();
+  }, [data]);
+
+  useEffect(() => () => { chartRef.current?.dispose(); chartRef.current = null; }, []);
+
+  const o = data?.overall;
+  return (
+    <section class="insights-card load-accuracy">
+      <header class="load-pattern-head">
+        <h2>Load forecast accuracy</h2>
+        <p class="muted">
+          How well the household-load forecast the optimizer plans against matched
+          reality, by local hour. <span class="la-key la-over">Blue</span> = over-forecast
+          (planned too much); <span class="la-key la-under">red</span> = under-forecast
+          (planned too little).
+        </p>
+      </header>
+      {res.loading && !data && <Spinner label="Loading load accuracy…" />}
+      {res.error && <p class="insights-error">Couldn't load accuracy: {res.error.message}</p>}
+      {data && o && o.n > 0 && (
+        <>
+          <div class="la-stats">
+            <div class="la-stat">
+              <span class="la-stat-val">{o.mae_kwh.toFixed(2)}</span>
+              <span class="la-stat-lbl">kWh/slot MAE</span>
+            </div>
+            <div class="la-stat">
+              <span class="la-stat-val">{o.bias_kwh >= 0 ? "+" : ""}{o.bias_kwh.toFixed(3)}</span>
+              <span class="la-stat-lbl">net bias (kWh/slot)</span>
+            </div>
+            <div class="la-stat">
+              <span class="la-stat-val">{o.mean_actual_kwh.toFixed(2)}</span>
+              <span class="la-stat-lbl">mean actual</span>
+            </div>
+            <div class="la-stat">
+              <span class="la-stat-val">{o.n}</span>
+              <span class="la-stat-lbl">slots ({data.window_days}d)</span>
+            </div>
+          </div>
+          <div ref={elRef} class="load-pattern-chart" />
+          <p class="muted load-pattern-meta">
+            Net bias near zero overall can still hide a diurnal pattern (the bars) —
+            measured against the committed plan, total household load (heat pump included).
+          </p>
+        </>
+      )}
+      {data && (!o || o.n === 0) && (
+        <p class="muted insights-empty">No load forecast-vs-actual data yet.</p>
+      )}
+    </section>
+  );
+}

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -293,3 +293,19 @@ export interface ResidualProfile {
 }
 export const getResidualProfile = () =>
   getJson<ResidualProfile>("/load/residual-profile");
+
+export interface LoadErrorStats {
+  n: number;
+  mae_kwh: number;
+  bias_kwh: number;
+  mean_forecast_kwh: number;
+  mean_actual_kwh: number;
+}
+export interface LoadErrorLog {
+  window_days: number;
+  n_slots_logged: number;
+  overall: LoadErrorStats;
+  per_hour_local: Record<string, LoadErrorStats>;
+}
+export const getLoadErrorLog = (windowDays = 30) =>
+  getJson<LoadErrorLog>(`/load/error-log?window_days=${windowDays}`);

--- a/ui/src/routes/insights.css
+++ b/ui/src/routes/insights.css
@@ -129,6 +129,23 @@
   margin-top: var(--space-2);
 }
 
+/* Load forecast accuracy card */
+.load-accuracy {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+.la-key { font-weight: 700; }
+.la-key.la-over { color: var(--pv, #38bdf8); }
+.la-key.la-under { color: var(--bad); }
+.la-stats {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: var(--space-3); margin: var(--space-3) 0 var(--space-2);
+}
+.la-stat { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.la-stat-val { font-size: var(--font-lg); font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
+.la-stat-lbl { font-size: var(--font-2xs); color: var(--text-mute); }
+
 /* ── fair-compare loading skeleton ─────────────────────────────────────
  * Self-contained (insights doesn't import home.css where .skel-text lives).
  * Ghost rows mirror the real table's rhythm so the eventual swap is calm. */

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -8,6 +8,7 @@ import { gbp, gbpSigned, kwh } from "../lib/format";
 import { makeChart, baseOption, chartTheme, barGradient, withAlpha, type EChartsType } from "../lib/charts";
 import type { FairTariffRow } from "../lib/types";
 import { LoadPatternCard } from "../components/insights/LoadPatternCard";
+import { LoadForecastAccuracyCard } from "../components/insights/LoadForecastAccuracyCard";
 import { SystemHealthCard } from "../components/insights/SystemHealthCard";
 import "./insights.css";
 
@@ -173,6 +174,7 @@ export default function Insights() {
       )}
 
       <LoadPatternCard />
+      <LoadForecastAccuracyCard />
       <SystemHealthCard />
     </div>
   );


### PR DESCRIPTION
## What
Surfaces the `load_error_log` measurement (Phase 1, #569) the backend collects but the UI didn't show. Complements **LoadPatternCard** (when the house spends) with **how well we predict it**, by local hour.

- New `GET /load/error-log` fetcher + types.
- `LoadForecastAccuracyCard`: headline MAE / net-bias / mean-actual / n-slots + a per-local-hour **bias bar chart** — over-forecast (planned too much, blue) vs under-forecast (planned too little, red) — visualising the diurnal pattern a near-zero overall bias hides.
- Read-only; degrades to nothing on 404/empty (older hem image). BarChart/MarkLine already registered in charts.ts.

Placed after LoadPatternCard in Insights.

## Verification
tsc + build clean. Will gstack-browse the live card after deploy (375px + 1280px).

Image: **ui** only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)