### PR TITLE
fix(ui): Outgoing-Agile export framing + Insights no-usage chart

### DIFF
--- a/ui/src/components/common/NowDot.tsx
+++ b/ui/src/components/common/NowDot.tsx
@@ -1,0 +1,10 @@
+// The "now" marker used in chart legends/hints. Replaces the ◉ text glyph
+// (no text-glyph markers per the design rules) with a small accent dot that
+// matches the on-chart now indicator.
+export function NowDot() {
+  return (
+    <svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true" style="vertical-align:middle">
+      <circle cx="4" cy="4" r="4" fill="var(--accent)" />
+    </svg>
+  );
+}

--- a/ui/src/components/common/RefreshCountdown.tsx
+++ b/ui/src/components/common/RefreshCountdown.tsx
@@ -40,6 +40,7 @@ export function RefreshCountdown({ lastFetchAt, intervalMs, loading, disabled, o
 
   return (
     <button class="refresh-cd" onClick={onRefresh}
+            aria-label={disabled ? `Just refreshed — available again in ${leftS}s` : "Refresh now"}
             title={disabled
               ? `Just refreshed — available again in ${leftS}s`
               : `Auto-refreshes every ${Math.round(intervalMs / 1000)}s — click to refresh now`}

--- a/ui/src/components/home/EnergyChartWidget.tsx
+++ b/ui/src/components/home/EnergyChartWidget.tsx
@@ -4,6 +4,7 @@ import { usePeriod, setGranularity, selectedPeriod, isCurrentPeriod } from "../.
 import { getImmutableCache, setImmutableCache } from "../../lib/poll";
 import { makeChart, baseOption, chartTheme, barGradient, areaGradient, withAlpha, type EChartsType } from "../../lib/charts";
 import { Icon } from "../common/Icon";
+import { NowDot } from "../common/NowDot";
 import type {
   PeriodInsightsResponse,
   PeriodChartPoint,
@@ -271,7 +272,7 @@ export function EnergyChartWidget({ execution, pv }: EnergyChartWidgetProps) {
           <span class="echart-l2"><span class="echart-l2-line" style="border-top-color:var(--import)" /> Grid</span>
           <span class="echart-l2"><span class="echart-l2-line" style="border-top-color:var(--batt)" /> Battery</span>
           <span class="echart-l2"><span class="echart-l2-line" style="border-top-color:var(--accent);border-top-style:dashed" /> SoC %</span>
-          <span class="echart-l2-hint">stack = load by use · grid/battery = how it was sourced · SoC right · ◉ now</span>
+          <span class="echart-l2-hint">stack = load by use · grid/battery = how it was sourced · SoC right · <NowDot /> now</span>
         </div>
       )}
 

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -76,7 +76,11 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, opp
     // the gap between them is the opportunity. On Outgoing Agile the green line
     // IS the curve and there's no separate comparison.
     const segRate = agile?.export_seg_rate_p ?? null;
-    const onSeg = segRate != null;
+    // On flat SEG we draw SEG as the actual line + Agile as the dashed "what
+    // you'd earn" overlay. On Outgoing Agile the Agile curve IS the actual
+    // export price, so no SEG framing. Prefer the authoritative export_mode;
+    // fall back to the segRate heuristic until /export/opportunity resolves.
+    const onSeg = opportunity ? opportunity.export_mode === "seg_flat" : segRate != null;
     const expPriceBy = new Map<string, number>();
     for (const es of agile?.export_slots ?? []) expPriceBy.set(normZ(es.valid_from), es.p);
     const agileExportPrice = slots.map((s) => expPriceBy.get(normZ(s.slot_utc)) ?? null);
@@ -97,7 +101,7 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, opp
         <div class="tlw-summary">
           <span class="tlw-summary-value">{genTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh solar</span></span>
           <span class="tlw-summary-value tlw-pos">{exportedTotal.toFixed(1)}<span class="tlw-summary-unit"> kWh export</span></span>
-          <span class="tlw-summary-label">expected today{segRate != null ? ` · export paid at ${segRate.toFixed(1)}p/kWh (SEG flat)` : ""}</span>
+          <span class="tlw-summary-label">expected today{onSeg && segRate != null ? ` · export paid at ${segRate.toFixed(1)}p/kWh (SEG flat)` : ""}</span>
         </div>
         <OppyLine o={opportunity} />
         {/* Export price line (green, right axis) mirrors Consumption's import
@@ -110,7 +114,7 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, opp
           <span><i style={`border-color:${t.pv}`} /> solar actual</span>
           <span><i class="dashed" style={`border-color:${withAlpha(t.pv, 0.6)}`} /> solar plan</span>
           <span><i style={`border-color:${t.exportColor}`} /> export kWh</span>
-          <span><i class="dashed" style={`border-color:${t.exportColor}`} /> export {onSeg ? `${segRate.toFixed(1)}p SEG` : "price"}</span>
+          <span><i class="dashed" style={`border-color:${t.exportColor}`} /> export {onSeg && segRate != null ? `${segRate.toFixed(1)}p SEG` : "price"}</span>
           {onSeg && <span><i class="dashed" style={`border-color:${t.warn}`} /> Outgoing Agile (alvo)</span>}
           <span>◉ now</span>
         </div>

--- a/ui/src/components/home/GenerationWidget.tsx
+++ b/ui/src/components/home/GenerationWidget.tsx
@@ -3,6 +3,7 @@ import { useFetch } from "../../lib/poll";
 import { getPvToday, getGridToday } from "../../lib/endpoints";
 import { MetricTimeline, localHM, nowIndexOf, periodPointLabel, type TimelineLine } from "./MetricTimeline";
 import { Spinner } from "../common/Spinner";
+import { NowDot } from "../common/NowDot";
 import { gbp } from "../../lib/format";
 import type { PeriodInsightsResponse, PvTodayResponse, GridTodayResponse, AgileTodayResponse, ExportOpportunityResponse } from "../../lib/types";
 import { isCurrentPeriod, type PeriodState } from "../../lib/period";
@@ -116,7 +117,7 @@ export function GenerationWidget({ period, periodData, periodLoading, agile, opp
           <span><i style={`border-color:${t.exportColor}`} /> export kWh</span>
           <span><i class="dashed" style={`border-color:${t.exportColor}`} /> export {onSeg && segRate != null ? `${segRate.toFixed(1)}p SEG` : "price"}</span>
           {onSeg && <span><i class="dashed" style={`border-color:${t.warn}`} /> Outgoing Agile (alvo)</span>}
-          <span>◉ now</span>
+          <span><NowDot /> now</span>
         </div>
       </div>
     );

--- a/ui/src/components/home/HeatingPlanWidget.tsx
+++ b/ui/src/components/home/HeatingPlanWidget.tsx
@@ -3,6 +3,7 @@ import { makeChart, baseOption, chartTheme, areaGradient, withAlpha, type EChart
 import { useResolvedTheme } from "../../lib/theme";
 import { reducedMotion } from "../../lib/motion";
 import type { HeatingPlanResponse } from "../../lib/types";
+import { NowDot } from "../common/NowDot";
 import "./heating-plan.css";
 
 interface Props {
@@ -166,7 +167,7 @@ export function HeatingPlanWidget({ plan, loading }: Props) {
           <span class="hpl-tok"><span class="hpl-line" style="border-top:1.5px dashed var(--import)" /> import p</span>
           <span class="hpl-tok"><span class="hpl-sw hpl-sw--heat" /> heating</span>
           <span class="hpl-tok"><span class="hpl-sw hpl-sw--neg" /> paid to import</span>
-          <span class="hpl-hint">◉ now · hover for detail</span>
+          <span class="hpl-hint"><NowDot /> now · hover for detail</span>
         </div>
       ) : null}
       {!plan?.slots?.length && !loading && <p class="muted">No heating plan available yet.</p>}

--- a/ui/src/components/home/TodayPlanWidget.tsx
+++ b/ui/src/components/home/TodayPlanWidget.tsx
@@ -3,6 +3,8 @@ import { makeChart, baseOption, chartTheme, areaGradient, withAlpha, type EChart
 import { useResolvedTheme } from "../../lib/theme";
 import { reducedMotion } from "../../lib/motion";
 import type { PvTodayResponse, ExecutionTodayResponse } from "../../lib/types";
+import { Icon } from "../common/Icon";
+import { NowDot } from "../common/NowDot";
 import "./today-plan.css";
 
 interface TodayPlanWidgetProps {
@@ -295,7 +297,7 @@ export function TodayPlanWidget({ pv, loading, execution, cheapThresholdP, peakT
     <div class="today-plan">
       {dayTotal != null && (
         <div class="today-plan-summary">
-          <span class="today-plan-summary-icon" aria-hidden="true">☀</span>
+          <span class="today-plan-summary-icon" aria-hidden="true"><Icon name="solar" size={14} /></span>
           <span class="today-plan-summary-value">{dayTotal.toFixed(1)}<span class="today-plan-summary-unit"> kWh</span></span>
           <span class="today-plan-summary-label">solar expected today (generated + forecast)</span>
         </div>
@@ -332,7 +334,7 @@ export function TodayPlanWidget({ pv, loading, execution, cheapThresholdP, peakT
             <span class="tpl-tok"><span class="tpl-sw tpl-sw--cheap" aria-hidden="true" /> cheap</span>
             <span class="tpl-tok"><span class="tpl-sw tpl-sw--peak" aria-hidden="true" /> peak</span>
           </span>
-          <span class="tpl-hint">◉ now · hover a slot for detail</span>
+          <span class="tpl-hint"><NowDot /> now · hover a slot for detail</span>
         </div>
       ) : null}
       {!pv?.slots?.length && !loading && <p class="muted">No plan data for today yet.</p>}

--- a/ui/src/routes/insights.tsx
+++ b/ui/src/routes/insights.tsx
@@ -134,26 +134,38 @@ export default function Insights() {
             </div>
           )}
 
-          {/* Export side-by-side: actual SEG vs the Outgoing Agile alternative */}
+          {/* Export valuation — on Outgoing Agile show the actual Agile earnings;
+              only on the old flat SEG show the SEG-vs-Agile switch opportunity. */}
           {data.export && data.export.export_kwh > 0.05 && (
             <div class="insights-export-panel">
               <span class="insights-export-title">Export</span>
-              <span>
-                <strong>{kwh(data.export.export_kwh)}</strong> exported · paid
-                {" "}<strong>{p2(data.export.seg_revenue_pence)}</strong> at SEG {data.export.seg_rate_p.toFixed(2)}p
-                {data.export.mode === "seg_flat" ? " (current)" : ""}
-              </span>
-              <span class="insights-export-alt">
-                would earn <strong>{p2(data.export.agile_revenue_pence)}</strong> on Outgoing Agile
-                (~{data.export.agile_avg_p.toFixed(1)}p avg)
-                {data.export.uplift_if_switch_pence > 1 && (
-                  <span class="insights-export-uplift"> → +{p2(data.export.uplift_if_switch_pence)} if you switch</span>
-                )}
-              </span>
+              {data.export.mode === "outgoing_agile" ? (
+                <span>
+                  <strong>{kwh(data.export.export_kwh)}</strong> exported · earned
+                  {" "}<strong>{p2(data.export.agile_revenue_pence)}</strong> on Outgoing Agile
+                  (~{data.export.agile_avg_p.toFixed(1)}p avg)
+                </span>
+              ) : (
+                <>
+                  <span>
+                    <strong>{kwh(data.export.export_kwh)}</strong> exported · paid
+                    {" "}<strong>{p2(data.export.seg_revenue_pence)}</strong> at SEG {data.export.seg_rate_p.toFixed(2)}p (current)
+                  </span>
+                  <span class="insights-export-alt">
+                    would earn <strong>{p2(data.export.agile_revenue_pence)}</strong> on Outgoing Agile
+                    (~{data.export.agile_avg_p.toFixed(1)}p avg)
+                    {data.export.uplift_if_switch_pence > 1 && (
+                      <span class="insights-export-uplift"> → +{p2(data.export.uplift_if_switch_pence)} if you switch</span>
+                    )}
+                  </span>
+                </>
+              )}
             </div>
           )}
 
-          <ComparisonChart rows={rows} />
+          {/* Standing-charges-only state (import_kwh < 1) shows the table only;
+              a comparison chart there would imply a real comparison. */}
+          {data.basis.import_kwh >= 1 && <ComparisonChart rows={rows} />}
 
           {/* Table */}
           <div class="insights-table-wrap">

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -3,6 +3,8 @@
  * Tariff/energy/chart colours stay the same in both themes for legibility. */
 
 :root, :root.theme-dark {
+  /* Native form controls / scrollbars match the dark theme. */
+  color-scheme: dark;
   /* surfaces — redesign (Claude Design handoff): richer, cooler near-black with
    * more elevation separation. */
   --bg: #090b11;
@@ -96,6 +98,7 @@
 
 /* Light theme — applied when src/lib/theme.ts sets .theme-light on <html>. */
 :root.theme-light {
+  color-scheme: light;
   --bg: #f5f6f8;
   --bg-card: #ffffff;
   --bg-card-2: #f1f5f9;
@@ -135,6 +138,7 @@
  * which overrides this. */
 @media (prefers-color-scheme: light) {
   :root:not(.theme-dark):not(.theme-light) {
+    color-scheme: light;
     --bg: #f8fafc;
     --bg-card: #ffffff;
     --bg-card-2: #f1f5f9;


### PR DESCRIPTION
Three user-reported display bugs + three minor design-audit nits. All **presentation-only** (backend numbers were already correct); frontend-only, so UI-image rebuild only.

## Bug 1 — export still framed as "flat SEG, switch to save"
After moving to Outgoing Agile, the Insights export panel showed "paid £0.14 at SEG 4.10p — would earn £0.41 on Outgoing Agile → +£0.28 if you switch". But £0.41 **is** the realised revenue now; there's no switch to make.

**Fix:** branch the export panel on `data.export.mode` — `outgoing_agile` shows actual Agile earnings (no SEG, no switch prompt); `seg_flat` keeps the switch opportunity. `GenerationWidget`: `onSeg` now derives from `export_mode` (was keyed off `segRate`), so on Agile it drops the SEG line/overlay/label.

## Bug 2 — Insights comparison chart shown in the no-usage state
With `import_kwh < 1` the page says "Not enough metered usage … standing charges only" but still drew the comparison chart. **Fix:** gate `<ComparisonChart>` on `import_kwh >= 1`; the table still shows.

## Minor design-audit nits (folded in)
- **F-012 no-emoji:** `☀` → `<Icon name="solar">`; the `◉` "now" legend glyphs (4 widgets) → shared `<NowDot/>` accent dot.
- **F-014 color-scheme:** set per theme (dark/light) so native controls/scrollbars match.
- **F-015:** `aria-label` on the `RefreshCountdown` button (was title-only).

## Verification
`npm run typecheck` + `npm run build` pass clean. Verified on prod after deploy.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
