### PR TITLE
feat: restore multi-day weather + solar forecast on the cockpit

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -528,9 +528,10 @@ async def api_v1_weather():
 def _api_v1_weather_sync():
     from ..weather import fetch_weather_panel_forecast_cached
 
-    # 96 h = a 4-day forecast for the redesign hero weather panel. Open-meteo
-    # direct (not the Quartz-merged planning fetch, which caps at the ~2-day PV
-    # horizon) — the panel only needs temp/cloud.
+    # 96 h = a 4-day forecast for the cockpit weather panel + multi-day strip.
+    # Open-meteo direct (not the Quartz-merged planning fetch, which caps at the
+    # ~2-day PV horizon). temp/cloud/pv + precipitation + WMO weather_code so the
+    # strip can show rain, not just cloud cover.
     fc = fetch_weather_panel_forecast_cached(hours=96)
     out = [{
         "time": f.time_utc.isoformat(),
@@ -538,6 +539,8 @@ def _api_v1_weather_sync():
         "pv_kw": f.estimated_pv_kw,
         "cloud_cover_pct": f.cloud_cover_pct,
         "irradiance_wm2": f.shortwave_radiation_wm2,
+        "precipitation_mm": f.precipitation_mm,
+        "weather_code": f.weather_code,
     } for f in fc]
     daikin = None
     try:
@@ -554,7 +557,10 @@ def _api_v1_weather_sync():
             }
     except Exception as e:
         daikin = {"error": str(e)}
-    return {"forecast": out[:48], "daikin": daikin}
+    # Return the full horizon (up to 96 h / 4 days) — the multi-day strip needs
+    # days 3-4. Was truncated to out[:48] (a 2-day leftover) which silently
+    # dropped half the fetched forecast.
+    return {"forecast": out, "daikin": daikin}
 
 
 @app.get("/api/v1/health")

--- a/src/weather.py
+++ b/src/weather.py
@@ -234,6 +234,8 @@ class HourlyForecast:
     estimated_pv_kw: float        # estimated PV generation for 4.5kWp system
     heating_demand_factor: float  # 0-1: how much heating is needed relative to base temp
     pv_direct: bool = False       # True when provider supplies site PV directly.
+    precipitation_mm: float = 0.0  # hourly precipitation total (mm); 0 outside Open-Meteo
+    weather_code: int = 0          # WMO weather code (0 clear … 61-67 rain … 95-99 storm)
 
 
 @dataclass
