### PR TITLE
fix(insights): decontaminate residual/heat-pump load profile of HEM LWT phantom heat

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -847,6 +847,17 @@ class Config:
     LP_LOAD_EXCLUDE_NEGATIVE_SLOTS: bool = os.getenv(
         "LP_LOAD_EXCLUDE_NEGATIVE_SLOTS", "true"
     ).lower() in ("true", "1", "yes")
+    # Drop half-hour slots inside a HEM nonzero LWT-offset window (+ the
+    # thermal-lag tail) from the residual load-profile sample (Tracked by #540).
+    # A positive LWT offset can WAKE the compressor (the June-2026 phantom-heat
+    # self-loop) — that heat is HEM-induced, not the household's organic load,
+    # so learning the residual / heat-pump heatmaps from it pollutes them (and
+    # the Insights Heating heatmap). Same rationale as the negative-slot drop
+    # above. Tail length reuses DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS. Set
+    # false to roll back to the old behaviour (include them).
+    LP_LOAD_EXCLUDE_LWT_OFFSET_SLOTS: bool = os.getenv(
+        "LP_LOAD_EXCLUDE_LWT_OFFSET_SLOTS", "true"
+    ).lower() in ("true", "1", "yes")
     LP_PEAK_EXPORT_PESSIMISTIC_FLOOR_KWH: float = float(
         os.getenv("LP_PEAK_EXPORT_PESSIMISTIC_FLOOR_KWH", "0.30")
     )

