### PR TITLE
feat(insights): top cards follow the period navigator + System-health empty-state

### DIFF
--- a/src/api/routers/pv.py
+++ b/src/api/routers/pv.py
@@ -366,19 +366,27 @@ def _date_from_iso(s: str) -> date:
 
 
 @router.get("/api/v1/load/residual-profile")
-async def get_residual_load_profile(window_days: int | None = None) -> dict[str, Any]:
+async def get_residual_load_profile(
+    window_days: int | None = None, end_date: str | None = None
+) -> dict[str, Any]:
     """The learned household residual-load profile the LP plans against (#477).
 
     Returns the per-(day-of-week, half-hour) median + p75 spread (resolved
     through the same fallback hierarchy the LP uses), the plain (h,m) baseline,
     the excluded "away" days, and coverage stats (how many days were calibrated
     against the measured Daikin split). Read-only, viewer-safe.
+
+    ``end_date`` (YYYY-MM-DD, local, inclusive) anchors the trailing window at a
+    past day so the Insights navigator can scope the heatmap to an earlier
+    period; omitted → the window ends now (#574 item 3).
     """
     # Clamp the caller-supplied window so a bad/huge value can't trigger a
     # full-table scan; None uses the configured default (the LP's window).
     if window_days is not None:
         window_days = max(1, min(int(window_days), 365))
-    prof = await asyncio.to_thread(db.residual_load_profile_v2, window_days=window_days)
+    prof = await asyncio.to_thread(
+        db.residual_load_profile_v2, window_days=window_days, end_date=end_date
+    )
 
     def _series(dow: int) -> list[dict[str, Any]]:
         out = []
