### PR TITLE
fix(ui): period-nav chart updates, Today button, immutable past-period cache

### DIFF
--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { getEnergyPeriod, getDaikinConsumption, getGridToday } from "../../lib/endpoints";
-import { usePeriod, setGranularity, selectedPeriod } from "../../lib/period";
+import { usePeriod, setGranularity, selectedPeriod, isCurrentPeriod } from "../../lib/period";
+import { getImmutableCache, setImmutableCache } from "../../lib/poll";
 import { makeChart, baseOption, chartTheme, barGradient, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
 import { Icon } from "../common/Icon";
 import type {
@@ -63,8 +64,34 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
 
   useEffect(() => {
     let alive = true;
-    setLoading(true);
     setError(null);
+
+    // "Past is past": a period that doesn't contain today never changes, so
+    // serve it from the immutable cache (instant, no flash) and skip the fetch.
+    const isPast = !isCurrentPeriod({ gran: granularity, anchor });
+    const cacheKey = `energychart:${granularity}:${anchor}`;
+    type Cached = {
+      period: PeriodInsightsResponse | null;
+      daikin: DaikinConsumptionResponse | null;
+      grid: GridTodayResponse | null;
+    };
+    const cached = isPast ? getImmutableCache<Cached>(cacheKey) : undefined;
+    if (cached) {
+      setPeriod(cached.period);
+      setDaikin(cached.daikin);
+      setGrid(cached.grid);
+      setLoading(false);
+      return () => { alive = false; };
+    }
+
+    // Clear the previous period's data BEFORE the async fetch so the render
+    // effect can't paint a stale chart while the new data is in flight (the
+    // "chart doesn't update when navigating back" bug).
+    setLoading(true);
+    setPeriod(null);
+    setDaikin(null);
+    setGrid(null);
+
     const opts: { date?: string; month?: string; year?: number } = {};
     if (granularity === "week") opts.date = anchor;
     else if (granularity === "month") opts.month = anchor.slice(0, 7);
@@ -88,6 +115,7 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
       setDaikin(d);
       setGrid(g);
       setLoading(false);
+      if (isPast) setImmutableCache(cacheKey, { period: p, daikin: d, grid: g });
     });
     return () => { alive = false; };
   }, [granularity, anchor]);

--- a/ui/src/components/insights/LoadForecastAccuracyCard.tsx
+++ b/ui/src/components/insights/LoadForecastAccuracyCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "preact/hooks";
 import { useFetch } from "../../lib/poll";
 import { getLoadErrorLog, type LoadErrorLog } from "../../lib/endpoints";
-import { periodDateRange, periodLabel, type PeriodState } from "../../lib/period";
+import { periodDateRange, periodLabel, isCurrentPeriod, type PeriodState } from "../../lib/period";
 import { makeChart, chartTheme, type EChartsType } from "../../lib/charts";
 import { Spinner } from "../common/Spinner";
 
@@ -13,6 +13,7 @@ export function LoadForecastAccuracyCard({ period }: { period: PeriodState }) {
   const res = useFetch<LoadErrorLog>(
     () => getLoadErrorLog({ startDate: start, endDate: end }),
     [start, end],
+    { cacheKey: `load-err:${start}:${end}`, immutable: !isCurrentPeriod(period) },
   );
   const data = res.data;
   const elRef = useRef<HTMLDivElement | null>(null);
@@ -71,7 +72,7 @@ export function LoadForecastAccuracyCard({ period }: { period: PeriodState }) {
           label: { show: false },
         },
       }],
-    });
+    }, { notMerge: true });
     chartRef.current.resize();
   }, [data]);
 

--- a/ui/src/components/insights/LoadPatternCard.tsx
+++ b/ui/src/components/insights/LoadPatternCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { useFetch } from "../../lib/poll";
 import { getResidualProfile, type ResidualProfile, type ResidualProfileSlot } from "../../lib/endpoints";
-import { periodWindow, periodLabel, type PeriodState } from "../../lib/period";
+import { periodWindow, periodLabel, isCurrentPeriod, type PeriodState } from "../../lib/period";
 import { makeChart, chartTheme, type EChartsType } from "../../lib/charts";
 import { Spinner } from "../common/Spinner";
 
