### PR TITLE
feat(thermal): #540 W1 — indoor temperature ingestion pipe

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -115,6 +115,7 @@ from .routers import appliances as appliances_router
 from .routers import dispatch as dispatch_router
 from .routers import energy_providers as energy_providers_router
 from .routers import pv as pv_router
+from .routers import sensors as sensors_router
 from .routers import status as status_router
 from .routers import workbench as workbench_router
 
@@ -338,6 +339,7 @@ app.include_router(workbench_router.router)
 app.include_router(dispatch_router.router)
 app.include_router(appliances_router.router)
 app.include_router(pv_router.router)
+app.include_router(sensors_router.router)
 app.include_router(status_router.router)
 
 # Mount the FastMCP streamable-HTTP transport at /mcp, guarded by a bearer

--- a/src/api/routers/sensors.py
+++ b/src/api/routers/sensors.py
@@ -25,7 +25,7 @@ router = APIRouter(tags=["sensors"])
 
 class IndoorReading(BaseModel):
     captured_at: str = Field(..., description="ISO-8601 UTC timestamp")
-    temp_c: float = Field(..., ge=-20, le=50)
+    temp_c: float = Field(..., ge=-20, le=45)  # indoor room; tight ceiling catches F/C slips
     room: str = "home"
     source: str | None = None
     quality: str | None = None

--- a/src/api/routers/sensors.py
+++ b/src/api/routers/sensors.py
@@ -1,0 +1,71 @@
+"""Indoor temperature ingestion (#540 W1).
+
+The Altherma has no room stat, so the house's indoor temperature has never been
+measured. This is the pipe the user's room sensors push into — a generic batch
+POST (admin-gated by the role middleware) plus a viewer-readable recent feed.
+Downstream: the LP initial state + the dispatch comfort guard read the freshest
+fresh reading; the W2 thermal learner reads the history.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from ... import db
+from ...config import config
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["sensors"])
+
+
+class IndoorReading(BaseModel):
+    captured_at: str = Field(..., description="ISO-8601 UTC timestamp")
+    temp_c: float = Field(..., ge=-20, le=50)
+    room: str = "home"
+    source: str | None = None
+    quality: str | None = None
+
+
+class IndoorReadingsBody(BaseModel):
+    readings: list[IndoorReading] = Field(..., min_length=1, max_length=2000)
+
+
+@router.post("/api/v1/sensors/indoor")
+async def post_indoor_readings(body: IndoorReadingsBody) -> dict[str, Any]:
+    """Ingest one or more indoor temperature readings (admin). Idempotent on
+    (captured_at, room). Returns how many new rows were written."""
+    written = db.save_indoor_readings([r.model_dump() for r in body.readings])
+    logger.info("indoor sensors: ingested %d/%d new readings", written, len(body.readings))
+    return {"received": len(body.readings), "written": written}
+
+
+@router.get("/api/v1/sensors/indoor")
+async def get_indoor_readings(hours: int = 24) -> dict[str, Any]:
+    """Recent indoor readings (viewer) + the freshest fresh house temperature and
+    its staleness, for the cockpit chart / a staleness chip."""
+    hours = max(1, min(int(hours), 168))
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Small future buffer so a reading that just arrived this second (end is
+    # exclusive) is still included.
+    end = (now + timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    rows = db.get_indoor_readings_range(start, end)
+    stale_min = int(getattr(config, "INDOOR_SENSOR_STALE_MINUTES", 30))
+    latest = db.get_latest_indoor_reading(max_age_minutes=stale_min)
+    # Also report the single newest row regardless of staleness, so the UI can say
+    # "last seen 4h ago" even when it's beyond the fresh window.
+    newest = rows[-1] if rows else None
+    return {
+        "hours": hours,
+        "n_readings": len(rows),
+        "readings": rows,
+        "latest_fresh": latest,             # None when nothing within the stale window
+        "newest_at": newest["captured_at"] if newest else None,
+        "stale_minutes": stale_min,
+        "configured": bool(rows),
+    }

--- a/src/config.py
+++ b/src/config.py
@@ -1364,6 +1364,10 @@ class Config:
     BUILDING_THERMAL_MASS_KWH_PER_K: float = float(os.getenv("BUILDING_THERMAL_MASS_KWH_PER_K", "12.0"))
     # INDOOR_SETPOINT_C is runtime-tunable via /api/v1/settings (#52) — see @property below.
     INDOOR_COMFORT_BAND_C: float = float(os.getenv("INDOOR_COMFORT_BAND_C", "1.5"))
+    # #540 W1 — a room-sensor reading older than this is treated as ABSENT (the
+    # comfort guard / LP fall back to the estimator), so a dead sensor can't
+    # freeze the LP on a stale indoor temperature.
+    INDOOR_SENSOR_STALE_MINUTES: int = int(os.getenv("INDOOR_SENSOR_STALE_MINUTES", "30"))
     RADIATOR_MAX_KW: float = float(os.getenv("RADIATOR_MAX_KW", "6.0"))
     # Physical climate (weather-compensation) curve from the Daikin panel.
     # Maps outdoor temperature to leaving-water temperature (LWT) via a straight line through

--- a/src/db.py
+++ b/src/db.py
@@ -888,6 +888,26 @@ def _migrate_schema(conn: sqlite3.Connection) -> None:
         )"""
     )
 
