### PR TITLE
fix(qa): add top-level h1 to cockpit landing for a11y outline

### DIFF
--- a/ui/src/routes/landing.tsx
+++ b/ui/src/routes/landing.tsx
@@ -146,6 +146,11 @@ export default function Landing() {
 
   return (
     <div class="home">
+      {/* Top-level page title for the document outline (visually hidden — the
+          glanceable hero is the visual anchor, no on-screen <h1> needed). The
+          scope <h2> below then sits under a real h1. */}
+      <h1 class="sr-only">Cockpit</h1>
+
       {/* Narrow screens only — wide screens get the chrome variant in the
           sticky TopNav (redesign P4c). Same global signal either way. */}
       <PeriodNavigator variant="page" />

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -122,6 +122,21 @@ code, pre {
 
 .grow { flex: 1; }
 
+/* Visually hidden but exposed to assistive tech — for page-title headings and
+   other labels the glanceable design omits visually. Standard clip recipe. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Reduced motion — disable all entrance/ambient/loop motion; final state is
  * instant. Number tweens snap via useAnimatedNumber's own guard. Power-flow
  * particles freeze into static proportional lines (handled in PowerFlow).


### PR DESCRIPTION
## What

The cockpit landing page (`/`) had no `<h1>` — only `h2`/`h3`. Screen-reader users got no page title in the heading outline on the most-visited route, and heading-jump (`H`) landed on a section `h2` instead of a page title. `/insights` already has a proper `<h1>`.

Fix: add a visually-hidden `<h1>Cockpit</h1>` as the first child of `.home`, so the existing deliberate `<h2 class="scope scope--period">` now sits under a real top-level heading. No visible chrome added — the glanceable hero stays the visual anchor.

Also adds a reusable `.sr-only` utility to `base.css` (none existed); the other open a11y gaps (chart text alternatives, etc.) will want it too.

## Why

Found by `/qa` on the **live prod cockpit** (2026-06-17). It was the only finding in an otherwise-clean pass (health 99.5/100). Advances `DESIGN.md` → Open Gaps → "A11y headings (F-001)".

## Files

- `ui/src/routes/landing.tsx` — visually-hidden `<h1>`
- `ui/src/styles/base.css` — `.sr-only` utility

## Verification

- `tsc -b` clean, `vite build` OK, `.sr-only` present in the built bundle.
- Re-verify on prod after the UI image deploys (the QA pass tested deployed prod, so live behavior ships with the next `hem-ui` deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)