@@ -24,9 +24,15 @@ const VIEW_DESC: Record<View, string> = {
  *  (tank/DHW) vs space heating from the measured Onecta meters (#574). */
 export function LoadPatternCard({ period }: { period: PeriodState }) {
   const { windowDays, endDate } = periodWindow(period);
+  // Anchored (month/year) past windows are immutable; the live recent window
+  // (day/week, no endDate) keeps refreshing.
   const res = useFetch<ResidualProfile>(
     () => getResidualProfile({ windowDays, endDate }),
     [windowDays, endDate],
+    {
+      cacheKey: `residual:${windowDays}:${endDate ?? "live"}`,
+      immutable: !!endDate && !isCurrentPeriod(period),
+    },
   );
   const data = res.data;
   const hasHp = !!data?.hp_by_dow;
@@ -103,7 +109,7 @@ export function LoadPatternCard({ period }: { period: PeriodState }) {
         emphasis: { itemStyle: { borderColor: t.text, borderWidth: 1 } },
         progressive: 0,
       }],
-    });
+    }, { notMerge: true });
     chartRef.current.resize();
   }, [data, view]);
 

--- a/ui/src/components/insights/SystemHealthCard.tsx
+++ b/ui/src/components/insights/SystemHealthCard.tsx
@@ -1,6 +1,6 @@
 import { useFetch } from "../../lib/poll";
 import { getLpScorecard } from "../../lib/endpoints";
-import { periodLastCompleteDay, type PeriodState } from "../../lib/period";
+import { periodLastCompleteDay, isCurrentPeriod, type PeriodState } from "../../lib/period";
 import type { LpScorecard } from "../../lib/types";
 
 // "System health" — the LP scorecard for the last COMPLETE day of the selected
