### PR TITLE
feat(insights): split heat-pump heatmap into Tank (DHW) vs Heating (space)

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -397,6 +397,13 @@ async def get_residual_load_profile(window_days: int | None = None) -> dict[str,
             for h in range(24) for m in (0, 30)
         ]
 
+    def _hp_component_series(dow: int, component: str) -> list[dict[str, Any]]:
+        return [
+            {"h": h, "m": m,
+             "median": round(db.lookup_hp_component_kwh(prof, dow, h, m, component=component), 4)}
+            for h in range(24) for m in (0, 30)
+        ]
+
     p = prof.get("profile", {})
     all_series = [
         {"h": h, "m": m,
@@ -408,6 +415,10 @@ async def get_residual_load_profile(window_days: int | None = None) -> dict[str,
         "by_dow": {str(d): _series(d) for d in range(7)},
         # Heat-pump (Daikin) split — the load the residual profile subtracts.
         "hp_by_dow": {str(d): _hp_series(d) for d in range(7)},
+        # TANK (DHW) vs HEATING (space) breakdown of the heat-pump load, from the
+        # measured Onecta meters (#574 item 2).
+        "hp_dhw_by_dow": {str(d): _hp_component_series(d, "hp_dhw_profile") for d in range(7)},
+        "hp_space_by_dow": {str(d): _hp_component_series(d, "hp_space_profile") for d in range(7)},
         "all": all_series,
         "flat": round(float(prof.get("flat", 0.0)), 4),
         "away_days": prof.get("away_days", []),

--- a/src/db.py
+++ b/src/db.py
@@ -2151,7 +2151,8 @@ def residual_load_profile_v2(
             flat = mean_consumption_kwh_from_execution_logs(limit=2016)
         return _finish({
             "profile": {(h, m): flat for h in range(24) for m in (0, 30)},
-            "hp_profile": {}, "spread": {}, "flat": flat, "away_days": [],
+            "hp_profile": {}, "hp_dhw_profile": {}, "hp_space_profile": {},
+            "spread": {}, "flat": flat, "away_days": [],
             "day_counts": {"weekday": 0, "weekend": 0, "away_excluded": 0,
                            "negative_excluded": dropped_negative, "total": 0},
             "calibrated_days": 0, "physics_only_days": 0,
@@ -2161,15 +2162,28 @@ def residual_load_profile_v2(
     # call them OUTSIDE our own lock block above).
     dates = sorted({s[1] for s in samples})
     measured_2h: dict[tuple[str, int], float] = {}
+    # DHW fraction of the measured heat-pump energy per (date, 2h-bucket) and per
+    # day, so the calibrated combined ``hp`` can be split into TANK (DHW) vs
+    # HEATING (space) for the Insights heatmap. The physics estimator models only
+    # space heating, so the split MUST come from the measured Onecta meters here,
+    # not from the physics shape (#574 item 2).
+    dhw_frac_2h: dict[tuple[str, int], float] = {}
     for r in get_daikin_consumption_2hourly_range(dates[0], dates[-1]):
-        h_ = r.get("kwh_heating") or 0.0
-        d_ = r.get("kwh_dhw") or 0.0
-        measured_2h[(str(r["date"]), int(r["bucket_idx"]))] = float(h_) + float(d_)
+        h_ = float(r.get("kwh_heating") or 0.0)
+        d_ = float(r.get("kwh_dhw") or 0.0)
+        tot = h_ + d_
+        measured_2h[(str(r["date"]), int(r["bucket_idx"]))] = tot
+        if tot > 1e-6:
+            dhw_frac_2h[(str(r["date"]), int(r["bucket_idx"]))] = d_ / tot
     measured_day: dict[str, float] = {}
+    dhw_frac_day: dict[str, float] = {}
     for r in get_daikin_consumption_daily_range(dates[0], dates[-1]):
-        h_ = r.get("kwh_heating") or 0.0
-        d_ = r.get("kwh_dhw") or 0.0
-        measured_day[str(r["date"])] = float(h_) + float(d_)
+        h_ = float(r.get("kwh_heating") or 0.0)
+        d_ = float(r.get("kwh_dhw") or 0.0)
+        tot = h_ + d_
+        measured_day[str(r["date"])] = tot
+        if tot > 1e-6:
+            dhw_frac_day[str(r["date"])] = d_ / tot
 
     def _clamp_k(k: float) -> float:
         return min(5.0, max(0.2, k))
@@ -2197,12 +2211,27 @@ def residual_load_profile_v2(
     # ``hp`` is the calibrated heat-pump (Daikin) slot energy we subtracted — kept
     # so we can publish its own per-(dow,hour) profile for the heat-pump heatmap.
     by_date_daytime: dict[str, list[float]] = {}
-    residual_samples: list[tuple[datetime, str, float, float]] = []  # (local, date_iso, residual, hp)
+    # (local, date_iso, residual, hp, hp_dhw, hp_space)
+    residual_samples: list[tuple[datetime, str, float, float, float, float]] = []
+
+    def _dhw_frac(date_iso: str, bucket_idx: int) -> float:
+        """Measured DHW share of heat-pump energy for the slot, 2h-bucket first,
+        then day. Default 0.0 (all heating) when no measured split exists — the
+        physics term is space-heating-shaped, so heating is the honest default."""
+        f = dhw_frac_2h.get((date_iso, bucket_idx))
+        if f is not None:
+            return f
+        f = dhw_frac_day.get(date_iso)
+        return f if f is not None else 0.0
+
     for local, date_iso, b, load_slot, physics_slot in samples:
         k = _calib(date_iso, b)
         hp = physics_slot * k
+        frac = _dhw_frac(date_iso, b)
+        hp_dhw = hp * frac
+        hp_space = hp - hp_dhw
         residual = max(0.0, load_slot - hp)
-        residual_samples.append((local, date_iso, residual, hp))
+        residual_samples.append((local, date_iso, residual, hp, hp_dhw, hp_space))
         if 9 <= local.hour < 21:
             by_date_daytime.setdefault(date_iso, []).append(residual)
 
@@ -2221,9 +2250,11 @@ def residual_load_profile_v2(
     # ``tiers`` for the heat-pump split so both heatmaps share the same buckets.
     tiers: dict[Any, list[float]] = {}
     hp_tiers: dict[Any, list[float]] = {}
+    hp_dhw_tiers: dict[Any, list[float]] = {}
+    hp_space_tiers: dict[Any, list[float]] = {}
     weekday_days: set[str] = set()
     weekend_days: set[str] = set()
-    for local, date_iso, residual, hp in residual_samples:
+    for local, date_iso, residual, hp, hp_dhw, hp_space in residual_samples:
         if date_iso in away_days:
             continue
         dow = local.weekday()
@@ -2234,17 +2265,20 @@ def residual_load_profile_v2(
         if _v2:  # day-of-week + weekday/weekend tiers (kill-switch off → (h,m) only)
             tiers.setdefault((dow, h, m), []).append(residual)
             tiers.setdefault((group, h, m), []).append(residual)
-            hp_tiers.setdefault((dow, h, m), []).append(hp)
-            hp_tiers.setdefault((group, h, m), []).append(hp)
+            for tt, val in ((hp_tiers, hp), (hp_dhw_tiers, hp_dhw), (hp_space_tiers, hp_space)):
+                tt.setdefault((dow, h, m), []).append(val)
+                tt.setdefault((group, h, m), []).append(val)
         tiers.setdefault((h, m), []).append(residual)
         hp_tiers.setdefault((h, m), []).append(hp)
+        hp_dhw_tiers.setdefault((h, m), []).append(hp_dhw)
+        hp_space_tiers.setdefault((h, m), []).append(hp_space)
 
     def _p75(vs: list[float]) -> float:
         if len(vs) < 2:
             return vs[0] if vs else 0.0
         return _quantiles(vs, n=4)[2]
 
-    retained = [r for (_l, d, r, _hp) in residual_samples if d not in away_days]
+    retained = [r for (_l, d, r, _hp, _hd, _hs) in residual_samples if d not in away_days]
     flat = _median(retained) if retained else (
         mean_fox_load_kwh_per_slot(limit=60) or mean_consumption_kwh_from_execution_logs(limit=2016)
     )
@@ -2259,10 +2293,20 @@ def residual_load_profile_v2(
     # Heat-pump profile — same tier structure, median per bucket. Unfilled buckets
     # mean "no heat-pump signal learned there" → the lookup falls back to 0, which
     # is the honest reading (the heat pump genuinely idles in many slots).
-    hp_profile: dict[Any, float] = {}
-    for key, vs in hp_tiers.items():
-        if len(vs) >= min_samples_per_bucket:
-            hp_profile[key] = _median(vs)
+    def _median_profile(tier_map: dict[Any, list[float]]) -> dict[Any, float]:
+        return {
+            key: _median(vs)
+            for key, vs in tier_map.items()
+            if len(vs) >= min_samples_per_bucket
+        }
+
+    hp_profile = _median_profile(hp_tiers)
+    # TANK (DHW) vs HEATING (space) split of the same heat-pump energy, from the
+    # measured Onecta meters (#574 item 2). Per-bucket medians won't sum exactly
+    # to ``hp_profile`` (median of a sum ≠ sum of medians), but each is the honest
+    # central estimate of its own component and the UI presents them as toggles.
+    hp_dhw_profile = _median_profile(hp_dhw_tiers)
+    hp_space_profile = _median_profile(hp_space_tiers)
 
     # Always fill all 48 (h, m) buckets (hour-aware fallback) so the lookup chain
     # has a guaranteed leaf below the dow/group tiers.
@@ -2299,6 +2343,8 @@ def residual_load_profile_v2(
     return _finish({
         "profile": profile,
         "hp_profile": hp_profile,
+        "hp_dhw_profile": hp_dhw_profile,
+        "hp_space_profile": hp_space_profile,
         "spread": spread,
         "flat": float(flat),
         "away_days": sorted(away_days),
@@ -2327,18 +2373,28 @@ def lookup_residual_kwh(profile_obj: dict[str, Any], dow: int, h: int, m: int) -
     return float(profile_obj.get("flat", 0.0))
 
 
-def lookup_hp_kwh(profile_obj: dict[str, Any], dow: int, h: int, m: int) -> float:
-    """Resolve the heat-pump (Daikin) kWh for a slot from a
+def lookup_hp_component_kwh(
+    profile_obj: dict[str, Any], dow: int, h: int, m: int, *, component: str = "hp_profile"
+) -> float:
+    """Resolve a heat-pump component kWh for a slot from a
     :func:`residual_load_profile_v2` object, same fallback hierarchy as
-    :func:`lookup_residual_kwh` but over ``hp_profile``. Returns 0.0 when no
-    heat-pump signal was learned for the slot (honest — the pump idles often)."""
-    hp = profile_obj.get("hp_profile", {})
+    :func:`lookup_residual_kwh`. ``component`` selects the series:
+    ``hp_profile`` (combined), ``hp_dhw_profile`` (tank), or
+    ``hp_space_profile`` (space heating). Returns 0.0 when no signal was learned
+    for the slot (honest — the pump idles often)."""
+    hp = profile_obj.get(component, {})
     group = "weekend" if dow >= 5 else "weekday"
     for key in ((dow, h, m), (group, h, m), (h, m)):
         v = hp.get(key)
         if v is not None:
             return float(v)
     return 0.0
+
+
+def lookup_hp_kwh(profile_obj: dict[str, Any], dow: int, h: int, m: int) -> float:
+    """Combined heat-pump (Daikin) kWh for a slot — see
+    :func:`lookup_hp_component_kwh`."""
+    return lookup_hp_component_kwh(profile_obj, dow, h, m, component="hp_profile")
 
 
 def lookup_residual_spread_kwh(profile_obj: dict[str, Any], dow: int, h: int, m: int) -> float:

--- a/tests/test_db_residual_profile_v2.py
+++ b/tests/test_db_residual_profile_v2.py
@@ -276,6 +276,43 @@ def test_heat_pump_profile_zero_when_warm() -> None:
     assert db.lookup_hp_kwh(prof, 2, 14, 0) == pytest.approx(0.0, abs=0.05)
 
 
+def test_hp_split_tank_vs_heating_from_measured_ratio() -> None:
+    """The combined hp profile splits into TANK (DHW) + HEATING (space) using the
+    measured Onecta ratio. A bucket measured 75% DHW / 25% heating splits the
+    calibrated heat-pump energy in that proportion, and the two components sum to
+    roughly the combined hp (#574 item 2)."""
+    days = _recent_days_of_weekday(3, 6)   # Thursdays, cold so physics > 0
+    for d in days:
+        _seed_local(d, 8, 0, load_kw=1.5, temp_c=2.0)
+        _seed_local(d, 8, 10, load_kw=1.5, temp_c=2.0)
+        # local 08:00 → bucket_idx 4; measured 0.6 DHW + 0.2 heating (75% tank).
+        _seed_daikin_2h(d, 4, heating=0.2, dhw=0.6)
+
+    prof = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    combined = db.lookup_hp_kwh(prof, 3, 8, 0)
+    tank = db.lookup_hp_component_kwh(prof, 3, 8, 0, component="hp_dhw_profile")
+    heating = db.lookup_hp_component_kwh(prof, 3, 8, 0, component="hp_space_profile")
+
+    assert combined > 0.0
+    assert tank > heating          # 75% DHW
+    assert tank + heating == pytest.approx(combined, abs=0.02)
+    assert tank == pytest.approx(0.75 * combined, abs=0.02)
+
+
+def test_hp_split_defaults_to_heating_without_measured_dhw() -> None:
+    """No measured DHW for the slot → the whole heat-pump estimate is attributed
+    to HEATING (the physics term is space-heating-shaped). Tank ≈ 0."""
+    days = _recent_days_of_weekday(2, 6)   # Wednesdays, cold; no daikin split seeded
+    for d in days:
+        _seed_local(d, 8, 0, load_kw=1.5, temp_c=2.0)
+        _seed_local(d, 8, 10, load_kw=1.5, temp_c=2.0)
+    prof = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    combined = db.lookup_hp_kwh(prof, 2, 8, 0)
+    assert combined > 0.0
+    assert db.lookup_hp_component_kwh(prof, 2, 8, 0, component="hp_dhw_profile") == pytest.approx(0.0, abs=1e-6)
+    assert db.lookup_hp_component_kwh(prof, 2, 8, 0, component="hp_space_profile") == pytest.approx(combined, abs=0.02)
+
+
 def test_lookup_hp_kwh_falls_back_to_zero_for_unknown_slot() -> None:
     for d in _recent_days_of_weekday(0, 6):   # Mondays only
         _seed_local(d, 8, 0, load_kw=1.0, temp_c=2.0)

--- a/ui/src/components/insights/LoadPatternCard.tsx
+++ b/ui/src/components/insights/LoadPatternCard.tsx
@@ -25,6 +25,10 @@ export function LoadPatternCard() {
   const res = useFetch<ResidualProfile>(getResidualProfile, []);
   const data = res.data;
   const hasHp = !!data?.hp_by_dow;
+  // Tank/Heating need the measured split series specifically — an older backend
+  // image can return hp_by_dow without them; gating on hp_dhw_by_dow stops the
+  // toggle from mislabelling Home data as Tank/Heating via the fallback.
+  const hasSplit = !!data?.hp_dhw_by_dow;
   const [view, setView] = useState<View>("home");
   const elRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
@@ -111,8 +115,7 @@ export function LoadPatternCard() {
               {([
                 ["home", "Home"],
                 ["hp", "Heat pump"],
-                ["tank", "Tank"],
-                ["heating", "Heating"],
+                ...(hasSplit ? ([["tank", "Tank"], ["heating", "Heating"]] as [View, string][]) : []),
               ] as [View, string][]).map(([v, label]) => (
                 <button
                   key={v}

--- a/ui/src/components/insights/LoadPatternCard.tsx
+++ b/ui/src/components/insights/LoadPatternCard.tsx
@@ -6,11 +6,21 @@ import { Spinner } from "../common/Spinner";
 
 const DOW = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-type View = "home" | "hp";
+type View = "home" | "hp" | "tank" | "heating";
 
-/** Per-(day-of-week × hour) median load heatmap. Two views: the residual
- *  household load (heat pump excluded — the profile the LP plans against, #477)
- *  and the heat-pump (Daikin) split it subtracts. */
+const HP_VIEWS = new Set<View>(["hp", "tank", "heating"]);
+
+const VIEW_DESC: Record<View, string> = {
+  home: "Median household load (heat pump excluded) by day-of-week and hour — the typical at-home pattern the optimizer plans against.",
+  hp: "Median heat-pump (Daikin) load by day-of-week and hour — the split subtracted from the household total.",
+  tank: "Median hot-water (DHW tank) heat-pump load by day-of-week and hour — measured from the Onecta meters.",
+  heating: "Median space-heating heat-pump load by day-of-week and hour — measured from the Onecta meters.",
+};
+
+/** Per-(day-of-week × hour) median load heatmap. Views: residual household load
+ *  (heat pump excluded — the profile the LP plans against, #477), the combined
+ *  heat-pump (Daikin) split it subtracts, and that split broken into hot-water
+ *  (tank/DHW) vs space heating from the measured Onecta meters (#574). */
 export function LoadPatternCard() {
   const res = useFetch<ResidualProfile>(getResidualProfile, []);
   const data = res.data;
@@ -24,8 +34,13 @@ export function LoadPatternCard() {
     if (!chartRef.current) chartRef.current = makeChart(elRef.current);
     const t = chartTheme();
 
-    const source: Record<string, ResidualProfileSlot[]> =
-      (view === "hp" && data.hp_by_dow) ? data.hp_by_dow : data.by_dow;
+    const hpSource: Record<View, Record<string, ResidualProfileSlot[]> | undefined> = {
+      home: data.by_dow,
+      hp: data.hp_by_dow,
+      tank: data.hp_dhw_by_dow,
+      heating: data.hp_space_by_dow,
+    };
+    const source: Record<string, ResidualProfileSlot[]> = hpSource[view] ?? data.by_dow;
 
     // 7 dow × 24 hours; value = mean of the two half-hour medians in the hour.
     const cells: [number, number, number][] = [];
@@ -43,7 +58,7 @@ export function LoadPatternCard() {
 
     // Heat-pump view gets a distinct (cool→warm) ramp so the two reads don't
     // get confused; residual keeps the established amber→red.
-    const ramp = view === "hp"
+    const ramp = HP_VIEWS.has(view)
       ? [t.bg ?? "#1b1f27", "#38bdf8", "#ef4444"]
       : [t.bg ?? "#1b1f27", t.pv ?? "#fbbf24", t.importColor ?? "#ef4444"];
 
@@ -93,24 +108,23 @@ export function LoadPatternCard() {
           <h2>When you spend the most</h2>
           {hasHp && (
             <div class="load-pattern-toggle" role="group" aria-label="Load view">
-              <button
-                class={view === "home" ? "is-active" : ""}
-                onClick={() => setView("home")}
-                type="button"
-              >Home</button>
-              <button
-                class={view === "hp" ? "is-active" : ""}
-                onClick={() => setView("hp")}
-                type="button"
-              >Heat pump</button>
+              {([
+                ["home", "Home"],
+                ["hp", "Heat pump"],
+                ["tank", "Tank"],
+                ["heating", "Heating"],
+              ] as [View, string][]).map(([v, label]) => (
+                <button
+                  key={v}
+                  class={view === v ? "is-active" : ""}
+                  onClick={() => setView(v)}
+                  type="button"
+                >{label}</button>
+              ))}
             </div>
           )}
         </div>
-        <p class="muted">
-          {view === "hp"
-            ? "Median heat-pump (Daikin) load by day-of-week and hour — the split subtracted from the household total."
-            : "Median household load (heat pump excluded) by day-of-week and hour — the typical at-home pattern the optimizer plans against."}
-        </p>
+        <p class="muted">{VIEW_DESC[view]}</p>
       </header>
       {res.loading && !data && <Spinner label="Loading load pattern…" />}
       {res.error && <p class="insights-error">Couldn't load the pattern: {res.error.message}</p>}

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -284,6 +284,8 @@ export interface ResidualProfileSlot { h: number; m: number; median: number; p75
 export interface ResidualProfile {
   by_dow: Record<string, ResidualProfileSlot[]>;
   hp_by_dow?: Record<string, ResidualProfileSlot[]>;
+  hp_dhw_by_dow?: Record<string, ResidualProfileSlot[]>;
+  hp_space_by_dow?: Record<string, ResidualProfileSlot[]>;
   all: ResidualProfileSlot[];
   flat: number;
   away_days: string[];


### PR DESCRIPTION
## What

The Insights load heatmap had a single combined heat-pump view. This splits it into **Tank (DHW)** and **Heating (space)** using the measured Onecta meters.

`residual_load_profile_v2` already read `kwh_heating`/`kwh_dhw` per 2-hourly bucket and summed them away. Now it keeps the measured DHW fraction per (date, 2h-bucket) and per day, and splits the calibrated combined heat-pump energy in that proportion.

The split is **measured, not physics-derived** (per decision): the physics estimator models only space heating, so a slot with no measured DHW defaults entirely to heating (the honest fallback).

## Changes

- `db.residual_load_profile_v2`: emit `hp_dhw_profile` + `hp_space_profile`.
- `db.lookup_hp_component_kwh(component=...)`: generalises `lookup_hp_kwh` (kept as a thin wrapper).
- `GET /api/v1/load/residual-profile`: add `hp_dhw_by_dow` + `hp_space_by_dow`.
- `LoadPatternCard`: **Home / Heat pump / Tank / Heating** toggle.

## Note

Per-bucket medians don't sum exactly to the combined hp (median of a sum != sum of medians), but each is the honest central estimate of its own component.

## Tests

`tests/test_db_residual_profile_v2.py`: + measured-ratio split (75% DHW -> tank > heating, components sum to combined) + default-to-heating when no measured DHW. 16 passed. UI tsc --noEmit clean.

Part of #574 (item 2)