@@ -420,6 +428,8 @@ async def get_residual_load_profile(window_days: int | None = None) -> dict[str,
         "hp_dhw_by_dow": {str(d): _hp_component_series(d, "hp_dhw_profile") for d in range(7)},
         "hp_space_by_dow": {str(d): _hp_component_series(d, "hp_space_profile") for d in range(7)},
         "all": all_series,
+        "window_days": window_days,
+        "end_date": end_date,
         "flat": round(float(prof.get("flat", 0.0)), 4),
         "away_days": prof.get("away_days", []),
         "day_counts": prof.get("day_counts", {}),
@@ -429,18 +439,34 @@ async def get_residual_load_profile(window_days: int | None = None) -> dict[str,
 
 
 @router.get("/api/v1/load/error-log")
-async def get_load_error_log(window_days: int = 30) -> dict[str, Any]:
+async def get_load_error_log(
+    window_days: int = 30, start_date: str | None = None, end_date: str | None = None
+) -> dict[str, Any]:
     """Committed LOAD-forecast-vs-actual summary from the persisted load_error_log
     (Phase-1 measurement). Overall MAE/bias + per-LOCAL-hour bias (load is
     occupancy-driven, so local hour is the meaningful axis — and the axis a
     future recent-bias corrector would act on). Read-only, viewer-safe.
+
+    With ``start_date``/``end_date`` (YYYY-MM-DD, local, inclusive) the summary is
+    scoped to that exact range so the Insights navigator can step day/week/month/
+    year (#574 item 3); otherwise it's the trailing ``window_days`` from now.
     """
-    window_days = max(1, min(int(window_days), 365))
-    now = datetime.now(UTC)
-    start = (now - timedelta(days=window_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    end = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    rows = await asyncio.to_thread(db.get_load_error_log_range, start, end)
     tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
+    if start_date and end_date:
+        try:
+            s_local = datetime.fromisoformat(str(start_date)).replace(tzinfo=tz)
+            e_local = datetime.fromisoformat(str(end_date)).replace(tzinfo=tz) + timedelta(days=1)
+            start = s_local.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            end = e_local.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            window_days = max(1, (e_local.date() - s_local.date()).days)
+        except (ValueError, TypeError):
+            start_date = end_date = None
+    if not (start_date and end_date):
+        window_days = max(1, min(int(window_days), 365))
+        now = datetime.now(UTC)
+        start = (now - timedelta(days=window_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        end = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    rows = await asyncio.to_thread(db.get_load_error_log_range, start, end)
 
     paired: list[tuple[float, float]] = []  # (forecast_total, actual)
     per_hour: dict[int, list[tuple[float, float]]] = {}

--- a/src/db.py
+++ b/src/db.py
@@ -1992,6 +1992,7 @@ def clear_residual_profile_cache() -> None:
 def residual_load_profile_v2(
     *,
     window_days: int | None = None,
+    end_date: str | None = None,
     min_samples_per_bucket: int = 4,
     use_cache: bool = True,
 ) -> dict[str, Any]:
@@ -2048,7 +2049,7 @@ def residual_load_profile_v2(
     # as new telemetry / the nightly Daikin sync land, so a 4-min TTL is safe and
     # collapses the per-solve cost to one rebuild. Keyed by DB_PATH so isolated
     # test DBs never share an entry.
-    cache_key = (config.DB_PATH, window_days, min_samples_per_bucket, _v2, exclude_neg)
+    cache_key = (config.DB_PATH, window_days, end_date, min_samples_per_bucket, _v2, exclude_neg)
     if use_cache:
         ent = _RESIDUAL_V2_CACHE.get(cache_key)
         if ent is not None and ent[0] > time.monotonic():
@@ -2061,7 +2062,22 @@ def residual_load_profile_v2(
 
     cop_curve = config.DAIKIN_COP_CURVE
     tz = ZoneInfo(config.BULLETPROOF_TIMEZONE)
-    cutoff_iso = (datetime.now(UTC) - timedelta(days=window_days)).isoformat().replace("+00:00", "Z")
+    # The window ENDS at end_date (local, inclusive) when given — so the Insights
+    # navigator can scope the heatmap to a past period — else at now. The lower
+    # bound is end − window_days. end_iso is None for the live (now) case so the
+    # query keeps its original single-bound form.
+    end_iso: str | None = None
+    if end_date:
+        try:
+            end_local = datetime.fromisoformat(str(end_date)).replace(tzinfo=tz)
+            anchor = (end_local + timedelta(days=1)).astimezone(UTC)  # exclusive upper bound
+            end_iso = anchor.isoformat().replace("+00:00", "Z")
+        except (ValueError, TypeError):
+            end_iso = None
+    anchor_utc = (
+        datetime.fromisoformat(end_iso.replace("Z", "+00:00")) if end_iso else datetime.now(UTC)
+    )
+    cutoff_iso = (anchor_utc - timedelta(days=window_days)).isoformat().replace("+00:00", "Z")
 
     with _lock:
         conn = get_connection()
@@ -2083,8 +2099,9 @@ def residual_load_profile_v2(
                            WHERE substr(mv.slot_time, 1, 13) = substr(pv.captured_at, 1, 13)
                            LIMIT 1) AS outdoor_latest_c
                    FROM pv_realtime_history pv
-                   WHERE pv.captured_at > ? AND pv.load_power_kw IS NOT NULL""",
-                (cutoff_iso,),
+                   WHERE pv.captured_at > ? AND pv.load_power_kw IS NOT NULL"""
+                + (" AND pv.captured_at < ?" if end_iso else ""),
+                (cutoff_iso, end_iso) if end_iso else (cutoff_iso,),
             )
             rows = cur.fetchall()
             # Negative-price slots over the window (same source the LP priced
@@ -2094,8 +2111,9 @@ def residual_load_profile_v2(
             if exclude_neg:
                 ncur = conn.execute(
                     """SELECT DISTINCT timestamp FROM execution_log
-                       WHERE timestamp > ? AND agile_price_pence < 0""",
-                    (cutoff_iso,),
+                       WHERE timestamp > ? AND agile_price_pence < 0"""
+                    + (" AND timestamp < ?" if end_iso else ""),
+                    (cutoff_iso, end_iso) if end_iso else (cutoff_iso,),
                 )
                 for nr in ncur.fetchall():
                     try:

--- a/tests/test_db_residual_profile_v2.py
+++ b/tests/test_db_residual_profile_v2.py
@@ -234,6 +234,37 @@ def test_cache_returns_same_object_until_cleared() -> None:
     assert d2 is not a  # cleared → rebuilt
 
 
+def test_end_date_anchors_window_to_past_period() -> None:
+    """end_date scopes the trailing window to a past anchor: a load spike AFTER
+    the anchor is excluded, one before it is included (#574 item 3)."""
+    # A recent Saturday with a high-load slot, and an OLDER Saturday with a low one.
+    sats = _recent_days_of_weekday(5, 6, start_ago=4)
+    recent, older = sats[0], sats[-1]
+    _seed_local(recent, 19, 0, load_kw=3.0)
+    _seed_local(recent, 19, 10, load_kw=3.0)
+    _seed_local(older, 19, 0, load_kw=0.6)
+    _seed_local(older, 19, 10, load_kw=0.6)
+
+    # Anchor the window to END the day before the recent spike → it's excluded,
+    # so the Saturday 19:00 median reflects only the older low-load day.
+    anchor = (recent - timedelta(days=1)).isoformat()
+    prof = db.residual_load_profile_v2(window_days=120, end_date=anchor, use_cache=False)
+    assert db.lookup_residual_kwh(prof, 5, 19, 0) == pytest.approx(0.3, abs=0.12)
+
+    # Without the anchor the recent high-load day pulls the median up.
+    full = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    assert db.lookup_residual_kwh(full, 5, 19, 0) > db.lookup_residual_kwh(prof, 5, 19, 0) + 0.3
+
+
+def test_end_date_is_part_of_cache_key() -> None:
+    """Different end_date anchors don't collide in the TTL cache."""
+    for d in _recent_days_of_weekday(5, 4):
+        _seed_local(d, 19, 0, load_kw=1.0)
+    a = db.residual_load_profile_v2(window_days=120)
+    b = db.residual_load_profile_v2(window_days=120, end_date="2026-01-01")
+    assert a is not b
+
+
 def test_residual_profile_endpoint_shape() -> None:
     """GET /api/v1/load/residual-profile returns JSON-serialisable per-dow series."""
     import asyncio

--- a/ui/src/components/insights/LoadForecastAccuracyCard.tsx
+++ b/ui/src/components/insights/LoadForecastAccuracyCard.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useRef } from "preact/hooks";
 import { useFetch } from "../../lib/poll";
 import { getLoadErrorLog, type LoadErrorLog } from "../../lib/endpoints";
+import { periodDateRange, periodLabel, type PeriodState } from "../../lib/period";
 import { makeChart, chartTheme, type EChartsType } from "../../lib/charts";
 import { Spinner } from "../common/Spinner";
 
 /** How well the household LOAD forecast the LP plans against matched reality,
  *  by local hour. Complements LoadPatternCard (when we spend) with how well we
  *  predict it. Surfaces the load_error_log measurement (Phase 1). Read-only. */
-export function LoadForecastAccuracyCard() {
-  const res = useFetch<LoadErrorLog>(() => getLoadErrorLog(30), []);
+export function LoadForecastAccuracyCard({ period }: { period: PeriodState }) {
+  const { start, end } = periodDateRange(period);
+  const res = useFetch<LoadErrorLog>(
+    () => getLoadErrorLog({ startDate: start, endDate: end }),
+    [start, end],
+  );
   const data = res.data;
   const elRef = useRef<HTMLDivElement | null>(null);
   const chartRef = useRef<EChartsType | null>(null);
@@ -114,7 +119,7 @@ export function LoadForecastAccuracyCard() {
         </>
       )}
       {data && (!o || o.n === 0) && (
-        <p class="muted insights-empty">No load forecast-vs-actual data yet.</p>
+        <p class="muted insights-empty">No load forecast-vs-actual data for {periodLabel(period)} yet.</p>
       )}
     </section>
   );

--- a/ui/src/components/insights/LoadPatternCard.tsx
+++ b/ui/src/components/insights/LoadPatternCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { useFetch } from "../../lib/poll";
 import { getResidualProfile, type ResidualProfile, type ResidualProfileSlot } from "../../lib/endpoints";
+import { periodWindow, periodLabel, type PeriodState } from "../../lib/period";
 import { makeChart, chartTheme, type EChartsType } from "../../lib/charts";
 import { Spinner } from "../common/Spinner";
 
@@ -21,8 +22,12 @@ const VIEW_DESC: Record<View, string> = {
  *  (heat pump excluded — the profile the LP plans against, #477), the combined
  *  heat-pump (Daikin) split it subtracts, and that split broken into hot-water
  *  (tank/DHW) vs space heating from the measured Onecta meters (#574). */
-export function LoadPatternCard() {
-  const res = useFetch<ResidualProfile>(getResidualProfile, []);
+export function LoadPatternCard({ period }: { period: PeriodState }) {
+  const { windowDays, endDate } = periodWindow(period);
+  const res = useFetch<ResidualProfile>(
+    () => getResidualProfile({ windowDays, endDate }),
+    [windowDays, endDate],
+  );
   const data = res.data;
   const hasHp = !!data?.hp_by_dow;
   // Tank/Heating need the measured split series specifically — an older backend
@@ -135,6 +140,8 @@ export function LoadPatternCard() {
         <>
           <div ref={elRef} class="load-pattern-chart" />
           <p class="muted load-pattern-meta">
+            {windowDays}-day pattern to {periodLabel(period)}
+            {" · "}
             {(dc.weekday ?? 0) + (dc.weekend ?? 0)} days learned
             ({dc.weekday ?? 0} weekday / {dc.weekend ?? 0} weekend)
             {(dc.away_excluded ?? 0) > 0 && <> · {dc.away_excluded} away day(s) excluded</>}

--- a/ui/src/components/insights/SystemHealthCard.tsx
+++ b/ui/src/components/insights/SystemHealthCard.tsx
@@ -1,38 +1,45 @@
 import { useFetch } from "../../lib/poll";
 import { getLpScorecard } from "../../lib/endpoints";
+import { periodLastCompleteDay, type PeriodState } from "../../lib/period";
 import type { LpScorecard } from "../../lib/types";
 
-// "System health" — yesterday's LP scorecard (the last COMPLETE day, so the
-// plan-vs-realised comparison isn't half-empty). Three slices: did the plan
-// match reality (dispatch accuracy), did optimising pay (vs a naive self-use
-// shadow), and how good were the forecasts the LP planned on. Renders nothing
-// when the scorecard endpoint or its data isn't there — this card is a
-// diagnostic, not a load-bearing surface.
-
-function yesterdayIso(): string {
-  const d = new Date();
-  d.setDate(d.getDate() - 1);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
+// "System health" — the LP scorecard for the last COMPLETE day of the selected
+// period (so the plan-vs-realised comparison isn't half-empty). Follows the
+// navigator: a past period shows its final day, the current period shows
+// yesterday. Three slices: did the plan match reality (dispatch accuracy), did
+// optimising pay (vs a naive self-use shadow), and how good were the forecasts
+// the LP planned on.
 
 const pct = (v: number | null | undefined) => (v == null ? "—" : `${Math.round(v)}%`);
 const pence = (v: number | null | undefined) =>
   v == null ? "—" : `${v >= 0 ? "" : "−"}£${Math.abs(v / 100).toFixed(2)}`;
 
-export function SystemHealthCard() {
-  const day = yesterdayIso();
+export function SystemHealthCard({ period }: { period: PeriodState }) {
+  const day = periodLastCompleteDay(period);
   const res = useFetch(() => getLpScorecard(day), [day]);
   const sc: LpScorecard | undefined = res.data?.scorecard;
-  if (!sc) return null;
 
-  const disp = sc.dispatch_accuracy;
-  const econ = sc.economic_value;
-  const fc = sc.forecast_accuracy;
   // The backend grades a data-less day "N/A" (a string, never null) — treat
-  // it as no-grade so an empty day renders nothing instead of a hollow card.
-  const grade = sc.grade && sc.grade !== "N/A" ? sc.grade : null;
+  // it as no-grade.
+  const grade = sc?.grade && sc.grade !== "N/A" ? sc.grade : null;
+  const disp = sc?.dispatch_accuracy;
+  const econ = sc?.economic_value;
+  const fc = sc?.forecast_accuracy;
   const hasAnything = !!(grade || disp?.n_slots_with_plan || econ?.lp_realised_cost_p != null);
-  if (!hasAnything) return null;
+
+  if (!sc || !hasAnything) {
+    // A diagnostic, not a load-bearing surface — but a quiet placeholder reads
+    // better than a blank page bottom on a data-thin day.
+    return (
+      <section class="syshealth">
+        <header class="syshealth-head">
+          <h2>System health</h2>
+          <span class="muted">LP scorecard · {day}</span>
+        </header>
+        <p class="muted insights-empty">No scorecard for {day} yet.</p>
+      </section>
+    );
+  }
 
   const avoided = econ?.lp_avoided_cost_p;
 

--- a/ui/src/lib/endpoints.ts
+++ b/ui/src/lib/endpoints.ts
@@ -287,14 +287,21 @@ export interface ResidualProfile {
   hp_dhw_by_dow?: Record<string, ResidualProfileSlot[]>;
   hp_space_by_dow?: Record<string, ResidualProfileSlot[]>;
   all: ResidualProfileSlot[];
+  window_days?: number | null;
+  end_date?: string | null;
   flat: number;
   away_days: string[];
   day_counts: { weekday?: number; weekend?: number; away_excluded?: number; negative_excluded?: number; total?: number };
   calibrated_days: number;
   physics_only_days: number;
 }
-export const getResidualProfile = () =>
-  getJson<ResidualProfile>("/load/residual-profile");
+export const getResidualProfile = (opts: { windowDays?: number; endDate?: string } = {}) => {
+  const q = new URLSearchParams();
+  if (opts.windowDays != null) q.set("window_days", String(opts.windowDays));
+  if (opts.endDate) q.set("end_date", opts.endDate);
+  const qs = q.toString();
+  return getJson<ResidualProfile>(`/load/residual-profile${qs ? `?${qs}` : ""}`);
+};
 
 export interface LoadErrorStats {
   n: number;
@@ -309,5 +316,10 @@ export interface LoadErrorLog {
   overall: LoadErrorStats;
   per_hour_local: Record<string, LoadErrorStats>;
 }
-export const getLoadErrorLog = (windowDays = 30) =>
-  getJson<LoadErrorLog>(`/load/error-log?window_days=${windowDays}`);
+export const getLoadErrorLog = (
+  arg: number | { startDate: string; endDate: string } = 30,
+) => {
+  if (typeof arg === "number") return getJson<LoadErrorLog>(`/load/error-log?window_days=${arg}`);
+  const q = new URLSearchParams({ start_date: arg.startDate, end_date: arg.endDate });
+  return getJson<LoadErrorLog>(`/load/error-log?${q.toString()}`);
+};

--- a/ui/src/lib/period.ts
+++ b/ui/src/lib/period.ts
@@ -92,6 +92,30 @@ export function periodDateRange(p: PeriodState): { start: string; end: string } 
   return { start: startISO, end: endISO > t ? t : endISO };
 }
 
+/** Trailing window + end anchor for the load HEATMAP, which needs several weeks
+ * of samples for a meaningful day-of-week × hour grid. The window ends at the
+ * navigator's period end and spans at least a per-granularity floor so day/week
+ * still render a sensible pattern while month/year cover their full span. */
+export function periodWindow(p: PeriodState): { windowDays: number; endDate: string } {
+  const { start, end } = periodDateRange(p);
+  const span = Math.round((parse(end).getTime() - parse(start).getTime()) / 86_400_000) + 1;
+  const floor = p.gran === "day" || p.gran === "week" ? 28 : span;
+  return { windowDays: Math.max(span, floor), endDate: end };
+}
+
+/** The last COMPLETE local day within the selected period — what the LP
+ * scorecard (plan-vs-realised) should show. For the current period that's
+ * yesterday; for a past period it's the period's end (already clamped to today
+ * by periodDateRange). */
+export function periodLastCompleteDay(p: PeriodState): string {
+  const { end } = periodDateRange(p);
+  const t = todayISO();
+  if (end < t) return end;            // wholly past period → its last day is complete
+  const d = parse(t);
+  d.setDate(d.getDate() - 1);         // current period → yesterday
+  return isoOf(d);
+}
+
 /** Query params for getEnergyPeriod(). */
 export function periodFetchOpts(p: PeriodState): { date?: string; month?: string; year?: number } {
   if (p.gran === "month") return { month: p.anchor.slice(0, 7) };

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -173,9 +173,9 @@ export default function Insights() {
         </>
       )}
 
-      <LoadPatternCard />
-      <LoadForecastAccuracyCard />
-      <SystemHealthCard />
+      <LoadPatternCard period={period} />
+      <LoadForecastAccuracyCard period={period} />
+      <SystemHealthCard period={period} />
     </div>
   );
 }


### PR DESCRIPTION
## What

The three Insights cards under the tariff table ignored the day/week/month/year navigator and used fixed windows. Now they re-scope with the navigator and reuse the already-cached server values for the chosen period.

| Card | Before | After |
|---|---|---|
| LoadForecastAccuracyCard | 30d fixed | navigator's exact `[start,end]` |
| LoadPatternCard heatmap | 120d fixed | anchored at period end, floored window |
| SystemHealthCard | yesterday fixed | period's last complete day + empty-state |

## Changes

**Backend**
- `residual_load_profile_v2(end_date=...)`: anchors the trailing window at a past day; `end_date` is part of the TTL cache key and bounds both the pv-sample and negative-slot queries. Omitted → unchanged live behaviour.
- `GET /load/residual-profile`: `end_date` param + window/end meta in the response.
- `GET /load/error-log`: `start_date`/`end_date` params (trailing `window_days` kept as default).

**Frontend**
- `period.ts`: `periodWindow()` (heatmap window+anchor, per-gran floor — a dow×hour grid needs weeks of samples) and `periodLastCompleteDay()` (scorecard day).
- The three cards take a `period` prop and re-fetch on change; heatmap meta states the effective window; SystemHealthCard renders a quiet "No scorecard yet" placeholder instead of nothing.

## Note

The heatmap is intrinsically a multi-week pattern, so for day/week the window is floored to 28 days ending at the navigator anchor (the meta says so) rather than collapsing to a meaningless 1-day grid. Month/year span their full range.

## Tests

`tests/test_db_residual_profile_v2.py`: + `end_date` anchors the window (a spike after the anchor is excluded) + `end_date` is part of the cache key. 24 passed. UI `tsc --noEmit` clean.

> Stacked on #575 (tank/heating split) — merge that first, then this.

Part of #574 (items 3 + 4)