@@ -16,7 +16,13 @@ const pence = (v: number | null | undefined) =>
 
 export function SystemHealthCard({ period }: { period: PeriodState }) {
   const day = periodLastCompleteDay(period);
-  const res = useFetch(() => getLpScorecard(day), [day]);
+  // Past periods are immutable; the current period's day is yesterday, whose
+  // scorecard can still change after the ~04:00 consumption backfill, so leave
+  // it live (refetch on revisit).
+  const res = useFetch(() => getLpScorecard(day), [day], {
+    cacheKey: `scorecard:${day}`,
+    immutable: !isCurrentPeriod(period),
+  });
   const sc: LpScorecard | undefined = res.data?.scorecard;
 
   // The backend grades a data-less day "N/A" (a string, never null) — treat

--- a/ui/src/components/shell/PeriodNavigator.tsx
+++ b/ui/src/components/shell/PeriodNavigator.tsx
@@ -2,6 +2,7 @@ import {
   usePeriod,
   setGranularity,
   stepPeriod,
+  goToNow,
   isCurrentPeriod,
   periodLabel,
   periodScope,
@@ -42,6 +43,9 @@ export function PeriodNavigator({ variant = "page" }: { variant?: "page" | "chro
         <span class="pnav-label" aria-live="polite">{label}</span>
         <button class="pnav-arrow" onClick={() => stepPeriod(1)} disabled={atNow}
                 aria-label="Next period" title={atNow ? "Already at the current period" : undefined}>›</button>
+        <button class="pnav-today" onClick={goToNow} disabled={atNow}
+                aria-label="Jump to the current period"
+                title={atNow ? "Already at the current period" : "Jump to now"}>Today</button>
       </div>
       <div class="pnav-grans" role="tablist" aria-label="Granularity">
         {GRANS.map((g) => (

--- a/ui/src/components/shell/period-nav.css
+++ b/ui/src/components/shell/period-nav.css
@@ -32,6 +32,24 @@
 .pnav-arrow:hover { background: var(--bg-card-2); }
 .pnav-arrow:disabled { opacity: 0.35; cursor: default; }
 
+/* "Today" quick-reset — sits after the next arrow; disabled (and visually
+ * recessed) once the selected period already contains today. */
+.pnav-today {
+  height: 32px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-dim);
+  font-size: var(--font-sm);
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 140ms ease, color 140ms ease, opacity 140ms ease;
+}
+.pnav-today:hover { background: var(--bg-card-2); color: var(--text); }
+.pnav-today:disabled { opacity: 0.35; cursor: default; }
+
 .pnav-label {
   min-width: 9ch;
   text-align: center;
@@ -103,6 +121,16 @@
   color: var(--text-dim);
   white-space: nowrap;
 }
+.pnav--chrome .pnav-today {
+  height: 28px;
+  padding: 0 10px;
+  font-size: var(--font-xs);
+  border: none;
+  background: var(--bg-card-2);
+  color: var(--text-dim);
+}
+.pnav--chrome .pnav-today:hover { background: var(--bg-card-3); color: var(--text); }
+.pnav--chrome .pnav-today:disabled:hover { background: var(--bg-card-2); color: var(--text-dim); }
 
 @media (max-width: 960px) { .pnav--chrome { display: none; } }
 @media (min-width: 961px) { .pnav--page { display: none; } }
@@ -118,4 +146,5 @@
   .pnav--page .pnav-label { min-width: 7ch; font-size: var(--font-sm); }
   .pnav--page .pnav-gran { padding: 5px 9px; font-size: var(--font-xs); }
   .pnav--page .pnav-arrow { width: 28px; height: 28px; font-size: 16px; }
+  .pnav--page .pnav-today { height: 28px; padding: 0 9px; font-size: var(--font-xs); }
 }

--- a/ui/src/lib/period.ts
+++ b/ui/src/lib/period.ts
@@ -52,6 +52,12 @@ export function setGranularity(gran: Granularity): void {
   selectedPeriod.value = { gran, anchor: cur > t ? t : cur };
 }
 
+/** Jump straight to the current period, keeping the chosen granularity — the
+ * "Today" affordance. Snaps the anchor to today so isCurrentPeriod() is true. */
+export function goToNow(): void {
+  selectedPeriod.value = { gran: selectedPeriod.value.gran, anchor: todayISO() };
+}
+
 /** Step the anchor backward (-1) or forward (+1) by one unit of the granularity. */
 export function stepPeriod(dir: -1 | 1): void {
   const { gran, anchor } = selectedPeriod.value;

--- a/ui/src/lib/poll.ts
+++ b/ui/src/lib/poll.ts
@@ -85,16 +85,52 @@ export function usePoll<T>(
   return { data, error, loading, refresh, lastFetchAt, intervalMs };
 }
 
-// Fetch-once hook for endpoints we don't poll.
+// Immutable response cache for COMPLETED past periods. "Past is past" — a
+// period that doesn't contain today never changes, so once fetched we keep it
+// forever (module-level Map → survives the unmount/remount that route changes
+// cause). The CURRENT period is never cached (callers pass immutable=false when
+// isCurrentPeriod), so live data always refreshes. Keyed by a caller-supplied
+// (endpoint, gran, anchor) string.
+const _immutableCache = new Map<string, unknown>();
+
+/** Read a value the caller previously stored via {@link setImmutableCache}.
+ * Used by hand-rolled fetch effects (e.g. EnergyChartWidget) that can't use
+ * the useFetch cache path. */
+export function getImmutableCache<T>(key: string | null | undefined): T | undefined {
+  return key ? (_immutableCache.get(key) as T | undefined) : undefined;
+}
+
+/** Store a value for a completed past period. No-op for a null key. */
+export function setImmutableCache(key: string | null | undefined, value: unknown): void {
+  if (key) _immutableCache.set(key, value);
+}
+
+export interface FetchOpts {
+  // Stable key for the immutable cache, e.g. `fair:${gran}:${anchor}`.
+  cacheKey?: string | null;
+  // Only cache + serve-from-cache when true (caller passes !isCurrentPeriod so
+  // the live current period always refetches).
+  immutable?: boolean;
+}
+
+// Fetch-once hook for endpoints we don't poll. With `opts.immutable` + a
+// `cacheKey` it serves a completed past period instantly from the module cache
+// and never refetches it (see _immutableCache).
 export function useFetch<T>(
   fn: () => Promise<T>,
   deps: ReadonlyArray<unknown> = [],
+  opts: FetchOpts = {},
 ): PollState<T> {
-  const [data, setData] = useState<T | null>(null);
+  const cacheKey = opts.immutable ? (opts.cacheKey ?? null) : null;
+  const initial = cacheKey != null ? (_immutableCache.get(cacheKey) as T | undefined) : undefined;
+
+  const [data, setData] = useState<T | null>(initial ?? null);
   const [error, setError] = useState<Error | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(initial === undefined);
   const fnRef = useRef(fn);
   fnRef.current = fn;
+  const keyRef = useRef(cacheKey);
+  keyRef.current = cacheKey;
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -105,12 +141,22 @@ export function useFetch<T>(
   }, []);
 
   const refresh = useRef(async () => {
+    // Immutable cache hit (past period already fetched) → serve instantly.
+    const k = keyRef.current;
+    if (k != null && _immutableCache.has(k)) {
+      if (!mountedRef.current) return;
+      setData(_immutableCache.get(k) as T);
+      setError(null);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     try {
       const next = await fnRef.current();
       if (!mountedRef.current) return;
       setData(next);
       setError(null);
+      if (keyRef.current != null) _immutableCache.set(keyRef.current, next);
     } catch (e) {
       if (!mountedRef.current) return;
       setError(e instanceof Error ? e : new Error(String(e)));

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "preact/hooks";
 import { useFetch } from "../lib/poll";
 import { getFairCompare } from "../lib/endpoints";
-import { usePeriod, periodLabel } from "../lib/period";
+import { usePeriod, periodLabel, isCurrentPeriod } from "../lib/period";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
 import { Pill } from "../components/common/Pill";
 import { gbp, gbpSigned, kwh } from "../lib/format";
@@ -22,6 +22,7 @@ export default function Insights() {
   const cmp = useFetch(
     () => getFairCompare(period.gran, period.anchor),
     [period.gran, period.anchor],
+    { cacheKey: `fair:${period.gran}:${period.anchor}`, immutable: !isCurrentPeriod(period) },
   );
   const data = cmp.data;
   const rows = data?.tariffs ?? [];

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -26,7 +26,7 @@ import { Icon } from "../components/common/Icon";
 import { Spinner } from "../components/common/Spinner";
 import { RefreshCountdown } from "../components/common/RefreshCountdown";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
-import { usePeriod, periodFetchOpts, periodScope } from "../lib/period";
+import { usePeriod, periodFetchOpts, periodScope, isCurrentPeriod } from "../lib/period";
 import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
 import { Hero } from "../components/home/Hero";
 import { HeatingWidget } from "../components/home/HeatingWidget";
@@ -108,6 +108,7 @@ export default function Landing() {
   const periodInsights = useFetch(
     () => getEnergyPeriod(period.gran, periodFetchOpts(period)),
     [period.gran, period.anchor],
+    { cacheKey: `energy:${period.gran}:${period.anchor}`, immutable: !isCurrentPeriod(period) },
   );
 
   // Publish the cockpit's per-source freshness map so the shell-level


### PR DESCRIPTION
Three issues reported while navigating the period selector across granularities (follow-up to #578, same release).

## 1. Charts didn't refresh when navigating back (week → day)
`EnergyChartWidget` (the cockpit consumption chart) painted the previous period's data: its render effect ran with the new granularity while `period`/`daikin`/`grid` state still held the old values. **Fix:** clear that state before the async fetch so the render effect can't paint a stale chart. Also added `{ notMerge: true }` to the two insights charts (`LoadPatternCard` heatmap, `LoadForecastAccuracyCard`) whose `setOption` merged stale series/visualMap when the new view had fewer points.

## 2. "Today" button
Added to `PeriodNavigator` (new `period.ts goToNow()`), disabled via the existing `isCurrentPeriod()` once the period contains today. Styled for page/chrome/phone variants.

## 3. Cache past periods ("past is past")
`useFetch` gains optional `{ cacheKey, immutable }`: an immutable hit serves instantly from a module-level `Map` (survives route unmount/remount) and never refetches; the **current** period passes `immutable=false` so live data still refreshes. Wired into fair-compare, energy/period, residual-profile (anchored only), error-log, scorecard, and `EnergyChartWidget`. Gated on `isCurrentPeriod` so live data is never staled.

`tsc --noEmit` + `vite build` clean.

Closes #579