### PR TITLE
fix(insights): stop heatmap navigation 504s (cold-rebuild stampede)

### DIFF
--- a/ui/src/components/insights/LoadPatternCard.tsx
+++ b/ui/src/components/insights/LoadPatternCard.tsx
@@ -140,7 +140,7 @@ export function LoadPatternCard({ period }: { period: PeriodState }) {
         <>
           <div ref={elRef} class="load-pattern-chart" />
           <p class="muted load-pattern-meta">
-            {windowDays}-day pattern to {periodLabel(period)}
+            {endDate ? `${windowDays}-day pattern to ${periodLabel(period)}` : `recent ${windowDays}-day pattern`}
             {" · "}
             {(dc.weekday ?? 0) + (dc.weekend ?? 0)} days learned
             ({dc.weekday ?? 0} weekday / {dc.weekend ?? 0} weekend)

--- a/ui/src/lib/period.ts
+++ b/ui/src/lib/period.ts
@@ -92,15 +92,25 @@ export function periodDateRange(p: PeriodState): { start: string; end: string } 
   return { start: startISO, end: endISO > t ? t : endISO };
 }
 
-/** Trailing window + end anchor for the load HEATMAP, which needs several weeks
- * of samples for a meaningful day-of-week × hour grid. The window ends at the
- * navigator's period end and spans at least a per-granularity floor so day/week
- * still render a sensible pattern while month/year cover their full span. */
-export function periodWindow(p: PeriodState): { windowDays: number; endDate: string } {
+/** Maximum heatmap lookback. The day-of-week × hour grid is a multi-week
+ * behavioural pattern, so a longer window adds little but each distinct window
+ * is an uncached ~2s server-side physics rebuild that serialises on the DB lock
+ * — capping bounds the worst case. Also the default the live profile is cached
+ * under, so day/week reuse the always-warm entry. */
+const HEATMAP_MAX_WINDOW_DAYS = 120;
+
+/** Trailing window + optional end anchor for the load HEATMAP.
+ *
+ * day/week → NO anchor: the heatmap is a multi-week pattern, not a per-day
+ * figure, so stepping day-by-day reuses the always-warm live 120-day profile
+ * (no cold rebuild, no DB-lock pile-up — the cause of the navigation 504s).
+ * month/year → anchored at the period end with a capped window; few distinct
+ * anchors, so the 4-min TTL cache absorbs repeat views. */
+export function periodWindow(p: PeriodState): { windowDays: number; endDate?: string } {
+  if (p.gran === "day" || p.gran === "week") return { windowDays: HEATMAP_MAX_WINDOW_DAYS };
   const { start, end } = periodDateRange(p);
   const span = Math.round((parse(end).getTime() - parse(start).getTime()) / 86_400_000) + 1;
-  const floor = p.gran === "day" || p.gran === "week" ? 28 : span;
-  return { windowDays: Math.max(span, floor), endDate: end };
+  return { windowDays: Math.min(Math.max(span, 28), HEATMAP_MAX_WINDOW_DAYS), endDate: end };
 }
 
 /** The last COMPLETE local day within the selected period — what the LP


### PR DESCRIPTION
## Problem

Reported live: stepping the period navigator across days on the "When you spend the most" heatmap → `Couldn't load the pattern: hem-api 504`. Regression from #576.

Each distinct `end_date` is an uncached ~2s server-side physics rebuild (`residual_load_profile_v2`). Stepping day-by-day fired a fresh cold rebuild every step; the GIL serialises the CPU-bound rebuilds → requests pile up past nginx's 60s `proxy_read_timeout` → 504. Year view also requested a 365-day window. (Single-request timing is fine — measured ~1.9s/2.1s/2.4s for 28/90/365d against a 60s timeout; it's the stampede.)

## Fix (UI only)

The day-of-week × hour heatmap is a multi-week behavioural pattern, not a per-day figure:
- **day/week → no `end_date`**: reuse the always-warm live 120-day profile (the cache entry the optimizer already keeps). Stepping days no longer changes the fetch key → no refetch, no rebuild, no pile-up.
- **month/year → anchored** at the period end with the window **capped at 120d** (was up to 365).

Meta label now reads "recent N-day pattern" (day/week) vs "N-day pattern to <period>" (month/year). The cheap per-day cards (accuracy, scorecard) are unchanged and still follow the navigator.

`tsc --noEmit` clean.

Closes #577