### PR TITLE
fix(tariff): single source of truth for Agile standing charge

### DIFF
--- a/src/analytics/fair_compare.py
+++ b/src/analytics/fair_compare.py
@@ -178,6 +178,19 @@ def _empty(requested_start: date, end_day: date, agile_start: date) -> dict[str,
     }
 
 
+def _catalogue_standing_pence(candidates: list, current_code: str) -> float:
+    """The LIVE catalogue standing (pence/day) for ``current_code`` within
+    ``candidates``, or 0.0 if the product isn't present / has no positive
+    standing. Pure lookup — no fallback, no network."""
+    for t in candidates:
+        if getattr(t, "product_code", None) == current_code:
+            sc = float(getattr(t.rates, "standing_charge_pence_per_day", 0) or 0)
+            if sc > 0:
+                return sc
+            break
+    return 0.0
+
+
 def _current_standing_per_day(candidates: list, current_code: str) -> float:
     """Standing charge (pence/day) to price the household's CURRENT tariff with.
 
@@ -188,12 +201,48 @@ def _current_standing_per_day(candidates: list, current_code: str) -> float:
     back to MANUAL only when the catalogue is offline or the current product
     isn't in it (standing must be > 0 to count as a real catalogue value).
     """
-    for t in candidates:
-        if getattr(t, "product_code", None) == current_code:
-            sc = float(getattr(t.rates, "standing_charge_pence_per_day", 0) or 0)
-            if sc > 0:
-                return sc
-            break
+    sc = _catalogue_standing_pence(candidates, current_code)
+    return sc if sc > 0 else float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0)
+
+
+# --- single source of truth for the household's current standing -----------
+#
+# Both this module (per fair-compare request) and pnl.compute_daily_pnl price
+# the Agile/realised side with the SAME standing charge, so the cockpit and the
+# Insights tariff table can never disagree on Agile's daily fee (the 2026-06-15
+# "winning on cockpit, losing to British Gas in Insights" contradiction was
+# exactly this: pnl used the stale 59.26p MANUAL value while fair-compare used
+# the live 62.22p catalogue value). pnl runs per-day over long periods, so the
+# network fetch is TTL-cached here; fair-compare already fetches the full
+# catalogue per request and reuses that list directly.
+_STANDING_CACHE: dict[str, float] = {"value": 0.0, "ts": 0.0}
+STANDING_CACHE_TTL_SECONDS = 6 * 3600
+
+
+def current_import_standing_pence() -> float:
+    """Live Octopus standing charge (pence/day) for the household's CURRENT
+    import product, TTL-cached, with a MANUAL fallback when the catalogue is
+    offline. The single source of truth shared by pnl and fair-compare."""
+    import time
+
+    now = time.time()
+    cached = float(_STANDING_CACHE.get("value") or 0.0)
+    if cached > 0 and (now - float(_STANDING_CACHE.get("ts") or 0.0)) < STANDING_CACHE_TTL_SECONDS:
+        return cached
+    val = 0.0
+    try:
+        from ..energy.octopus_products import get_available_tariffs
+
+        candidates = get_available_tariffs(max_products=15)
+        val = _catalogue_standing_pence(candidates, _current_product_code())
+    except Exception:  # noqa: BLE001 — offline catalogue must never break pnl
+        logger.debug("current_import_standing_pence: catalogue fetch failed", exc_info=True)
+        val = 0.0
+    if val > 0:
+        _STANDING_CACHE["value"] = val
+        _STANDING_CACHE["ts"] = now
+        return val
+    # Don't cache the fallback — retry the catalogue on the next call.
     return float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0)
 
 

--- a/src/analytics/pnl.py
+++ b/src/analytics/pnl.py
@@ -314,7 +314,14 @@ def compute_daily_pnl(day: date) -> dict[str, Any]:
     )
     export_kwh = export_both["export_kwh"]
     real_import_cost, import_kwh = _realised_import_pence(day)
-    standing_p = float(config.MANUAL_STANDING_CHARGE_PENCE_PER_DAY or 0)
+    # Single source of truth with fair_compare: price Agile's daily fee with the
+    # LIVE Octopus catalogue standing (TTL-cached), not the stale MANUAL config.
+    # Keeps the cockpit's "beating fixed" verdict consistent with the Insights
+    # tariff table (the 2026-06-15 cockpit-vs-Insights contradiction). Falls back
+    # to MANUAL_STANDING_CHARGE when the catalogue is offline.
+    from .fair_compare import current_import_standing_pence
+
+    standing_p = current_import_standing_pence()
     # Per-tariff fairness (matches src/analytics/fair_compare): SVT uses its own
     # standing; non-Agile shadows don't earn the Outgoing Agile export revenue —
     # they'd be on the same flat SEG the household is actually on (EXPORT_SEG_RATE_PENCE).

--- a/tests/test_fair_compare_standing.py
+++ b/tests/test_fair_compare_standing.py
@@ -45,3 +45,58 @@ def test_zero_or_missing_catalogue_standing_falls_back_to_manual(monkeypatch):
     monkeypatch.setattr(config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 59.26, raising=False)
     cands = [_product("AGILE-24-10-01", 0.0)]
     assert _current_standing_per_day(cands, "AGILE-24-10-01") == pytest.approx(59.26)
