### PR TITLE
fix(daikin): outdoor cutoff on positive LWT offsets + thermal-lag tail (kills June phantom heat)

### DIFF
--- a/docs/WINTER_THERMAL_MODEL.md
+++ b/docs/WINTER_THERMAL_MODEL.md
@@ -178,7 +178,21 @@ and no calibration that can eat its own output.*
     peak setback −2 °C can stay as interim until W3 lands).
 11. **Demand gate now** (independent of sensors): no positive LWT offset when
     trailing-48 h measured `kwh_heating ≈ 0` — stops the June waste pattern
-    permanently, regardless of season.
+    permanently, regardless of season. **(Shipped #541.)**
+11b. **Outdoor cutoff + thermal-lag tail (SHIPPED — `fix/lwt-outdoor-cutoff-…`).**
+    The #541 demand gate alone proved foolable in prod: positive offsets woke
+    the compressor (heating 0.0 → ~4.6 kWh/day from Jun 5, 2026), and the
+    HEM-induced heat bled into the 2-h bucket *after* each offset window —
+    counted as natural demand, latching the gate open (`measured_window_kwh`
+    sat at 1.0 just over the 0.5 floor). Two fixes: (a) an **exogenous outdoor
+    cutoff** (`DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C`, default 15 °C) suppresses
+    POSITIVE offsets per-slot — the self-loop can't fake the weather; the −2
+    setback is never cut. (b) the decontamination excludes
+    `DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS` (default 1) trailing buckets per
+    window. Verified on the prod DB: `measured_window_kwh` 1.0 → 0.0 (demand
+    gate now reads closed) and `positive_offset_suppressed_by_outdoor` → true at
+    20 °C. (`space_heating_gate_state` keeps `preheat_suppressed` scoped to the
+    demand gate — "all LWT off" — distinct from the warm-day positive-only flag.)
 
 **Phase W4 — validate before the heating season peaks**
 12. Replay scorecard: simulated winter days, plan-vs-actual indoor trajectory
@@ -191,8 +205,10 @@ and no calibration that can eat its own output.*
 - `BUILDING_UA_W_PER_K` 180 → ~600 (measured) and
   `BUILDING_THERMAL_MASS_KWH_PER_K` 8 → ~12 (τ ≈ 20 h prior) so the existing
   estimator fallback stops being 3.5× optimistic.
-- The W3-item-11 demand gate (small PR, kills the active June waste).
-- `k_per_degc` decontamination filter (small PR).
+- The W3-item-11 demand gate (small PR, kills the active June waste). **DONE #541.**
+- Outdoor cutoff on positive offsets + thermal-lag tail exclusion (closes the
+  residual self-loop #541 left open). **DONE — see item 11b.**
+- `k_per_degc` decontamination filter (small PR). **DONE #541.**
 
 ---
 

--- a/src/config.py
+++ b/src/config.py
@@ -1221,6 +1221,30 @@ class Config:
     DAIKIN_LWT_PREHEAT_DEMAND_LOOKBACK_HOURS: int = int(
         os.getenv("DAIKIN_LWT_PREHEAT_DEMAND_LOOKBACK_HOURS", "48")
     )
+    # Outdoor-temperature cutoff for POSITIVE LWT offsets (Tracked by #540).
+    # The demand gate above is endogenous (trailing measured heating) and can
+    # be fooled by its own output: a positive offset (cheap +BOOST or
+    # negative-price +NEGATIVE_BOOST) WAKES the compressor, and some of that
+    # HEM-induced heat bleeds into 2-h buckets just AFTER the offset window
+    # (thermal lag) → counted as natural demand → gate latches open (the live
+    # June-2026 self-loop: heating 0 → ~4.6 kWh/day once active LWT was on).
+    # Outdoor temperature is an EXOGENOUS signal the loop cannot fake: above a
+    # heating-degree-day base (~15.5 °C, CIBSE) a UK heat-pump house needs
+    # little/no space heat, so positive offsets are suppressed PER SLOT against
+    # the micro-climate-calibrated forecast temp. The NEGATIVE peak setback
+    # (-2) is never cut — it cannot wake the compressor. Default 15 sits just
+    # below the firmware's own 18 °C ambient heating cutoff
+    # (DAIKIN_WEATHER_CURVE_HIGH_C) on purpose. Set high (e.g. 99) to disable.
+    DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C: float = float(
+        os.getenv("DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C", "15.0")
+    )
+    # Thermal-lag tail exclusion for the demand-gate decontamination: also drop
+    # this many 2-h buckets AFTER each offset window from the measured-heating
+    # read, so offset-induced heat that bleeds past the window close cannot
+    # re-open the gate during convergence. Default 1 (~2 h). 0 = old behaviour.
+    DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS: int = int(
+        os.getenv("DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS", "1")
+    )
     OPTIMIZATION_DISABLE_WEATHER_REGULATION: bool = os.getenv(
         "OPTIMIZATION_DISABLE_WEATHER_REGULATION", "false"
     ).lower() in ("true", "1", "yes")

--- a/src/db.py
+++ b/src/db.py
@@ -4086,6 +4086,10 @@ def measured_space_heating_kwh_excluding_offset_windows(
         daily = get_daikin_consumption_daily_range(start_date, end_date)
         return float(sum(r.get("kwh_heating") or 0.0 for r in daily))
 
+    # Thermal-lag tail: HEM-induced heat bleeds into the 2-h bucket(s) AFTER an
+    # offset window closes (the live June self-loop counted those as natural
+    # demand and latched the gate open). Exclude this many trailing buckets too.
+    tail_buckets = max(0, int(getattr(config, "DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS", 1)))
     excluded: set[tuple[str, int]] = set()
     for s_iso, e_iso in get_nonzero_lwt_offset_windows(start_date, end_date):
         try:
@@ -4093,9 +4097,10 @@ def measured_space_heating_kwh_excluding_offset_windows(
             e = datetime.fromisoformat(e_iso.replace("Z", "+00:00")).astimezone(tz)
         except (ValueError, TypeError):
             continue
+        e_padded = e + timedelta(hours=2 * tail_buckets)
         cur = s.replace(minute=0, second=0, microsecond=0)
         cur = cur.replace(hour=(cur.hour // 2) * 2)
-        while cur < e:
+        while cur < e_padded:
             excluded.add((cur.date().isoformat(), cur.hour // 2))
             cur += timedelta(hours=2)
 

--- a/src/scheduler/lp_dispatch.py
+++ b/src/scheduler/lp_dispatch.py
@@ -309,16 +309,23 @@ def _preheat_lwt_offset(
     temperature in cheap slots (pre-heat the house, store heat in the thermal
     mass) and set it back in peak slots (coast). Returns:
 
-    * ``None`` when the feature is disabled, or when ``outdoor_c`` is at/above
-      ``DAIKIN_WEATHER_CURVE_HIGH_C`` — the firmware won't be running the
-      compressor, so we emit nothing and stay climate-hands-off on warm days
-      (which also keeps the Daikin daily quota untouched).
+    * ``None`` when the feature is disabled.
     * an ``int`` offset otherwise: ``+BOOST`` (price ≤ cheap tier),
       ``PEAK_SETBACK`` (price ≥ peak tier), else ``0`` (neutral — let the
       firmware's natural weather curve run).
 
     The offset is the only thing HEM writes; the firmware curve still decides
     *when* to heat — we only nudge the water temperature when it already is.
+
+    **Outdoor cutoff (Tracked by #540):** ``outdoor_c`` (the micro-climate-
+    calibrated forecast temperature for the slot) gates the POSITIVE offsets
+    only. At/above ``DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C`` a heat-pump house
+    needs little/no space heat, so a positive offset would only WAKE the
+    compressor for nothing (the June-2026 phantom-heating self-loop). This is
+    an EXOGENOUS gate the measured-demand gate's own output cannot fool. The
+    NEGATIVE peak setback is NEVER cut — it can only let the unit coast, never
+    wake it. (PR #496 had removed the old blunt cutoff because it also killed
+    the setback mid-paid-window; this version cuts positives only.)
 
     ``indoor_c`` is a forward-looking hook for a future room sensor. While no
     sensor exists it is ``None`` and the comfort guard is a no-op. Once wired,
@@ -327,32 +334,29 @@ def _preheat_lwt_offset(
     """
     if not config.DAIKIN_LWT_PREHEAT_ENABLED:
         return None
-    # No outdoor cutoff: the Daikin firmware applies the offset relative to its
-    # OWN weather curve and decides whether to run the compressor, so emitting
-    # the offset when it's mild doesn't force pointless heating — the firmware
-    # ignores it above its own heating ambient threshold. We just set the offset;
-    # the unit owns the on/off. (Was previously gated at DAIKIN_WEATHER_CURVE_
-    # HIGH_C, which cut the offset mid-paid-window — the user's call to remove.)
 
     boost = int(config.DAIKIN_LWT_PREHEAT_BOOST_C)
     neg_boost = int(getattr(config, "DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", boost))
     setback = int(config.DAIKIN_LWT_PREHEAT_PEAK_SETBACK_C)
     band = float(config.DAIKIN_LWT_PREHEAT_COMFORT_BAND_C)
     setpoint = float(config.INDOOR_SETPOINT_C)
+    # Exogenous outdoor cutoff — suppresses POSITIVE offsets only (see docstring).
+    # A non-finite temp (sensor/forecast glitch) fails SAFE → suppress, since the
+    # cutoff IS the anti-phantom-heat guard; a transient self-corrects next plan.
+    cutoff = float(getattr(config, "DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C", 15.0))
+    too_warm_for_heat = (not math.isfinite(outdoor_c)) or outdoor_c >= cutoff
 
     if price_p < 0:
         # PAID to import — push space heating to the TOP of the operating range
         # (clamped below) to bank the most thermal mass while we're paid for it,
-        # not the modest cheap-slot nudge. The old outdoor-temp cutoff was
-        # removed; what keeps this from firing on a non-heating house is the
-        # measured DEMAND GATE in _write_lwt_preheat_actions (#540 — a
-        # positive offset can WAKE the compressor, June 2026).
-        off = neg_boost
+        # not the modest cheap-slot nudge. Suppressed when it's warm enough that
+        # the compressor would only wake to waste it (#540 phantom-heat guard).
+        off = 0 if too_warm_for_heat else neg_boost
         # Comfort guard (sensor-ready): don't over-heat an already-warm room.
         if indoor_c is not None and indoor_c >= setpoint + band:
             off = 0
     elif price_p <= cheap_thr:
-        off = boost
+        off = 0 if too_warm_for_heat else boost
         # Comfort guard (sensor-ready): don't pre-heat an already-warm room.
         if indoor_c is not None and indoor_c >= setpoint + band:
             off = 0
@@ -456,8 +460,14 @@ def _lwt_preheat_pairs(
     for i in range(n):
         mid = plan.slot_starts_utc[i] + timedelta(minutes=15)
         fc = get_forecast_for_slot(mid, forecast)
-        outdoor = fc.temperature_c if fc else (
-            plan.temp_outdoor_c[i] if i < len(plan.temp_outdoor_c) else 0.0
+        # Prefer the LP's micro-climate-CALIBRATED outdoor temp (what the house
+        # feels) over the raw Open-Meteo forecast — the outdoor cutoff in
+        # _preheat_lwt_offset is evaluated against this. Fall back to the raw
+        # forecast, then 0.0. (The price tiers are price-based, so this choice
+        # only affects the cutoff comparison, never the boost/setback tiering.)
+        outdoor = (
+            plan.temp_outdoor_c[i] if i < len(plan.temp_outdoor_c)
+            else (fc.temperature_c if fc else 0.0)
         )
         price = plan.price_pence[i] if i < len(plan.price_pence) else 0.0
         offsets.append(_preheat_lwt_offset(
@@ -969,6 +979,20 @@ def space_heating_gate_state() -> dict[str, Any]:
         logger.debug("space_heating_gate_state: measured read failed", exc_info=True)
     demand_present = _space_heating_demand_present()
     preheat_enabled = bool(getattr(config, "DAIKIN_LWT_PREHEAT_ENABLED", False))
+
+    # Exogenous outdoor cutoff (#540): the chip should explain a warm-day
+    # suppression even when the (possibly self-fed) demand gate is open. Read
+    # the freshest live outdoor temp; None when telemetry is absent.
+    cutoff = float(getattr(config, "DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C", 15.0))
+    current_outdoor: float | None = None
+    try:
+        tel = db.get_latest_daikin_telemetry(source="live")
+        if tel and tel.get("outdoor_temp_c") is not None:
+            current_outdoor = round(float(tel["outdoor_temp_c"]), 1)
+    except Exception:  # pragma: no cover - status read must not fail
+        logger.debug("space_heating_gate_state: outdoor telemetry read failed", exc_info=True)
+    suppressed_by_outdoor = current_outdoor is not None and current_outdoor >= cutoff
+
     return {
         "preheat_enabled": preheat_enabled,
         "gate_enabled": floor > 0,
@@ -976,7 +1000,15 @@ def space_heating_gate_state() -> dict[str, Any]:
         "measured_window_kwh": measured,
         "threshold_kwh": floor,
         "lookback_hours": lookback,
-        # The one-line story the chip renders:
+        "outdoor_cutoff_c": cutoff,
+        "current_outdoor_c": current_outdoor,
+        # Positive offsets (boost / neg-boost) are cut when warm REGARDLESS of
+        # the demand gate; the −2 peak setback still fires (it can only coast).
+        "positive_offset_suppressed_by_outdoor": suppressed_by_outdoor,
+        # Demand-gate verdict: when shut, _write_lwt_preheat_actions writes NO
+        # rows at all (setback included). Kept scoped to the demand gate so the
+        # chip can distinguish "all LWT off" (this) from "positives off, setback
+        # still active" (positive_offset_suppressed_by_outdoor) on a warm day.
         "preheat_suppressed": preheat_enabled and floor > 0 and not demand_present,
     }
 

--- a/tests/test_lwt_demand_gate.py
+++ b/tests/test_lwt_demand_gate.py
@@ -219,3 +219,147 @@ def test_daily_fallback_clean_data_still_counts():
         date=y.date().isoformat(), kwh_total=6.0, kwh_heating=6.0, source="onecta",
     )
     assert db.measured_space_heating_kwh_excluding_offset_windows(48) == pytest.approx(6.0)
+
+
+# ---------------------------------------------------------------------------
+# Outdoor cutoff on POSITIVE offsets (Tracked by #540) — the exogenous gate
+# the measured-demand self-loop cannot fool (June-2026 phantom heating).
+# ---------------------------------------------------------------------------
+
+_THR = dict(cheap_thr=8.0, peak_thr=30.0)
+
+
+@pytest.fixture
+def _preheat_cfg(monkeypatch):
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_ENABLED", True, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_BOOST_C", 3, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_NEGATIVE_BOOST_C", 10, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_PEAK_SETBACK_C", -2, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_COMFORT_BAND_C", 1.0, raising=False)
+    monkeypatch.setattr(app_config, "OPTIMIZATION_LWT_OFFSET_MIN", -10, raising=False)
+    monkeypatch.setattr(app_config, "OPTIMIZATION_LWT_OFFSET_MAX", 10, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C", 15.0, raising=False)
+
+
+def test_positive_boost_suppressed_when_warm(_preheat_cfg):
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(2.0, 19.0, **_THR) == 0
+
+
+def test_positive_boost_allowed_when_cold(_preheat_cfg):
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(2.0, 5.0, **_THR) == 3
+
+
+def test_negprice_boost_suppressed_when_warm(_preheat_cfg):
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(-2.0, 19.0, **_THR) == 0
+
+
+def test_negprice_boost_allowed_when_cold(_preheat_cfg):
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(-2.0, 2.0, **_THR) == 10
+
+
+def test_peak_setback_allowed_when_warm(_preheat_cfg):
+    """The −2 setback can only let the unit coast — never cut by the cutoff."""
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(35.0, 25.0, **_THR) == -2
+
+
+def test_peak_setback_allowed_when_cold(_preheat_cfg):
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(35.0, 0.0, **_THR) == -2
+
+
+def test_cutoff_boundary_is_inclusive(_preheat_cfg):
+    """outdoor == cutoff suppresses (>=)."""
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(2.0, 15.0, **_THR) == 0
+
+
+def test_cutoff_disabled_high_value(_preheat_cfg, monkeypatch):
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C", 99.0, raising=False)
+    from src.scheduler.lp_dispatch import _preheat_lwt_offset as f
+    assert f(2.0, 30.0, **_THR) == 3
+
+
+def test_pairs_no_positive_window_when_warm(_preheat_cfg, monkeypatch):
+    """Integration: a warm forecast yields NO positive lwt_preheat windows even
+    when prices are cheap — closes the self-loop at the source."""
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_MIN_BLOCK_SLOTS", 4, raising=False)
+    from src.scheduler import lp_dispatch
+    from src.scheduler.lp_optimizer import LpPlan
+    starts = [datetime(2026, 6, 12, 9, tzinfo=UTC) + i * timedelta(minutes=30) for i in range(6)]
+    warm = LpPlan(
+        ok=True, status="Optimal", objective_pence=0.0, slot_starts_utc=starts,
+        price_pence=[2.0] * 6, temp_outdoor_c=[19.0] * 6,
+        cheap_threshold_pence=8.0, peak_threshold_pence=30.0,
+    )
+    assert lp_dispatch._lwt_preheat_pairs(warm, []) == []
+    cold = LpPlan(
+        ok=True, status="Optimal", objective_pence=0.0, slot_starts_utc=starts,
+        price_pence=[2.0] * 6, temp_outdoor_c=[4.0] * 6,
+        cheap_threshold_pence=8.0, peak_threshold_pence=30.0,
+    )
+    assert len(lp_dispatch._lwt_preheat_pairs(cold, [])) == 1  # one boost window
+
+
+# ---------------------------------------------------------------------------
+# Thermal-lag tail exclusion in the decontamination
+# ---------------------------------------------------------------------------
+
+def test_decontam_excludes_tail_bucket(monkeypatch):
+    """Heat bleeding into the bucket AFTER an offset window closes must not
+    count as natural demand (default tail = 1 bucket)."""
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS", 1, raising=False)
+    from src import db
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 5, 1.5)          # 10-12 local — just after window
+    _seed_offset_action(y.replace(hour=8), 2.0, 3)  # window 08-10 (bucket 4)
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == 0.0
+
+
+def test_decontam_tail_zero_keeps_old_behaviour(monkeypatch):
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS", 0, raising=False)
+    from src import db
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 5, 1.5)
+    _seed_offset_action(y.replace(hour=8), 2.0, 3)
+    assert db.measured_space_heating_kwh_excluding_offset_windows(48) == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# space_heating_gate_state surfaces the outdoor cutoff
+# ---------------------------------------------------------------------------
+
+def test_gate_state_reports_outdoor_cutoff(monkeypatch):
+    """Demand gate OPEN (natural heat seeded) but warm outside → POSITIVE offsets
+    are flagged suppressed-by-outdoor, while preheat_suppressed stays scoped to
+    the demand gate (the −2 setback still fires, so it is NOT 'all off')."""
+    from src import db
+    from src.scheduler import lp_dispatch
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_ENABLED", True, raising=False)
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C", 15.0, raising=False)
+    y = _yesterday_local()
+    _seed_2h(y.date().isoformat(), 4, 1.5)  # natural demand → demand gate open
+    monkeypatch.setattr(db, "get_latest_daikin_telemetry", lambda *, source=None: {"outdoor_temp_c": 19.0})
+    st = lp_dispatch.space_heating_gate_state()
+    assert st["demand_present"] is True
+    assert st["outdoor_cutoff_c"] == 15.0
+    assert st["current_outdoor_c"] == 19.0
+    assert st["positive_offset_suppressed_by_outdoor"] is True
+    # Demand gate is OPEN → not "all off"; the setback still fires.
+    assert st["preheat_suppressed"] is False
+
+
+def test_gate_state_preheat_suppressed_when_demand_absent(monkeypatch):
+    """No measured demand → preheat_suppressed True (the demand gate shuts ALL
+    offset rows, setback included)."""
+    from src import db
+    from src.scheduler import lp_dispatch
+    monkeypatch.setattr(app_config, "DAIKIN_LWT_PREHEAT_ENABLED", True, raising=False)
+    monkeypatch.setattr(db, "get_latest_daikin_telemetry", lambda *, source=None: {"outdoor_temp_c": 5.0})
+    st = lp_dispatch.space_heating_gate_state()
+    assert st["demand_present"] is False
+    assert st["preheat_suppressed"] is True

--- a/tests/test_lwt_preheat.py
+++ b/tests/test_lwt_preheat.py
@@ -2,10 +2,15 @@
 
 Open-loop price-tier offset: boost the leaving-water temperature in cheap
 slots, set it back in peak slots, neutral otherwise. Offset is an INTEGER in
-the device range, only emitted while the firmware is plausibly heating
-(outdoor < curve high anchor), and clamped so we can never exceed the Daikin
-quota at the dispatch boundary. A sensor-ready comfort hook is wired but
-no-op until a room sensor exists.
+the device range, clamped so we can never exceed the Daikin quota at the
+dispatch boundary. A sensor-ready comfort hook is wired but no-op until a
+room sensor exists.
+
+POSITIVE offsets are gated by an outdoor-temperature cutoff
+(``DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C``, Tracked by #540): above it the house
+needs no space heat, so a positive offset would only wake the compressor for
+nothing (the June-2026 phantom-heating self-loop). The NEGATIVE peak setback
+is never cut — it can only let the unit coast.
 """
 from __future__ import annotations
 
@@ -57,8 +62,8 @@ def test_smooth_preserves_none():
 # Tiers used throughout: cheap ≤ 12, peak ≥ 25 (the prod defaults).
 CHEAP = 12.0
 PEAK = 25.0
-COLD = 5.0   # outdoor < DAIKIN_WEATHER_CURVE_HIGH_C (18) → heating active
-WARM = 20.0  # outdoor ≥ 18 → firmware idle
+COLD = 5.0   # outdoor < DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C (15) → positives allowed
+WARM = 20.0  # outdoor ≥ 15 → positive offsets suppressed (setback still allowed)
 
 
 @pytest.fixture
@@ -71,6 +76,7 @@ def enabled(monkeypatch):
     monkeypatch.setattr(config, "OPTIMIZATION_LWT_OFFSET_MIN", -10.0)
     monkeypatch.setattr(config, "OPTIMIZATION_LWT_OFFSET_MAX", 5.0)
     monkeypatch.setattr(config, "DAIKIN_WEATHER_CURVE_HIGH_C", 18.0)
+    monkeypatch.setattr(config, "DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C", 15.0)
     monkeypatch.setattr(config, "INDOOR_SETPOINT_C", 21.0)
     # Disable thermal-coherence smoothing for the per-slot windowing tests so a
     # short test sequence isn't collapsed; smoothing is exercised separately.
@@ -89,11 +95,12 @@ def test_disabled_returns_none(monkeypatch):
     assert _off(5.0, COLD) is None
 
 
-def test_warm_day_still_emits_offset(enabled):
-    # No outdoor cutoff: the offset is emitted regardless of outdoor temp; the
-    # Daikin firmware (its own weather curve) decides whether to actually heat.
-    assert _off(5.0, WARM) == 3       # cheap → +3 (firmware ignores if too warm)
-    assert _off(30.0, WARM) == -2     # peak → setback
+def test_warm_day_suppresses_boost_keeps_setback(enabled):
+    # Outdoor cutoff (#540): a cheap+warm slot would only wake the compressor
+    # for nothing → suppressed to 0. The peak setback can only coast → still
+    # emitted regardless of outdoor temp.
+    assert _off(5.0, WARM) == 0        # cheap+warm → suppressed
+    assert _off(30.0, WARM) == -2      # peak → setback (never cut)
 
 
 def test_cheap_slot_boosts(enabled):
@@ -113,10 +120,10 @@ def test_negative_boost_clamped_to_offset_max(enabled, monkeypatch):
     assert _off(-3.0, COLD) == 5  # clamp at MAX=5
 
 
-def test_negative_warm_day_still_boosts(enabled):
-    # Paid window: push the offset to max regardless of outdoor temp — the
-    # firmware decides whether to heat (cutoff removed).
-    assert _off(-3.0, WARM) == 5  # fixture clamp MAX=5
+def test_negative_warm_day_suppressed(enabled):
+    # Even a PAID (negative-price) slot must not boost when it's warm — a
+    # positive offset wakes the compressor for phantom heat (#540). Suppressed.
+    assert _off(-3.0, WARM) == 0
 
 
 def test_peak_slot_sets_back(enabled):
@@ -204,13 +211,11 @@ def test_neutral_slots_emit_nothing(enabled):
     assert _lwt_preheat_pairs(plan, []) == []
 
 
-def test_warm_slots_still_emit(enabled):
-    # Cutoff removed: cheap+warm slots still emit the offset (the firmware
-    # decides whether to heat). One +3 boost window over the three slots.
+def test_warm_slots_suppress_boost(enabled):
+    # Outdoor cutoff (#540): cheap+warm slots emit NO positive window — closes
+    # the summer phantom-heat self-loop at the source.
     plan = _plan([5, 5, 5], [WARM] * 3)
-    pairs = _lwt_preheat_pairs(plan, [])
-    assert len(pairs) == 1
-    assert pairs[0][1]["params"]["lwt_offset"] == 3
+    assert _lwt_preheat_pairs(plan, []) == []
 
 
 def test_restore_returns_offset_to_zero(enabled):


### PR DESCRIPTION
## Why

The #541 demand gate proved **foolable in prod**. Active LWT pre-heat writes positive offsets by price tier (+3 cheap, +10 negative-price). In a London June with **zero real space-heating demand**, those positives *wake the compressor*: daily `kwh_heating` was `0.0` through Jun 4, then jumped to **2–8 kWh/day (~4.6 avg) from Jun 5, 2026** — exactly when active LWT was enabled. Worse, the HEM-induced heat bleeds into the 2-h bucket *just after* each offset window (e.g. 22:00–24:00 on Jun 11/12/14), gets counted as natural demand, and **latches the gate open** (`measured_window_kwh` sat at `1.0`, just over the `0.5` floor) — a low-grade self-sustaining loop the `WINTER_THERMAL_MODEL.md` warned about.

Found while investigating "why are we touching LWT if it changes nothing in summer." Answer: it wasn't dormant — it was wasting ~4.6 kWh/day for zero comfort.

## What

1. **Exogenous outdoor cutoff** (`DAIKIN_LWT_PREHEAT_OUTDOOR_CUTOFF_C`, default 15 °C, HDD base): suppress **POSITIVE** offsets per-slot against the micro-climate-calibrated forecast temp — a signal the self-loop *cannot fake*. The −2 peak setback is **never** cut (it can only let the unit coast, never wake it). Non-finite temp fails **safe** (suppress). `_lwt_preheat_pairs` now prefers the calibrated `plan.temp_outdoor_c`.
2. **Thermal-lag tail exclusion** (`DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS`, default 1): the demand-gate decontamination also drops the trailing bucket(s) after each offset window, so bled heat can't re-open the gate.
3. `space_heating_gate_state()` surfaces `outdoor_cutoff_c` / `current_outdoor_c` / `positive_offset_suppressed_by_outdoor`; `preheat_suppressed` stays scoped to the demand gate ("all LWT off") vs the warm-day positive-only flag.

## Verification

- **Prod DB copy:** `measured_window_kwh` **1.0 → 0.0** (demand gate now reads closed), `positive_offset_suppressed_by_outdoor: true` at 20 °C, `preheat_suppressed: true`.
- Unit tests extended (`tests/test_lwt_demand_gate.py`): cutoff matrix (warm suppresses boost/neg-boost, never the setback, boundary inclusive, disable path), tail exclusion (default 1 + back-compat 0), gate-state fields. Updated the legacy #496 "warm slots still emit" tests in `tests/test_lwt_preheat.py` to the corrected behaviour.
- **Full suite green** (1715 passed, 3 skipped, 1 xfailed).

## Notes

- The −2 setback is deliberately preserved — it's harmless in summer and useful in winter peaks.
- Re-enable aggressive positive LWT actuation only once #540 lands a real thermal state that proves the saving.

Tracked by #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)