### PR TITLE
fix(ui): a11y HIGH findings — chart text alternatives + modal focus trap

### DIFF
--- a/ui/src/components/cockpit/PowerFlow.tsx
+++ b/ui/src/components/cockpit/PowerFlow.tsx
@@ -83,8 +83,16 @@ export function PowerFlow({ state }: PowerFlowProps) {
   const pvToBatt = "M 110 112 C 80 150 80 180 110 198";
   const gridToBatt = "M 338 230 C 280 240 200 240 142 230";
 
+  // Text alternative for screen readers — the animated SVG is aria-hidden, so
+  // summarise the live flows in kW with direction.
+  const kw = (v: number) => `${Math.abs(v).toFixed(1)} kW`;
+  const flowSummary =
+    `Live power flow: solar ${kw(s.solar_kw)}, home ${kw(s.load_kw)}, ` +
+    `battery ${battCharging ? `charging ${kw(s.battery_kw)}` : battDischarging ? `discharging ${kw(s.battery_kw)}` : "idle"}, ` +
+    `grid ${gridImporting ? `importing ${kw(s.grid_kw)}` : gridExporting ? `exporting ${kw(s.grid_kw)}` : "idle"}`;
+
   return (
-    <div class="powerflow" aria-label="Live power flow">
+    <div class="powerflow" role="img" aria-label={flowSummary}>
       <svg viewBox="0 0 480 310" class="powerflow-svg" aria-hidden="true">
         <defs>
           <filter id="pf-glow" x="-50%" y="-50%" width="200%" height="200%">

--- a/ui/src/components/common/Modal.tsx
+++ b/ui/src/components/common/Modal.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from "preact";
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import "./modal.css";
 
 interface ModalProps {
@@ -11,21 +11,70 @@ interface ModalProps {
   width?: "sm" | "md" | "lg";
 }
 
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), ' +
+  'select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 export function Modal({ open, onClose, title, footer, children, width = "md" }: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // The element that had focus before the dialog opened — restored on close.
+  const restoreRef = useRef<HTMLElement | null>(null);
+  // Hold onClose in a ref so the focus effect can depend on [open] alone and
+  // never re-run (re-grabbing focus) just because the parent re-rendered.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     if (!open) return;
+    const dialog = dialogRef.current;
+    restoreRef.current = (document.activeElement as HTMLElement | null) ?? null;
+
+    const focusables = (): HTMLElement[] =>
+      dialog ? Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE)) : [];
+
+    // Move focus into the dialog (first focusable, else the dialog itself).
+    (focusables()[0] ?? dialog)?.focus();
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== "Tab" || !dialog) return;
+      // Focus trap: keep Tab / Shift+Tab cycling inside the dialog.
+      const items = focusables();
+      if (items.length === 0) {
+        e.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !dialog.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !dialog.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
     };
+
     document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      // Return focus to whatever opened the dialog (the trigger).
+      restoreRef.current?.focus?.();
+    };
+  }, [open]);
 
   if (!open) return null;
 
   return (
     <div class="modal-backdrop" onClick={onClose} role="presentation">
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         class={`modal modal--${width}`}
         onClick={(e) => e.stopPropagation()}
         role="dialog"

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -252,7 +252,7 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
       {/* Host wrap — loading state overlays (position:absolute) so it never
           displaces the chart, killing load-jump. */}
       <div class="echart-host-wrap">
-        <div class="echart-host" ref={elRef} aria-label="Load details chart" />
+        <div class="echart-host" ref={elRef} role="img" aria-label="Load details chart" />
         {loading && <div class="echart-state">Loading…</div>}
         {error && <div class="echart-state echart-state--err">{error}</div>}
       </div>

--- a/ui/src/components/home/MetricTimeline.tsx
+++ b/ui/src/components/home/MetricTimeline.tsx
@@ -217,7 +217,22 @@ export function MetricTimeline({
     }, { notMerge: true });
   }, [labels, lines, prices, nowIdx, cheapAt, peakAt, barMode, theme, unit]);
 
-  return <div ref={ref} style={{ width: "100%", height: `${height}px` }} />;
+  // Text alternative for screen readers — the canvas itself is opaque to AT,
+  // so name the series + unit (and the price overlay when present).
+  const hasPrice = !!prices && prices.some((p) => p != null);
+  const chartLabel =
+    `${barMode ? "Bar chart" : "Time-series chart"} in ${unit}: ` +
+    `${lines.map((l) => l.name).join(", ")}` +
+    `${hasPrice ? `, with ${priceLabel} overlay` : ""}`;
+
+  return (
+    <div
+      ref={ref}
+      role="img"
+      aria-label={chartLabel}
+      style={{ width: "100%", height: `${height}px` }}
+    />
+  );
 }
 
 export function localHM(iso: string): string {

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -286,5 +286,5 @@ function ComparisonChart({ rows }: { rows: FairTariffRow[] }) {
     }, { notMerge: true });
   }, [rows]);
 
-  return <div ref={ref} class="insights-chart" />;
+  return <div ref={ref} class="insights-chart" role="img" aria-label="Tariff cost comparison — your usage priced on each tariff" />;
 }


### PR DESCRIPTION
The two remaining **HIGH** accessibility findings from the cockpit design audit (the rest shipped in #591). Independent of #591 — no overlapping files.

## What's in here (1 commit each)

**F-002 — Charts had no screen-reader text alternative.** The 3 ECharts canvases + the PowerFlow SVG were opaque to assistive tech, so the product's core data (price / PV / load / live flow) was invisible to screen-reader users. Each chart container now has `role="img"` + a data-derived `aria-label`:
- `MetricTimeline` — names its series + unit, and the price overlay when present (e.g. *"Time-series chart in kWh: Base, Appliances, Heat-pump, with Import price overlay"*).
- `PowerFlow` — live summary with direction (e.g. *"Live power flow: solar 1.2 kW, home 0.8 kW, battery charging 0.4 kW, grid exporting 0.1 kW"*); the animated SVG stays `aria-hidden`.
- `EnergyChartWidget` (already had a label) + the Insights comparison chart — get `role="img"` + label.

**F-004 — Modal had no focus trap or focus restoration.** `aria-modal="true"` was set but not enforced: Tab escaped to the page behind the open dialog and focus wasn't returned to the trigger on close. Now focus moves into the dialog on open, `Tab` / `Shift+Tab` cycle within it, Escape still closes, and focus is restored to the opener on close. The focus effect keys on `[open]` only (`onClose` held in a ref) so a parent re-render can't re-grab focus.

## Verification

- `npm run typecheck` + `npm run build` pass clean (the echarts chunk-size warning is pre-existing vendor bundling).
- The Modal change is a standard focus-management pattern; chart labels derive from data the components already hold and render unconditionally on the container.
- Not live-verified against a running app: the cockpit gates content behind a data fetch that can't reach prod's API cross-origin from a local `vite preview` (CORS). Renders correctly once data loads in a real deploy.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)