--- a/src/db.py
+++ b/src/db.py
@@ -2042,6 +2042,10 @@ def residual_load_profile_v2(
     # plunge happened to land on. Drop them from the sample. Kill-switch via
     # LP_LOAD_EXCLUDE_NEGATIVE_SLOTS=false.
     exclude_neg = bool(getattr(config, "LP_LOAD_EXCLUDE_NEGATIVE_SLOTS", True))
+    # Drop HEM-commanded LWT-offset windows (+ thermal-lag tail) too — a positive
+    # offset wakes the compressor (June phantom-heat self-loop), so that heat is
+    # HEM-induced, not organic load. Same treatment as the negative-price boost.
+    exclude_lwt = bool(getattr(config, "LP_LOAD_EXCLUDE_LWT_OFFSET_SLOTS", True))
 
     # Short-TTL cache — this 120-day rebuild runs the physics estimator over
     # ~thousands of pv samples and is called multiple times per optimizer solve
@@ -2049,7 +2053,7 @@ def residual_load_profile_v2(
     # as new telemetry / the nightly Daikin sync land, so a 4-min TTL is safe and
     # collapses the per-solve cost to one rebuild. Keyed by DB_PATH so isolated
     # test DBs never share an entry.
-    cache_key = (config.DB_PATH, window_days, end_date, min_samples_per_bucket, _v2, exclude_neg)
+    cache_key = (config.DB_PATH, window_days, end_date, min_samples_per_bucket, _v2, exclude_neg, exclude_lwt)
     if use_cache:
         ent = _RESIDUAL_V2_CACHE.get(cache_key)
         if ent is not None and ent[0] > time.monotonic():
@@ -2128,6 +2132,26 @@ def residual_load_profile_v2(
         finally:
             conn.close()
 
+    # HEM LWT-offset windows over the same span (Tracked by #540). Built OUTSIDE
+    # the lock above — get_nonzero_lwt_offset_windows takes _lock itself. Expand
+    # each window [start, end + thermal-lag tail) into half-hour UTC slot keys so
+    # Pass 1 can drop the HEM-induced (phantom) heating the same way it drops the
+    # negative-price boost. The tail mirrors the demand-gate decontamination.
+    lwt_offset_slots: set[str] = set()
+    if exclude_lwt:
+        tail_h = 2 * max(0, int(getattr(config, "DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS", 1)))
+        for s_iso, e_iso in get_nonzero_lwt_offset_windows(cutoff_iso[:10], anchor_utc.date().isoformat()):
+            try:
+                s_w = datetime.fromisoformat(s_iso.replace("Z", "+00:00")).astimezone(UTC)
+                e_w = (datetime.fromisoformat(e_iso.replace("Z", "+00:00")).astimezone(UTC)
+                       + timedelta(hours=tail_h))
+            except (ValueError, TypeError):
+                continue
+            cur_t = s_w.replace(minute=(s_w.minute // 30) * 30, second=0, microsecond=0)
+            while cur_t < e_w:
+                lwt_offset_slots.add(cur_t.isoformat().replace("+00:00", "Z"))
+                cur_t += timedelta(minutes=30)
+
     # Pass 1 — parse, compute the pure-physics Daikin estimate per sample, and
     # accumulate physics totals per (local_date, 2h-bucket) for calibration.
     from datetime import datetime as _dt
@@ -2136,6 +2160,7 @@ def residual_load_profile_v2(
     physics_day: dict[str, float] = {}
     dropped_no_meteo = 0
     dropped_negative = 0
+    dropped_lwt_offset = 0
     for row in rows:
         outdoor = row["outdoor_history_c"]
         if outdoor is None:
@@ -2148,12 +2173,15 @@ def residual_load_profile_v2(
             local = ts.astimezone(tz)
         except (ValueError, TypeError):
             continue
-        if exclude_neg and neg_slots:
+        if (exclude_neg and neg_slots) or lwt_offset_slots:
             sm = (ts.minute // 30) * 30
             skey = (ts.replace(minute=sm, second=0, microsecond=0)
                     .astimezone(UTC).isoformat().replace("+00:00", "Z"))
-            if skey in neg_slots:
+            if exclude_neg and skey in neg_slots:
                 dropped_negative += 1
+                continue
+            if skey in lwt_offset_slots:
+                dropped_lwt_offset += 1
                 continue
         load_slot = float(row["load_power_kw"]) * 0.5
         physics_slot = _physics_daikin_slot_kwh(float(outdoor), cop_curve)
@@ -2172,7 +2200,8 @@ def residual_load_profile_v2(
             "hp_profile": {}, "hp_dhw_profile": {}, "hp_space_profile": {},
             "spread": {}, "flat": flat, "away_days": [],
             "day_counts": {"weekday": 0, "weekend": 0, "away_excluded": 0,
-                           "negative_excluded": dropped_negative, "total": 0},
+                           "negative_excluded": dropped_negative,
+                           "lwt_offset_excluded": dropped_lwt_offset, "total": 0},
             "calibrated_days": 0, "physics_only_days": 0,
         })
 
@@ -2371,6 +2400,7 @@ def residual_load_profile_v2(
             "weekend": len(weekend_days),
             "away_excluded": len(away_days),
             "negative_excluded": dropped_negative,
+            "lwt_offset_excluded": dropped_lwt_offset,
             "total": len(set(dates)),
         },
         "calibrated_days": calibrated_days,

--- a/tests/test_db_residual_profile_v2.py
+++ b/tests/test_db_residual_profile_v2.py
@@ -178,6 +178,54 @@ def test_negative_price_slots_kept_when_killswitch_off(monkeypatch) -> None:
     assert prof["profile"][(1, 2, 0)] == pytest.approx(1.5, abs=0.1)
 
 
+def _seed_lwt_offset(d: date, hour: int, hours: float, offset: int = 3) -> None:
+    """Seed a nonzero HEM lwt_preheat offset window starting LOCAL (hour:00) on d."""
+    start_utc = datetime(d.year, d.month, d.day, hour, 0, tzinfo=LON).astimezone(UTC)
+    db.upsert_action(
+        plan_date=d.isoformat(),
+        start_time=start_utc.isoformat().replace("+00:00", "Z"),
+        end_time=(start_utc + timedelta(hours=hours)).isoformat().replace("+00:00", "Z"),
+        device="daikin", action_type="lwt_preheat",
+        params={"lwt_offset": offset, "lp_optimizer": True}, status="completed",
+    )
+
+
+def test_lwt_offset_slots_excluded_by_default() -> None:
+    """A positive LWT offset wakes the compressor (June phantom-heat self-loop);
+    that HEM-induced load must be dropped so the learned profile / heat-pump
+    heatmaps reflect organic demand, not HEM's own echo (Tracked by #540)."""
+    tues = _recent_days_of_weekday(1, 6)
+    for d in tues:
+        # 14:00 inside a HEM offset window — phantom-boosted load → excluded.
+        _seed_local(d, 14, 0, load_kw=3.0)
+        _seed_lwt_offset(d, 14, 1.0, offset=3)   # 14:00–15:00 window (+ tail)
+        # 19:00 organic evening, no offset, beyond the tail → retained.
+        _seed_local(d, 19, 0, load_kw=0.6)
+
+    prof = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    assert prof["day_counts"]["lwt_offset_excluded"] >= 6
+    # The boosted offset-window bucket is gone → lookup falls well below 1.5 kWh.
+    assert db.lookup_residual_kwh(prof, 1, 14, 0) < 1.0
+    # The organic bucket survives untouched.
+    assert prof["profile"][(1, 19, 0)] == pytest.approx(0.3, abs=0.1)
+
+
+def test_lwt_offset_slots_kept_when_killswitch_off(monkeypatch) -> None:
+    """LP_LOAD_EXCLUDE_LWT_OFFSET_SLOTS=false → legacy behaviour (slots retained)."""
+    from src.config import config as cfg
+    monkeypatch.setattr(cfg, "LP_LOAD_EXCLUDE_LWT_OFFSET_SLOTS", False, raising=False)
+
+    tues = _recent_days_of_weekday(1, 6)
+    for d in tues:
+        _seed_local(d, 14, 0, load_kw=3.0)
+        _seed_lwt_offset(d, 14, 1.0, offset=3)
+
+    prof = db.residual_load_profile_v2(window_days=120, use_cache=False)
+    assert prof["day_counts"]["lwt_offset_excluded"] == 0
+    # Boosted offset-window slots retained → bucket median = 3.0 kW × 0.5 h = 1.5 kWh.
+    assert prof["profile"][(1, 14, 0)] == pytest.approx(1.5, abs=0.1)
+
+
 def test_fallback_hierarchy_and_min_samples() -> None:
     """A (dow,h,m) bucket below min_samples is dropped; lookup falls to (h,m).
     Every (h,m) leaf is always present."""


### PR DESCRIPTION
## Why

While auditing the cockpit/Insights data (the solar-hero "too perfect" thread), I checked whether the June LWT phantom heating polluted the Insights load heatmaps. It does.

`residual_load_profile_v2` powers the LP base-load forecast **and** the Insights **"Home"**, **"Tank (DHW)"** and **"Heating (Space)"** heatmaps. It learns from raw measured Fox load + the measured Onecta heating/DHW split — which **includes** the phantom space-heating the active LWT offsets created (a positive offset wakes the compressor; daily `kwh_heating` went `0 → ~4.6 kWh/day` from Jun 5 until PR #583). That consumption is HEM-induced, not the household's organic load.

Measured on a **prod DB copy**: the `hp_space` heatmap total was inflated **~17%** (9.59 → 7.96 kWh) and the residual ~1.7%. (My first read guessed the physics estimator would gate it all out — empirically the 5× calibration cap let a meaningful chunk through, so the fix is warranted.)

## What

Drop half-hour samples inside a HEM nonzero LWT-offset window (+ the thermal-lag tail) from the profile — **exactly the existing negative-price-slot drop pattern**, reusing `get_nonzero_lwt_offset_windows` and `DAIKIN_LWT_PREHEAT_DECONTAM_TAIL_BUCKETS`.

- New kill-switch `LP_LOAD_EXCLUDE_LWT_OFFSET_SLOTS` (default `true`).
- Surfaced as `day_counts.lwt_offset_excluded`.
- **General**, not June-specific: any future offset-window contamination is excluded too.

## Verification

- Prod DB copy: **2745** contaminated samples dropped over the window, `hp_space` 9.59 → 7.96, **no days lost** (31 retained), profile stays healthy.
- Tests mirror the negative-slot pair (`test_lwt_offset_slots_excluded_by_default` + killswitch-off). Load/residual suite green (46 passed).

Pairs with #583 (stops new phantom heat) and #584 (cockpit forecast display). Tracked by #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)