### PR TITLE
fix(ui): design-audit quick wins — a11y outline, mobile overflow, token hygiene

### DIFF
--- a/ui/src/components/common/Widget.tsx
+++ b/ui/src/components/common/Widget.tsx
@@ -35,10 +35,10 @@ export function Widget({
   return (
     <section class={`widget widget--${size} widget--tone-${tone} ${cls}`}>
       <header class="widget-header">
-        <div class="widget-header-title">
+        <h3 class="widget-header-title">
           {icon && <span class="widget-header-icon" aria-hidden="true">{icon}</span>}
           {title}
-        </div>
+        </h3>
         <div class="widget-header-meta">
           {badge && <span class="widget-header-badge">{badge}</span>}
           {action}

--- a/ui/src/components/common/widget.css
+++ b/ui/src/components/common/widget.css
@@ -88,6 +88,9 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  /* rendered as an <h3> for document outline — neutralise default heading
+     margin so the header layout is unchanged. */
+  margin: 0;
   font-size: 0.7rem;
   font-weight: 700;
   color: var(--text-dim);

--- a/ui/src/components/home/heating.css
+++ b/ui/src/components/home/heating.css
@@ -20,7 +20,7 @@
   font-size: 0.65rem;
 }
 .heating-refresh-error {
-  color: var(--danger, #ef4444);
+  color: var(--bad);
   font-size: var(--font-sm);
   margin-top: var(--space-2);
 }

--- a/ui/src/components/settings/SettingField.tsx
+++ b/ui/src/components/settings/SettingField.tsx
@@ -51,7 +51,7 @@ export function SettingField({ spec, pending, onChange, onRevert }: SettingField
               step={stepFor(spec)}
               unit={unit}
               defaultValue={spec.default as number}
-              ariaLabel={spec.key}
+              ariaLabel={labelFor(spec.key)}
               onChange={(n) => onChange(spec.key, n)}
             />
           );
@@ -63,7 +63,7 @@ export function SettingField({ spec, pending, onChange, onRevert }: SettingField
               min={spec.min ?? null}
               max={spec.max ?? null}
               step={stepFor(spec)}
-              ariaLabel={spec.key}
+              ariaLabel={labelFor(spec.key)}
               onChange={(n) => onChange(spec.key, n)}
             />
             {unit && <span class="setting-input-unit">{unit}</span>}
@@ -73,7 +73,7 @@ export function SettingField({ spec, pending, onChange, onRevert }: SettingField
         return (
           <Toggle
             value={!!value}
-            ariaLabel={spec.key}
+            ariaLabel={labelFor(spec.key)}
             onChange={(v) => onChange(spec.key, v)}
           />
         );
@@ -82,7 +82,7 @@ export function SettingField({ spec, pending, onChange, onRevert }: SettingField
           <Select
             value={String(value)}
             options={spec.enum || []}
-            ariaLabel={spec.key}
+            ariaLabel={labelFor(spec.key)}
             onChange={(v) => onChange(spec.key, v)}
           />
         );
@@ -90,7 +90,7 @@ export function SettingField({ spec, pending, onChange, onRevert }: SettingField
         return (
           <TextInput
             value={String(value)}
-            ariaLabel={spec.key}
+            ariaLabel={labelFor(spec.key)}
             onChange={(v) => onChange(spec.key, v)}
           />
         );

--- a/ui/src/components/shell/period-nav.css
+++ b/ui/src/components/shell/period-nav.css
@@ -148,3 +148,14 @@
   .pnav--page .pnav-arrow { width: 28px; height: 28px; font-size: 16px; }
   .pnav--page .pnav-today { height: 28px; padding: 0 9px; font-size: var(--font-xs); }
 }
+
+/* Sub-phone (≤430px): the stepper + 4-segment granularity toggle can't share
+ * one row on the narrowest devices and were overflowing the page sideways
+ * (41px horizontal scroll at 390px). Let the toggle drop to its own full-width
+ * row instead — guaranteed no horizontal page scroll, still well inside the
+ * first fold. Overrides the nowrap set in the ≤640px block above. */
+@media (max-width: 430px) {
+  .pnav--page { flex-wrap: wrap; row-gap: var(--space-2); }
+  .pnav--page .pnav-grans { width: 100%; justify-content: space-between; }
+  .pnav--page .pnav-gran { flex: 1; text-align: center; }
+}

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -150,12 +150,13 @@ export default function Landing() {
           sticky TopNav (redesign P4c). Same global signal either way. */}
       <PeriodNavigator variant="page" />
 
-      {/* ── PERIOD-VIEW scope (redesign) — names what the hero is scoped to. */}
-      <div class="scope scope--period">
-        <span class="scope-dot" />
+      {/* ── PERIOD-VIEW scope (redesign) — names what the hero is scoped to.
+          <h2> so the cockpit has a real document outline (period section). */}
+      <h2 class="scope scope--period">
+        <span class="scope-dot" aria-hidden="true" />
         {scope.scope} · period view
         {scope.date && <span class="scope-when">{scope.date}</span>}
-      </div>
+      </h2>
 
       <Hero metrics={metrics.data} metricsLoading={metrics.loading} cockpit={data} agile={agile.data}
             period={periodInsights.data} periodState={period}
@@ -166,11 +167,11 @@ export default function Landing() {
           that ignores the period selector above. Live power = the animated
           flow + rates + battery, with its committed plan as the card foot;
           Live heating = the plan chart first, gauges demoted beneath it. */}
-      <div class="scope scope--live">
-        <span class="scope-dot" />
+      <h2 class="scope scope--live">
+        <span class="scope-dot" aria-hidden="true" />
         Live now
         <span class="scope-when">always now — ignores the period above</span>
-      </div>
+      </h2>
       <div class="widget-band live-band">
         <div class="live-band-head">
           <Icon name="power-live" size={13} /> Live · self-driving

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -12,10 +12,11 @@
   --border: #2b3340;
   --border-strong: #3a4350;
 
-  /* text */
+  /* text — --text-mute lightened from #6b7280 (≈3.63:1 on --bg-card, below
+   * WCAG AA for small labels) to ≈5.1:1 while staying dimmer than --text-dim. */
   --text: #f3f4f6;
   --text-dim: #9ca3af;
-  --text-mute: #6b7280;
+  --text-mute: #838b98;
 
   /* brand + state */
   --accent: #3b82f6;
@@ -29,6 +30,11 @@
   --standard: #6b7280;
   --peak: #f59e0b;
   --peak-export: #ef4444;
+  /* paid-to-import / negative band on the price timeline + appliance chips.
+   * Was a never-defined var(--neg, …) fallback in several files — now a real
+   * token (same colour, no longer a silent literal). Distinct from
+   * --neg-price (the deeper tariff-band blue). */
+  --neg: #38bdf8;
 
   /* energy-flow domains (charts + power-flow svg) */
   --pv: #fbbf24;
@@ -37,6 +43,9 @@
   --house: #c084fc;
   --import: #ef4444;
   --export: #10b981;
+  /* heating/tank thermal line on the heating-plan chart. Was a never-defined
+   * var(--thermal, …) fallback — now a real token (same colour). */
+  --thermal: #fb923c;
 
   /* spacing scale (4px base) */
   --space-1: 0.25rem;


### PR DESCRIPTION
Top 5 quick wins from a deep design audit of the live cockpit (build `8f22e35`, audit-only). All low-risk CSS/semantics; no behavioural change. Full audit report (15 findings, 5 high / 6 medium / 4 low) lives under `~/.gstack/projects/.../designs/design-audit-20260616/`.

## What's in here (1 commit each)

| Finding | Fix | Impact |
|---|---|---|
| **F-001** Cockpit had **zero `<h1>`–`<h6>`** | Scope labels → `<h2>`, `Widget` title → `<h3>` (margin neutralised, no visual change) | Screen readers now get a document outline on the primary page |
| **F-003** Mobile horizontal page scroll | Period/granularity bar drops the toggle to its own full-width row below 430px | No 41px sideways scroll at 390px (it's an installable PWA) |
| **F-005** Phantom CSS tokens | Define `--thermal` / `--neg`; replace `--danger` with the identical `--bad` | Removes silent hardcoded colours masquerading as `var(--x, #fallback)` |
| **F-006** Muted text below AA | `--text-mute` `#6b7280` (≈3.63:1) → `#838b98` (≈5.1:1) in dark theme | Small labels clear WCAG AA on `--bg-card` |
| **F-007** Settings "Label in Name" | Control `aria-label` uses `labelFor(spec.key)` not the raw env key | SR announces "Normal tank target", not "DHW_TEMP_NORMAL_C" (WCAG 2.5.3) |

## Verification

- `npm run typecheck` + `npm run build` both pass clean (the echarts chunk-size warning is pre-existing vendor bundling, untouched here).
- The two structural changes (F-001 headings, F-003 layout) are unambiguous in the diff; the only layout risk (default heading margins) is neutralised on `.widget-header-title` (`.scope` already set its own margins).
- A live render against a local `vite preview` was **not** completed: the landing route gates content behind the primary data fetch, which can't reach prod's API cross-origin from localhost (CORS). These render correctly once data loads in a real deploy.

## Deliberately scoped out (noted in the audit, not done here)

- Stale drifted `var(--ok, #36d399)` / `--cheap` / `--text-mute` fallbacks across ~10 files — dead code (the token always wins) and some feed ECharts/inline color strings; churning them risks chart regressions for zero visual gain.
- The remaining HIGH findings (charts have no accessible text alternative; `Modal.tsx` has no focus trap/restoration) and the rest of the mediums are bigger than "quick win" and want their own PRs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)