### PR TITLE
fix(ui): cockpit solar shows committed forecast, not actual-blend mislabeled as forecast

### DIFF
--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -56,8 +56,11 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, opp
     if (!slots.length) return <p class="muted">No generation data for this day yet.</p>;
     const labels = slots.map((s) => localHM(s.slot_utc));
     const nowIdx = nowIndexOf(slots, pv?.now_utc);
-    const solarPlan = slots.map((s, i) =>
-      nowIdx >= 0 && i > nowIdx ? round2(s.pv_forecast_kwh) : round2(s.pv_planned_kwh ?? s.pv_forecast_kwh));
+    // "Solar plan" = the COMMITTED LP forecast across the WHOLE day (frozen at
+    // solve time), not the live forward forecast for future slots — otherwise
+    // the dashed "plan" line silently became the weather model's latest revision
+    // past `now`. Fall back to the live forecast only where uncommitted.
+    const solarPlan = slots.map((s) => round2(s.pv_planned_kwh ?? s.pv_forecast_kwh));
     const solarActual = slots.map((s) => (s.pv_actual_kwh == null ? null : round2(s.pv_actual_kwh)));
     // Grid export realised, aligned to the pv axis by slot_utc.
     const expBy = new Map<string, number>();
@@ -84,11 +87,10 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, opp
       { name: "Export", color: t.exportColor, data: exportActual, width: 1.75 },
       ...(onSeg ? [{ name: "Outgoing Agile", color: t.warn, data: agileExportPrice, dashed: true, isPrice: true } as TimelineLine] : []),
     ];
-    const nowMs = pv?.now_utc ? new Date(pv.now_utc).getTime() : Date.now();
-    const genTotal = slots.reduce((sum, s) => {
-      const elapsed = new Date(s.slot_utc).getTime() + 30 * 60_000 <= nowMs;
-      return sum + ((elapsed ? (s.pv_actual_kwh ?? s.pv_forecast_kwh) : s.pv_forecast_kwh) ?? 0);
-    }, 0);
+    // "expected today" = the COMMITTED full-day forecast (pv_planned_kwh),
+    // matching the label — not actual(past)+forecast(future), which converges to
+    // the day's actual by evening and so stops being an "expectation".
+    const genTotal = slots.reduce((sum, s) => sum + ((s.pv_planned_kwh ?? s.pv_forecast_kwh) ?? 0), 0);
     const exportedTotal = grid?.totals?.export_actual_kwh ?? 0;
     return (
       <div class="tlw">

--- a/ui/src/components/home/Hero.tsx
+++ b/ui/src/components/home/Hero.tsx
@@ -183,15 +183,18 @@ function HeroWeather({ weather, pv }: { weather?: WeatherResponse | null; pv?: P
   const markPct = hi != null && lo != null && hi > lo
     ? Math.max(6, Math.min(94, ((outdoor - lo) / (hi - lo)) * 100)) : 50;
 
-  // Solar today: generated so far (actual) toward the DAY total (locked actuals
-  // for elapsed slots + forecast for the rest). Using the day total — not the
-  // forward-only forecast — so it stays meaningful in the evening (forecast → 0).
+  // Solar today: generated so far (actual) vs the day-ahead FORECAST. The total
+  // is the COMMITTED full-day forecast (pv_planned_kwh, frozen at solve time) —
+  // not a blend of actual(past)+live-forward-forecast(future), which collapses
+  // to the actual total in the evening (showing a meaningless 18.3/18.3, always
+  // 100%) and hides the real forecast. pv_planned is full-day so it stays
+  // meaningful all evening; fall back to the live forecast where uncommitted.
   const pvNowMs = pv?.now_utc ? new Date(pv.now_utc).getTime() : nowMs;
   const slots = pv?.slots ?? [];
   const elapsedOf = (s: { slot_utc: string }) => new Date(s.slot_utc).getTime() + 30 * 60_000 <= pvNowMs;
   const solarDone = slots.reduce((a, s) => a + (s.pv_actual_kwh ?? 0), 0);
   const solarTotal = slots.length
-    ? slots.reduce((a, s) => a + ((elapsedOf(s) ? (s.pv_actual_kwh ?? s.pv_forecast_kwh) : s.pv_forecast_kwh) ?? 0), 0)
+    ? slots.reduce((a, s) => a + ((s.pv_planned_kwh ?? s.pv_forecast_kwh) ?? 0), 0)
     : (pv?.forecast_kwh_day_total ?? 0);
   const solarToGo = slots.reduce((a, s) => (!elapsedOf(s) ? a + (s.pv_forecast_kwh ?? 0) : a), 0);
   const solarPct = solarTotal > 0 ? Math.min(100, Math.round((solarDone / solarTotal) * 100)) : 0;


### PR DESCRIPTION
## Why

The user noticed the hero showed **"18.3 / 18.3 kWh forecast"** for solar and felt it was "too perfect." It is — the displayed *forecast* number isn't a forecast.

The hero and GenerationWidget computed the "forecast/plan/expected" total as a **blend of actual(past) + live-forward forecast(future)**. That blend collapses to the day's actual total by evening (so "18.3 / 18.3", always 100% generated), and the live forward-only forecast is `0` for elapsed slots so it can't carry the past. The real day-ahead forecast (`pv_planned_kwh`, frozen at LP solve time — the same number the `/pv/today` `accuracy` block uses) was **ignored**.

Verified on prod `/pv/today`: actual **18.33** vs committed forecast **18.53** (~1% miss, bias −0.2) — honest and close, but *not* identical. The cockpit was hiding the real comparison.

## What

Use the **committed full-day forecast** (`pv_planned_kwh`) as the forecast/plan/expected total, live forecast as a per-slot fallback where uncommitted:
- **Hero** solar progress total → committed forecast → now `18.3 / 18.5 kWh forecast` (a true % of forecast; stays meaningful all evening since `pv_planned` is full-day, unlike the forward-only live forecast that zeroes out).
- **GenerationWidget** dashed *"Solar plan"* line → committed plan across the **whole** day (was silently the live weather revision past `now`).
- **GenerationWidget** *"expected today"* total → committed forecast (matches the label).

## Scope / verification

- UI-only (cockpit), separate image. `tsc -b --noEmit` clean.
- The rest of the cockpit audited OK: `TodayPlanWidget` (already distinguishes committed/live/actual), `PowerFlow`/`LivePowerWidget`/`HeatingWidget` (live metered), `ApplianceWidget` (labels scheduled vs window). Insights numbers audited honest (load-accuracy committed-vs-metered, tariff single-sourced #573).

Tracked by #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)