### PR TITLE
fix(ui): coordinate Insights loading on navigation + local-date drill-down

### DIFF
--- a/tests/test_lwt_demand_gate.py
+++ b/tests/test_lwt_demand_gate.py
@@ -132,7 +132,11 @@ def test_k_regression_skips_hem_offset_days(monkeypatch):
     from src import db
 
     # Seed 10 days of heating + meteo coverage; mark 3 as offset days.
-    today = datetime.now(TZ).date()
+    # Anchor to the SAME date basis the function uses (compute_daikin_lwt_kw_
+    # calibration windows off date.today(), system-local) — not Europe/London —
+    # else at the UTC↔BST day boundary the most-recent offset day lands a day
+    # outside the calibration window and skipped_hem_offset reads 2 not 3 (flake).
+    today = datetime.now().date()
     for back in range(1, 11):
         d = today - timedelta(days=back)
         db.upsert_daikin_consumption_daily(

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -207,7 +207,9 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
       const lbl = params?.name;
       if (!lbl) return;
       if (granularity === "week" || granularity === "month") {
-        const today = new Date().toISOString().slice(0, 10);
+        // LOCAL today — the bar labels are built from local dates, so a UTC date
+        // here failed the match in the 00:00–01:00 BST window (drill-down dead).
+        const today = localTodayISO();
         if (lbl === today) setGranularity("day");
       } else if (granularity === "year") {
         if (/^\d{4}-\d{2}$/.test(lbl)) {

--- a/ui/src/components/insights/LoadForecastAccuracyCard.tsx
+++ b/ui/src/components/insights/LoadForecastAccuracyCard.tsx
@@ -13,7 +13,7 @@ export function LoadForecastAccuracyCard({ period }: { period: PeriodState }) {
   const res = useFetch<LoadErrorLog>(
     () => getLoadErrorLog({ startDate: start, endDate: end }),
     [start, end],
-    { cacheKey: `load-err:${start}:${end}`, immutable: !isCurrentPeriod(period) },
+    { cacheKey: `load-err:${start}:${end}`, immutable: !isCurrentPeriod(period), track: true },
   );
   const data = res.data;
   const elRef = useRef<HTMLDivElement | null>(null);
@@ -80,7 +80,7 @@ export function LoadForecastAccuracyCard({ period }: { period: PeriodState }) {
 
   const o = data?.overall;
   return (
-    <section class="insights-card load-accuracy">
+    <section class={`insights-card load-accuracy${res.loading && data ? " is-updating" : ""}`}>
       <header class="load-pattern-head">
         <h2>Load forecast accuracy</h2>
         <p class="muted">

--- a/ui/src/components/insights/LoadPatternCard.tsx
+++ b/ui/src/components/insights/LoadPatternCard.tsx
@@ -32,6 +32,7 @@ export function LoadPatternCard({ period }: { period: PeriodState }) {
     {
       cacheKey: `residual:${windowDays}:${endDate ?? "live"}`,
       immutable: !!endDate && !isCurrentPeriod(period),
+      track: true,
     },
   );
   const data = res.data;
@@ -117,7 +118,7 @@ export function LoadPatternCard({ period }: { period: PeriodState }) {
 
   const dc = data?.day_counts ?? {};
   return (
-    <section class="insights-card load-pattern">
+    <section class={`insights-card load-pattern${res.loading && data ? " is-updating" : ""}`}>
       <header class="load-pattern-head">
         <div class="load-pattern-titlerow">
           <h2>When you spend the most</h2>

--- a/ui/src/components/insights/SystemHealthCard.tsx
+++ b/ui/src/components/insights/SystemHealthCard.tsx
@@ -22,6 +22,7 @@ export function SystemHealthCard({ period }: { period: PeriodState }) {
   const res = useFetch(() => getLpScorecard(day), [day], {
     cacheKey: `scorecard:${day}`,
     immutable: !isCurrentPeriod(period),
+    track: true,
   });
   const sc: LpScorecard | undefined = res.data?.scorecard;
 
@@ -50,7 +51,7 @@ export function SystemHealthCard({ period }: { period: PeriodState }) {
   const avoided = econ?.lp_avoided_cost_p;
 
   return (
-    <section class="syshealth">
+    <section class={`syshealth${res.loading && res.data ? " is-updating" : ""}`}>
       <header class="syshealth-head">
         <h2>System health</h2>
         <span class="muted">LP scorecard · {sc.day}</span>

--- a/ui/src/lib/poll.ts
+++ b/ui/src/lib/poll.ts
@@ -1,4 +1,17 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import { signal } from "@preact/signals-core";
+import { useComputed } from "@preact/signals";
+
+// Count of in-flight tracked fetches (opts.track). A page can render ONE shared
+// "updating…" affordance off this so independent per-card fetches with very
+// different latencies read as a single coordinated refresh instead of a
+// piecemeal, half-stale page (the Insights navigation jank).
+const _inflight = signal(0);
+
+/** Reactive count of tracked fetches currently in flight. */
+export function useInflight(): number {
+  return useComputed(() => _inflight.value).value;
+}
 
 // usePoll runs `fn` every `intervalMs` while the document is visible.
 // It pauses on visibilitychange → hidden and resumes on visible.
@@ -111,6 +124,9 @@ export interface FetchOpts {
   // Only cache + serve-from-cache when true (caller passes !isCurrentPeriod so
   // the live current period always refetches).
   immutable?: boolean;
+  // Count this fetch in the shared in-flight tally (useInflight) so the page can
+  // show one coordinated "updating…" cue. A cache hit never counts (no fetch).
+  track?: boolean;
 }
 
 // Fetch-once hook for endpoints we don't poll. With `opts.immutable` + a
@@ -131,6 +147,8 @@ export function useFetch<T>(
   fnRef.current = fn;
   const keyRef = useRef(cacheKey);
   keyRef.current = cacheKey;
+  const trackRef = useRef(!!opts.track);
+  trackRef.current = !!opts.track;
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -141,7 +159,8 @@ export function useFetch<T>(
   }, []);
 
   const refresh = useRef(async () => {
-    // Immutable cache hit (past period already fetched) → serve instantly.
+    // Immutable cache hit (past period already fetched) → serve instantly. No
+    // network → never counts toward the in-flight tally.
     const k = keyRef.current;
     if (k != null && _immutableCache.has(k)) {
       if (!mountedRef.current) return;
@@ -151,6 +170,8 @@ export function useFetch<T>(
       return;
     }
     setLoading(true);
+    const tracked = trackRef.current;
+    if (tracked) _inflight.value++;
     try {
       const next = await fnRef.current();
       if (!mountedRef.current) return;
@@ -161,6 +182,8 @@ export function useFetch<T>(
       if (!mountedRef.current) return;
       setError(e instanceof Error ? e : new Error(String(e)));
     } finally {
+      // Always balances the increment, even if the component unmounted mid-fetch.
+      if (tracked) _inflight.value--;
       if (mountedRef.current) setLoading(false);
     }
   }).current;

--- a/ui/src/routes/insights.css
+++ b/ui/src/routes/insights.css
@@ -212,3 +212,58 @@
 }
 .syshealth-value { font-size: 0.88rem; color: var(--text); }
 .syshealth-sub { font-size: 0.74rem; color: var(--text-dim); }
+
+/* --- Navigation loading coordination ---
+   ONE shared "updating…" strip for the whole period-scoped page (driven by the
+   in-flight fetch tally), plus a per-section dim so the independently-fetched
+   cards read as a single coordinated refresh instead of a piecemeal, half-stale
+   page. The strip reserves height always (no layout shift) and only animates +
+   shows its label when on. */
+.insights-updating {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  height: 2px;
+  margin: 0 0 0.5rem;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+.insights-updating.is-on { opacity: 1; }
+.insights-updating-bar {
+  position: relative;
+  flex: 1;
+  height: 2px;
+  border-radius: 2px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.insights-updating-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: 38%;
+  border-radius: 2px;
+  background: var(--accent);
+  animation: insights-updating-slide 1.1s ease-in-out infinite;
+}
+.insights-updating-label {
+  font-size: 0.72rem;
+  color: var(--text-mute);
+  white-space: nowrap;
+}
+@keyframes insights-updating-slide {
+  0% { left: -40%; }
+  100% { left: 100%; }
+}
+/* Stale content stays visible (no blank flash) but is dimmed + non-interactive
+   while its own fetch is in flight, so the eye knows it's refreshing. */
+.insights-compare.is-updating,
+.insights-card.is-updating,
+.syshealth.is-updating {
+  opacity: 0.5;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .insights-updating-bar::after { animation: none; left: 0; width: 100%; opacity: 0.5; }
+}

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "preact/hooks";
-import { useFetch } from "../lib/poll";
+import { useFetch, useInflight } from "../lib/poll";
 import { getFairCompare } from "../lib/endpoints";
 import { usePeriod, periodLabel, isCurrentPeriod } from "../lib/period";
 import { PeriodNavigator } from "../components/shell/PeriodNavigator";
@@ -19,10 +19,11 @@ const p2 = (p: number) => gbp(p / 100);
 // imports credit the bill). Scoped by the shared day/week/month/year navigator.
 export default function Insights() {
   const period = usePeriod();
+  const inflight = useInflight();
   const cmp = useFetch(
     () => getFairCompare(period.gran, period.anchor),
     [period.gran, period.anchor],
-    { cacheKey: `fair:${period.gran}:${period.anchor}`, immutable: !isCurrentPeriod(period) },
+    { cacheKey: `fair:${period.gran}:${period.anchor}`, immutable: !isCurrentPeriod(period), track: true },
   );
   const data = cmp.data;
   const rows = data?.tariffs ?? [];
@@ -44,6 +45,15 @@ export default function Insights() {
       </header>
 
       <PeriodNavigator variant="page" />
+
+      {/* One shared cue for the whole period-scoped page: the cards below fetch
+          independently with very different latencies (the fair-compare replay +
+          heatmap rebuild take seconds; the rest are instant), so without this
+          the page updates piecemeal and looks half-stale on navigation. */}
+      <div class={`insights-updating${inflight > 0 ? " is-on" : ""}`} role="status" aria-live="polite">
+        <span class="insights-updating-bar" />
+        <span class="insights-updating-label">Updating {periodLabel(period)}…</span>
+      </div>
 
       {/* The first compare for a period is a heavy server-side replay (can
           take seconds before the TTL cache warms). A ghost table reads as
@@ -74,7 +84,7 @@ export default function Insights() {
       )}
 
       {data && rows.length > 0 && (
-        <>
+        <div class={`insights-compare${cmp.loading ? " is-updating" : ""}`}>
           {/* Winner banner — suppressed when there's too little metered usage to
               compare meaningfully (otherwise "you're cheapest" reads trivially). */}
           {data.basis.import_kwh < 1 ? (
@@ -171,7 +181,7 @@ export default function Insights() {
             yours, priced by proxy (its per-slot rates aren't published). Export valued at each
             tariff's own rate (0 where it offers none; SVT/fixed assume a standard SEG).
           </p>
-        </>
+        </div>
       )}
 
       <LoadPatternCard period={period} />


### PR DESCRIPTION
## Why

The user reported Insights navigation still "feels weird — cards lag / flicker / don't update together." Root cause (not a data bug): the page's sections fetch **independently with very different latencies** — the fair-compare replay and the heatmap rebuild take seconds; the smaller cards are instant. `useFetch` keeps the previous period's data on refetch (good — avoids a blank flash) but with **no visual cue**, so on navigation the page silently shows a **mix of new + old-period data** and updates piecemeal.

## What

Make the refresh **visible and coordinated** — still stale-while-revalidate (no skeleton re-flash):
- **`poll.ts`**: a shared in-flight fetch tally (`opts.track` + `useInflight()` signal). A cache hit never counts. Increment before the request, decrement in `finally` (balanced even if the component unmounts mid-fetch).
- **Insights page**: ONE **"Updating &lt;period&gt;…"** progress strip driven by the tally (height always reserved → no layout shift), plus a **per-section dim** (`opacity` + `pointer-events:none`) on the fair-compare block and the 3 cards while each one's own fetch is in flight. `prefers-reduced-motion` honoured.

Also fixes a **real TZ bug** found in the same audit: the energy chart's week/month bar **drill-down** compared the bar label against a **UTC** date (`new Date().toISOString()`), so clicking "today" to drill into the day did nothing in the 00:00–01:00 BST window. Uses the local date (`localTodayISO`) the labels are built from.

## Scope / verification

- UI-only (cockpit + insights), separate image. `tsc -b --noEmit` + `vite build` clean.
- Stale-while-revalidate preserved; the immutable past-period cache path is untouched (cache hits don't flash the strip).

Follows the #578/#580/#582 navigation work.