+    # Winter thermal #540 W1 — indoor temperature ingestion. The Altherma has no
+    # room stat (daikin_room_temp is 100% NULL), so the house's indoor temp has
+    # never been measured. This is the pipe the user's room sensors push into;
+    # multi-room from day one. Idempotent on (captured_at, room). Read by the LP
+    # initial state + the dispatch comfort guard (no-op until fresh rows arrive)
+    # and, later, the W2 thermal learner.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS room_temperature_history (
+            captured_at TEXT NOT NULL,
+            room        TEXT NOT NULL DEFAULT 'home',
+            temp_c      REAL NOT NULL,
+            source      TEXT,
+            quality     TEXT,
+            PRIMARY KEY (captured_at, room)
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_room_temp_captured ON room_temperature_history(captured_at)"
+    )
+
     # V14: presence_periods — manually-flagged periods of household presence
     # (home / travel / guests) so future load-pattern analyses + LP calibration
     # can de-bias the rolling load profile by occupancy. Read by analytics
@@ -4215,6 +4235,89 @@ def get_fox_energy_dates_for_month(year: int, month: int) -> set[str]:
                 (f"{prefix}%",),
             )
             return {r["date"] for r in cur.fetchall()}
+        finally:
+            conn.close()
+
+
+def save_indoor_readings(readings: list[dict[str, Any]]) -> int:
+    """Batch-insert indoor temperature readings (#540 W1). Each dict:
+    ``{captured_at, temp_c, room?, source?, quality?}``. Idempotent on
+    (captured_at, room) so re-pushes don't double-count. Returns rows written.
+
+    ``captured_at`` is normalised to canonical UTC Z form so a getter keyed on
+    ISO string ordering is correct regardless of the pusher's offset format.
+    """
+    written = 0
+    with _lock:
+        conn = get_connection()
+        try:
+            for r in readings:
+                ts = _parse_iso_utc(r.get("captured_at"))
+                temp = r.get("temp_c")
+                if ts is None or temp is None:
+                    continue
+                key = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+                cur = conn.execute(
+                    """INSERT OR IGNORE INTO room_temperature_history
+                       (captured_at, room, temp_c, source, quality)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (key, str(r.get("room") or "home"), float(temp),
+                     r.get("source"), r.get("quality")),
+                )
+                written += cur.rowcount
+            conn.commit()
+        finally:
+            conn.close()
+    return written
+
+
+def get_latest_indoor_reading(max_age_minutes: int = 30) -> dict[str, Any] | None:
+    """Freshest house indoor temperature (#540 W1), or None when no reading is
+    within ``max_age_minutes`` (→ caller falls back to the estimator).
+
+    Multi-room aware: returns the MEAN of the latest reading per room (within the
+    staleness window), plus the newest ``captured_at`` and the room list, so the
+    comfort guard / LP get one representative house temperature."""
+    cutoff = (datetime.now(UTC) - timedelta(minutes=max_age_minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT room, temp_c, captured_at FROM room_temperature_history r
+                   WHERE captured_at >= ?
+                     AND captured_at = (
+                       SELECT MAX(captured_at) FROM room_temperature_history
+                       WHERE room = r.room AND captured_at >= ?)""",
+                (cutoff, cutoff),
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+    if not rows:
+        return None
+    temps = [float(r["temp_c"]) for r in rows]
+    return {
+        "temp_c": round(sum(temps) / len(temps), 2),
+        "captured_at": max(str(r["captured_at"]) for r in rows),
+        "rooms": sorted({str(r["room"]) for r in rows}),
+        "n_rooms": len(rows),
+    }
+
+
+def get_indoor_readings_range(start_utc_iso: str, end_utc_iso: str) -> list[dict[str, Any]]:
+    """Per-reading rows in ``[start, end)`` (all rooms), oldest first. For the
+    cockpit chart + the W2 thermal learner."""
+    with _lock:
+        conn = get_connection()
+        try:
+            cur = conn.execute(
+                """SELECT captured_at, room, temp_c, source, quality
+                   FROM room_temperature_history
+                   WHERE captured_at >= ? AND captured_at < ?
+                   ORDER BY captured_at""",
+                (start_utc_iso, end_utc_iso),
+            )
+            return [dict(r) for r in cur.fetchall()]
         finally:
             conn.close()
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -519,6 +519,33 @@ def build_mcp() -> FastMCP:
         }
 
     @mcp.tool(
+        name="save_indoor_temperature",
+        description=(
+            "Record an indoor room temperature reading (#540 W1). Feeds the LP "
+            "initial state + the dispatch comfort guard (freshest fresh reading) "
+            "and the winter thermal learner. captured_at defaults to now (UTC); "
+            "pass an ISO-8601 UTC string to backfill. room defaults to 'home'. "
+            "Idempotent on (captured_at, room)."
+        ),
+    )
+    def save_indoor_temperature(
+        temp_c: float,
+        room: str = "home",
+        captured_at: str | None = None,
+        source: str | None = "mcp",
+    ) -> dict[str, Any]:
+        from datetime import UTC, datetime
+
+        ts = captured_at or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            written = db.save_indoor_readings([
+                {"captured_at": ts, "temp_c": float(temp_c), "room": room, "source": source}
+            ])
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+        return {"ok": True, "written": written, "captured_at": ts, "room": room}
+
+    @mcp.tool(
         name="set_inverter_mode",
         description=(
             "Set Fox ESS inverter work mode. Valid modes: Self Use, Feed-in Priority, "

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -1021,14 +1021,21 @@ def _write_lwt_preheat_actions(
         )
         return 0
 
-    # Sensor-ready hook: read the latest LIVE indoor temperature if any exists.
-    # Currently null in ~all rows → the comfort guard is a no-op until a room
-    # sensor lands. One clean seam; no rework when the sensor arrives.
+    # Indoor temperature for the comfort guard: prefer a FRESH room-sensor reading
+    # (#540 W1); fall back to live Daikin telemetry (NULL on this Altherma); else
+    # None → guard is a no-op. A stale sensor is treated as absent (staleness
+    # window) so a dead sensor can't wedge the guard on an old value.
     indoor_c: float | None = None
     try:
-        tel = db.get_latest_daikin_telemetry(source="live")
-        if tel and tel.get("indoor_temp_c") is not None:
-            indoor_c = float(tel["indoor_temp_c"])
+        s = db.get_latest_indoor_reading(
+            max_age_minutes=int(getattr(config, "INDOOR_SENSOR_STALE_MINUTES", 30))
+        )
+        if s is not None:
+            indoor_c = float(s["temp_c"])
+        else:
+            tel = db.get_latest_daikin_telemetry(source="live")
+            if tel and tel.get("indoor_temp_c") is not None:
+                indoor_c = float(tel["indoor_temp_c"])
     except Exception:  # pragma: no cover — telemetry read must never break dispatch
         indoor_c = None
 

--- a/src/scheduler/optimizer.py
+++ b/src/scheduler/optimizer.py
@@ -1139,19 +1139,32 @@ def _persist_lp_snapshots(
         ),
     }
 
+    # #540 W1 — freshest room-sensor reading (None until sensors push / when stale).
+    _w1_indoor_initial_c: float | None = None
+    try:
+        _s = db.get_latest_indoor_reading(
+            max_age_minutes=int(getattr(config, "INDOOR_SENSOR_STALE_MINUTES", 30))
+        )
+        if _s is not None:
+            _w1_indoor_initial_c = float(_s["temp_c"])
+    except Exception:  # pragma: no cover — must never break a solve
+        _w1_indoor_initial_c = None
+
     inputs_row = {
         "run_at_utc": run_at_iso,
         "plan_date": plan_date,
         "horizon_hours": int(config.LP_HORIZON_HOURS),
         "soc_initial_kwh": float(initial.soc_kwh),
         "tank_initial_c": float(initial.tank_temp_c),
-        # PR Phase B: indoor_initial_c retained as schema column for back-compat
-        # but now written as None — the LP no longer carries an indoor-temp
-        # state variable (Daikin Altherma has no room sensor here).
-        "indoor_initial_c": None,
+        # Phase B dropped the LP indoor-temp STATE variable (no room sensor here).
+        # #540 W1: now that room sensors push into room_temperature_history, record
+        # the freshest reading on the snapshot (source="sensor") so it's captured
+        # for the W2 learner + audits. The LP doesn't re-gain t_in until W3; this
+        # is observation-only for now.
+        "indoor_initial_c": _w1_indoor_initial_c,
         "soc_source": getattr(initial, "soc_source", "unknown"),
         "tank_source": getattr(initial, "tank_source", "unknown"),
-        "indoor_source": "removed_phase_b",
+        "indoor_source": ("sensor" if _w1_indoor_initial_c is not None else "removed_phase_b"),
         "base_load_json": json.dumps([round(float(x), 4) for x in base_load]),
         "micro_climate_offset_c": float(micro_climate_offset or 0.0),
         "forecast_fetch_at_utc": forecast_fetch_at_utc,

--- a/tests/test_indoor_sensors.py
+++ b/tests/test_indoor_sensors.py
@@ -1,0 +1,109 @@
+"""#540 W1 — indoor temperature ingestion (table + save/get + endpoint).
+
+Idempotent multi-room save; freshest-within-staleness getter (mean across rooms);
+range query; POST writes + GET surfaces latest_fresh/newest_at.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src import db
+from src.config import config as app_config
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(app_config, "DB_PATH", str(tmp_path / "t.db"), raising=False)
+    db.init_db()
+
+
+def _z(dt: datetime) -> str:
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_save_is_idempotent_and_multiroom() -> None:
+    now = datetime.now(UTC)
+    rows = [
+        {"captured_at": _z(now), "temp_c": 20.5, "room": "living"},
+        {"captured_at": _z(now), "temp_c": 19.0, "room": "bedroom"},
+    ]
+    assert db.save_indoor_readings(rows) == 2
+    # Re-push same (captured_at, room) → no new rows.
+    assert db.save_indoor_readings(rows) == 0
+    # A different room at the same instant is a new row.
+    assert db.save_indoor_readings([{"captured_at": _z(now), "temp_c": 18.0, "room": "office"}]) == 1
+
+
+def test_latest_is_mean_across_rooms_within_staleness() -> None:
+    now = datetime.now(UTC)
+    db.save_indoor_readings([
+        {"captured_at": _z(now), "temp_c": 20.0, "room": "living"},
+        {"captured_at": _z(now), "temp_c": 22.0, "room": "bedroom"},
+    ])
+    latest = db.get_latest_indoor_reading(max_age_minutes=30)
+    assert latest is not None
+    assert latest["temp_c"] == pytest.approx(21.0)  # mean(20, 22)
+    assert latest["n_rooms"] == 2
+    assert set(latest["rooms"]) == {"living", "bedroom"}
+
+
+def test_stale_reading_treated_as_absent() -> None:
+    old = datetime.now(UTC) - timedelta(hours=2)
+    db.save_indoor_readings([{"captured_at": _z(old), "temp_c": 20.0, "room": "living"}])
+    assert db.get_latest_indoor_reading(max_age_minutes=30) is None  # beyond stale window
+
+
+def test_latest_picks_freshest_per_room() -> None:
+    now = datetime.now(UTC)
+    db.save_indoor_readings([
+        {"captured_at": _z(now - timedelta(minutes=20)), "temp_c": 18.0, "room": "living"},
+        {"captured_at": _z(now), "temp_c": 21.0, "room": "living"},  # fresher → wins
+    ])
+    latest = db.get_latest_indoor_reading(max_age_minutes=30)
+    assert latest["temp_c"] == pytest.approx(21.0)
+    assert latest["n_rooms"] == 1
+
+
+def test_range_query() -> None:
+    now = datetime.now(UTC)
+    db.save_indoor_readings([
+        {"captured_at": _z(now - timedelta(hours=1)), "temp_c": 19.0},
+        {"captured_at": _z(now), "temp_c": 20.0},
+    ])
+    rows = db.get_indoor_readings_range(_z(now - timedelta(hours=2)), _z(now + timedelta(minutes=1)))
+    assert len(rows) == 2
+    assert rows[0]["temp_c"] == pytest.approx(19.0)  # oldest first
+
+
+def test_endpoint_post_and_get() -> None:
+    import asyncio
+    from src.api.routers import sensors as sr
+
+    now = datetime.now(UTC)
+    body = sr.IndoorReadingsBody(readings=[
+        sr.IndoorReading(captured_at=_z(now), temp_c=20.5, room="living"),
+        sr.IndoorReading(captured_at=_z(now), temp_c=19.5, room="bedroom"),
+    ])
+    post = asyncio.run(sr.post_indoor_readings(body))
+    assert post == {"received": 2, "written": 2}
+
+    got = asyncio.run(sr.get_indoor_readings(hours=24))
+    assert got["n_readings"] == 2
+    assert got["latest_fresh"]["temp_c"] == pytest.approx(20.0)  # mean
+    assert got["newest_at"] is not None
+    assert got["configured"] is True
+    import json
+    json.dumps(got)
+
+
+def test_endpoint_empty_state() -> None:
+    import asyncio
+    from src.api.routers import sensors as sr
+
+    got = asyncio.run(sr.get_indoor_readings(hours=24))
+    assert got["n_readings"] == 0
+    assert got["latest_fresh"] is None
+    assert got["configured"] is False


### PR DESCRIPTION
## What
The W1 foundation of the winter thermal epic (#540). It's sensor-first — the Altherma has no room stat, so indoor temp has never been measured, blocking W2 (learner) / W3 (LP t_in). Today's load-calibration finding (the diurnal load bias is mostly **heat-pump timing**, not base-load) points the real winter gain here. This is the pipe the user's room sensors push into.

**Zero-impact until fresh readings arrive** — every consumer falls back to current behaviour when there's no fresh sensor row.

## Pieces
- `room_temperature_history` table (multi-room, idempotent on captured_at+room).
- `save_indoor_readings` (batch) + `get_latest_indoor_reading(max_age)` (mean across rooms' freshest within the staleness window; None when stale) + `get_indoor_readings_range`.
- `POST /api/v1/sensors/indoor` (admin, batch) + `GET` (viewer: feed + latest_fresh + newest_at + staleness) + `save_indoor_temperature` MCP tool.
- Wired: dispatch comfort guard prefers a fresh sensor reading over the (NULL) Daikin telemetry; LP records freshest reading as `indoor_initial_c`/`indoor_source=sensor` on the inputs snapshot (observation-only until W3).
- `INDOOR_SENSOR_STALE_MINUTES=30` — a dead sensor can't wedge the LP on a stale value.

## Tests
idempotent multi-room save; mean-across-rooms freshest; stale→absent; range; endpoint POST+GET + empty state. 251 passed across indoor/optimizer/dispatch/mcp/api subset.

## How the user pushes data
`POST /api/v1/sensors/indoor` with admin bearer, body `{"readings":[{"captured_at":"...Z","temp_c":20.5,"room":"living"}]}` — from Home Assistant / a script / ESPHome / the MCP tool. Multi-room supported.

## Next
W1b: cockpit chart + staleness chip. Then W2 (thermal learner) once ~2 weeks of readings accrue.

Image: **hem**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)