### PR TITLE
fix(ui): auto-recover from stale lazy-chunk after a deploy

### DIFF
--- a/ui/src/components/common/WidgetBoundary.tsx
+++ b/ui/src/components/common/WidgetBoundary.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren } from "preact";
 import { Icon } from "./Icon";
 import { useErrorBoundary } from "preact/hooks";
+import { isChunkLoadError, reloadForFreshChunks } from "../../lib/chunkReload";
 import "./widget-boundary.css";
 
 interface WidgetBoundaryProps {
@@ -15,18 +16,26 @@ export function WidgetBoundary({ label, children }: WidgetBoundaryProps) {
   const [error, resetError] = useErrorBoundary();
 
   if (error) {
+    // A stale lazy-chunk (the widget's JS 404s after a deploy) can't be fixed by
+    // re-running the same dead import — a full reload pulls the fresh build.
+    const chunkStale = isChunkLoadError(error);
     return (
       <div class="widget-boundary-error" role="alert">
         <div class="widget-boundary-error-icon" aria-hidden="true"><Icon name="warn" size={18} /></div>
         <div class="widget-boundary-error-body">
           <div class="widget-boundary-error-title">
-            {label ? `${label} couldn't render` : "This widget couldn't render"}
+            {chunkStale
+              ? `${label ?? "This widget"} needs a refresh (new version deployed)`
+              : (label ? `${label} couldn't render` : "This widget couldn't render")}
           </div>
           <div class="widget-boundary-error-detail">
             {error instanceof Error ? error.message : String(error)}
           </div>
-          <button class="widget-boundary-error-retry" onClick={() => resetError()}>
-            Retry
+          <button
+            class="widget-boundary-error-retry"
+            onClick={() => { if (!chunkStale || !reloadForFreshChunks()) resetError(); }}
+          >
+            {chunkStale ? "Reload" : "Retry"}
           </button>
         </div>
       </div>

--- a/ui/src/lib/chunkReload.ts
+++ b/ui/src/lib/chunkReload.ts
@@ -1,0 +1,43 @@
+// Stale lazy-chunk recovery.
+//
+// After a UI deploy the hashed lazy-chunk filenames change (e.g.
+// HeatingPlanWidget-B1w8BjzK.js → -D2apYkIO.js). A tab opened BEFORE the deploy
+// still holds the old references, so a later lazy import 404s with "Failed to
+// fetch dynamically imported module". The in-app "Retry" can't help — it re-runs
+// the same dead URL. Recover transparently instead: on a chunk-load failure,
+// full-reload ONCE to pull the fresh index.html + new hashes.
+//
+// Guarded by a short sessionStorage cooldown so a genuinely broken deploy (the
+// new chunk also fails) can't reload-loop — after one attempt we fall through to
+// the error UI.
+
+const RELOAD_KEY = "hem:chunk-reload-at";
+const COOLDOWN_MS = 15_000;
+
+/** True when the error looks like a missing/failed dynamic-import chunk. */
+export function isChunkLoadError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /dynamically imported module|Importing a module script failed|error loading dynamically imported|Failed to fetch dynamically/i.test(msg);
+}
+
+/** Reload once to recover from a stale-chunk error. Returns false when we're
+ *  still in the cooldown (already tried recently) so the caller can show the
+ *  error UI instead of looping. */
+export function reloadForFreshChunks(): boolean {
+  let last = 0;
+  try { last = Number(sessionStorage.getItem(RELOAD_KEY) || 0); } catch { /* private mode */ }
+  if (Date.now() - last < COOLDOWN_MS) return false;
+  try { sessionStorage.setItem(RELOAD_KEY, String(Date.now())); } catch { /* ignore */ }
+  window.location.reload();
+  return true;
+}
+
+/** Wire global recovery for Vite's dynamic-import preload failures. Call once at
+ *  boot. ``vite:preloadError`` fires when a lazy() import's chunk can't load;
+ *  preventing default stops Vite rethrowing (which would crash to the boundary)
+ *  and we reload to the fresh build. In cooldown we let it fall through. */
+export function installChunkReload(): void {
+  window.addEventListener("vite:preloadError", (e: Event) => {
+    if (reloadForFreshChunks()) e.preventDefault();
+  });
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { App } from "./app";
 // paint (avoids a flash of wrong-theme).
 import "./lib/theme";
 import { applyMotionClass } from "./lib/motion";
+import { installChunkReload } from "./lib/chunkReload";
 import "./styles/tokens.css";
 import "./styles/base.css";
 import "./styles/shell.css";
@@ -11,6 +12,8 @@ import "./styles/shell.css";
 // Set the reduce-motion html class before first paint so the CSS animation
 // gates match the motion preference (default: on, overriding the OS setting).
 applyMotionClass();
+// Recover transparently when a post-deploy stale lazy-chunk fails to load.
+installChunkReload();
 
 const root = document.getElementById("app");
 if (!root) throw new Error("#app missing from index.html");


### PR DESCRIPTION
## Why

User saw transient *"live heating couldn't render — Failed to fetch dynamically imported module: …/HeatingPlanWidget-B1w8BjzK.js"*. Confirmed on prod: the current image serves `HeatingPlanWidget-**D2apYkIO**.js` and the old `B1w8BjzK` hash is **gone**.

This is the classic **stale lazy-chunk after deploy**: a tab opened before a deploy still references the old hashed chunk; a later `lazy()` import 404s. The rapid back-to-back UI deploys this session made it show up. The in-app **"Retry"** couldn't fix it — it re-runs the *same dead URL*; only a manual hard refresh recovered.

## What

Recover transparently:
- **`main.tsx`** wires a global **`vite:preloadError`** handler that full-reloads **once** on a chunk-load failure (fresh `index.html` → new hashes), guarded by a **15s sessionStorage cooldown** so a genuinely broken deploy can't reload-loop.
- **`WidgetBoundary`** detects a chunk-load error and turns **"Retry" → "Reload"** (full reload, not a re-import of the dead hash), with a clearer *"new version deployed"* title.
- New `lib/chunkReload.ts` holds the detection + guarded-reload helpers.

UI-only; `tsc` + `vite build` clean. The original error was transient (a hard refresh fixes it); this makes the recovery automatic.