+
+
+# --- current_import_standing_pence (cached SoT shared with pnl) --------------
+
+import src.analytics.fair_compare as fc
+
+
+@pytest.fixture(autouse=True)
+def _reset_standing_cache():
+    fc._STANDING_CACHE["value"] = 0.0
+    fc._STANDING_CACHE["ts"] = 0.0
+    yield
+    fc._STANDING_CACHE["value"] = 0.0
+    fc._STANDING_CACHE["ts"] = 0.0
+
+
+def test_current_import_standing_prefers_live_catalogue(monkeypatch):
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE-24-10-01-A", raising=False)
+    monkeypatch.setattr(config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 59.26, raising=False)
+    monkeypatch.setattr(
+        "src.energy.octopus_products.get_available_tariffs",
+        lambda **_: [_product("VAR-22-11-01", 44.35), _product("AGILE-24-10-01", 62.22)],
+    )
+    assert fc.current_import_standing_pence() == pytest.approx(62.22)
+
+
+def test_current_import_standing_caches_within_ttl(monkeypatch):
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE-24-10-01-A", raising=False)
+    calls = {"n": 0}
+
+    def _fetch(**_):
+        calls["n"] += 1
+        return [_product("AGILE-24-10-01", 62.22)]
+
+    monkeypatch.setattr("src.energy.octopus_products.get_available_tariffs", _fetch)
+    assert fc.current_import_standing_pence() == pytest.approx(62.22)
+    assert fc.current_import_standing_pence() == pytest.approx(62.22)
+    assert calls["n"] == 1  # second call served from cache, no second fetch
+
+
+def test_current_import_standing_offline_falls_back_without_caching(monkeypatch):
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE-24-10-01-A", raising=False)
+    monkeypatch.setattr(config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 59.26, raising=False)
+
+    def _boom(**_):
+        raise RuntimeError("octopus offline")
+
+    monkeypatch.setattr("src.energy.octopus_products.get_available_tariffs", _boom)
+    assert fc.current_import_standing_pence() == pytest.approx(59.26)
+    # Fallback is NOT cached — a recovered catalogue is picked up next call.
+    monkeypatch.setattr(
+        "src.energy.octopus_products.get_available_tariffs",
+        lambda **_: [_product("AGILE-24-10-01", 62.22)],
+    )
+    assert fc.current_import_standing_pence() == pytest.approx(62.22)

--- a/tests/test_fair_compare_standing.py
+++ b/tests/test_fair_compare_standing.py
@@ -85,6 +85,23 @@ def test_current_import_standing_caches_within_ttl(monkeypatch):
     assert calls["n"] == 1  # second call served from cache, no second fetch
 
 
+def test_current_import_standing_refetches_after_ttl_expiry(monkeypatch):
+    monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE-24-10-01-A", raising=False)
+    calls = {"n": 0}
+
+    def _fetch(**_):
+        calls["n"] += 1
+        return [_product("AGILE-24-10-01", 62.22)]
+
+    monkeypatch.setattr("src.energy.octopus_products.get_available_tariffs", _fetch)
+    assert fc.current_import_standing_pence() == pytest.approx(62.22)
+    assert calls["n"] == 1
+    # Age the cached entry past the TTL → next call re-fetches.
+    fc._STANDING_CACHE["ts"] -= fc.STANDING_CACHE_TTL_SECONDS + 1
+    assert fc.current_import_standing_pence() == pytest.approx(62.22)
+    assert calls["n"] == 2
+
+
 def test_current_import_standing_offline_falls_back_without_caching(monkeypatch):
     monkeypatch.setattr(config, "OCTOPUS_TARIFF_CODE", "E-1R-AGILE-24-10-01-A", raising=False)
     monkeypatch.setattr(config, "MANUAL_STANDING_CHARGE_PENCE_PER_DAY", 59.26, raising=False)


### PR DESCRIPTION
## Problem

The cockpit and Insights gave **opposite tariff verdicts for the same day**: cockpit said "beating fixed", Insights said "switch to British Gas to save". Confirmed against live prod (import 0.574 kWh today → cockpit `delta_vs_fixed_tariff_real_gbp = +£0.127`).

Root cause: the two surfaces priced **Agile's daily standing charge with different values**:
- **pnl** (cockpit) → `MANUAL_STANDING_CHARGE_PENCE_PER_DAY` ≈ **59.26p** (stale hand-set config)
- **fair_compare** (Insights) → live Octopus catalogue ≈ **62.22p**

On a low-usage day the energy term is tiny, so the ~21p/day standing gap vs British Gas (41.14p) dominates the ranking. With the lower 59.26p Agile standing the cockpit still showed Agile ≤ BG ("winning"); fair_compare's live 62.22p flipped it the other way.

## Fix

`fair_compare.current_import_standing_pence()` — the live catalogue standing for the household's current product, TTL-cached (6h) with a MANUAL fallback when the catalogue is offline. `pnl.compute_daily_pnl` now prices the realised Agile bill with this shared value. Both surfaces agree.

Consequence (correct): on near-zero-usage days the cockpit now honestly shows "behind fixed" — Agile genuinely costs more per day at low usage because it carries the higher standing. The British Gas comparator keeps its own standing (41.14p) unchanged.

The fallback is never cached, so a recovered catalogue is picked up on the next call. pnl runs per-day over long periods → the TTL cache means one fetch per period, not per day.

## Tests

`tests/test_fair_compare_standing.py`: + cache-hit (single fetch within TTL), offline fallback not cached, live-catalogue preference. 26 passed (incl. pnl real-money + periods).

Part of #574 (item 1)