@@ -491,7 +493,7 @@ def _fetch_open_meteo_forecast(
         url = (
             "https://api.open-meteo.com/v1/forecast?"
             f"latitude={lat}&longitude={lon}"
-            "&hourly=temperature_2m,cloud_cover,shortwave_radiation_instant"
+            "&hourly=temperature_2m,cloud_cover,shortwave_radiation_instant,precipitation,weather_code"
             f"&forecast_days={max(2, (hours // 24) + 1)}"
             "&timezone=UTC"
         )
@@ -506,6 +508,8 @@ def _fetch_open_meteo_forecast(
     temps = hourly.get("temperature_2m") or []
     clouds = hourly.get("cloud_cover") or []
     radiation = hourly.get("shortwave_radiation_instant") or []
+    precip = hourly.get("precipitation") or []
+    wcodes = hourly.get("weather_code") or []
 
     now = datetime.now(UTC)
     result: list[HourlyForecast] = []
@@ -521,6 +525,8 @@ def _fetch_open_meteo_forecast(
             temp_c = float(temps[i]) if i < len(temps) and temps[i] is not None else 10.0
             cloud_pct = float(clouds[i]) if i < len(clouds) and clouds[i] is not None else 50.0
             rad_wm2 = float(radiation[i]) if i < len(radiation) and radiation[i] is not None else 0.0
+            precip_mm = float(precip[i]) if i < len(precip) and precip[i] is not None else 0.0
+            wcode = int(wcodes[i]) if i < len(wcodes) and wcodes[i] is not None else 0
             result.append(
                 HourlyForecast(
                     time_utc=dt,
@@ -529,6 +535,8 @@ def _fetch_open_meteo_forecast(
                     shortwave_radiation_wm2=rad_wm2,
                     estimated_pv_kw=estimate_pv_kw(rad_wm2),
                     heating_demand_factor=compute_heating_demand_factor(temp_c),
+                    precipitation_mm=precip_mm,
+                    weather_code=wcode,
                 )
             )
         except (ValueError, IndexError, TypeError):

--- a/ui/src/components/home/ForecastStrip.tsx
+++ b/ui/src/components/home/ForecastStrip.tsx
@@ -1,0 +1,122 @@
+import type { WeatherResponse, WeatherSlot } from "../../lib/types";
+import "./forecast-strip.css";
+
+// Multi-day (4-day) weather + solar outlook for the cockpit. Aggregates the
+// hourly /weather forecast (96 h) into per-day buckets: hi/lo temp, a condition
+// (rain from the WMO weather_code / precipitation, else cloud cover), and the
+// estimated PV kWh for the day. SVG glyphs only (no emoji).
+type Cond = "sun" | "sun-cloud" | "cloud" | "rain";
+
+interface DayAgg {
+  key: string;
+  label: string;
+  hi: number;
+  lo: number;
+  pvKwh: number;
+  cond: Cond;
+  condLabel: string;
+}
+
+// WMO weather code (+ precip / cloud fallback) → glyph + label. Snow/fog fold
+// onto the cloud glyph (rare here) with an honest label; rain covers drizzle →
+// showers → thunderstorm.
+function condFor(code: number, precipMm: number, cloud: number | null): { cond: Cond; label: string } {
+  if (code >= 95) return { cond: "rain", label: "Storm" };
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86) return { cond: "cloud", label: "Snow" };
+  if (code >= 51 || precipMm >= 0.5) return { cond: "rain", label: "Rain" };
+  if (code === 45 || code === 48) return { cond: "cloud", label: "Fog" };
+  if (cloud == null || cloud < 25) return { cond: "sun", label: "Clear" };
+  if (cloud < 60) return { cond: "sun-cloud", label: "Partly cloudy" };
+  if (cloud < 85) return { cond: "cloud", label: "Cloudy" };
+  return { cond: "cloud", label: "Overcast" };
+}
+
+export function ForecastStrip({ weather }: { weather?: WeatherResponse | null }) {
+  const fc = weather?.forecast ?? [];
+  if (fc.length < 24) return null; // need at least ~a day to be useful
+
+  const byDay = new Map<string, WeatherSlot[]>();
+  for (const s of fc) {
+    const key = new Date(s.time).toDateString();
+    let arr = byDay.get(key);
+    if (!arr) { arr = []; byDay.set(key, arr); }
+    arr.push(s);
+  }
+
+  const todayKey = new Date().toDateString();
+  const days: DayAgg[] = [];
+  for (const [key, slots] of byDay) {
+    const temps = slots.map((s) => s.temp_c);
+    const hi = Math.max(...temps);
+    const lo = Math.min(...temps);
+    const pvKwh = slots.reduce((a, s) => a + Math.max(0, s.pv_kw || 0), 0);
+    const precipTotal = slots.reduce((a, s) => a + Math.max(0, s.precipitation_mm || 0), 0);
+    // Daytime hours drive the condition (a clear night shouldn't read "Clear day").
+    const dayHrs = slots.filter((s) => { const h = new Date(s.time).getHours(); return h >= 8 && h <= 18; });
+    const ref = dayHrs.length ? dayHrs : slots;
+    const worstCode = ref.reduce((m, s) => Math.max(m, s.weather_code ?? 0), 0);
+    const meanCloud = ref.length ? ref.reduce((a, s) => a + (s.cloud_cover_pct ?? 0), 0) / ref.length : null;
+    const { cond, label } = condFor(worstCode, precipTotal, meanCloud);
+    const isToday = key === todayKey;
+    days.push({
+      key,
+      label: isToday ? "Today" : new Date(key).toLocaleDateString([], { weekday: "short" }),
+      hi, lo, pvKwh, cond, condLabel: label,
+    });
+  }
+
+  const shown = days.slice(0, 4);
+  if (shown.length < 2) return null;
+
+  return (
+    <div class="fcstrip" role="group" aria-label="Multi-day weather and solar forecast">
+      {shown.map((d) => (
+        <div class="fcstrip-day" key={d.key}>
+          <span class="fcstrip-label">{d.label}</span>
+          <CondGlyph cond={d.cond} />
+          <span class="fcstrip-cond">{d.condLabel}</span>
+          <span class="fcstrip-temp"><b>{Math.round(d.hi)}°</b> <span class="fcstrip-lo">{Math.round(d.lo)}°</span></span>
+          <span class="fcstrip-pv">{d.pvKwh.toFixed(1)}<span class="fcstrip-pv-unit"> kWh PV</span></span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CondGlyph({ cond }: { cond: Cond }) {
+  const pv = "var(--pv, #fbbf24)";
+  const mute = "var(--text-mute, #9ca3af)";
+  const rain = "var(--grid, #60a5fa)";
+  if (cond === "sun") {
+    return (
+      <svg class="fcstrip-icon" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="12" r="4.5" fill={pv} />
+        <g stroke={pv} stroke-width="2" stroke-linecap="round">
+          <path d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M19.1 4.9l-1.8 1.8M6.7 17.3l-1.8 1.8" />
+        </g>
+      </svg>
+    );
+  }
+  if (cond === "sun-cloud") {
+    return (
+      <svg class="fcstrip-icon" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="8" cy="8" r="3.5" fill={pv} />
+        <g stroke={pv} stroke-width="1.6" stroke-linecap="round"><path d="M8 1.5V3M1.5 8H3M3.4 3.4l1 1M12.6 3.4l-1 1" /></g>
+        <path d="M9 19h8a3.3 3.3 0 0 0 .4-6.58A5 5 0 0 0 8 11.8 3 3 0 0 0 9 19z" fill={mute} fill-opacity="0.9" />
+      </svg>
+    );
+  }
+  if (cond === "rain") {
+    return (
+      <svg class="fcstrip-icon" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M7 15h10a4 4 0 0 0 .5-7.97A6 6 0 0 0 6 6.5 3.5 3.5 0 0 0 7 15z" fill={mute} fill-opacity="0.85" />
+        <g stroke={rain} stroke-width="1.8" stroke-linecap="round"><path d="M8 18l-1 2.5M12 18l-1 2.5M16 18l-1 2.5" /></g>
+      </svg>
+    );
+  }
+  return (
+    <svg class="fcstrip-icon" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M7 18h10a4 4 0 0 0 .5-7.97A6 6 0 0 0 6 9.5 3.5 3.5 0 0 0 7 18z" fill={mute} fill-opacity="0.85" />
+    </svg>
+  );
+}

--- a/ui/src/components/home/forecast-strip.css
+++ b/ui/src/components/home/forecast-strip.css
@@ -1,0 +1,69 @@
+/* Multi-day forecast strip — a borderless card (matching the widget surface)
+ * holding 4 evenly-split day columns. Collapses to 2-per-row on phones. */
+.fcstrip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background-color: var(--bg-card);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0) 42%);
+  border: 1px solid rgba(255, 255, 255, 0.045);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+:root.theme-light .fcstrip {
+  background-image: none;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: var(--shadow);
+}
+
+.fcstrip-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  text-align: center;
+}
+/* Divider between days (not before the first). */
+.fcstrip-day + .fcstrip-day {
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-2);
+}
+
+.fcstrip-label {
+  font-size: var(--font-2xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.fcstrip-icon { margin: 2px 0; }
+.fcstrip-cond {
+  font-size: var(--font-2xs);
+  color: var(--text-mute);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+.fcstrip-temp {
+  font-size: var(--font-sm);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.fcstrip-temp b { font-weight: 700; }
+.fcstrip-lo { color: var(--text-mute); }
+.fcstrip-pv {
+  font-size: var(--font-xs);
+  color: var(--pv);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.fcstrip-pv-unit { color: var(--text-mute); font-weight: 400; }
+
+@media (max-width: 560px) {
+  .fcstrip { grid-template-columns: repeat(2, 1fr); row-gap: var(--space-3); }
+  /* In a 2-col layout the left-divider only makes sense on the right column. */
+  .fcstrip-day:nth-child(odd) { border-left: none; padding-left: 0; }
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -245,6 +245,8 @@ export interface WeatherSlot {
   pv_kw: number;
   cloud_cover_pct?: number | null;
   irradiance_wm2?: number | null;
+  precipitation_mm?: number | null;
+  weather_code?: number | null;   // WMO code (0 clear … 61-67 rain … 95-99 storm)
 }
 
 export interface WeatherResponse {

--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -29,6 +29,7 @@ import { PeriodNavigator } from "../components/shell/PeriodNavigator";
 import { usePeriod, periodFetchOpts, periodScope, isCurrentPeriod } from "../lib/period";
 import { LivePowerWidget } from "../components/cockpit/LivePowerWidget";
 import { Hero } from "../components/home/Hero";
+import { ForecastStrip } from "../components/home/ForecastStrip";
 import { HeatingWidget } from "../components/home/HeatingWidget";
 import { PlanMini } from "../components/home/PlanMini";
 import { FeedbackPanel } from "../components/home/FeedbackPanel";
@@ -162,6 +163,9 @@ export default function Landing() {
             period={periodInsights.data} periodState={period}
             periodLoading={periodInsights.loading} todayCum={todayCum.data}
             weather={weather.data} pv={pvToday.data} />
+
+      {/* Days ahead — 4-day weather + solar outlook (temp, rain, PV kWh/day). */}
+      <ForecastStrip weather={weather.data} />
 
       {/* ── LIVE scope + band (redesign) — the always-now, self-driving surface
           that ignores the period selector above. Live power = the animated


### PR DESCRIPTION
The next-days forecast (temp, rain, PV estimate) disappeared in the #525 cockpit redesign — `WeatherWidget` was orphaned (dead code) and the Hero panel shows today-only. This restores a 4-day outlook.

## Root cause
- #525 replaced the weather widget with a today-only `HeroWeather` panel; `WeatherWidget` (the forecast strip) is defined but imported nowhere.
- The `/weather` endpoint fetched 96h (4 days) but returned `out[:48]` — a 2-day leftover that silently dropped days 3-4.
- No precipitation in the forecast model, so "is it raining" was only ever inferred from cloud cover (the Hero even has a dead "Rain" branch).

## Changes
**Backend** (`src/weather.py`, `src/api/main.py`):
- Add hourly `precipitation` + `weather_code` (WMO) to the Open-Meteo fetch and `HourlyForecast` (defaulted, so Quartz/calibration constructors are unaffected).
- Return the full 96h horizon (drop the `out[:48]` truncation); emit `precipitation_mm` + `weather_code` per slot.
- Verified against the live Open-Meteo API from prod: `precipitation:[0.30,0.00…]`, `weather_code:[51,3,…]` (51 = drizzle → classified as rain).

**Frontend** (`ui/`):
- New `ForecastStrip` below the hero: 4 day columns, each with a condition glyph (rain from `weather_code`/precip, else cloud cover — **SVG, no emoji**), hi/lo temp, and estimated PV kWh/day. Daytime hours (08–18) drive the condition. Degrades to cloud-based conditions if the payload predates the backend fields.

## Deploy note
This touches the **backend** (main image) + frontend (UI image) — both rebuild on merge; deploy recreates `hem` + `hem-ui`.

## Verification
`npm run typecheck` + `npm run build` pass; `pytest tests/test_quartz_forecast.py` passes (forecast constructors unaffected). Full live verification on prod after deploy.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)