### PR TITLE
fix(ui): render the real intraday consumption chart for past days

### DIFF
--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "preact/hooks";
-import { getEnergyPeriod, getDaikinConsumption, getGridToday } from "../../lib/endpoints";
+import { getEnergyPeriod, getDaikinConsumption, getGridToday, getExecutionToday, getPvToday } from "../../lib/endpoints";
 import { usePeriod, setGranularity, selectedPeriod, isCurrentPeriod } from "../../lib/period";
 import { getImmutableCache, setImmutableCache } from "../../lib/poll";
 import { makeChart, baseOption, chartTheme, barGradient, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
@@ -16,6 +16,13 @@ import type {
 import "./energy-chart.css";
 
 type Granularity = "day" | "week" | "month" | "year";
+
+interface DayPastData {
+  exec: ExecutionTodayResponse | null;
+  pv: PvTodayResponse | null;
+  grid: GridTodayResponse | null;
+  daikin: DaikinConsumptionResponse | null;
+}
 
 // Local-date ISO (matches lib/period.ts) — avoids the UTC drift that
 // `toISOString().slice(0,10)` causes near the day boundary.
@@ -57,6 +64,10 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
   const [daikin, setDaikin] = useState<DaikinConsumptionResponse | null>(null);
   // Day view: per-slot grid import + battery discharge — for the "by source" stack.
   const [grid, setGrid] = useState<GridTodayResponse | null>(null);
+  // Past day: the same per-slot data the live "today" view uses, fetched for the
+  // selected date (the today endpoints all accept ?date=). Lets a past day render
+  // the real intraday chart instead of a single daily-total bar.
+  const [dayData, setDayData] = useState<DayPastData | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const elRef = useRef<HTMLDivElement | null>(null);
@@ -70,6 +81,41 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
     // serve it from the immutable cache (instant, no flash) and skip the fetch.
     const isPast = !isCurrentPeriod({ gran: granularity, anchor });
     const cacheKey = `energychart:${granularity}:${anchor}`;
+
+    // PAST DAY → fetch the same per-slot data the live "today" view uses, for
+    // that date (the today endpoints all accept ?date=), and render the real
+    // intraday chart. Per-slot history IS captured (execution_log etc.), so the
+    // old single-bar fallback (#424) is no longer needed.
+    if (granularity === "day" && !isToday) {
+      const cachedDay = getImmutableCache<DayPastData>(cacheKey);
+      if (cachedDay) {
+        setDayData(cachedDay);
+        setLoading(false);
+        return () => { alive = false; };
+      }
+      setLoading(true);
+      setDayData(null);
+      setPeriod(null);
+      setDaikin(null);
+      setGrid(null);
+      Promise.all([
+        getExecutionToday(anchor).catch(() => null),
+        getPvToday(anchor).catch(() => null),
+        getGridToday(anchor).catch(() => null),
+        getDaikinConsumption("day", { date: anchor }).catch(() => null),
+      ]).then(([e, p, g, dk]) => {
+        if (!alive) return;
+        const v: DayPastData = { exec: e, pv: p, grid: g, daikin: dk };
+        setDayData(v);
+        setLoading(false);
+        setImmutableCache(cacheKey, v); // past day → immutable
+      });
+      return () => { alive = false; };
+    }
+
+    // Non-past-day path uses the period/daikin state — clear any past-day data.
+    setDayData(null);
+
     type Cached = {
       period: PeriodInsightsResponse | null;
       daikin: DaikinConsumptionResponse | null;
@@ -124,14 +170,19 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
     if (!elRef.current) return;
     if (!chartRef.current) chartRef.current = makeChart(elRef.current);
     const chart = chartRef.current;
-    const option = granularity === "day" && isToday
-      ? optionForDay(execution, pv ?? null, grid)
+    const pastDayView = granularity === "day" && !isToday;
+    const option = granularity === "day"
+      ? optionForDay(
+          pastDayView ? dayData?.exec ?? null : execution,
+          pastDayView ? dayData?.pv ?? null : (pv ?? null),
+          pastDayView ? dayData?.grid ?? null : grid,
+        )
       : optionForPeriod(period, daikin, granularity);
     chart.setOption(option, true);
     // Resize handling now lives centrally in makeChart (rAF-debounced
     // ResizeObserver) — the per-effect observer this widget carried would
     // double every resize() call.
-  }, [granularity, period, daikin, grid, execution, pv, isToday]);
+  }, [granularity, period, daikin, grid, dayData, execution, pv, isToday]);
 
   useEffect(() => () => {
     if (chartRef.current) {
@@ -160,15 +211,19 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
     return () => { c.off("click", handler); };
   }, [granularity]);
 
-  const dayHasSlots = granularity === "day" && isToday && !!execution?.slots?.length;
-  const isPastDay = granularity === "day" && !isToday;
+  // Per-slot data for the day view — props for today, the date-fetched set for
+  // a past day (so both render the same intraday chart).
+  const pastDayView = granularity === "day" && !isToday;
+  const effExec = pastDayView ? dayData?.exec ?? null : execution;
+  const effDaikin = pastDayView ? dayData?.daikin ?? null : daikin;
+  const dayHasSlots = granularity === "day" && !!effExec?.slots?.length;
   // Foot summary — LOAD totals only (grid/solar moved to Insights).
   const summary = period ? { load: period.energy.load_kwh } : null;
-  const daikinTotals = daikin?.totals;
-  const todayTotals = granularity === "day" && isToday && execution?.totals
+  const daikinTotals = effDaikin?.totals;
+  const dayTotals = granularity === "day" && effExec?.totals
     ? {
-        load: execution.totals.load_kwh ?? null,
-        residual: execution.totals.residual_kwh_est ?? null,
+        load: effExec.totals.load_kwh ?? null,
+        residual: effExec.totals.residual_kwh_est ?? null,
       }
     : null;
 
@@ -191,16 +246,10 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
         {error && <div class="echart-state echart-state--err">{error}</div>}
       </div>
 
-      {granularity === "day" && isToday && !dayHasSlots && (
+      {granularity === "day" && !dayHasSlots && !loading && (
         <div class="echart-flag">
           <span class="echart-flag-icon"><Icon name="schedule" size={14} /></span>
-          No execution data for today yet — switch to Week.
-        </div>
-      )}
-      {isPastDay && (
-        <div class="echart-flag">
-          <span class="echart-flag-icon"><Icon name="schedule" size={14} /></span>
-          Daily totals shown — per-slot history for past days isn't captured yet (#424).
+          {isToday ? "No execution data for today yet — switch to Week." : "No per-slot data recorded for this day."}
         </div>
       )}
       {granularity === "day" && dayHasSlots && (
@@ -235,13 +284,13 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
           )}
         </div>
       )}
-      {todayTotals && (
+      {dayTotals && (
         <div class="echart-foot">
           <span class="echart-foot-grp">
-            <strong>Today so far</strong>&nbsp;
-            {todayTotals.residual != null && <span class="echart-tok echart-tok-resid">{fmt(todayTotals.residual)} residual load</span>}
-            {todayTotals.load != null && (
-              <>{" · "}<span class="echart-tok echart-tok-load">{fmt(todayTotals.load)} total demand</span></>
+            <strong>{isToday ? "Today so far" : "Total"}</strong>&nbsp;
+            {dayTotals.residual != null && <span class="echart-tok echart-tok-resid">{fmt(dayTotals.residual)} residual load</span>}
+            {dayTotals.load != null && (
+              <>{" · "}<span class="echart-tok echart-tok-load">{fmt(dayTotals.load)} total demand</span></>
             )}
             {daikinTotals && (daikinTotals.kwh_total || 0) > 0 && (
               <>

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -56,10 +56,18 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
   // Granularity + anchor come from the shared period navigator so the chart
   // re-scopes together with the Hero + cost breakdown.
   const { gran: granularity, anchor } = usePeriod();
-  // Local "today" (matches period.ts) — the per-slot day chart only has data
-  // for today (historical per-slot capture is #424).
+  // Local "today" (matches period.ts).
   const todayLocalISO = localTodayISO();
   const isToday = anchor === todayLocalISO;
+  // Yesterday's per-slot consumption_kwh is still "settling": the nightly
+  // consumption backfill (~04:00 local) rewrites the noisy heartbeat estimate
+  // with the metered reading. So only days STRICTLY older than yesterday are
+  // safe to cache immutably; yesterday is refetched on each visit.
+  const yesterdayLocalISO = (() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  })();
   const [period, setPeriod] = useState<PeriodInsightsResponse | null>(null);
   const [daikin, setDaikin] = useState<DaikinConsumptionResponse | null>(null);
   // Day view: per-slot grid import + battery discharge — for the "by source" stack.
@@ -87,7 +95,8 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
     // intraday chart. Per-slot history IS captured (execution_log etc.), so the
     // old single-bar fallback (#424) is no longer needed.
     if (granularity === "day" && !isToday) {
-      const cachedDay = getImmutableCache<DayPastData>(cacheKey);
+      const settled = anchor < yesterdayLocalISO; // consumption backfill done
+      const cachedDay = settled ? getImmutableCache<DayPastData>(cacheKey) : undefined;
       if (cachedDay) {
         setDayData(cachedDay);
         setLoading(false);
@@ -108,7 +117,7 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
         const v: DayPastData = { exec: e, pv: p, grid: g, daikin: dk };
         setDayData(v);
         setLoading(false);
-        setImmutableCache(cacheKey, v); // past day → immutable
+        if (settled) setImmutableCache(cacheKey, v); // only fully-settled past days
       });
       return () => { alive = false; };
     }


### PR DESCRIPTION
## Problem

A past day (e.g. yesterday) on the cockpit consumption chart showed a weird single daily-total bar instead of the 30-min intraday chart shown for today — flagged with a stale "#424: per-slot history isn't captured yet".

That note is outdated: per-slot history **is** captured (`execution_log` / `pv_realtime_history`), and `/execution/today`, `/pv/today`, `/grid/today` **all already accept `?date=`**. `GenerationWidget` already renders past days this way; `EnergyChartWidget` was the only intraday chart still falling back, because it rendered `optionForDay` only when `isToday`.

Verified on prod: `/execution/today?date=2026-06-14` → 48 slots, `/pv/today?date=...` → 48 slots w/ base_load + price, `/grid/today?date=...` → 48 slots, 41 with import.

## Fix

For any past day, fetch execution/pv/grid/daikin for that date (mirroring GenerationWidget's pattern) and render the same intraday `optionForDay` chart — load-by-use stack, grid/battery source overlay, SoC, tariff bands, forecast line. The "now" marker self-disables (now is outside a past day). Past-day data is immutable so it's cached (`energychart:day:<date>`); today keeps using the live props. Removed the stale #424 fallback + flag; footer header reads "Total" for a past day vs "Today so far".

Only `EnergyChartWidget` needed this — GenerationWidget already handles past days; the other cockpit widgets are live/now and not period-scoped.

`tsc --noEmit` + `vite build` clean.

Closes #581